### PR TITLE
Add compiler defines needed to use boost on windows.

### DIFF
--- a/CMake/kwiver-config-build.cmake.in
+++ b/CMake/kwiver-config-build.cmake.in
@@ -21,6 +21,9 @@ set(KWIVER_TEST_INCLUDE_DIRS
 
 if (WIN32)
   set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/bin")
+  add_definitions(-DBOOST_ALL_NO_LIB)
+  add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
+
 else ()
   set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/lib")
 endif ()

--- a/CMake/kwiver-config-install.cmake.in
+++ b/CMake/kwiver-config-install.cmake.in
@@ -9,6 +9,8 @@ set(KWIVER_BUILT_SHARED  @BUILD_SHARED_LIBS@)
 
 if (WIN32)
   set(libdir "bin")
+  add_definitions(-DBOOST_ALL_NO_LIB)
+  add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
 else ()
   set(libdir "lib@LIB_SUFFIX@")
 endif ()


### PR DESCRIPTION
These defines are needed by packages that use KWIVER and
are passed through the CMake package config file.