### PR TITLE
Upgrade Travis CI compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,19 @@
 sudo: false
 
 language: cpp
-compiler:
-  - gcc
-  - clang
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env: COMPILER=g++-4.8
+    - compiler: clang
+      env: COMPILER=clang++-3.4
 
 cache:
   directories:
@@ -28,7 +38,8 @@ script:
   - export PATH=$HOME/deps/bin:$PATH
   - mkdir build
   - cd build
-  - cmake -DKWIVER_ENABLE_ARROWS=ON
+  - cmake -DCMAKE_CXX_COMPILER=$COMPILER
+          -DKWIVER_ENABLE_ARROWS=ON
           -DKWIVER_ENABLE_CERES=ON
           -DKWIVER_ENABLE_C_BINDINGS=ON
           -DKWIVER_ENABLE_DOCS=OFF

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
           packages:
             - g++-4.8
       env: COMPILER=g++-4.8
-    - compiler: clang
-      env: COMPILER=clang++-3.4
+    - compiler: clang # default is 3.4
+      env: COMPILER=clang++
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,13 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-      env: COMPILER=g++-4.8
-    - compiler: clang # default is 3.4
-      env: COMPILER=clang++
+      env:
+        - C_COMPILER=gcc-4.8
+        - CXX_COMPILER=g++-4.8
+    - compiler: clang
+      env: # default clang is version 3.4
+        - C_COMPILER=clang
+        - CXX_COMPILER=clang++
 
 cache:
   directories:
@@ -27,7 +25,10 @@ before_script:
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
+    - g++-4.8
     - libproj-dev
     - libgl1-mesa-dev
     - libxt-dev
@@ -38,7 +39,8 @@ script:
   - export PATH=$HOME/deps/bin:$PATH
   - mkdir build
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER
+  - cmake -DCMAKE_C_COMPILER=$C_COMPILER
+          -DCMAKE_CXX_COMPILER=$CXX_COMPILER
           -DKWIVER_ENABLE_ARROWS=ON
           -DKWIVER_ENABLE_CERES=ON
           -DKWIVER_ENABLE_C_BINDINGS=ON

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -68,6 +68,7 @@ build_repo ()
     cmake ../source \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/ \
           -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_COMPILER=$COMPILER \
           $CMAKE_OPTS
     make -j2
     $INSTALL_CMD

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -68,7 +68,8 @@ build_repo ()
     cmake ../source \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/ \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_CXX_COMPILER=$COMPILER \
+          -DCMAKE_CXX_COMPILER=$CXX_COMPILER \
+          -DCMAKE_C_COMPILER=$C_COMPILER \
           $CMAKE_OPTS
     make -j2
     $INSTALL_CMD


### PR DESCRIPTION
This branch upgrades the GCC compiler to version 4.8 for the Ubuntu 12.04 environment used by Travis-CI.  This is now the minimum supported version of GCC since we require C++11.