### PR TITLE
Remove quotes around list of libraries.

### DIFF
--- a/CMake/kwiver-config-build.cmake.in
+++ b/CMake/kwiver-config-build.cmake.in
@@ -21,7 +21,7 @@ else ()
   set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/lib")
 endif ()
 
-set(KWIVER_LIBRARIES           "@kwiver_libs@")
+set(KWIVER_LIBRARIES           @kwiver_libs@)
 set(KWIVER_ENABLE_PYTHON       "@KWIVER_ENABLE_PYTHON@")
 set(KWIVER_LIBRARY_DIRS        "${KWIVER_LIBRARY_DIR}"  "${Boost_LIBRARY_DIRS}")
 set(KWIVER_MODULE_DIR          "${KWIVER_LIBRARY_DIR}/modules")

--- a/CMake/kwiver-config-install.cmake.in
+++ b/CMake/kwiver-config-install.cmake.in
@@ -3,7 +3,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/kwiver-config-targets.cmake")
 
 # Build the appropriate include directory
 # This file currently being installed to: {install_root}/lib/cmake/kwiver/
-set(KWIVER_LIBRARIES            "@kwiver_libs@")
+set(KWIVER_LIBRARIES            @kwiver_libs@)
 
 set(KWIVER_BUILT_SHARED  "@BUILD_SHARED_LIBS@")
 


### PR DESCRIPTION
The quotes prevent the list of libraries from being treated as a list.
They are treated as a string leading to many libraries not found.