### PR TITLE
Fix export macros for Windows build, and export from plugins

### DIFF
--- a/CMake/utils/algorithm-utils-targets.cmake
+++ b/CMake/utils/algorithm-utils-targets.cmake
@@ -69,7 +69,6 @@ function(algorithms_create_plugin    base_lib)
   # create module library given generated source, linked to given library
   set(library_subdir /modules)
   set(no_version ON)
-  set(no_export_header ON)
 
   kwiver_add_plugin( ${plugin_name}
     SOURCES  ${ARGN}

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -33,7 +33,7 @@
  * \brief Defaults plugin algorithm registration interface impl
  */
 
-#include <arrows/core/kwiver_algo_core_export.h>
+#include <arrows/core/kwiver_algo_core_plugin_export.h>
 #include <vital/algo/algorithm_factory.h>
 
 #include <arrows/core/close_loops_bad_frames_only.h>
@@ -61,7 +61,7 @@ namespace arrows {
 namespace core {
 
 extern "C"
-KWIVER_ALGO_CORE_EXPORT
+KWIVER_ALGO_CORE_PLUGIN_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {

--- a/arrows/ocv/draw_detected_object_set.h
+++ b/arrows/ocv/draw_detected_object_set.h
@@ -50,7 +50,7 @@ namespace ocv {
 
 /// An abstract base class for algorithms which draw tracks on top of
 /// images in various ways, for analyzing results.
-class VITAL_EXPORT draw_detected_object_set
+class KWIVER_ALGO_OCV_EXPORT draw_detected_object_set
   : public vital::algorithm_impl< draw_detected_object_set, vital::algo::draw_detected_object_set>
 {
 public:

--- a/arrows/ocv/register_algorithms.cxx
+++ b/arrows/ocv/register_algorithms.cxx
@@ -33,7 +33,7 @@
  * \brief OpenCV algorithm registration implementation
  */
 
-#include <arrows/ocv/kwiver_algo_ocv_export.h>
+#include <arrows/ocv/kwiver_algo_ocv_plugin_export.h>
 #include <vital/algo/algorithm_factory.h>
 
 #include <opencv2/opencv_modules.hpp>
@@ -72,7 +72,7 @@ namespace arrows {
 namespace ocv {
 
 extern "C"
-KWIVER_ALGO_OCV_EXPORT
+KWIVER_ALGO_OCV_PLUGIN_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {

--- a/arrows/proj/register_algorithms.cxx
+++ b/arrows/proj/register_algorithms.cxx
@@ -33,18 +33,17 @@
  * \brief PROJ algorithm registration implementation
  */
 
-#include <arrows/proj/kwiver_algo_proj_export.h>
+#include <arrows/proj/kwiver_algo_proj_plugin_export.h>
 #include <vital/algo/algorithm_factory.h>
 
 #include <arrows/proj/geo_map.h>
-
 
 namespace kwiver {
 namespace arrows {
 namespace proj {
 
 extern "C"
-KWIVER_ALGO_PROJ_EXPORT
+KWIVER_ALGO_PROJ_PLUGIN_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {

--- a/arrows/vxl/register_algorithms.cxx
+++ b/arrows/vxl/register_algorithms.cxx
@@ -33,7 +33,7 @@
  * \brief Register VXL algorithms implementation
  */
 
-#include <arrows/vxl/kwiver_algo_vxl_export.h>
+#include <arrows/vxl/kwiver_algo_vxl_plugin_export.h>
 #include <vital/algo/algorithm_factory.h>
 
 #include <arrows/vxl/bundle_adjust.h>
@@ -55,7 +55,7 @@ namespace arrows {
 namespace vxl {
 
 extern "C"
-KWIVER_ALGO_VXL_EXPORT
+KWIVER_ALGO_VXL_PLUGIN_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -88,7 +88,7 @@ private:
 
 // -----------------------------------------------------------------
 template <class IMPL>
-class VITAL_ALGO_EXPORT algorithm_factory_0
+class algorithm_factory_0
   : public algorithm_factory
 {
 public:

--- a/vital/algo/draw_detected_object_set.h
+++ b/vital/algo/draw_detected_object_set.h
@@ -48,7 +48,7 @@ namespace algo {
 
 /// An abstract base class for algorithms which draw tracks on top of
 /// images in various ways, for analyzing results.
-class VITAL_EXPORT draw_detected_object_set
+class VITAL_ALGO_EXPORT draw_detected_object_set
   : public kwiver::vital::algorithm_def<draw_detected_object_set>
 {
 public:


### PR DESCRIPTION
This commit generates export headers for plugins. This is required for
the Windows build. Also, update several export macros used in the code
to match the libraries they are in.