### PR TITLE
Fix visual studio errors

### DIFF
--- a/arrows/ocv/bounding_box.h
+++ b/arrows/ocv/bounding_box.h
@@ -56,7 +56,6 @@ namespace ocv {
  * @return Equivalent bounding box.
  */
 template <typename T>
-KWIVER_ALGO_OCV_EXPORT
 kwiver::vital::bounding_box<T> convert( const CvRect& vbox )
 {
   typename kwiver::vital::bounding_box<T>::vector_type bb_tl( vbox.x, vbox.y );
@@ -73,7 +72,6 @@ kwiver::vital::bounding_box<T> convert( const CvRect& vbox )
  * @return Equivalent CvRect
  */
 template <typename T>
-KWIVER_ALGO_OCV_EXPORT
 CvRect convert(const kwiver::vital::bounding_box<T>& bbox )
 {
   // Note that CvRect has integer values. If T is a floating type. the

--- a/arrows/vxl/CMakeLists.txt
+++ b/arrows/vxl/CMakeLists.txt
@@ -60,11 +60,12 @@ kwiver_add_library( kwiver_algo_vxl
   )
 target_link_libraries( kwiver_algo_vxl
   PUBLIC               kwiver_algo
-                       vil vidl vgl
+                       vil vpgl vgl
   PRIVATE              vital_klv
                        vital_video_metadata
                        rrel rsdl
                        vnl
+                       vidl
                        vgl_algo
                        vpgl_algo
   )

--- a/arrows/vxl/bounding_box.h
+++ b/arrows/vxl/bounding_box.h
@@ -55,7 +55,6 @@ namespace vxl {
  * @return Equivalent bounding box.
  */
 template <typename T>
-KWIVER_ALGO_VXL_EXPORT
 kwiver::vital::bounding_box<T> convert( const vgl_box_2d<T>& vbox )
 {
   return kwiver::vital::bounding_box<T>( vbox.min_x(),
@@ -74,7 +73,6 @@ kwiver::vital::bounding_box<T> convert( const vgl_box_2d<T>& vbox )
  * @return Equivalent vgl_box_2d
  */
 template <typename T>
-KWIVER_ALGO_VXL_EXPORT
 vgl_box_2d<T> convert(const kwiver::vital::bounding_box<T>& bbox )
 {
   return vgl_box_2d<T>( bbox.min_x(), bbox.max_x(),


### PR DESCRIPTION
There is still one error in Vital not accounted for.  test_logger.cxx uses `unsetenv` which is apparently not available on Windows.