### PR TITLE
Namespace exported targets

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -237,6 +237,7 @@ function(kwiver_export_targets file)
   get_property(export_targets GLOBAL PROPERTY kwiver_export_targets)
   export(
     TARGETS ${export_targets}
+    NAMESPACE kwiver::
     ${ARGN}
     FILE "${file}"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ kwiver_install(
 
 kwiver_install(
   EXPORT      ${kwiver_export_name}
+  NAMESPACE   kwiver::
   DESTINATION "${kwiver_cmake_install_dir}"
   FILE        kwiver-config-targets.cmake
   )


### PR DESCRIPTION
Modify target export so that our exported targets are all namespace prefixed with `kwiver::`.