### PR TITLE
Update documentation

### DIFF
--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -53,6 +53,17 @@ namespace vital {
  * directly accessed, or the location in a specific CRS may be requested.
  * Requests for a specific CRS are cached, so that CRS conversion does not need
  * to be performed every time.
+ *
+ * The CRS values shall correspond to geodetic CRS's as specified by the
+ * European Petroleum Survey Group (EPSG) Spatial Reference System Identifiers
+ * (SRID's). Some well known values are defined by kwiver::vital::SRID.
+ *
+ * Note that the underlying values are ordered easting, northing, for
+ * consistency with Euclidean convention (X, Y), and \em not northing, easting
+ * as is sometimes used for geo-coordinates.
+ *
+ * \see https://en.wikipedia.org/wiki/Spatial_reference_system,
+ *      http://www.epsg.org/, https://epsg-registry.org/
  */
 class VITAL_EXPORT geo_point
 {
@@ -65,24 +76,46 @@ public:
   virtual ~geo_point() VITAL_DEFAULT_DTOR
 
   /**
-   * \throws std::out_of_range if no location has been set.
+   * \brief Accessor for location in original CRS.
+   *
+   * \returns The location in the CRS that was used to set the location.
+   * \throws std::out_of_range Thrown if no location has been set.
+   *
+   * \see crs()
    */
   geo_raw_point_t location() const;
+
+  /**
+   * \brief Accessor for original CRS.
+   *
+   * \returns The CRS used to set the location.
+   *
+   * \see location()
+   */
   int crs() const;
 
   /**
+   * \brief Accessor for the location.
+   *
+   * \returns The location in the requested CRS.
    * \throws std::runtime_error if the conversion fails.
    */
   geo_raw_point_t location( int crs ) const;
 
+  /**
+   * \brief Set location.
+   *
+   * This sets the geo-coordinate to the specified location, which is defined
+   * by the raw location and specified CRS.
+   */
   void set_location( geo_raw_point_t const&, int crs );
 
   /**
-   * @brief Does point have a specified location.
+   * \brief Test if point has a specified location.
    *
    * This method checks the object to see if any location data has been set.
    *
-   * @return \b true if object is default constructed.
+   * \returns \c true if object is default constructed.
    */
   bool is_empty() const;
 

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -48,7 +48,7 @@ namespace vital {
  * This enumeration provides a set of well known coordinate reference systems
  * (CRS's). The numeric values correspond to geodetic CRS's as specified by
  * the European Petroleum Survey Group (EPSG) Spatial Reference System
- * Identifier (SRID).
+ * Identifiers (SRID).
  *
  * \note UTM SRID's are obtained by adding the UTM zone number to the base
  *       SRID

--- a/vital/types/query_plan.h
+++ b/vital/types/query_plan.h
@@ -73,33 +73,104 @@ public:
   query_plan();
   ~query_plan() VITAL_DEFAULT_DTOR
 
+  /// Accessor for query plan unique identifier. \see set_id
   uid id() const;
+  /// Accessor for query plan type. \see set_type
   query_type type() const;
 
+  /// Accessor for temporal filter. \see set_temporal_filter
   filter temporal_filter() const;
+  /// Accessor for temporal lower bound. \see set_temporal_bounds
   timestamp temporal_lower_bound() const;
+  /// Accessor for temporal upper bound. \see set_temporal_bounds
   timestamp temporal_upper_bound() const;
 
+  /// Accessor for spatial filter. \see set_spatial_filter
   filter spatial_filter() const;
+  /// Accessor for spatial region. \see set_spatial_region
   geo_polygon spatial_region() const;
 
+  /// Accessor for stream filter. \see set_stream_filter
   std::string stream_filter() const;
 
+  /// Accessor for query descriptors. \see set_descriptors
   track_descriptor_set_sptr descriptors() const;
+  /// Accessor for relevancy threshold. \see set_threshold
   double threshold() const;
 
+  /**
+   * \brief Set the query plan unique identifier.
+   *
+   * This sets the query plan unique identifier. Users should ensure that this
+   * identifier uniquely identifies the query plan within the system. This
+   * permits the system to recognize if the same query plan is reused. Once the
+   * query plan has been seen by any component other than the original creator,
+   * the identifier should be changed if the query plan is modified in any way.
+   */
   void set_id( uid const& );
   void set_type( query_type );
 
+  /**
+   * \brief Set the temporal filter.
+   *
+   * This sets the temporal filter, which is used to decide how the temporal
+   * bounds are applied to decide if a potential result is applicable to the
+   * query.
+   */
   void set_temporal_filter( filter );
+
+  /**
+   * \brief Set the temporal bounds.
+   *
+   * This sets the temporal bounds which are used, in conjunction with the
+   * temporal filter, to limit the query results based on their temporal
+   * locality.
+   *
+   * \throws std::logic_error Thrown if \p upper is less than \p lower.
+   */
   void set_temporal_bounds( timestamp const& lower, timestamp const& upper );
 
+  /**
+   * \brief Set the spatial filter.
+   *
+   * This sets the spatial filter, which is used to decide how the spatial
+   * region is applied to decide if a potential result is applicable to the
+   * query.
+   */
   void set_spatial_filter( filter );
+
+  /**
+   * \brief Set the spatial region.
+   *
+   * This sets the spatial region which is used, in conjunction with the
+   * spatial filter, to limit the query results based on their spatial
+   * locality.
+   */
   void set_spatial_region( geo_polygon const& );
 
+  /**
+   * \brief Set the stream filter.
+   *
+   * This sets the stream filter, which is a string that the system uses to
+   * decide if a potential result is applicable to the query based on the
+   * source of the result's data.
+   */
   void set_stream_filter( std::string const& );
 
+  /**
+   * \brief Set the query plan descriptors.
+   *
+   * This sets the descriptors that are used to select an initial set of
+   * results. This applies only to similarity queries.
+   */
   void set_descriptors( track_descriptor_set_sptr );
+
+  /**
+   * \brief Set the relevancy threshold.
+   *
+   * This sets the threshold that will be used to filter results based on their
+   * relevancy score. This applies only to similarity queries.
+   */
   void set_threshold( double );
 
 protected:

--- a/vital/types/timestamp.h
+++ b/vital/types/timestamp.h
@@ -49,7 +49,7 @@ namespace vital {
  *
  * A timestamp has the notion of valid time and valid frame. This is
  * useful when dealing with interpolated timestamps. In this case, a
- * timestamps may have a time, but no frame.
+ * timestamp may have a time, but no frame.
  *
  * When comparing timestamps, they must be from the same domain. If
  * not, then they are not comparable and \b all relative operators


### PR DESCRIPTION
Add documentation of recently introduced types, and improve the bits of documentation that were present previously. Fix a typo in `timestamp` documentation.