### PR TITLE
different includes for cvRect are needed between v2.4 and v3.0

### DIFF
--- a/arrows/ocv/bounding_box.h
+++ b/arrows/ocv/bounding_box.h
@@ -39,7 +39,11 @@
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/types/bounding_box.h>
+#ifndef KWIVER_HAS_OPENCV_VER_3
+#include <opencv2/core/types_c.h>      // OCV rect
+#else
 #include <opencv2/core.hpp>            // OCV rect
+#endif
 
 
 namespace kwiver {


### PR DESCRIPTION
This change addresses errors on dashboard builds that are still using OpenCV 2.4