### PR TITLE
Add the KWIVER_USE_BUILD_TREE option to the build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
           -DKWIVER_ENABLE_TRACK_ORACLE=OFF
           -DKWIVER_ENABLE_VISCL=OFF
           -DKWIVER_ENABLE_VXL=ON
+          -DKWIVER_USE_BUILD_TREE=ON
           ../
   - make -j2
   - ctest


### PR DESCRIPTION
This option will add the build tree to the plugin loader path so plugins will be found when they are not otherwise installed. 