### PR TITLE
Remove check for impossible null reference.

### DIFF
--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -1803,14 +1803,6 @@ void
 process::priv
 ::connect_input_port(port_t const& port, edge_t const& edge)
 {
-  // This may seem really strange, but it happens during execption
-  // handling.
-  if ( &port == 0 )
-  {
-    LOG_ERROR( m_logger, "Port reference is NULL" );
-    return;
-  }
-
   if (!input_ports.count(port))
   {
     throw no_such_port_exception(name, port);


### PR DESCRIPTION
Null references do not exist in C++ and we don't need to check for them.
This code was generating the following warning:

warning: reference cannot be bound to dereferenced null pointer in
well-defined C++ code; comparison may be assumed to always evaluate to
false

If there really is a case in exception handling where the reference is
null, it seems that should be handled elsewhere, e.g. before a NULL
pointer is converted to a reference.