### PR TITLE
Replace plugin loading mechanism in failing tests

### DIFF
--- a/arrows/core/tests/test_triangulate_landmarks.cxx
+++ b/arrows/core/tests/test_triangulate_landmarks.cxx
@@ -32,9 +32,8 @@
 #include <test_scene.h>
 #include <test_triangulate_landmarks.h>
 
-#include <vital/algorithm_plugin_manager.h>
-
 #include <arrows/core/triangulate_landmarks.h>
+#include <arrows/core/register_algorithms.h>
 
 
 #define TEST_ARGS ()
@@ -48,8 +47,7 @@ main(int argc, char* argv[])
 
   testname_t const testname = argv[1];
 
-  // locate all plugins
-  kwiver::vital::algorithm_plugin_manager::instance().register_plugins();
+  kwiver::arrows::core::register_algorithms();
 
   RUN_TEST(testname);
 }

--- a/arrows/ocv/tests/test_estimate_homography.cxx
+++ b/arrows/ocv/tests/test_estimate_homography.cxx
@@ -36,8 +36,6 @@
 #include <test_common.h>
 #include <test_random_point.h>
 
-#include <vital/algorithm_plugin_manager.h>
-
 #include <arrows/ocv/register_algorithms.h>
 #include <arrows/ocv/estimate_homography.h>
 
@@ -67,8 +65,7 @@ main(int argc, char* argv[])
 
   testname_t const testname = argv[1];
 
-  // locate all plugins
-  kwiver::vital::algorithm_plugin_manager::instance().register_plugins();
+  kwiver::arrows::ocv::register_algorithms();
 
   RUN_TEST(testname);
 }


### PR DESCRIPTION
Most tests for algorithm creation explictly load just the plugin for the
algorithm being tested.  In two cases, the generic register_plugins()
call was used instead.  This causes tests to fail when the plugin search
path is not configured correctly.  This change makes the plugin loading
consistent across algorithms.