### PR TITLE
Install CMake Find*.cmake scripts used by KWIVER

### DIFF
--- a/CMake/kwiver-install-utils.cmake
+++ b/CMake/kwiver-install-utils.cmake
@@ -16,6 +16,12 @@ install(
         "${utils_dir}/kwiver-flags-msvc.cmake"
         "${utils_dir}/kwiver-flags-clang.cmake"
         "${utils_dir}/kwiver-configcheck.cmake"
+        "${utils_dir}/CommonFindMacros.cmake"
+        "${utils_dir}/FindEigen3.cmake"
+        "${utils_dir}/FindLog4cplus.cmake"
+        "${utils_dir}/FindLog4cxx.cmake"
+        "${utils_dir}/FindPROJ.cmake"
+        "${utils_dir}/FindTinyXML.cmake"
   DESTINATION "${kwiver_cmake_install_dir}"
   )
 


### PR DESCRIPTION
These were once installed and then removed.  It would be useful to reuse
them in projects that build on KWIVER to help find the same versions of
these packages