### PR TITLE
Add missing CMakeDependentOption include in doxygen utils cmake

### DIFF
--- a/CMake/utils/kwiver-utils-doxygen.cmake
+++ b/CMake/utils/kwiver-utils-doxygen.cmake
@@ -4,6 +4,7 @@
 
 find_package(Doxygen)
 
+include(CMakeDependentOption)
 cmake_dependent_option(${CMAKE_PROJECT_NAME}_ENABLE_DOCS
   "Build KWIVER documentation via Doxygen." OFF
   DOXYGEN_FOUND OFF


### PR DESCRIPTION
When using kwiver in another project that has not yet explicitly
CMake included ``CMakeDependentOption``, inclusion of ``kwiver-utils``
fails with ``Unknown CMake command "cmake_dependent_option"``. Adding
an include in the doxygen utils CMake file where the use of
``CMakeDependentOption`` is used.