### PR TITLE
Require Boost libraries only when needed.

### DIFF
--- a/CMake/kwiver-depends-Boost.cmake
+++ b/CMake/kwiver-depends-Boost.cmake
@@ -1,23 +1,27 @@
 # Required Boost external dependency
 
-if(WIN32)
-  set(Boost_USE_STATIC_LIBS TRUE)
-  set(Boost_WIN_MODULES chrono)
+if (KWIVER_ENABLE_SPROKIT OR KWIVER_ENABLE_TRACK_ORACLE)
+
+  if(WIN32)
+    set(Boost_USE_STATIC_LIBS TRUE)
+    set(Boost_WIN_MODULES chrono)
+  endif()
+
+  find_package(Boost 1.55 REQUIRED
+    COMPONENTS
+      chrono
+      date_time
+      ${kwiver_boost_python_package}
+      filesystem
+      program_options
+      regex
+      system
+      thread)
+
+  add_definitions(-DBOOST_ALL_NO_LIB)
+
+  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+  link_directories(${Boost_LIBRARY_DIRS})
+
 endif()
-
-find_package(Boost 1.55 REQUIRED
-  COMPONENTS
-    chrono
-    date_time
-    ${kwiver_boost_python_package}
-    filesystem
-    program_options
-    regex
-    system
-    thread)
-
-add_definitions(-DBOOST_ALL_NO_LIB)
-
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
 ####


### PR DESCRIPTION
If not building Sprokit or Track Oracle you should not need Boost.

A better solution would require only the Boost components needed by each component when that component is enabled rather than require the union.  E.g. I should be able to build Track Oracle without having Boost Python.