### PR TITLE
Enable thread safety in Cereal

### DIFF
--- a/vital/internal/cereal/macros.hpp
+++ b/vital/internal/cereal/macros.hpp
@@ -53,7 +53,7 @@
     archives are accessed by only one thread at a time; it is safe
     to use multiple archives in paralel, but not to access one archive
     from many places simultaneously. */
-#define CEREAL_THREAD_SAFE 0
+#define CEREAL_THREAD_SAFE 1
 #endif // CEREAL_THREAD_SAFE
 
 // ######################################################################


### PR DESCRIPTION
Cereal is not thread safe by default, but provides a way to enable
thread safety at a small performance cost.  This commit enables thread
safety in Cereal by default.  Note that it is still not safe to access
one archive from multiple threads, but with this change it is safe to
access a different archive in each thread.