### PR TITLE
Dev/deboostify sprokit 1

### DIFF
--- a/sprokit/processes/core/image_writer_process.cxx
+++ b/sprokit/processes/core/image_writer_process.cxx
@@ -36,7 +36,7 @@
 #include <vital/types/timestamp.h>
 #include <vital/algo/image_io.h>
 #include <vital/exceptions.h>
-#include <vital/util/string_format.h>
+#include <vital/util/string.h>
 
 #include <kwiver_type_traits.h>
 

--- a/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
@@ -102,7 +102,7 @@ BOOST_PYTHON_MODULE(config)
   class_<kwiver::vital::config_block_value_t>("ConfigValue"
     , "A value in the configuration.");
 
-  class_<kwiver::vital::config_block, kwiver::vital::config_block_sptr, boost::noncopyable>("Config"
+  class_<kwiver::vital::config_block, kwiver::vital::config_block_sptr, kwiver::vital::noncopyable>("Config"
     , "A key-value store of configuration values"
     , no_init)
     .def("subblock", &kwiver::vital::config_block::subblock

--- a/sprokit/src/bindings/python/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/edge.cxx
@@ -64,7 +64,7 @@ BOOST_PYTHON_MODULE(edge)
     .def(vector_indexing_suite<sprokit::edges_t>())
   ;
 
-  class_<sprokit::edge, sprokit::edge_t, boost::noncopyable>("Edge"
+  class_<sprokit::edge, sprokit::edge_t, kwiver::vital::noncopyable>("Edge"
     , "A communication channel between processes."
     , no_init)
     .def(init<>())

--- a/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
@@ -44,7 +44,7 @@ using namespace boost::python;
 
 BOOST_PYTHON_MODULE(pipeline)
 {
-  class_<sprokit::pipeline, sprokit::pipeline_t, boost::noncopyable>("Pipeline"
+  class_<sprokit::pipeline, sprokit::pipeline_t, kwiver::vital::noncopyable>("Pipeline"
     , "A data structure for a collection of connected processes."
     , no_init)
     .def(init<>())

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -252,7 +252,7 @@ BOOST_PYTHON_MODULE(process)
     .def_readonly("frequency", &sprokit::process::port_info::frequency)
   ;
 
-  implicitly_convertible<boost::shared_ptr<sprokit::process::port_info>, sprokit::process::port_info_t>();
+  implicitly_convertible<std::shared_ptr<sprokit::process::port_info>, sprokit::process::port_info_t>();
 
   class_<sprokit::process::conf_info, sprokit::process::conf_info_t>("ConfInfo"
     , "Information about a configuration on a process."
@@ -263,7 +263,7 @@ BOOST_PYTHON_MODULE(process)
     .def_readonly("tunable", &sprokit::process::conf_info::tunable)
   ;
 
-  implicitly_convertible<boost::shared_ptr<sprokit::process::conf_info>, sprokit::process::conf_info_t>();
+  implicitly_convertible<std::shared_ptr<sprokit::process::conf_info>, sprokit::process::conf_info_t>();
 
   class_<sprokit::process::data_info, sprokit::process::data_info_t>("DataInfo"
     , "Information about a set of data packets from edges."
@@ -280,9 +280,9 @@ BOOST_PYTHON_MODULE(process)
     .value("valid", sprokit::process::check_valid)
   ;
 
-  implicitly_convertible<boost::shared_ptr<sprokit::process::data_info>, sprokit::process::data_info_t>();
+  implicitly_convertible<std::shared_ptr<sprokit::process::data_info>, sprokit::process::data_info_t>();
 
-  class_<wrap_process, boost::noncopyable>("PythonProcess"
+  class_<wrap_process, kwiver::vital::noncopyable>("PythonProcess"
     , "The base class for Python processes."
     , no_init)
     .def(init<kwiver::vital::config_block_sptr>())

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -342,7 +342,7 @@ wrap_process_cluster
 object
 cluster_from_process(sprokit::process_t const& process)
 {
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(process);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(process);
 
   if (!cluster)
   {

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
@@ -101,7 +101,7 @@ static object cluster_from_process(sprokit::process_t const& process);
 
 BOOST_PYTHON_MODULE(process_cluster)
 {
-  class_<wrap_process_cluster, boost::noncopyable>("PythonProcessCluster"
+  class_<wrap_process_cluster, kwiver::vital::noncopyable>("PythonProcessCluster"
     , "The base class for Python process clusters."
     , no_init)
     .def(init<kwiver::vital::config_block_sptr>())

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -62,7 +62,7 @@ BOOST_PYTHON_MODULE(process_factory)
   class_<kwiver::vital::plugin_manager::module_t>("ProcessModule"
     , "The type for a process module name.");
 
-  class_<sprokit::process, sprokit::process_t, boost::noncopyable>("Process"
+  class_<sprokit::process, sprokit::process_t, kwiver::vital::noncopyable>("Process"
     , "The base class of processes."
     , no_init)
     .def("configure", &sprokit::process::configure
@@ -131,7 +131,8 @@ BOOST_PYTHON_MODULE(process_factory)
     .def(vector_indexing_suite<sprokit::processes_t>())
   ;
 
-  class_<sprokit::process_cluster, sprokit::process_cluster_t, bases<sprokit::process>, boost::noncopyable>("ProcessCluster"
+  class_<sprokit::process_cluster, sprokit::process_cluster_t, bases<sprokit::process>,
+         kwiver::vital::noncopyable>("ProcessCluster"
     , "The base class of process clusters."
     , no_init);
 
@@ -154,7 +155,7 @@ BOOST_PYTHON_MODULE(process_factory)
 
 
   //+ convert this to process_factory
-  class_<sprokit::process_factory, sprokit::process_factory, boost::noncopyable>("ProcessFactory"
+  class_<sprokit::process_factory, sprokit::process_factory, kwiver::vital::noncopyable>("ProcessFactory"
     , "A registry of all known process types."
     , no_init)
   ;

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
@@ -68,7 +68,7 @@ class wrap_scheduler
 
 BOOST_PYTHON_MODULE(scheduler)
 {
-  class_<wrap_scheduler, boost::noncopyable>("PythonScheduler"
+  class_<wrap_scheduler, kwiver::vital::noncopyable>("PythonScheduler"
     , "The base class for Python schedulers."
     , no_init)
     .def(init<sprokit::pipeline_t, kwiver::vital::config_block_sptr>())

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -79,7 +79,7 @@ BOOST_PYTHON_MODULE(scheduler_factory)
   class_<kwiver::vital::plugin_manager::module_t>("SchedulerModule"
     , "The type for a scheduler module name.");
 
-  class_<sprokit::scheduler, sprokit::scheduler_t, boost::noncopyable>("Scheduler"
+  class_<sprokit::scheduler, sprokit::scheduler_t, kwiver::vital::noncopyable>("Scheduler"
     , "An abstract class which offers an interface for pipeline execution strategies."
     , no_init)
     .def("start", &sprokit::scheduler::start
@@ -90,7 +90,7 @@ BOOST_PYTHON_MODULE(scheduler_factory)
       , "Stop the execution of the pipeline.")
   ;
 
-  class_<sprokit::scheduler_factory, sprokit::scheduler_factory, boost::noncopyable>("SchedulerFactory"
+  class_<sprokit::scheduler_factory, sprokit::scheduler_factory, kwiver::vital::noncopyable>("SchedulerFactory"
     , "A registry of all known scheduler types."
     , no_init)
 

--- a/sprokit/src/processes/examples/any_source_process.h
+++ b/sprokit/src/processes/examples/any_source_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file any_source_process.h
  *
  * \brief Declaration of the any source process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class any_source_process
@@ -84,7 +81,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT any_source_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/const_number_process.h
+++ b/sprokit/src/processes/examples/const_number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file const_number_process.h
  *
  * \brief Declaration of the constant number process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class const_number_process
@@ -93,7 +90,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT const_number_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/const_process.h
+++ b/sprokit/src/processes/examples/const_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file const_process.h
  *
  * \brief Declaration of the const process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class const_process
@@ -84,7 +81,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT const_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/data_dependent_process.h
+++ b/sprokit/src/processes/examples/data_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file data_dependent_process.h
  *
  * \brief Declaration of the data dependent process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class data_dependent_process
@@ -104,7 +101,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT data_dependent_process
     void make_ports();
 
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/duplicate_process.h
+++ b/sprokit/src/processes/examples/duplicate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "examples-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file duplicate_process.h
@@ -93,7 +91,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT duplicate_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/expect_process.h
+++ b/sprokit/src/processes/examples/expect_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,7 +83,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT expect_process
     void _reconfigure(kwiver::vital::config_block_sptr const& conf);
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/feedback_process.h
+++ b/sprokit/src/processes/examples/feedback_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "examples-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file feedback_process.h
@@ -92,7 +90,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT feedback_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/flow_dependent_process.h
+++ b/sprokit/src/processes/examples/flow_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file flow_dependent_process.h
  *
  * \brief Declaration of the flow dependent process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class flow_dependent_process
@@ -112,7 +109,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT flow_dependent_process
     void make_ports();
 
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/multiplication_process.h
+++ b/sprokit/src/processes/examples/multiplication_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file multiplication_process.h
  *
  * \brief Declaration of the multiplication process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class multiplication_process
@@ -89,7 +86,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT multiplication_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/multiplier_cluster.h
+++ b/sprokit/src/processes/examples/multiplier_cluster.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process_cluster.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file multiplier_cluster.h
  *
  * \brief Declaration of the multiplier cluster.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class multiplier_cluster
@@ -65,13 +62,15 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT multiplier_cluster
      * \param config The configuration for the process.
      */
     multiplier_cluster(kwiver::vital::config_block_sptr const& config);
+
     /**
      * \brief Destructor.
      */
-    ~multiplier_cluster();
+    virtual ~multiplier_cluster();
+
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/mutate_process.h
+++ b/sprokit/src/processes/examples/mutate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file mutate_process.h
  *
  * \brief Declaration of the mutate process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class mutate_process
@@ -84,7 +81,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT mutate_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/print_number_process.h
+++ b/sprokit/src/processes/examples/print_number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file print_number_process.h
  *
  * \brief Declaration of the number printer process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class print_number_process
@@ -98,7 +95,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT print_number_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/shared_process.h
+++ b/sprokit/src/processes/examples/shared_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "examples-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file shared_process.h
@@ -84,7 +82,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT shared_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/skip_process.h
+++ b/sprokit/src/processes/examples/skip_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "examples-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file skip_process.h
@@ -98,7 +96,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT skip_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/tagged_flow_dependent_process.h
+++ b/sprokit/src/processes/examples/tagged_flow_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "examples-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file tagged_flow_dependent_process.h
@@ -93,7 +91,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT tagged_flow_dependent_process
     void make_ports();
 
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/take_number_process.h
+++ b/sprokit/src/processes/examples/take_number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file take_number_process.h
  *
  * \brief Declaration of the number taking process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class take_number_process
@@ -84,7 +81,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT take_number_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/take_string_process.h
+++ b/sprokit/src/processes/examples/take_string_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file take_string_process.h
  *
  * \brief Declaration of the string taking process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class take_string_process
@@ -84,7 +81,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT take_string_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/tunable_process.h
+++ b/sprokit/src/processes/examples/tunable_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,13 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/scoped_ptr.hpp>
-
 /**
  * \file tunable_process.h
  *
  * \brief Declaration of the tunable process.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 /**
  * \class tunable_process
@@ -100,7 +97,7 @@ class SPROKIT_PROCESSES_EXAMPLES_NO_EXPORT tunable_process
     void _reconfigure(kwiver::vital::config_block_sptr const& conf);
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/flow/collate_process.h
+++ b/sprokit/src/processes/flow/collate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,6 @@
 #include "flow-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 namespace sprokit {
 
@@ -90,7 +88,7 @@ class SPROKIT_PROCESSES_FLOW_NO_EXPORT collate_process
     port_info_t _input_port_info(port_t const& port);
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 } // end namespace

--- a/sprokit/src/processes/flow/distribute_process.h
+++ b/sprokit/src/processes/flow/distribute_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,6 @@
 #include "flow-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 namespace sprokit {
 
@@ -90,7 +88,7 @@ class SPROKIT_PROCESSES_FLOW_NO_EXPORT distribute_process
     port_info_t _output_port_info(port_t const& port);
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/flow/pass_process.h
+++ b/sprokit/src/processes/flow/pass_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "flow-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file pass_process.h
@@ -88,7 +86,7 @@ class SPROKIT_PROCESSES_FLOW_NO_EXPORT pass_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/flow/sink_process.h
+++ b/sprokit/src/processes/flow/sink_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "flow-config.h"
 
 #include <sprokit/pipeline/process.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file sink_process.h
@@ -84,7 +82,7 @@ class SPROKIT_PROCESSES_FLOW_NO_EXPORT sink_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/helpers/functions/function_process.h
+++ b/sprokit/src/processes/helpers/functions/function_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,7 +73,7 @@ class SPROKIT_NO_EXPORT CLASS_NAME(name)               \
     void _step();                                    \
   private:                                           \
     class priv;                                      \
-    boost::scoped_ptr<priv> d;                       \
+    std::unique_ptr<priv> d;                       \
 }
 
 #endif // SPROKIT_PROCESSES_HELPER_FUNCTIONS_FUNCTION_PROCESS_H

--- a/sprokit/src/schedulers/examples/thread_pool_scheduler.h
+++ b/sprokit/src/schedulers/examples/thread_pool_scheduler.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include <schedulers/examples/schedulers_examples_export.h>
 
 #include <sprokit/pipeline/scheduler.h>
-
-#include <boost/scoped_ptr.hpp>
 
 #include <cstddef>
 
@@ -97,7 +95,7 @@ class SCHEDULERS_EXAMPLES_NO_EXPORT thread_pool_scheduler
     void _stop();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 } // end namespace

--- a/sprokit/src/schedulers/sync_scheduler.cxx
+++ b/sprokit/src/schedulers/sync_scheduler.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,12 +46,12 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 
 #include <deque>
 #include <iterator>
 #include <map>
 #include <queue>
+#include <memory>
 
 /**
  * \file sync_scheduler.cxx
@@ -182,7 +182,7 @@ sync_scheduler::priv
   VITAL_FOREACH (process::name_t const& name, names)
   {
     process_t const proc = pipe->process_by_name(name);
-    edge_t const monitor_edge = boost::make_shared<edge>(edge_conf);
+    edge_t const monitor_edge = std::make_shared<edge>(edge_conf);
 
     proc->connect_output_port(process::port_heartbeat, monitor_edge);
     monitor_edges[name] = monitor_edge;

--- a/sprokit/src/schedulers/sync_scheduler.h
+++ b/sprokit/src/schedulers/sync_scheduler.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include <schedulers/schedulers_export.h>
 
 #include <sprokit/pipeline/scheduler.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file sync_scheduler.h
@@ -98,7 +96,7 @@ class SCHEDULERS_NO_EXPORT sync_scheduler
 
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 } // end namespace

--- a/sprokit/src/schedulers/thread_per_process_scheduler.cxx
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,8 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/make_shared.hpp>
+
+#include <memory>
 
 /**
  * \file thread_per_process_scheduler.cxx
@@ -61,7 +62,7 @@ class thread_per_process_scheduler::priv
 
     void run_process(process_t const& process);
 
-    boost::scoped_ptr<boost::thread_group> process_threads;
+    std::unique_ptr<boost::thread_group> process_threads;
 
     typedef boost::shared_mutex mutex_t;
     typedef boost::shared_lock<mutex_t> shared_lock_t;
@@ -177,7 +178,7 @@ thread_per_process_scheduler::priv
   kwiver::vital::config_block_sptr const edge_conf = monitor_edge_config();
 
   name_thread(process->name());
-  edge_t monitor_edge = boost::make_shared<edge>(edge_conf);
+  edge_t monitor_edge = std::make_shared<edge>(edge_conf);
 
   process->connect_output_port(process::port_heartbeat, monitor_edge);
 

--- a/sprokit/src/schedulers/thread_per_process_scheduler.h
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include <schedulers/schedulers_export.h>
 
 #include <sprokit/pipeline/scheduler.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file thread_per_process_scheduler.h
@@ -98,7 +96,7 @@ protected:
 
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/doc/design.dox
+++ b/sprokit/src/sprokit/pipeline/doc/design.dox
@@ -16,7 +16,7 @@
  * copies from occurring and simplify memory management.
  *
  * The use of \c typedef within the codebase also simplifies changing core types
- * if necessary (e.g., replacing \c boost::shared_ptr with a different managed
+ * if necessary (e.g., replacing \c std::shared_ptr with a different managed
  * pointer class).
  *
  * Some of the core classes (i.e., \ref sprokit::datum and \ref sprokit::stamp) are

--- a/sprokit/src/sprokit/pipeline/doc/examples/how_to_process.cxx.ex
+++ b/sprokit/src/sprokit/pipeline/doc/examples/how_to_process.cxx.ex
@@ -15,7 +15,7 @@ class compare_string_process
     void _step();
   private:
     class priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 class compare_string_process::priv

--- a/sprokit/src/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/sprokit/pipeline/edge.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,7 +108,7 @@ class edge::priv
     priv(bool depends_, size_t capacity_, bool blocking_);
     ~priv();
 
-    typedef boost::weak_ptr<process> process_ref_t;
+    typedef std::weak_ptr<process> process_ref_t;
 
     bool full_of_data() const;
     void complete_check() const;

--- a/sprokit/src/sprokit/pipeline/edge.h
+++ b/sprokit/src/sprokit/pipeline/edge.h
@@ -34,10 +34,11 @@
 #include "pipeline-config.h"
 
 #include <vital/config/config_block.h>
+#include <vital/noncopyable.h>
+
 #include "types.h"
 
 #include <boost/chrono/system_clocks.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -109,7 +110,7 @@ typedef std::vector< edge_t > edges_t;
  * \ingroup base_classes
  */
 class SPROKIT_PIPELINE_EXPORT edge
-  : private boost::noncopyable
+  : private kwiver::vital::noncopyable
 {
 public:
   /**

--- a/sprokit/src/sprokit/pipeline/edge.h
+++ b/sprokit/src/sprokit/pipeline/edge.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,6 @@
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <vector>
 
@@ -336,7 +335,7 @@ public:
 
 private:
   class SPROKIT_PIPELINE_NO_EXPORT priv;
-  boost::scoped_ptr< priv > d;
+  std::unique_ptr< priv > d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,6 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/functional.hpp>
-#include <boost/make_shared.hpp>
 
 #include <functional>
 #include <map>
@@ -57,7 +56,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
-
+#include <memory>
 #include <cstddef>
 
 /**
@@ -248,7 +247,7 @@ pipeline
 
   d->check_duplicate_name(name);
 
-  process_cluster_t const cluster = boost::dynamic_pointer_cast<process_cluster>(process);
+  process_cluster_t const cluster = std::dynamic_pointer_cast<process_cluster>(process);
 
   process::name_t parent;
 
@@ -1820,7 +1819,7 @@ pipeline::priv
     }
 
     // Create a new edge
-    edge_t const e = boost::make_shared<edge>(edge_config);
+    edge_t const e = std::make_shared<edge>(edge_config);
 
     edge_map[i] = e;
 

--- a/sprokit/src/sprokit/pipeline/pipeline.h
+++ b/sprokit/src/sprokit/pipeline/pipeline.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,8 +37,6 @@
 #include "types.h"
 
 #include <vital/noncopyable.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file pipeline.h
@@ -491,7 +489,7 @@ class SPROKIT_PIPELINE_EXPORT pipeline
     SPROKIT_PIPELINE_NO_EXPORT void stop();
 
     class SPROKIT_PIPELINE_NO_EXPORT priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/pipeline.h
+++ b/sprokit/src/sprokit/pipeline/pipeline.h
@@ -36,7 +36,8 @@
 #include "process.h"
 #include "types.h"
 
-#include <boost/noncopyable.hpp>
+#include <vital/noncopyable.h>
+
 #include <boost/scoped_ptr.hpp>
 
 /**
@@ -56,7 +57,7 @@ namespace sprokit
  * \ingroup base_classes
  */
 class SPROKIT_PIPELINE_EXPORT pipeline
-  : boost::noncopyable
+  : private kwiver::vital::noncopyable
 {
   public:
     /**

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -44,11 +44,10 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/optional.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <map>
 #include <utility>
+#include <memory>
 
 /**
  * \file process.cxx
@@ -1025,7 +1024,7 @@ process
                      port_description_t const& description_,
                      port_frequency_t const& frequency_)
 {
-  declare_input_port(port, boost::make_shared<port_info>(
+  declare_input_port(port, std::make_shared<port_info>(
     type_,
     flags_,
     description_,
@@ -1089,7 +1088,7 @@ process
                       port_description_t const& description_,
                       port_frequency_t const& frequency_)
 {
-  declare_output_port(port, boost::make_shared<port_info>(
+  declare_output_port(port, std::make_shared<port_info>(
     type_,
     flags_,
     description_,
@@ -1259,7 +1258,7 @@ process
                             kwiver::vital::config_block_description_t const& description_,
                             bool tunable_)
 {
-  declare_configuration_key(key, boost::make_shared<conf_info>(
+  declare_configuration_key(key, std::make_shared<conf_info>(
     def_,
     description_,
     tunable_));
@@ -1545,7 +1544,7 @@ process
     }
   }
 
-  return boost::make_shared<data_info>(in_sync, max_type);
+  return std::make_shared<data_info>(in_sync, max_type);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -39,16 +39,16 @@
 
 #include <vital/config/config_block.h>
 #include <vital/logger/logger.h>
+#include <vital/noncopyable.h>
 
 #include <boost/cstdint.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/rational.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
+#include <memory>
 
 /**
  * \file process.h
@@ -96,7 +96,7 @@ typedef std::vector<process_t> processes_t;
  * \ingroup base_classes
  */
 class SPROKIT_PIPELINE_EXPORT process
-  : boost::noncopyable
+  : kwiver::vital::noncopyable
 {
   public:
     /// The type for the type of a process.
@@ -194,7 +194,7 @@ class SPROKIT_PIPELINE_EXPORT process
         port_frequency_t const frequency;
     };
     /// Type for information about a port.
-    typedef boost::shared_ptr<port_info const> port_info_t;
+    typedef std::shared_ptr<port_info const> port_info_t;
 
     /**
      * \class conf_info process.h <sprokit/pipeline/process.h>
@@ -227,7 +227,7 @@ class SPROKIT_PIPELINE_EXPORT process
         bool const tunable;
     };
     /// Type for information about a configuration parameter.
-    typedef boost::shared_ptr<conf_info const> conf_info_t;
+    typedef std::shared_ptr<conf_info const> conf_info_t;
 
     /**
      * \class data_info process.h <sprokit/pipeline/process.h>
@@ -259,7 +259,7 @@ class SPROKIT_PIPELINE_EXPORT process
         datum::type_t const max_status;
     };
     /// Type for information about a set of data.
-    typedef boost::shared_ptr<data_info const> data_info_t;
+    typedef std::shared_ptr<data_info const> data_info_t;
 
     /**
      * \brief Data checking levels. All levels include lower levels.

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -1286,7 +1286,7 @@ class SPROKIT_PIPELINE_EXPORT process
     SPROKIT_PIPELINE_NO_EXPORT void reconfigure_with_provides(kwiver::vital::config_block_sptr const& conf);
 
     class SPROKIT_PIPELINE_NO_EXPORT priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 template <typename T>

--- a/sprokit/src/sprokit/pipeline/process_cluster.h
+++ b/sprokit/src/sprokit/pipeline/process_cluster.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
 #include "pipeline-config.h"
 
 #include "process.h"
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file process_cluster.h
@@ -215,7 +213,7 @@ class SPROKIT_PIPELINE_EXPORT process_cluster
 
   private:
     class SPROKIT_PIPELINE_NO_EXPORT priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/process_factory.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,8 +44,6 @@
 
 #include <sprokit/pipeline/process.h>
 
-#include <boost/make_shared.hpp>
-
 #include <functional>
 #include <memory>
 
@@ -71,7 +69,7 @@ process_t
 create_new_process(kwiver::vital::config_block_sptr const& conf)
 {
   // Note boost pointer
-  return boost::make_shared<T>(conf);
+  return std::make_shared<T>(conf);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/scheduler.h
+++ b/sprokit/src/sprokit/pipeline/scheduler.h
@@ -35,8 +35,8 @@
 
 #include "types.h"
 #include <vital/config/config_block.h>
+#include <vital/noncopyable.h>
 
-#include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
 
 /**
@@ -60,7 +60,7 @@ namespace sprokit
  * \ingroup base_classes
  */
 class SPROKIT_PIPELINE_EXPORT scheduler
-  : boost::noncopyable
+  : private kwiver::vital::noncopyable
 {
   public:
     /// The type of registry keys.

--- a/sprokit/src/sprokit/pipeline/scheduler.h
+++ b/sprokit/src/sprokit/pipeline/scheduler.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,8 +36,6 @@
 #include "types.h"
 #include <vital/config/config_block.h>
 #include <vital/noncopyable.h>
-
-#include <boost/scoped_ptr.hpp>
 
 /**
  * \file scheduler.h
@@ -165,7 +163,7 @@ class SPROKIT_PIPELINE_EXPORT scheduler
 
   private:
     class SPROKIT_PIPELINE_NO_EXPORT priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,8 +42,6 @@
 
 #include <sprokit/pipeline/scheduler.h>
 
-#include <boost/make_shared.hpp>
-
 #include <functional>
 #include <memory>
 
@@ -69,7 +67,7 @@ scheduler_t
 create_new_scheduler( pipeline_t const& pipe,
                       kwiver::vital::config_block_sptr const& conf)
 {
-  return boost::make_shared<T>(pipe, conf);
+  return std::make_shared<T>(pipe, conf);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/stamp.h
+++ b/sprokit/src/sprokit/pipeline/stamp.h
@@ -33,10 +33,11 @@
 
 #include "pipeline-config.h"
 
+#include <vital/noncopyable.h>
+
 #include "types.h"
 
 #include <boost/cstdint.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 
 /**
@@ -58,7 +59,7 @@ namespace sprokit
 class SPROKIT_PIPELINE_EXPORT stamp
   : private boost::equality_comparable<sprokit::stamp
   , boost::less_than_comparable1<sprokit::stamp
-  , boost::noncopyable
+  , kwiver::vital::noncopyable
     > >
 {
   public:

--- a/sprokit/src/sprokit/pipeline/types.h
+++ b/sprokit/src/sprokit/pipeline/types.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,10 +33,9 @@
 
 #include "pipeline-config.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <exception>
 #include <string>
+#include <memory>
 
 /**
  * \file types.h
@@ -59,31 +58,31 @@ typedef std::string module_t;
 
 class datum;
 /// A typedef used to handle \link datum edge data\endlink.
-typedef boost::shared_ptr<datum const> datum_t;
+typedef std::shared_ptr<datum const> datum_t;
 
 class edge;
 /// A typedef used to handle \link edge edges\endlink.
-typedef boost::shared_ptr<edge> edge_t;
+typedef std::shared_ptr<edge> edge_t;
 
 class pipeline;
 /// A typedef used to handle \link pipeline pipelines\endlink.
-typedef boost::shared_ptr<pipeline> pipeline_t;
+typedef std::shared_ptr<pipeline> pipeline_t;
 
 class process;
 /// A typedef used to handle \link process processes\endlink.
-typedef boost::shared_ptr<process> process_t;
+typedef std::shared_ptr<process> process_t;
 
 class process_cluster;
 /// A typedef used to handle \link process_cluster process clusters\endlink.
-typedef boost::shared_ptr<process_cluster> process_cluster_t;
+typedef std::shared_ptr<process_cluster> process_cluster_t;
 
 class scheduler;
 /// A typedef used to handle \link scheduler schedulers\endlink.
-typedef boost::shared_ptr<scheduler> scheduler_t;
+typedef std::shared_ptr<scheduler> scheduler_t;
 
 class stamp;
 /// A typedef used to handle \link stamp stamps\endlink.
-typedef boost::shared_ptr<stamp const> stamp_t;
+typedef std::shared_ptr<stamp const> stamp_t;
 
 /**
  * \class pipeline_exception types.h <sprokit/pipeline/types.h>

--- a/sprokit/src/sprokit/pipeline_util/cluster_creator.cxx
+++ b/sprokit/src/sprokit/pipeline_util/cluster_creator.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,14 +39,14 @@
 #include "provided_by_cluster.h"
 #include "extract_literal_value.h"
 
+#include <vital/vital_foreach.h>
+
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/foreach.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 
 #include <algorithm>
+#include <memory>
 
 namespace sprokit {
 
@@ -81,7 +81,7 @@ cluster_creator
 
   process::names_t proc_names;
 
-  BOOST_FOREACH( bakery_base::process_decl_t const & proc_decl, m_bakery.m_processes )
+  VITAL_FOREACH( bakery_base::process_decl_t const & proc_decl, m_bakery.m_processes )
   {
     process::name_t const& proc_name = proc_decl.first;
 
@@ -97,7 +97,7 @@ cluster_creator
 
   // Append the given configuration to the declarations from the parsed blocks.
   kwiver::vital::config_block_keys_t const& keys = config->available_values();
-  BOOST_FOREACH( kwiver::vital::config_block_key_t const & key, keys )
+  VITAL_FOREACH( kwiver::vital::config_block_key_t const & key, keys )
   {
     kwiver::vital::config_block_value_t const value = config->get_value< kwiver::vital::config_block_value_t > ( key );
     bakery_base::config_reference_t const ref = bakery_base::config_reference_t( value );
@@ -112,13 +112,13 @@ cluster_creator
 
   kwiver::vital::config_block_sptr const full_config = bakery_base::extract_configuration_from_decls( all_configs );
 
-  typedef boost::shared_ptr< loaded_cluster > loaded_cluster_t;
+  typedef std::shared_ptr< loaded_cluster > loaded_cluster_t;
 
   // Pull out the main config block to the top-level.
   kwiver::vital::config_block_sptr const cluster_config = full_config->subblock_view( type );
   full_config->merge_config( cluster_config );
 
-  loaded_cluster_t const cluster = boost::make_shared< loaded_cluster > ( full_config );
+  loaded_cluster_t const cluster = std::make_shared< loaded_cluster > ( full_config );
 
   cluster_bakery::opt_cluster_component_info_t const& opt_info = m_bakery.m_cluster;
 
@@ -133,7 +133,7 @@ cluster_creator
   kwiver::vital::config_block_sptr const main_config = m_default_config->subblock_view( type );
 
   // Declare configuration values.
-  BOOST_FOREACH( cluster_config_t const & conf, info.m_configs )
+  VITAL_FOREACH( cluster_config_t const & conf, info.m_configs )
   {
     config_value_t const& config_value = conf.config_value;
     config_key_t const& config_key = config_value.key;
@@ -160,7 +160,7 @@ cluster_creator
   extract_literal_value const literal_value = extract_literal_value();
 
   // Add config mappings.
-  BOOST_FOREACH( bakery_base::config_decl_t const & decl, mapped_decls )
+  VITAL_FOREACH( bakery_base::config_decl_t const & decl, mapped_decls )
   {
     kwiver::vital::config_block_key_t const& key = decl.first;
     bakery_base::config_info_t const& mapping_info = decl.second;
@@ -200,7 +200,7 @@ cluster_creator
   }
 
   // Add processes.
-  BOOST_FOREACH( bakery_base::process_decl_t const & proc_decl, m_bakery.m_processes )
+  VITAL_FOREACH( bakery_base::process_decl_t const & proc_decl, m_bakery.m_processes )
   {
     process::name_t const& proc_name = proc_decl.first;
     process::type_t const& proc_type = proc_decl.second;
@@ -214,7 +214,7 @@ cluster_creator
   {
     process::port_flags_t const input_flags;
 
-    BOOST_FOREACH( cluster_input_t const & input, info.m_inputs )
+    VITAL_FOREACH( cluster_input_t const & input, info.m_inputs )
     {
       process::port_description_t const& description = input.description;
       process::port_t const& port = input.from;
@@ -227,7 +227,7 @@ cluster_creator
 
       process::port_addrs_t const& addrs = input.targets;
 
-      BOOST_FOREACH( process::port_addr_t const & addr, addrs )
+      VITAL_FOREACH( process::port_addr_t const & addr, addrs )
       {
         process::name_t const& mapped_name = addr.first;
         process::port_t const& mapped_port = addr.second;
@@ -244,7 +244,7 @@ cluster_creator
   {
     process::port_flags_t const output_flags;
 
-    BOOST_FOREACH( cluster_output_t const & output, info.m_outputs )
+    VITAL_FOREACH( cluster_output_t const & output, info.m_outputs )
     {
       process::port_description_t const& description = output.description;
       process::port_t const& port = output.to;
@@ -269,7 +269,7 @@ cluster_creator
   }
 
   // Add connections.
-  BOOST_FOREACH( process::connection_t const & connection, m_bakery.m_connections )
+  VITAL_FOREACH( process::connection_t const & connection, m_bakery.m_connections )
   {
     process::port_addr_t const& upstream_addr = connection.first;
     process::port_addr_t const& downstream_addr = connection.second;

--- a/sprokit/src/sprokit/pipeline_util/cluster_info.h
+++ b/sprokit/src/sprokit/pipeline_util/cluster_info.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,7 +80,7 @@ class SPROKIT_PIPELINE_UTIL_EXPORT cluster_info
 };
 
 /// A handle to information about a cluster.
-typedef boost::shared_ptr<cluster_info> cluster_info_t;
+typedef std::shared_ptr<cluster_info> cluster_info_t;
 
 } // end namespace sprokit
 

--- a/sprokit/src/sprokit/pipeline_util/export_dot.cxx
+++ b/sprokit/src/sprokit/pipeline_util/export_dot.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/ref.hpp>
 
 #include <map>
@@ -49,6 +48,7 @@
 #include <set>
 #include <utility>
 #include <vector>
+#include <memory>
 
 /// \todo Implement a depth option to suppress recursion into too many clusters.
 /// \todo Improve the color scheme.
@@ -216,7 +216,7 @@ export_dot(std::ostream& ostr, process_cluster_t const& cluster, std::string con
     throw null_cluster_export_dot_exception();
   }
 
-  pipeline_t const pipe = boost::make_shared<pipeline>();
+  pipeline_t const pipe = std::make_shared<pipeline>();
 
   pipe->add_process(cluster);
 

--- a/sprokit/src/sprokit/pipeline_util/pipe_bakery.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipe_bakery.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,6 @@
 #include <sprokit/pipeline/process_cluster.h>
 #include <sprokit/pipeline/process_factory.h>
 
-#include <boost/make_shared.hpp>
 #include <memory>
 
 /**
@@ -108,7 +107,7 @@ bake_pipe_blocks( pipe_blocks const& blocks )
   // Create pipeline.
   kwiver::vital::config_block_sptr const pipeline_conf = global_conf->subblock_view( config_pipeline_key );
 
-  pipe = boost::make_shared< pipeline > ( pipeline_conf );
+  pipe = std::make_shared< pipeline > ( pipeline_conf );
 
   // Create processes.
   {
@@ -197,7 +196,7 @@ bake_cluster_blocks( cluster_blocks const& blocks )
   process::description_t const& description = bakery.m_description;
   process_factory_func_t const ctor = cluster_creator( bakery );
 
-  cluster_info_t const info = boost::make_shared< cluster_info > ( type, description, ctor );
+  cluster_info_t const info = std::make_shared< cluster_info > ( type, description, ctor );
 
   return info;
 }

--- a/sprokit/src/sprokit/pipeline_util/provider_dereferencer.cxx
+++ b/sprokit/src/sprokit/pipeline_util/provider_dereferencer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 #include "provider_dereferencer.h"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 namespace sprokit {
 
@@ -44,8 +44,8 @@ provider_dereferencer
 ::provider_dereferencer()
   : m_providers()
 {
-  m_providers[bakery_base::provider_system] = boost::make_shared< system_provider > ();
-  m_providers[bakery_base::provider_environment] = boost::make_shared< environment_provider > ();
+  m_providers[bakery_base::provider_system] = std::make_shared< system_provider > ();
+  m_providers[bakery_base::provider_environment] = std::make_shared< environment_provider > ();
 }
 
 
@@ -54,7 +54,7 @@ provider_dereferencer
 ::provider_dereferencer( kwiver::vital::config_block_sptr const conf )
   : m_providers()
 {
-  m_providers[bakery_base::provider_config] = boost::make_shared< config_provider > ( conf );
+  m_providers[bakery_base::provider_config] = std::make_shared< config_provider > ( conf );
 }
 
 

--- a/sprokit/src/sprokit/pipeline_util/providers.h
+++ b/sprokit/src/sprokit/pipeline_util/providers.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 #include <vital/config/config_block.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 /**
  * \file providers.h
@@ -49,7 +49,7 @@ namespace sprokit
 // ==================================================================
 class provider;
 /// Type to more easily handle providers.
-typedef boost::shared_ptr<provider> provider_t;
+typedef std::shared_ptr<provider> provider_t;
 
 /**
  * \class provider providers.h "providers.h"

--- a/sprokit/src/sprokit/python/util/python_allow_threads.h
+++ b/sprokit/src/sprokit/python/util/python_allow_threads.h
@@ -33,7 +33,7 @@
 
 #include "util-config.h"
 
-#include <boost/noncopyable.hpp>
+#include <vital/noncopyable.h>
 
 #include <Python.h>
 
@@ -55,7 +55,7 @@ namespace python
  * \brief RAII class for calling into non-Python code.
  */
 class SPROKIT_PYTHON_UTIL_EXPORT python_allow_threads
-  : boost::noncopyable
+  : kwiver::vital::noncopyable
 {
   public:
     /**

--- a/sprokit/src/sprokit/python/util/python_gil.h
+++ b/sprokit/src/sprokit/python/util/python_gil.h
@@ -33,7 +33,7 @@
 
 #include "util-config.h"
 
-#include <boost/noncopyable.hpp>
+#include <vital/noncopyable.h>
 
 #include <Python.h>
 
@@ -55,7 +55,7 @@ namespace python
  * \brief Grabs the Python GIL and uses RAII to ensure it is released.
  */
 class SPROKIT_PYTHON_UTIL_EXPORT python_gil
-  : boost::noncopyable
+  : kwiver::vital::noncopyable
 {
   public:
     /**

--- a/sprokit/src/sprokit/python/util/python_wrap_const_shared_ptr.h
+++ b/sprokit/src/sprokit/python/util/python_wrap_const_shared_ptr.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,8 @@
 
 #include <boost/python/pointee.hpp>
 #include <boost/get_pointer.hpp>
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 // Retrieved from http://mail.python.org/pipermail/cplusplus-sig/2006-November/011329.html
 namespace boost
@@ -45,13 +46,13 @@ namespace python
 template <typename T>
 inline
 T*
-get_pointer(boost::shared_ptr<T const> const& p)
+get_pointer(std::shared_ptr<T const> const& p)
 {
   return const_cast<T*>(p.get());
 }
 
 template <typename T>
-struct pointee<boost::shared_ptr<T const> >
+struct pointee<std::shared_ptr<T const> >
 {
   typedef T type;
 };

--- a/sprokit/src/sprokit/scoring/statistics.h
+++ b/sprokit/src/sprokit/scoring/statistics.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,9 +33,7 @@
 
 #include "scoring-config.h"
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
-
+#include <memory>
 #include <vector>
 
 /**
@@ -147,11 +145,11 @@ class SPROKIT_SCORING_EXPORT statistics
     double standard_deviation() const;
   private:
     class SPROKIT_SCORING_NO_EXPORT priv;
-    boost::scoped_ptr<priv> d;
+    std::unique_ptr<priv> d;
 };
 
 /// A handle to statistics class.
-typedef boost::shared_ptr<statistics> statistics_t;
+typedef std::shared_ptr<statistics> statistics_t;
 
 }
 

--- a/sprokit/src/sprokit/tools/pipeline_builder.h
+++ b/sprokit/src/sprokit/tools/pipeline_builder.h
@@ -38,9 +38,10 @@
 
 #include <sprokit/pipeline/types.h>
 
+#include <vital/noncopyable.h>
+
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <boost/noncopyable.hpp>
 
 #include <istream>
 #include <string>
@@ -61,7 +62,7 @@ namespace sprokit
  * the pipeline which is ready to process.
  */
 class SPROKIT_TOOLS_EXPORT pipeline_builder
-  : boost::noncopyable
+  : kwiver::vital::noncopyable
 {
 public:
   /**

--- a/sprokit/src/sprokit/tools/tool_io.h
+++ b/sprokit/src/sprokit/tools/tool_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,16 +35,15 @@
 
 #include <sprokit/pipeline_util/path.h>
 
-#include <boost/shared_ptr.hpp>
-
 #include <istream>
 #include <ostream>
+#include <memory>
 
 namespace sprokit
 {
 
-typedef boost::shared_ptr<std::istream> istream_t;
-typedef boost::shared_ptr<std::ostream> ostream_t;
+typedef std::shared_ptr<std::istream> istream_t;
+typedef std::shared_ptr<std::ostream> ostream_t;
 
 SPROKIT_TOOLS_EXPORT istream_t open_istream(sprokit::path_t const& path);
 SPROKIT_TOOLS_EXPORT ostream_t open_ostream(sprokit::path_t const& path);

--- a/sprokit/src/tools/pipe_config.cxx
+++ b/sprokit/src/tools/pipe_config.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -254,7 +254,7 @@ config_printer
     }
 
     sprokit::process_cluster_t const cluster = m_pipe->cluster_by_name(name);
-    sprokit::process_t const proc = boost::static_pointer_cast<sprokit::process>(cluster);
+    sprokit::process_t const proc = std::static_pointer_cast<sprokit::process>(cluster);
 
     static std::string const kind = "cluster";
 
@@ -296,7 +296,7 @@ config_printer
       {
         sprokit::process_cluster_t const cluster = m_pipe->cluster_by_name(name);
 
-        proc = boost::static_pointer_cast<sprokit::process>(cluster);
+        proc = std::static_pointer_cast<sprokit::process>(cluster);
       }
       catch (sprokit::no_such_process_exception const& /*e*/)
       {

--- a/sprokit/src/tools/pipe_to_dot.cxx
+++ b/sprokit/src/tools/pipe_to_dot.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,14 +128,14 @@ sprokit_tool_main(int argc, char const* argv[])
       conf->set_value(sprokit::process::config_name, graph_name);
 
       sprokit::process_t const proc = info->ctor(conf);
-      cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+      cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
     }
     else if (have_cluster_type)
     {
       sprokit::process::type_t const type = vm["cluster-type"].as<sprokit::process::type_t>();
 
       sprokit::process_t const proc = sprokit::create_process(type, graph_name, conf);
-      cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+      cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
       if (!cluster)
       {

--- a/sprokit/tests/sprokit/pipeline/schedulers_test.cxx
+++ b/sprokit/tests/sprokit/pipeline/schedulers_test.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 
 #include <sprokit/config.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 using namespace sprokit;
 

--- a/sprokit/tests/sprokit/pipeline/test_edge.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_edge.cxx
@@ -48,9 +48,9 @@
 #endif
 #include <boost/thread/thread.hpp>
 #include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -136,7 +136,7 @@ IMPLEMENT_TEST(null_config)
   kwiver::vital::config_block_sptr const config;
 
   EXPECT_EXCEPTION(sprokit::null_edge_config_exception,
-                   boost::make_shared<sprokit::edge>(config),
+                   std::make_shared<sprokit::edge>(config),
                    "when passing a NULL config to an edge");
 }
 
@@ -144,7 +144,7 @@ IMPLEMENT_TEST(makes_dependency)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   if (!edge->makes_dependency())
   {
@@ -153,7 +153,7 @@ IMPLEMENT_TEST(makes_dependency)
 
   config->set_value(sprokit::edge::config_dependency, "false");
 
-  sprokit::edge_t const edge2 = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge2 = std::make_shared<sprokit::edge>(config);
 
   if (edge2->makes_dependency())
   {
@@ -166,7 +166,7 @@ IMPLEMENT_TEST(new_has_no_data)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   if (edge->has_data())
   {
@@ -178,7 +178,7 @@ IMPLEMENT_TEST(new_is_not_full)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   if (edge->full_of_data())
   {
@@ -190,7 +190,7 @@ IMPLEMENT_TEST(new_has_count_zero)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   if (edge->datum_count())
   {
@@ -202,7 +202,7 @@ IMPLEMENT_TEST(push_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -230,7 +230,7 @@ IMPLEMENT_TEST(peek_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -260,7 +260,7 @@ IMPLEMENT_TEST(peek_datum_index)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -301,7 +301,7 @@ IMPLEMENT_TEST(pop_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -324,7 +324,7 @@ IMPLEMENT_TEST(get_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -354,7 +354,7 @@ IMPLEMENT_TEST(null_upstream_process)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::process_t const process;
 
@@ -367,7 +367,7 @@ IMPLEMENT_TEST(null_downstream_process)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::process_t const process;
 
@@ -384,7 +384,7 @@ IMPLEMENT_TEST(set_upstream_process)
 
   sprokit::process_t const process = sprokit::create_process(proc_type, sprokit::process::name_t());
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
 
   edge->set_upstream_process(process);
 
@@ -401,7 +401,7 @@ IMPLEMENT_TEST(set_downstream_process)
 
   sprokit::process_t const process = sprokit::create_process(proc_type, sprokit::process::name_t());
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
 
   edge->set_downstream_process(process);
 
@@ -414,7 +414,7 @@ IMPLEMENT_TEST(push_data_into_complete)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -444,7 +444,7 @@ IMPLEMENT_TEST(get_data_from_complete)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   edge->mark_downstream_as_complete();
 
@@ -484,7 +484,7 @@ IMPLEMENT_TEST(capacity)
 
   config->set_value(sprokit::edge::config_capacity, value_capacity);
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -536,7 +536,7 @@ IMPLEMENT_TEST(try_push_datum)
 
   config->set_value(sprokit::edge::config_capacity, 1);
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -575,7 +575,7 @@ IMPLEMENT_TEST(try_push_datum)
 
 IMPLEMENT_TEST(try_get_datum)
 {
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
 
   time_point_t const start = time_clock_t::now();
 

--- a/sprokit/tests/sprokit/pipeline/test_modules.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_modules.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,7 +85,7 @@ IMPLEMENT_TEST(envvar)
 
   sprokit::scheduler::type_t const sched_type = sprokit::scheduler::type_t("test");
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>();
 
   sprokit::create_scheduler(sched_type, pipeline);
 }

--- a/sprokit/tests/sprokit/pipeline/test_pipeline.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_pipeline.cxx
@@ -1,5 +1,5 @@
 /*keg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,9 @@
 #include <sprokit/pipeline/scheduler.h>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/lexical_cast.hpp>
+
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -70,7 +71,7 @@ IMPLEMENT_TEST( null_config )
   kwiver::vital::config_block_sptr const config;
 
   EXPECT_EXCEPTION( sprokit::null_pipeline_config_exception,
-                    boost::make_shared< sprokit::pipeline > ( config ),
+                    std::make_shared< sprokit::pipeline > ( config ),
                     "passing a NULL config to the pipeline" );
 }
 
@@ -1824,7 +1825,7 @@ IMPLEMENT_TEST( reconfigure_before_setup )
 
   sprokit::process_t const expect = create_process( proc_type, proc_name );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( expect );
 
@@ -1867,9 +1868,9 @@ IMPLEMENT_TEST( reconfigure )
   conf->set_value( check_reconfigure_process::config_should_reconfigure, "true" );
   conf->set_value( sprokit::process::config_name, proc_name );
 
-  sprokit::process_t const check = boost::make_shared< check_reconfigure_process > ( conf );
+  sprokit::process_t const check = std::make_shared< check_reconfigure_process > ( conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( check );
   pipeline->setup_pipeline();
@@ -1911,18 +1912,18 @@ IMPLEMENT_TEST( reconfigure_only_top_level )
   conf->set_value( check_reconfigure_process::config_should_reconfigure, "false" );
   conf->set_value( sprokit::process::config_name, proc_name );
 
-  typedef boost::shared_ptr< sample_cluster > sample_cluster_t;
+  typedef std::shared_ptr< sample_cluster > sample_cluster_t;
 
   const auto cluster_conf = kwiver::vital::config_block::empty_config();
   const auto cluster_name = sprokit::process::name_t( "cluster" );
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   cluster->_add_process( proc_name, proc_type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -1957,7 +1958,7 @@ create_process( sprokit::process::type_t const&   type,
 sprokit::pipeline_t
 create_pipeline()
 {
-  return boost::make_shared< sprokit::pipeline > ();
+  return std::make_shared< sprokit::pipeline > ();
 }
 
 
@@ -1980,7 +1981,7 @@ create_scheduler( sprokit::pipeline_t const& pipe )
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  return boost::make_shared< dummy_scheduler > ( pipe, config );
+  return std::make_shared< dummy_scheduler > ( pipe, config );
 }
 
 

--- a/sprokit/tests/sprokit/pipeline/test_process.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process.cxx
@@ -39,7 +39,7 @@
 #include <sprokit/pipeline/process_exception.h>
 #include <sprokit/pipeline/process_factory.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -171,9 +171,9 @@ IMPLEMENT_TEST(connect_after_init)
 
   const auto config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
-  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>(config);
+  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>(config);
 
   // Only the pipeline can properly initialize a process.
   pipe->add_process(process);
@@ -641,7 +641,7 @@ sprokit::process::port_type_t const remove_ports_process::output_port = sprokit:
 IMPLEMENT_TEST(remove_input_port)
 {
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(type));
 
   proc->_remove_input_port(remove_ports_process::input_port);
 
@@ -655,7 +655,7 @@ IMPLEMENT_TEST(remove_input_port)
 IMPLEMENT_TEST(remove_output_port)
 {
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(type));
 
   proc->_remove_output_port(remove_ports_process::output_port);
 
@@ -670,7 +670,7 @@ IMPLEMENT_TEST(remove_non_exist_input_port)
 {
   const auto port = sprokit::process::port_t("port");
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(type));
 
   EXPECT_EXCEPTION(sprokit::no_such_port_exception,
                    proc->_remove_input_port(port),
@@ -683,7 +683,7 @@ IMPLEMENT_TEST(remove_non_exist_output_port)
 {
   const auto port = sprokit::process::port_t("port");
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(type));
 
   EXPECT_EXCEPTION(sprokit::no_such_port_exception,
                    proc->_remove_output_port(port),
@@ -697,7 +697,7 @@ IMPLEMENT_TEST(remove_only_tagged_flow_dependent_port)
   const auto port = sprokit::process::port_t("port");
   const auto flow_type = sprokit::process::type_flow_dependent + sprokit::process::port_type_t("tag");
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(flow_type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(flow_type));
 
   proc->_remove_input_port(remove_ports_process::input_port);
   proc->set_output_port_type(remove_ports_process::output_port, type);
@@ -719,7 +719,7 @@ IMPLEMENT_TEST(remove_tagged_flow_dependent_port)
 {
   const auto flow_type = sprokit::process::type_flow_dependent + sprokit::process::port_type_t("tag");
   const auto type = sprokit::process::port_type_t("type");
-  boost::scoped_ptr<remove_ports_process> proc(new remove_ports_process(flow_type));
+  std::unique_ptr<remove_ports_process> proc(new remove_ports_process(flow_type));
 
   proc->set_output_port_type(remove_ports_process::output_port, type);
   proc->_remove_output_port(remove_ports_process::output_port);
@@ -878,7 +878,7 @@ IMPLEMENT_TEST(reconfigure_tunable)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -911,7 +911,7 @@ IMPLEMENT_TEST(reconfigure_non_tunable)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -945,7 +945,7 @@ IMPLEMENT_TEST(reconfigure_extra_parameters)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -978,7 +978,7 @@ sprokit::edge_t
 create_edge()
 {
   const auto config = kwiver::vital::config_block::empty_config();
-  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
 
   return edge;
 }

--- a/sprokit/tests/sprokit/pipeline/test_process_cluster.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_cluster.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@
 #include <sprokit/pipeline/process_cluster_exception.h>
 #include <sprokit/pipeline/process_exception.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -70,7 +70,7 @@ public:
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( configure )
 {
-  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
 
   cluster->configure();
 }
@@ -79,7 +79,7 @@ IMPLEMENT_TEST( configure )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( init )
 {
-  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
 
   cluster->configure();
   cluster->init();
@@ -89,7 +89,7 @@ IMPLEMENT_TEST( init )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( step )
 {
-  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
 
   cluster->configure();
   cluster->init();
@@ -121,13 +121,13 @@ public:
   void _connect( name_t const& upstream_name, port_t const& upstream_port,
                  name_t const& downstream_name, port_t const& downstream_port );
 };
-typedef boost::shared_ptr< sample_cluster > sample_cluster_t;
+typedef std::shared_ptr< sample_cluster > sample_cluster_t;
 
 
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( add_process )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "orphan" );
@@ -169,7 +169,7 @@ IMPLEMENT_TEST( add_process )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( duplicate_name )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "orphan" );
@@ -187,7 +187,7 @@ IMPLEMENT_TEST( duplicate_name )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_config )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -199,7 +199,7 @@ IMPLEMENT_TEST( map_config )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_config_after_process )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -220,7 +220,7 @@ IMPLEMENT_TEST( map_config_no_exist )
 {
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -241,7 +241,7 @@ IMPLEMENT_TEST( map_config_read_only )
 
   sprokit::process::name_t const cluster_name = sprokit::process::name_t( "cluster" );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -282,7 +282,7 @@ IMPLEMENT_TEST( map_config_ignore_override )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -312,7 +312,7 @@ IMPLEMENT_TEST( map_config_ignore_override )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -336,7 +336,7 @@ IMPLEMENT_TEST( map_input )
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "print_number" );
@@ -400,7 +400,7 @@ IMPLEMENT_TEST( map_input )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_twice )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "print_number" );
@@ -423,7 +423,7 @@ IMPLEMENT_TEST( map_input_twice )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -437,7 +437,7 @@ IMPLEMENT_TEST( map_input_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_port_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "no_such_port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -462,7 +462,7 @@ IMPLEMENT_TEST( map_output )
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "numbers" );
@@ -526,7 +526,7 @@ IMPLEMENT_TEST( map_output )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_twice )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -550,7 +550,7 @@ IMPLEMENT_TEST( map_output_twice )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -564,7 +564,7 @@ IMPLEMENT_TEST( map_output_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_port_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "no_such_port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -581,7 +581,7 @@ IMPLEMENT_TEST( map_output_port_no_exist )
 
 IMPLEMENT_TEST( connect )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -648,7 +648,7 @@ IMPLEMENT_TEST( connect )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_upstream_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -668,7 +668,7 @@ IMPLEMENT_TEST( connect_upstream_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_upstream_port_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -691,7 +691,7 @@ IMPLEMENT_TEST( connect_upstream_port_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_downstream_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -711,7 +711,7 @@ IMPLEMENT_TEST( connect_downstream_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_downstream_port_no_exist )
 {
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -742,7 +742,7 @@ IMPLEMENT_TEST( reconfigure_pass_tunable_mappings )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -770,7 +770,7 @@ IMPLEMENT_TEST( reconfigure_pass_tunable_mappings )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -794,7 +794,7 @@ IMPLEMENT_TEST( reconfigure_no_pass_untunable_mappings )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -821,7 +821,7 @@ IMPLEMENT_TEST( reconfigure_no_pass_untunable_mappings )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -847,7 +847,7 @@ IMPLEMENT_TEST( reconfigure_pass_extra )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "expect" );
@@ -864,7 +864,7 @@ IMPLEMENT_TEST( reconfigure_pass_extra )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -888,7 +888,7 @@ IMPLEMENT_TEST( reconfigure_tunable_only_if_mapped )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "expect" );
@@ -906,7 +906,7 @@ IMPLEMENT_TEST( reconfigure_tunable_only_if_mapped )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -933,7 +933,7 @@ IMPLEMENT_TEST( reconfigure_mapped_untunable )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -961,7 +961,7 @@ IMPLEMENT_TEST( reconfigure_mapped_untunable )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();

--- a/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@
 #include <sprokit/pipeline/process_registry_exception.h>
 #include <sprokit/pipeline/types.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 static void test_process( sprokit::process::type_t const& type );
 
@@ -255,7 +255,7 @@ test_process_input_ports( sprokit::process_t const process )
                   "(" << process->type() << "." << port << ")" );
     }
 
-    sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
 
     process->connect_input_port( port, edge );
 
@@ -318,8 +318,8 @@ test_process_output_ports( sprokit::process_t const process )
                   "(" << process->type() << "." << port << ")" );
     }
 
-    sprokit::edge_t edge1 = boost::make_shared< sprokit::edge > ( config );
-    sprokit::edge_t edge2 = boost::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge1 = std::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge2 = std::make_shared< sprokit::edge > ( config );
 
     process->connect_output_port( port, edge1 );
     process->connect_output_port( port, edge2 );
@@ -348,7 +348,7 @@ test_process_invalid_input_port( sprokit::process_t const process )
                     process->input_port_info( non_existent_port ),
                     "requesting the info for a non-existent input port" );
 
-  sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
+  sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
 
   EXPECT_EXCEPTION( sprokit::no_such_port_exception,
                     process->connect_input_port( non_existent_port, edge ),
@@ -367,7 +367,7 @@ test_process_invalid_output_port( sprokit::process_t const process )
                     process->output_port_info( non_existent_port ),
                     "requesting the info for a non-existent output port" );
 
-  sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
+  sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
 
   EXPECT_EXCEPTION( sprokit::no_such_port_exception,
                     process->connect_output_port( non_existent_port, edge ),

--- a/sprokit/tests/sprokit/pipeline/test_process_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_registry.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -164,7 +164,7 @@ IMPLEMENT_TEST(register_cluster)
 
   sprokit::process_t const cluster_from_reg = sprokit::create_process(cluster_type, sprokit::process::name_t(), config);
 
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(cluster_from_reg);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(cluster_from_reg);
 
   if (!cluster)
   {
@@ -175,7 +175,7 @@ IMPLEMENT_TEST(register_cluster)
 
   sprokit::process_t const not_a_cluster_from_reg = sprokit::create_process(type, sprokit::process::name_t(), config);
 
-  sprokit::process_cluster_t const not_a_cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(not_a_cluster_from_reg);
+  sprokit::process_cluster_t const not_a_cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(not_a_cluster_from_reg);
 
   if (not_a_cluster)
   {

--- a/sprokit/tests/sprokit/pipeline/test_run.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_run.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,8 +41,8 @@
 
 #include <boost/cstdint.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/make_shared.hpp>
 
+#include <memory>
 #include <fstream>
 
 #define TEST_ARGS (sprokit::scheduler::type_t const& scheduler_type)
@@ -630,5 +630,5 @@ create_process(sprokit::process::type_t const& type, sprokit::process::name_t co
 sprokit::pipeline_t
 create_pipeline()
 {
-  return boost::make_shared<sprokit::pipeline>();
+  return std::make_shared<sprokit::pipeline>();
 }

--- a/sprokit/tests/sprokit/pipeline/test_scheduler.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@
 #include <sprokit/pipeline/scheduler_exception.h>
 #include <sprokit/pipeline/scheduler_factory.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -254,7 +254,7 @@ IMPLEMENT_TEST(restart)
   sched->start();
   sched->stop();
 
-  boost::shared_ptr<null_scheduler> const null_sched = boost::dynamic_pointer_cast<null_scheduler>(sched);
+  std::shared_ptr<null_scheduler> const null_sched = std::dynamic_pointer_cast<null_scheduler>(sched);
 
   null_sched->reset_pipeline();
 
@@ -265,7 +265,7 @@ IMPLEMENT_TEST(restart)
 sprokit::scheduler_t
 create_scheduler(sprokit::scheduler::type_t const& type)
 {
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>();
 
   return sprokit::create_scheduler(type, pipeline);
 }
@@ -282,14 +282,14 @@ create_minimal_scheduler()
 
   sprokit::process_t const proc = sprokit::create_process(type, name);
 
-  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
 
   pipe->add_process(proc);
   pipe->setup_pipeline();
 
   kwiver::vital::config_block_sptr const conf = kwiver::vital::config_block::empty_config();
 
-  sprokit::scheduler_t const sched = boost::make_shared<null_scheduler>(pipe, conf);
+  sprokit::scheduler_t const sched = std::make_shared<null_scheduler>(pipe, conf);
 
   return sched;
 }

--- a/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@
 #include <sprokit/pipeline/scheduler_registry_exception.h>
 #include <sprokit/pipeline/types.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #define TEST_ARGS ()
 
@@ -92,7 +92,7 @@ IMPLEMENT_TEST(load_schedulers)
 
   auto factories =  kwiver::vital::plugin_manager::instance().get_factories<sprokit::scheduler>();
 
-  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
 
   VITAL_FOREACH( auto fact, factories )
   {
@@ -172,7 +172,7 @@ IMPLEMENT_TEST(unknown_types)
 {
   sprokit::scheduler::type_t const non_existent_scheduler = sprokit::scheduler::type_t("no_such_scheduler");
 
-  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
 
   EXPECT_EXCEPTION(sprokit::no_such_scheduler_type_exception,
                    sprokit::create_scheduler(non_existent_scheduler, pipe),

--- a/sprokit/tests/sprokit/pipeline_util/test_export_dot.cxx
+++ b/sprokit/tests/sprokit/pipeline_util/test_export_dot.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,8 +42,7 @@
 #include <sprokit/pipeline/process_factory.h>
 #include <sprokit/pipeline/pipeline_exception.h>
 
-#include <boost/make_shared.hpp>
-
+#include <memory>
 #include <sstream>
 
 #define TEST_ARGS (sprokit::path_t const& pipe_file)
@@ -91,7 +90,7 @@ IMPLEMENT_TEST(pipeline_empty_name)
   sprokit::process::type_t const type = sprokit::process::type_t("orphan");
   sprokit::process_t const proc = sprokit::create_process(type, sprokit::process::name_t());
 
-  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
 
   pipe->add_process(proc);
 
@@ -166,7 +165,7 @@ IMPLEMENT_TEST(cluster_empty_name)
   const auto conf = kwiver::vital::config_block::empty_config();
 
   sprokit::process_t const proc = info->ctor(conf);
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   std::ostringstream sstr;
 
@@ -188,7 +187,7 @@ IMPLEMENT_TEST(cluster_multiplier)
   conf->set_value(sprokit::process::config_name, name);
 
   sprokit::process_t const proc = info->ctor(conf);
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   std::ostringstream sstr;
 

--- a/sprokit/tests/sprokit/pipeline_util/test_pipe_bakery.cxx
+++ b/sprokit/tests/sprokit/pipeline_util/test_pipe_bakery.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2016 by Kitware, Inc.
+ * Copyright 2012-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-
+#include <memory>
 #include <cstdlib>
 
 #define TEST_ARGS (sprokit::path_t const& pipe_file)
@@ -669,7 +669,7 @@ IMPLEMENT_TEST(cluster_multiplier)
 
   sprokit::process_t const proc = ctor(config);
 
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   if (!cluster)
   {
@@ -821,7 +821,7 @@ IMPLEMENT_TEST(cluster_map_config)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -849,7 +849,7 @@ IMPLEMENT_TEST(cluster_map_config_tunable)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -880,7 +880,7 @@ DONT_IMPLEMENT_TEST(cluster_map_config_redirect)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -918,7 +918,7 @@ DONT_IMPLEMENT_TEST(cluster_map_config_modified)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -955,7 +955,7 @@ IMPLEMENT_TEST(cluster_map_config_not_read_only)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -990,7 +990,7 @@ IMPLEMENT_TEST(cluster_map_config_only_provided)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -1026,7 +1026,7 @@ IMPLEMENT_TEST(cluster_map_config_only_conf_provided)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -1064,7 +1064,7 @@ IMPLEMENT_TEST(cluster_map_config_to_non_process)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -1099,7 +1099,7 @@ IMPLEMENT_TEST(cluster_map_config_not_from_cluster)
     return;
   }
 
-  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(cluster);
   pipeline->setup_pipeline();
@@ -1263,7 +1263,7 @@ create_process(sprokit::process::type_t const& type, sprokit::process::name_t co
 sprokit::pipeline_t
 create_pipeline()
 {
-  return boost::make_shared<sprokit::pipeline>();
+  return std::make_shared<sprokit::pipeline>();
 }
 
 sprokit::process_cluster_t
@@ -1281,7 +1281,7 @@ setup_map_config_cluster(sprokit::process::name_t const& name, sprokit::path_t c
 
   sprokit::process_t const proc = ctor(config);
 
-  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   return cluster;
 }

--- a/vital/config/token_type_config.cxx
+++ b/vital/config/token_type_config.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ token_type_config::
 bool
 token_type_config::
 lookup_entry (kwiver::vital::config_block_key_t const& name,
-              std::string& result)
+              std::string& result) const
 {
   bool retcode( true );
 

--- a/vital/config/token_type_config.h
+++ b/vital/config/token_type_config.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,7 +72,7 @@ public:
 
   /** Lookup name in token type resolver.
    */
-  virtual bool lookup_entry (std::string const& name, std::string& result);
+  virtual bool lookup_entry (std::string const& name, std::string& result) const;
 
 
 private:

--- a/vital/util/CMakeLists.txt
+++ b/vital/util/CMakeLists.txt
@@ -46,6 +46,7 @@ set( public_headers
   source_location.h
 
   data_stream_reader.h
+  string.h
   string_editor.h
   token_expander.h
   token_expand_editor.h

--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,14 +28,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef KWIVER_VITAL_UTIL_STRING_FORMAT_H
+#define KWIVER_VITAL_UTIL_STRING_FORMAT_H
+
 #include <stdarg.h>  // For va_start, etc.
 #include <memory>    // For std::unique_ptr
+#include <string>
+#include <algorithm>
 
 namespace kwiver {
 namespace vital {
 
 /**
  * @brief Printf style formatting for std::string
+ *
+ * This function creates a std::string from an printf style input
+ * format specifier and a list of values.
  *
  * @param fmt_str Formatting string using embedded printf format specifiers.
  *
@@ -69,4 +77,24 @@ string_format( const std::string fmt_str, ... )
   return std::string( formatted.get() );
 }
 
+
+/**
+ * @brief Does string start with pattern
+ *
+ * This function checks to see if the input starts with the supplied
+ * pattern.
+ *
+ * @param input String to be checked
+ * @param pattern String to use for checking.
+ *
+ * @return \b true if string starts with pattern
+ */
+inline bool
+starts_with( const std::string& input, const std::string& pattern)
+{
+  return input.compare( 0, pattern.size(), pattern );
+}
+
 } } // end namespace
+
+#endif /* KWIVER_VITAL_UTIL_STRING_FORMAT_H */

--- a/vital/util/token_type.h
+++ b/vital/util/token_type.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,7 +59,7 @@ public:
    * @param[out] result Translated string
    * @return TRUE if name found in table; false otherwise
    */
-  virtual bool lookup_entry (std::string const& name, std::string& result) = 0;
+  virtual bool lookup_entry (std::string const& name, std::string& result) const = 0;
 
 
 protected:

--- a/vital/util/token_type_env.cxx
+++ b/vital/util/token_type_env.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ token_type_env::
 // ----------------------------------------------------------------
 bool
 token_type_env::
-lookup_entry (std::string const& name, std::string& result)
+lookup_entry (std::string const& name, std::string& result) const
 {
   bool retcode( true );
 

--- a/vital/util/token_type_env.h
+++ b/vital/util/token_type_env.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ public:
 
   /** Lookup name in token type resolver.
    */
-  virtual bool lookup_entry (std::string const& name, std::string& result);
+  virtual bool lookup_entry (std::string const& name, std::string& result) const;
 
 }; // end class token_type_env
 

--- a/vital/util/token_type_symtab.cxx
+++ b/vital/util/token_type_symtab.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2014-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,14 +68,14 @@ remove_entry (std::string const& name)
 // ----------------------------------------------------------------
 bool
 token_type_symtab::
-lookup_entry (std::string const& name, std::string& result)
+lookup_entry (std::string const& name, std::string& result) const
 {
   bool retcode( false );
   result.clear();
 
   if ( m_table.count( name ) )
   {
-    result = m_table[name];
+    result = m_table.at(name);
     retcode = true;
   }
 

--- a/vital/util/token_type_symtab.h
+++ b/vital/util/token_type_symtab.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2014-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ public:
 
   /** Lookup name in token type resolver.
    */
-  virtual bool lookup_entry (std::string const& name, std::string& result);
+  virtual bool lookup_entry (std::string const& name, std::string& result) const;
 
   /** Add entry to table.
    */

--- a/vital/util/token_type_sysenv.cxx
+++ b/vital/util/token_type_sysenv.cxx
@@ -58,8 +58,9 @@ token_type_sysenv::
 // ----------------------------------------------------------------
 bool
 token_type_sysenv::
-lookup_entry (std::string const& name, std::string& result)
+lookup_entry (std::string const& name, std::string& result) const
 {
+  kwiversys::SystemInformation* SI( const_cast< kwiversys::SystemInformation* >(&m_sysinfo) );
 
   if ("cwd" == name) // current directory
   {
@@ -71,8 +72,8 @@ lookup_entry (std::string const& name, std::string& result)
   else if ("numproc" == name)   // number of processors/cores
   {
     std::stringstream sval;
-    unsigned int numCPU = m_sysinfo.GetNumberOfLogicalCPU();
-    // unsigned int numCPU = m_sysinfo.GetNumberOfPhysicalCPU();
+    unsigned int numCPU = SI->GetNumberOfLogicalCPU();
+    // unsigned int numCPU = SI->GetNumberOfPhysicalCPU();
     sval << numCPU;
     result = sval.str();
     return true;
@@ -82,7 +83,7 @@ lookup_entry (std::string const& name, std::string& result)
   else if ("totalvirtualmemory" == name)
   {
     std::stringstream sval;
-    sval <<  m_sysinfo.GetTotalVirtualMemory();
+    sval <<  SI->GetTotalVirtualMemory();
     result = sval.str();
     return true;
   }
@@ -91,7 +92,7 @@ lookup_entry (std::string const& name, std::string& result)
   else if ("availablevirtualmemory" == name)
   {
     std::stringstream sval;
-    sval << m_sysinfo.GetAvailableVirtualMemory();
+    sval << SI->GetAvailableVirtualMemory();
     result = sval.str();
     return true;
   }
@@ -100,7 +101,7 @@ lookup_entry (std::string const& name, std::string& result)
   else if ("totalphysicalmemory" == name)
   {
     std::stringstream sval;
-    sval << m_sysinfo.GetTotalPhysicalMemory();
+    sval << SI->GetTotalPhysicalMemory();
     result = sval.str();
     return true;
   }
@@ -109,7 +110,7 @@ lookup_entry (std::string const& name, std::string& result)
   else if ("availablephysicalmemory" == name)
   {
     std::stringstream sval;
-    sval << m_sysinfo.GetAvailablePhysicalMemory();
+    sval << SI->GetAvailablePhysicalMemory();
     result = sval.str();
     return true;
   }
@@ -117,49 +118,49 @@ lookup_entry (std::string const& name, std::string& result)
   // ----------------------------------------------------------------
   else if ("hostname" == name)   // network name of system
   {
-    result = m_sysinfo.GetHostname();
+    result = SI->GetHostname();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("domainname" == name)
   {
-    result = m_sysinfo.GetFullyQualifiedDomainName();
+    result = SI->GetFullyQualifiedDomainName();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("osname" == name)
   {
-    result = m_sysinfo.GetOSName();
+    result = SI->GetOSName();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("osdescription" == name)
   {
-    result = m_sysinfo.GetOSDescription();
+    result = SI->GetOSDescription();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("osplatform" == name)
   {
-    result = m_sysinfo.GetOSPlatform();
+    result = SI->GetOSPlatform();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("osversion" == name)
   {
-    result = m_sysinfo.GetOSVersion();
+    result = SI->GetOSVersion();
     return true;
   }
 
   // ----------------------------------------------------------------
   else if ("is64bits" == name)
   {
-    if ( 1 == m_sysinfo.Is64Bits())
+    if ( 1 == SI->Is64Bits())
     {
       result = "TRUE";
     }
@@ -174,7 +175,7 @@ lookup_entry (std::string const& name, std::string& result)
   // ----------------------------------------------------------------
   else if ("iswindows" == name)
   {
-    if ( 1 == m_sysinfo.GetOSIsWindows())
+    if ( 1 == SI->GetOSIsWindows())
     {
       result = "TRUE";
     }
@@ -189,7 +190,7 @@ lookup_entry (std::string const& name, std::string& result)
   // ----------------------------------------------------------------
   else if ("islinux" == name)
   {
-    if ( 1 == m_sysinfo.GetOSIsLinux())
+    if ( 1 == SI->GetOSIsLinux())
     {
       result = "TRUE";
     }
@@ -204,7 +205,7 @@ lookup_entry (std::string const& name, std::string& result)
   // ----------------------------------------------------------------
   else if ("isapple" == name)
   {
-    if ( 1 == m_sysinfo.GetOSIsApple())
+    if ( 1 == SI->GetOSIsApple())
     {
       result = "TRUE";
     }

--- a/vital/util/token_type_sysenv.h
+++ b/vital/util/token_type_sysenv.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,9 @@ public:
 
   /** Lookup name in token type resolver.
    */
-  virtual bool lookup_entry (std::string const& name, std::string& result);
+  virtual bool lookup_entry (std::string const& name, std::string& result) const;
 
+private:
   kwiversys::SystemInformation m_sysinfo;
 
 }; // end class token_type_sysenv


### PR DESCRIPTION
This change handles the low hanging fruit. Smart pointers were converted from boost to std.
Noncopyable converted to vital version.

There will be more deboostification in additional branches.