### PR TITLE
link to Glog only if Ceres was built with GLog

### DIFF
--- a/arrows/ceres/CMakeLists.txt
+++ b/arrows/ceres/CMakeLists.txt
@@ -34,8 +34,13 @@ kwiver_add_library( kwiver_algo_ceres
   )
 target_link_libraries( kwiver_algo_ceres
   PUBLIC               kwiver_algo
-  PRIVATE              ceres glog
+  PRIVATE              ceres
   )
+if(NOT CERES_USES_MINILOG)
+  target_link_libraries( kwiver_algo_ceres
+    PRIVATE              glog
+    )
+endif()
 
 algorithms_create_plugin( kwiver_algo_ceres
   algorithm_plugin_interface.cxx

--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ project(arrows_test_ceres)
 include(kwiver-test-setup)
 
 set(test_libraries    kwiver_algo_ceres)
+if(NOT CERES_USES_MINILOG)
+  list(APPEND test_libraries glog)
+endif()
 
 ##############################
 # Algorithms Ceres tests


### PR DESCRIPTION
This patch fixes a build error on Mac OS occurring because Ceres tests didn't link to GLog.  However, this branch also address an anticipated problem if Ceres is not built with GLog.  For example, GLog is not supported in Fletch on Windows yet, so Ceres will build with its internal minilog instead.