### PR TITLE
Support OpenCV 3.X

### DIFF
--- a/CMake/kwiver-depends-OpenCV.cmake
+++ b/CMake/kwiver-depends-OpenCV.cmake
@@ -7,10 +7,10 @@ option( KWIVER_ENABLE_OPENCV
 
 set( USE_OPENCV False )
 if( KWIVER_ENABLE_OPENCV )
-  find_package( OpenCV 2.4.6 REQUIRED )
+  find_package( OpenCV REQUIRED )
   include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
 
-  if( OpenCV_VERSION VERSION_GREATER "2.4" )
+  if( OpenCV_VERSION VERSION_GREATER "2.4.6" )
     set( USE_OPENCV True )
     if( OpenCV_VERSION VERSION_GREATER "3.0" OR
         OpenCV_VERSION VERSION_EQUAL "3.0")
@@ -19,7 +19,7 @@ if( KWIVER_ENABLE_OPENCV )
     endif()
 
   else()
-    message( FATAL_ERROR "OpenCV version must be at least 2.4" )
+    message( FATAL_ERROR "OpenCV version must be at least 2.4.6" )
   endif()
 endif( KWIVER_ENABLE_OPENCV )
 

--- a/arrows/ocv/bounding_box.h
+++ b/arrows/ocv/bounding_box.h
@@ -39,7 +39,7 @@
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/types/bounding_box.h>
-#include <opencv2/core/types_c.h>            // OCV rect
+#include <opencv2/core.hpp>            // OCV rect
 
 
 namespace kwiver {

--- a/arrows/ocv/hough_circle_detector.cxx
+++ b/arrows/ocv/hough_circle_detector.cxx
@@ -35,6 +35,8 @@
 
 #include "hough_circle_detector.h"
 
+#include <vector>
+
 #include <arrows/ocv/image_container.h>
 
 #include <opencv2/core/core.hpp>
@@ -169,7 +171,7 @@ detect( vital::image_container_sptr image_data) const
   // Reduce the noise so we avoid false circle detection
   cv::GaussianBlur( src_gray, src_gray, cv::Size( 9, 9 ), 2, 2 );
 
-  cv::vector< cv::Vec3f > circles;
+  std::vector< cv::Vec3f > circles;
 
   // Apply the Hough Transform to find the circles
   cv::HoughCircles( src_gray, // i: source image


### PR DESCRIPTION
These changes are to support OpenCV 3.X in KWIVER.  These are fixes for vital and arrows.  I have not build sprokit with OpenCV 3.X yet.  Additional Changes may be needed.