### PR TITLE
Add wait call to allow pipeline threads to terminate before application.

### DIFF
--- a/sprokit/processes/adapters/tests/basic_test.cxx
+++ b/sprokit/processes/adapters/tests/basic_test.cxx
@@ -270,6 +270,7 @@ IMPLEMENT_TEST( embedded_pipeline )
     }
   } // end while
 
+  ep.wait();
 }
 
 
@@ -329,4 +330,6 @@ IMPLEMENT_TEST( embedded_pipeline_source )
     }
 
   } // end while
+
+  ep.wait();
 }


### PR DESCRIPTION
There was a intermittent failure in these tests where the application
thread would terminate before the pipeline thread.