### PR TITLE
Fix bug in vital starts_with() function.

### DIFF
--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -92,7 +92,7 @@ string_format( const std::string fmt_str, ... )
 inline bool
 starts_with( const std::string& input, const std::string& pattern)
 {
-  return input.compare( 0, pattern.size(), pattern );
+  return (0 == input.compare( 0, pattern.size(), pattern ) );
 }
 
 } } // end namespace


### PR DESCRIPTION
Return code from string compare was misinterpreted.