### PR TITLE
BUG FIX: Changed include order so that python compiles on Mac OS X 10.11

### DIFF
--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -28,14 +28,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#include <boost/python/import.hpp>
+
 #include "registration.h"
 
 #include <sprokit/pipeline/utils.h>
 
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
-
-#include <boost/python/import.hpp>
 
 #include <Python.h>
 

--- a/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
@@ -28,11 +28,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sprokit/pipeline/datum.h>
-
-#include <sprokit/python/any_conversion/prototypes.h>
-#include <sprokit/python/any_conversion/registration.h>
-#include <sprokit/python/util/python_gil.h>
 
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
@@ -43,6 +38,12 @@
 #include <boost/python/object.hpp>
 #include <boost/any.hpp>
 #include <boost/cstdint.hpp>
+
+#include <sprokit/pipeline/datum.h>
+
+#include <sprokit/python/any_conversion/prototypes.h>
+#include <sprokit/python/any_conversion/registration.h>
+#include <sprokit/python/util/python_gil.h>
 
 #include <limits>
 #include <string>

--- a/sprokit/src/bindings/python/sprokit/pipeline/stamp.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/stamp.cxx
@@ -28,8 +28,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sprokit/pipeline/stamp.h>
-
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 // XXX(python): 2.7
@@ -41,6 +39,8 @@
 #if PY_VERSION_HEX >= 0x02070000
 #include <boost/python/scope.hpp>
 #endif
+
+#include <sprokit/pipeline/stamp.h>
 
 /**
  * \file stamp.cxx

--- a/sprokit/src/bindings/python/sprokit/pipeline/utils.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/utils.cxx
@@ -28,11 +28,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sprokit/pipeline/utils.h>
-
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>
+
+#include <sprokit/pipeline/utils.h>
 
 /**
  * \file utils.cxx

--- a/sprokit/src/sprokit/python/any_conversion/registration.cxx
+++ b/sprokit/src/sprokit/python/any_conversion/registration.cxx
@@ -28,13 +28,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "registration.h"
-
-#include <vital/vital_foreach.h>
-#include <vital/logger/logger.h>
-
-#include <sprokit/python/util/python_gil.h>
-
 #include <boost/python/converter/registry.hpp>
 #include <boost/python/errors.hpp>
 #include <boost/python/to_python_converter.hpp>
@@ -43,6 +36,13 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/any.hpp>
 #include <boost/optional.hpp>
+
+#include "registration.h"
+
+#include <vital/vital_foreach.h>
+#include <vital/logger/logger.h>
+
+#include <sprokit/python/util/python_gil.h>
 
 #include <map>
 


### PR DESCRIPTION
Python compilation was failing on Mac OS X with errors like:

```
In file included from /Users/brian/playspace/viame-hackathon/VIAME/packages/kwiver/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx:33:
In file included from /Users/brian/playspace/viame-hackathon/VIAME/packages/kwiver/sprokit/src/sprokit/python/any_conversion/prototypes.h:38:
In file included from /Users/brian/playspace/viame-hackathon/VIAME-build/install/include/boost/python/converter/registry.hpp:7:
In file included from /Users/brian/playspace/viame-hackathon/VIAME-build/install/include/boost/python/type_id.hpp:14:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/ostream:138:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/ios:216:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__locale:468:15: error: C++ requires a type specifier for all declarations
    char_type toupper(char_type __c) const
```

The fix was to move the boost includes above all other includes.