### PR TITLE
Add feature to control default logger threshold.

### DIFF
--- a/CMake/setup_KWIVER.sh.in
+++ b/CMake/setup_KWIVER.sh.in
@@ -8,4 +8,7 @@ export PATH=$this_dir/bin:$PATH
 export LD_LIBRARY_PATH=$this_dir/lib:$LD_LIBRARY_PATH
 export KWIVER_PLUGIN_PATH=$this_dir/lib/modules:$KWIVER_PLUGIN_PATH
 
+# Set default log reporting level for default logger.
+# export KWIVER_DEFAULT_LOG_LEVEL=info
+
 # Append here

--- a/vital/logger/default_logger.cxx
+++ b/vital/logger/default_logger.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #include <vital/logger/vital_logger_export.h>
 #include "default_logger.h"
 #include "kwiver_logger.h"
+#include <kwiversys/SystemTools.hxx>
 
 #include <memory>
 #include <mutex>
@@ -39,6 +40,7 @@
 #include <iomanip>
 #include <iostream>
 #include <string.h>
+#include <algorithm>
 
 namespace kwiver {
 namespace vital {
@@ -67,8 +69,47 @@ public:
   /// CTOR
   default_logger( logger_ns::logger_factory_default* p, std::string const& name )
     : kwiver_logger( p, name ),
-    m_logLevel( kwiver_logger::LEVEL_TRACE )
-  { }
+#if defined( NDEBUG )
+    m_logLevel( kwiver_logger::LEVEL_WARN ) // default for release builds
+#else
+    m_logLevel( kwiver_logger::LEVEL_TRACE ) // default for debug builds
+#endif
+  {
+    // Allow env variable to override default log level
+    std::string level;
+    if ( kwiversys::SystemTools::GetEnv( "KWIVER_DEFAULT_LOG_LEVEL", level ) )
+    {
+      // Convert input to lower for easier comparison
+      std::transform(level.begin(), level.end(), level.begin(), ::tolower);
+
+      if ( "trace" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_TRACE;
+      }
+      else if ( "debug" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_DEBUG;
+      }
+      else if ( "info" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_INFO;
+      }
+      else if ( "warn" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_WARN;
+      }
+      else if ( "error" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_ERROR;
+      }
+      else if ( "fatal" == level )
+      {
+        m_logLevel = kwiver_logger::LEVEL_FATAL;
+      }
+
+      // If the level is not recognised, then leave at default
+    }
+  }
 
   virtual ~default_logger() VITAL_DEFAULT_DTOR
 
@@ -272,7 +313,4 @@ logger_factory_default
   return log;
 }
 
-
-}
-}
-}     // end namespace
+} } }     // end namespace

--- a/vital/logger/default_logger.h
+++ b/vital/logger/default_logger.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,11 +45,22 @@ namespace logger_ns {
 /**
  * @brief Factory for default underlying logger.
  *
- * This class represents the factory for the mini_logger logging service.
+ * This class represents the factory for the default logging service.
  *
- * An object of this type can be created early in the program
- * execution (i.e. static initializer time), which is before the
- * initialize method is called.
+ * This is a minimal implementation of a kwiver logger. The logging
+ * level is set to a default threshold depending on the build mode. If
+ * built in debug mode, the threshold is set to display TRACE level
+ * messages and above, which is all lob messages. If built in release
+ * mode, the threshold is set to display WARN level messages and
+ * above, which results in a much reduced logger output.
+ *
+ * The default log threshold can be overridden by an environment
+ * variable "KWIVER_DEFAULT_LOG_LEVEL". If this is set to a
+ * recognizable level, the default will be set to that level. If the
+ * level is not recognized, the default level is unchanged and no
+ * error message is generated.
+ *
+ * Recognized levels are: trace, debug, info, warn, error, fatal.
  */
 class logger_factory_default
   : public kwiver_logger_factory


### PR DESCRIPTION
The default level is set to warn if built in release mode and trace if
built in debug mode. This default level can be changed by an environment
variable KWIVER_DEFAULT_LOG_LEVEL.