### PR TITLE
Make select methods reentrant.

### DIFF
--- a/doc/release-notes/1.1.0.txt
+++ b/doc/release-notes/1.1.0.txt
@@ -153,9 +153,6 @@ Vital
    is to respond in real-time. A typical parameter that could be
    varied in this manner would be a threshold or a scaling value.
 
- * Added mutex to allow concurrent access to detected_object and
-   detected_object_type objects.
-
 Sprokit
 
  * Added sprokit port operations that have timeout. Allows process to
@@ -246,3 +243,6 @@ Vital
    convert BGR to RGB and copied data instead of simply calling the
    corresponding C++ code.  This has been removed.  Another solution
    should be found if this causes problems elsewhere.
+
+ * Moved list copy in detected_object_set to eliminate collisions in
+   select methods.

--- a/doc/release-notes/1.1.0.txt
+++ b/doc/release-notes/1.1.0.txt
@@ -153,6 +153,8 @@ Vital
    is to respond in real-time. A typical parameter that could be
    varied in this manner would be a threshold or a scaling value.
 
+ * Added mutex to allow concurrent access to detected_object and
+   detected_object_type objects.
 
 Sprokit
 

--- a/vital/types/detected_object_set.cxx
+++ b/vital/types/detected_object_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,12 +108,7 @@ void
 detected_object_set::
 add( detected_object_sptr object )
 {
-  // keep list ordered
-  m_detected_objects.insert (
-      std::upper_bound( m_detected_objects.begin(), m_detected_objects.end(),
-                        object, descending_confidence() ),
-      object
-    );
+  m_detected_objects.push_back( object );
 }
 
 
@@ -129,15 +124,10 @@ size() const
 // ------------------------------------------------------------------
 detected_object::vector_t
 detected_object_set::
-select( double threshold )
+select( double threshold ) const
 {
   // The main list can get out of order if somebody updates the
   // confidence value of a detection directly
-
-  ///@todo Find a way of determining if the list needs sorting or is
-  ///already sorted.
-  std::sort( m_detected_objects.begin(), m_detected_objects.end(),
-             descending_confidence() );
 
   detected_object::vector_t vect;
 
@@ -149,6 +139,8 @@ select( double threshold )
     }
   }
 
+  std::sort( vect.begin(), vect.end(), descending_confidence() );
+
   return vect;
 }
 
@@ -156,7 +148,7 @@ select( double threshold )
 // ------------------------------------------------------------------
 detected_object::vector_t
 detected_object_set::
-select( const std::string& class_name, double threshold )
+select( const std::string& class_name, double threshold )const
 {
   // Intermediate sortable data structure
   std::vector< std::pair< double, detected_object_sptr > > data;
@@ -210,7 +202,7 @@ select( const std::string& class_name, double threshold )
 // ------------------------------------------------------------------
 kwiver::vital::attribute_set_sptr
 detected_object_set::
-attributes()
+attributes() const
 {
   return m_attrs;
 }

--- a/vital/types/detected_object_set.cxx
+++ b/vital/types/detected_object_set.cxx
@@ -108,6 +108,11 @@ void
 detected_object_set::
 add( detected_object_sptr object )
 {
+  if ( ! object )
+  {
+    throw std::runtime_error( "Passing null pointer to detected_object_set::add()" );
+  }
+
   m_detected_objects.push_back( object );
 }
 

--- a/vital/types/detected_object_set.h
+++ b/vital/types/detected_object_set.h
@@ -58,6 +58,11 @@ typedef std::shared_ptr< detected_object_set > detected_object_set_sptr;
  *
  * This class represents a ordered set of detected objects. The
  * detections are ordered on their basic confidence value.
+ *
+ * Reentrancy considerations: Typical usage for a set is for a single
+ * detector thread to create a set. It is possible to have an
+ * application where two threads are accessing the same set
+ * concurrently.
  */
 class VITAL_EXPORT detected_object_set final
   : private noncopyable
@@ -131,7 +136,7 @@ public:
    *
    * @return List of detections.
    */
-  detected_object::vector_t select( double threshold = detected_object_type::INVALID_SCORE );
+  detected_object::vector_t select( double threshold = detected_object_type::INVALID_SCORE ) const;
 
   /**
    * @brief Select detections based on class_name
@@ -153,7 +158,7 @@ public:
    * @return List of detections.
    */
   detected_object::vector_t select( const std::string& class_name,
-                                    double             threshold = detected_object_type::INVALID_SCORE );
+                                    double             threshold = detected_object_type::INVALID_SCORE ) const;
 
   /**
    * @brief Get attributes set.
@@ -164,7 +169,7 @@ public:
    *
    * @return Pointer to attribute set or NULL
    */
-  attribute_set_sptr attributes();
+  attribute_set_sptr attributes() const;
 
   /**
    * @brief Attach attributes set to this object.

--- a/vital/types/detected_object_type.cxx
+++ b/vital/types/detected_object_type.cxx
@@ -45,7 +45,7 @@ const double detected_object_type::INVALID_SCORE = std::numeric_limits< double >
 
 // Master list of all class_names
 std::set< std::string > detected_object_type::s_master_name_set;
-
+std::mutex detected_object_type::s_table_mutex;
 
 // ==================================================================
 namespace {
@@ -162,6 +162,7 @@ set_score( const std::string& class_name, double score )
 {
   // Check to see if class_name is in the master set.
   // If not, add it
+  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
   auto it = s_master_name_set.find( class_name );
   if ( it == s_master_name_set.end() )
   {
@@ -250,6 +251,7 @@ const std::string*
 detected_object_type::
 find_string( const std::string& str ) const
 {
+  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
   auto it = s_master_name_set.find( str );
   if ( it == s_master_name_set.end() )
   {
@@ -268,6 +270,7 @@ std::vector< std::string >
 detected_object_type::
 all_class_names()
 {
+  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
   std::vector< std::string > names( s_master_name_set.begin(), s_master_name_set.end() );
   return names;
 }

--- a/vital/types/detected_object_type.h
+++ b/vital/types/detected_object_type.h
@@ -42,6 +42,7 @@
 #include <map>
 #include <set>
 #include <memory>
+#include <mutex>
 
 namespace kwiver {
 namespace vital {
@@ -227,6 +228,9 @@ private:
    * set_score().
    */
   static std::set< std::string > s_master_name_set;
+
+  // Used to control access to shared resources
+  static std::mutex s_table_mutex;
 };
 
 // typedef for a object_type shared pointer


### PR DESCRIPTION
The select methods now do not modify the object.

The intent for this class was to create and maintain a sorted list of detections, but it is possible for the sort key (confidence) to be changed externally. This necessitated sorting the objects in the select() methods before returning to ensure that they were ordered correctly. Sorting the internal list caused problems during concurrent access, so, with this change, the outputs are sorted after they are copied into a local vector. This change has no performance impact since the objects were always sorted.