### PR TITLE
Add export of test utils header dir in build CMake config

### DIFF
--- a/CMake/kwiver-config-build.cmake.in
+++ b/CMake/kwiver-config-build.cmake.in
@@ -15,6 +15,10 @@ set(KWIVER_INCLUDE_DIRS
   "@KWIVER_BINARY_DIR@/sprokit/src"
   "@EIGEN3_INCLUDE_DIR@" )
 
+set(KWIVER_TEST_INCLUDE_DIRS
+  "@KWIVER_SOURCE_DIR@/tests"
+  )
+
 if (WIN32)
   set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/bin")
 else ()


### PR DESCRIPTION
Added a variable (``KWIVER_TEST_INCLUDE_DIRS``) to be present in ``kwiver-config.cmake`` for a build of
kwiver. This allows projects that use kwiver to not have to replicate
utilities like that defined in ``test_common.h`` that are required for
the ``kwiver-utils-tests`` functions.