### PR TITLE
Remove statement that requires static Boost on Windows.

### DIFF
--- a/CMake/kwiver-depends-Boost.cmake
+++ b/CMake/kwiver-depends-Boost.cmake
@@ -3,7 +3,6 @@
 if (KWIVER_ENABLE_SPROKIT OR KWIVER_ENABLE_TRACK_ORACLE)
 
   if(WIN32)
-    set(Boost_USE_STATIC_LIBS TRUE)
     set(Boost_WIN_MODULES chrono)
   endif()
 


### PR DESCRIPTION
Previously there were issues building shared Boost on Windows in Fletch.
Those issues have since been (mostly) resolved.  Requiring static Boost
libraries now causes KWIVER to fail to find Boost when built against
Boost from Fletch.