### PR TITLE
Dev/add process instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ CMAKE_DEPENDENT_OPTION(KWIVER_ENABLE_PROCESSES "Should the KWIVER Sprokit Proces
 OPTION(KWIVER_USE_BUILD_TREE "Whether to include the build-tree plugin directory to the default plugin path list" OFF )
 MARK_AS_ADVANCED(KWIVER_USE_BUILD_TREE)
 
+option( KWIVER_ENABLE_EXTRAS "Enable extras content" OFF )
 
 ## TODO: How should pytgon and c lib interact?
 OPTION( KWIVER_ENABLE_C_BINDINGS     "Enable C bindings libraries" OFF)
@@ -230,6 +231,10 @@ endif()
 
 if (KWIVER_ENABLE_SPROKIT)
   add_subdirectory(sprokit)
+endif()
+
+if (KWIVER_ENABLE_EXTRAS)
+  add_subdirectory(extras)
 endif()
 
 ###

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -1,0 +1,15 @@
+###
+# Extras
+
+option( KWIVER_ENABLE_RightTrack "Add RightTrack integration" OFF )
+
+# Add common include directories to be made available for extras
+include_directories ( "${KWIVER_SOURCE_DIR}" )
+include_directories ( "${KWIVER_SOURCE_DIR}/sprokit/src" )
+include_directories ( "${KWIVER_BINARY_DIR}/sprokit/src" )
+
+if (KWIVER_ENABLE_RightTrack)
+  add_subdirectory(RightTrack)
+endif()
+
+add_subdirectory( process_instrumentation )

--- a/extras/RightTrack/CMakeLists.txt
+++ b/extras/RightTrack/CMakeLists.txt
@@ -1,0 +1,21 @@
+###
+# RightTrack plugin
+
+# Should use find module for this, but RightTrack needs to be upgraded.
+find_library (RIGHT_TRACK_LIB right_track )
+SET ( RIGHT_TRACK_DIR "" CACHE FILEPATH "Location of include files" )
+
+include_directories ( "${RIGHT_TRACK_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" )
+
+kwiver_add_plugin( RightTrack_plugin
+  SOURCES          register_plugin.cxx
+                   rt_process_instrumentation.h
+                   rt_process_instrumentation.cxx
+                   ${CMAKE_CURRENT_BINARY_DIR}/righttrack_plugin_export.h
+  PRIVATE          vital
+                   vital_vpm
+                   "${RIGHT_TRACK_LIB}"
+                   vcl vpl vul vsl
+                   sprokit_pipeline
+  SUBDIR           modules
+  )

--- a/extras/RightTrack/register_plugin.cxx
+++ b/extras/RightTrack/register_plugin.cxx
@@ -1,0 +1,48 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vital/plugin_loader/plugin_manager.h>
+#include <righttrack_plugin_export.h>
+
+#include "rt_process_instrumentation.h"
+
+
+extern "C"
+RIGHTTRACK_PLUGIN_EXPORT
+void
+register_factories( kwiver::vital::plugin_loader& vpm )
+{
+  kwiver::vital::plugin_factory_handle_t fact =
+    vpm.ADD_FACTORY( sprokit::process_instrumentation, sprokit::rt_process_instrumentation );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "RightTrack");
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Sprokit process instrumentation implementation using RightTrack.");
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+}

--- a/extras/RightTrack/rt_process_instrumentation.cxx
+++ b/extras/RightTrack/rt_process_instrumentation.cxx
@@ -1,0 +1,190 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rt_process_instrumentation.h"
+
+#include <sprokit/pipeline/process.h>
+
+namespace sprokit {
+
+#define INIT_COLOR -1
+#define RESET_COLOR -1
+#define FLUSH_COLOR -1
+#define STEP_COLOR -1
+#define CONFIGURE_COLOR -1
+#define RECONFIGURE_COLOR -1
+
+
+// ------------------------------------------------------------------
+rt_process_instrumentation::
+rt_process_instrumentation()
+{
+}
+
+
+// ------------------------------------------------------------------
+rt_process_instrumentation::
+~rt_process_instrumentation()
+{ }
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+configure( kwiver::vital::config_block_sptr const config )
+{
+  m_init_event.reset( new RightTrack::BoundedEvent( process().name() + ".init",
+                                                    process().name(), INIT_COLOR ) );
+
+  m_reset_event.reset( new RightTrack::BoundedEvent( process().name() + ".reset",
+                                                     process().name(), RESET_COLOR ) );
+
+  m_flush_event.reset( new RightTrack::BoundedEvent( process().name() + ".flush",
+                                                     process().name(), FLUSH_COLOR ) );
+
+  m_step_event.reset( new RightTrack::BoundedEvent( process().name()+ ".step",
+                                                    process().name(), STEP_COLOR ) );
+
+  m_configure_event.reset( new RightTrack::BoundedEvent( process().name() + ".configure",
+                                                         process().name(), CONFIGURE_COLOR ) );
+
+  m_reconfigure_event.reset( new RightTrack::BoundedEvent( process().name() + ".reconfigure",
+                                                           process().name(), RECONFIGURE_COLOR ) );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_init_processing( std::string const& data )
+{
+  m_init_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_init_processing()
+{
+  m_init_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_reset_processing( std::string const& data )
+{
+  m_reset_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_reset_processing()
+{
+  m_reset_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_flush_processing( std::string const& data )
+{
+  m_flush_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_flush_processing()
+{
+  m_flush_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_step_processing( std::string const& data )
+{
+  m_step_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_step_processing()
+{
+  m_step_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_configure_processing( std::string const& data )
+{
+  m_configure_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_configure_processing()
+{
+  m_configure_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_reconfigure_processing( std::string const& data )
+{
+  m_reconfigure_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_reconfigure_processing()
+{
+  m_reconfigure_event->End();
+}
+
+} // end namespace

--- a/extras/RightTrack/rt_process_instrumentation.h
+++ b/extras/RightTrack/rt_process_instrumentation.h
@@ -1,0 +1,88 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+f * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef KWIVER_EXTRAS_RT_PROCESS_INSTRUMENTATION_H
+#define KWIVER_EXTRAS_RT_PROCESS_INSTRUMENTATION_H
+
+#include <sprokit/pipeline/process_instrumentation.h>
+
+#include <RightTrack/BoundedEvent.h>
+
+#include <memory>
+
+
+namespace sprokit {
+
+// ----------------------------------------------------------------
+/**
+ * @brief Process instrumentation using RightTrack tool.
+ *
+ */
+class rt_process_instrumentation
+: public process_instrumentation
+{
+public:
+  // -- CONSTRUCTORS --
+  rt_process_instrumentation();
+  virtual ~rt_process_instrumentation();
+
+  virtual void configure( kwiver::vital::config_block_sptr const config );
+
+  virtual void start_init_processing( std::string const& data );
+  virtual void stop_init_processing();
+
+  virtual void start_reset_processing( std::string const& data );
+  virtual void stop_reset_processing();
+
+  virtual void start_flush_processing( std::string const& data );
+  virtual void stop_flush_processing();
+
+  virtual void start_step_processing( std::string const& data );
+  virtual void stop_step_processing();
+
+  virtual void start_configure_processing( std::string const& data );
+  virtual void stop_configure_processing();
+
+  virtual void start_reconfigure_processing( std::string const& data );
+  virtual void stop_reconfigure_processing();
+
+private:
+  std::unique_ptr< RightTrack::BoundedEvent > m_init_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_reset_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_flush_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_step_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_configure_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_reconfigure_event;
+}; // end class rt_process_instrumentation
+
+} // end namespace
+
+#endif // KWIVER_EXTRAS_RT_PROCESS_INSTRUMENTATION_H

--- a/extras/process_instrumentation/CMakeLists.txt
+++ b/extras/process_instrumentation/CMakeLists.txt
@@ -1,0 +1,25 @@
+###
+# process instrumentation plugins
+#
+set( sources
+  register_plugin.cxx
+  logger_process_instrumentation.cxx
+  )
+
+set( headers
+  logger_process_instrumentation.h
+  )
+
+include_directories ( "${CMAKE_CURRENT_BINARY_DIR}" )
+
+
+kwiver_add_plugin( instrumentation_plugin
+  SOURCES          ${sources}
+                   ${headers}
+                   ${CMAKE_CURRENT_BINARY_DIR}/instrumentation_plugin_export.h
+  PRIVATE          vital
+                   vital_vpm
+                   vital_logger
+                   sprokit_pipeline
+  SUBDIR           modules
+  )

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -1,0 +1,157 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "logger_process_instrumentation.h"
+
+#include <sprokit/pipeline/process.h>
+
+namespace sprokit {
+
+// ------------------------------------------------------------------
+logger_process_instrumentation::
+logger_process_instrumentation()
+  : m_logger( kwiver::vital::get_logger( "sprokit.process_instrumentation" ) )
+{ }
+
+
+logger_process_instrumentation::
+~logger_process_instrumentation()
+{ }
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+  start_init_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": start_init_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_init_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_init_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+start_reset_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": stop_init_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_reset_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_reset_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+start_flush_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": start_reset_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_flush_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_flush_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+start_step_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": start_step_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_step_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_step_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+start_configure_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": start_configure_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_configure_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_configure_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+start_reconfigure_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process().name() << ": start_reconfigure_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_reconfigure_processing()
+{
+  LOG_INFO( m_logger, process().name() << ": stop_reconfigure_processing" );
+}
+
+
+} // end namespace

--- a/extras/process_instrumentation/logger_process_instrumentation.h
+++ b/extras/process_instrumentation/logger_process_instrumentation.h
@@ -1,0 +1,87 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for process instrumentation.
+ */
+
+#ifndef SPROKIT_LOGGER_PROCESS_INSTRUMENTATION_H
+#define SPROKIT_LOGGER_PROCESS_INSTRUMENTATION_H
+
+
+#include <sprokit/pipeline/process_instrumentation.h>
+#include <vital/logger/logger.h>
+
+#include <string>
+
+namespace sprokit {
+
+// -----------------------------------------------------------------
+/**
+ * \brief Base class for process instrumentation.
+ *
+ * This class is the abstract base class for process instrumentation.
+ * It defines the interface processes can use to access an
+ * instrumentation package using the strategy pattern.
+ */
+class logger_process_instrumentation
+  : public process_instrumentation
+{
+public:
+  logger_process_instrumentation();
+  virtual ~logger_process_instrumentation();
+
+  virtual void start_init_processing( std::string const& data );
+  virtual void stop_init_processing();
+
+  virtual void start_reset_processing( std::string const& data );
+  virtual void stop_reset_processing();
+
+  virtual void start_flush_processing( std::string const& data );
+  virtual void stop_flush_processing();
+
+  virtual void start_step_processing( std::string const& data );
+  virtual void stop_step_processing();
+
+  virtual void start_configure_processing( std::string const& data );
+  virtual void stop_configure_processing();
+
+  virtual void start_reconfigure_processing( std::string const& data );
+  virtual void stop_reconfigure_processing();
+
+private:
+  kwiver::vital::logger_handle_t m_logger;
+
+}; // end class logger_process_instrumentation
+
+} // end namespace
+
+#endif // SPROKIT_LOGGER_PROCESS_INSTRUMENTATION_H

--- a/extras/process_instrumentation/register_plugin.cxx
+++ b/extras/process_instrumentation/register_plugin.cxx
@@ -1,0 +1,47 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vital/plugin_loader/plugin_manager.h>
+#include <instrumentation_plugin_export.h>
+
+#include "logger_process_instrumentation.h"
+
+extern "C"
+INSTRUMENTATION_PLUGIN_EXPORT
+void
+register_factories( kwiver::vital::plugin_loader& vpm )
+{
+  kwiver::vital::plugin_factory_handle_t fact =
+    vpm.ADD_FACTORY( sprokit::process_instrumentation, sprokit::logger_process_instrumentation );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "logger");
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Sprokit process instrumentation implementation using logger.");
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+}

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -8,6 +8,7 @@ set(pipeline_srcs
   pipeline_exception.cxx
   process.cxx
   process_factory.cxx
+  process_instrumentation.cxx
   process_exception.cxx
   process_cluster.cxx
   process_cluster_exception.cxx
@@ -19,7 +20,8 @@ set(pipeline_srcs
   stamp.cxx
   types.cxx
   utils.cxx
-  version.cxx)
+  version.cxx
+  )
 
 set(pipeline_headers
   datum.h
@@ -30,6 +32,7 @@ set(pipeline_headers
   pipeline_exception.h
   process.h
   process_factory.h
+  process_instrumentation.h
   process_exception.h
   process_cluster.h
   process_cluster_exception.h
@@ -41,7 +44,8 @@ set(pipeline_headers
   stamp.h
   types.h
   utils.h
-  version.h)
+  version.h
+  )
 
 set(pipeline_private_headers)
 

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,8 +56,7 @@
  * \brief Header for \link sprokit::process processes\endlink.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /// A group of processes.
 typedef std::vector<process_t> processes_t;
@@ -523,6 +522,8 @@ class SPROKIT_PIPELINE_EXPORT process
     static property_t const property_unsync_input;
     /// A property which indicates that the output of the process is not synchronized.
     static property_t const property_unsync_output;
+    /// Indicates that the process supports instrumentation call
+    static property_t const property_instrumented;
 
     /// The name of the heartbeat port.
     static port_t const port_heartbeat;
@@ -654,6 +655,7 @@ class SPROKIT_PIPELINE_EXPORT process
 
 
   protected:
+
     /**
      * \brief Constructor.
      *
@@ -1221,6 +1223,54 @@ class SPROKIT_PIPELINE_EXPORT process
      * \returns Information about the data given.
      */
     static data_info_t edge_data_info(edge_data_t const& data);
+
+//@{
+    /**
+     * \brief Process instrumentation interface.
+     *
+     * These calls are available to the process writer to self
+     * instrument the process implementation. Unfortunately there is
+     * no way to put this instrumentation in the interface since a
+     * process is responsible for getting inputs and pushing outputs.
+     *
+     * The start call is used to indicate the beginning of substantial processing.
+     * The end call is used to indicate the end of substantial processing.
+     *
+     * Instrumentation is enabled by supplying the following config
+     * entries in the pipeline definition file for each process that
+     * is to be instrumented.
+     *
+     * process process_type
+     *   :: my_proc
+     *     : _instrumentation:type  none   # default value. disabled
+     *     : _instrumentation:type  RightTrack  # enables RightTrack instrumentation for this process
+     *     : _instrumentation:RightTrack:foo   value    # instrumentation provider specific config.
+     *
+     */
+    void start_init_processing( std::string const& data );
+    void start_init_processing();
+    void stop_init_processing();
+
+    void start_reset_processing( std::string const& data );
+    void start_reset_processing();
+    void stop_reset_processing( );
+
+    void start_flush_processing( std::string const& data );
+    void start_flush_processing();
+    void stop_flush_processing( );
+
+    void start_step_processing( std::string const& data );
+    void start_step_processing();
+    void stop_step_processing( );
+
+    void start_configure_processing( std::string const& data );
+    void start_configure_processing();
+    void stop_configure_processing( );
+
+    void start_reconfigure_processing( std::string const& data );
+    void start_reconfigure_processing();
+    void stop_reconfigure_processing( );
+//@}
 
   private:
     kwiver::vital::config_block_value_t config_value_raw(kwiver::vital::config_block_key_t const& key) const;

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
@@ -1,0 +1,64 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Implementation for process instrumentation.
+ */
+
+#include "process_instrumentation.h"
+
+namespace sprokit {
+
+process_instrumentation::
+process_instrumentation()
+  : m_process( 0 )
+{ }
+
+
+process_instrumentation::
+~process_instrumentation()
+{ }
+
+
+void
+process_instrumentation::
+set_process( sprokit::process const& proc )
+{
+  m_process = &proc;
+}
+
+
+void
+process_instrumentation::
+configure( kwiver::vital::config_block_sptr const config )
+{ }
+
+} // end namespace sprokit

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.h
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.h
@@ -1,0 +1,106 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for process instrumentation.
+ */
+
+#ifndef SPROKIT_PROCESS_INSTRUMENTATION_H
+#define SPROKIT_PROCESS_INSTRUMENTATION_H
+
+#include "pipeline-config.h"
+
+#include <vital/config/config_block.h>
+
+#include <string>
+
+namespace sprokit {
+
+class process; // incomplete type
+
+
+// -----------------------------------------------------------------
+/**
+ * \brief Base class for process instrumentation.
+ *
+ * This class is the abstract base class for process instrumentation.
+ * It defines the interface processes can use to access an
+ * instrumentation package using the strategy pattern.
+ */
+class SPROKIT_PIPELINE_EXPORT process_instrumentation
+{
+public:
+  process_instrumentation();
+  virtual ~process_instrumentation();
+
+  void set_process( sprokit::process const& proc );
+
+  virtual void start_init_processing( std::string const& data ) = 0;
+  virtual void stop_init_processing() = 0;
+
+  virtual void start_reset_processing( std::string const& data ) = 0;
+  virtual void stop_reset_processing() = 0;
+
+  virtual void start_flush_processing( std::string const& data ) = 0;
+  virtual void stop_flush_processing() = 0;
+
+  virtual void start_step_processing( std::string const& data ) = 0;
+  virtual void stop_step_processing() = 0;
+
+  virtual void start_configure_processing( std::string const& data ) = 0;
+  virtual void stop_configure_processing() = 0;
+
+  virtual void start_reconfigure_processing( std::string const& data ) = 0;
+  virtual void stop_reconfigure_processing() = 0;
+
+
+  /**
+   * @brief Get process that is being instrumented.
+   *
+   *
+   * @return Reference to process object.
+   */
+  sprokit::process const& process() const { return *m_process; }
+
+  /**
+   * @brief Configure provider.
+   *
+   * @param conf Configuration block.
+   */
+  virtual void configure( kwiver::vital::config_block_sptr const conf );
+
+private:
+  sprokit::process const* m_process;
+}; // end class process_instrumentation
+
+} // end namespace
+
+#endif /* SPROKIT_PROCESS_INSTRUMENTATION_H */

--- a/sprokit/src/sprokit/pipeline/scheduler.h
+++ b/sprokit/src/sprokit/pipeline/scheduler.h
@@ -79,30 +79,35 @@ class SPROKIT_PIPELINE_EXPORT scheduler
      * \throws restart_scheduler_exception Thrown when the scheduler was already started.
      */
     void start();
+
     /**
      * \brief Wait until execution is finished.
      *
      * \throws restart_scheduler_exception Thrown when the scheduler has not been started.
      */
     void wait();
+
     /**
      * \brief Pause execution.
      *
      * \throws pause_before_start_exception Thrown when the scheduler has not been started.
      */
     void pause();
+
     /**
      * \brief Resume execution.
      *
      * \throws resume_unpaused_scheduler_exception Thrown when the scheduler is not paused.
      */
     void resume();
+
     /**
      * \brief Stop execution of the pipeline.
      *
      * \throws stop_before_start_exception Thrown when the scheduler has not been started.
      */
     void stop();
+
   protected:
     /**
      * \brief Constructor.
@@ -119,18 +124,22 @@ class SPROKIT_PIPELINE_EXPORT scheduler
      * pipeline. Exceptions should be thrown instead.
      */
     virtual void _start() = 0;
+
     /**
      * \brief Wait until execution is finished.
      */
     virtual void _wait() = 0;
+
     /**
      * \brief Pause execution.
      */
     virtual void _pause() = 0;
+
     /**
      * \brief Resume execution.
      */
     virtual void _resume() = 0;
+
     /**
      * \brief Stop execution of the pipeline.
      *
@@ -153,6 +162,7 @@ class SPROKIT_PIPELINE_EXPORT scheduler
      * \returns The pipeline.
      */
     pipeline_t pipeline() const;
+
   private:
     class SPROKIT_PIPELINE_NO_EXPORT priv;
     boost::scoped_ptr<priv> d;

--- a/sprokit/src/sprokit/pipeline/stamp.h
+++ b/sprokit/src/sprokit/pipeline/stamp.h
@@ -88,6 +88,7 @@ class SPROKIT_PIPELINE_EXPORT stamp
      * \returns True if \p st and \c *this have the same value, false otherwise.
      */
     bool operator == (stamp const& st) const;
+
     /**
      * \brief Compare two stamps for an order.
      *
@@ -96,6 +97,7 @@ class SPROKIT_PIPELINE_EXPORT stamp
      * \returns True if \p st has a higher value than \c *this, false otherwise.
      */
     bool operator <  (stamp const& st) const;
+
   private:
     typedef uint64_t index_t;
 


### PR DESCRIPTION
Add support for instrumenting process behaviour. Instrumentation is optional and is controlled on a per-process basis using the process configuration. The instrumentation provider can be selected from a number of loadable implementations. Only processes with the *property_instrumented* property.

Requiring this property prevents unexpected results when instrumentation is activated for a process that is not instrumented.

Current instrumentation providers are:
- Log events
- RightTrack event analysis package (external package, not supplied in this repository)