### PR TITLE
Fix typo in test

### DIFF
--- a/sprokit/tests/sprokit/test/test_test.cxx
+++ b/sprokit/tests/sprokit/test/test_test.cxx
@@ -105,7 +105,7 @@ IMPLEMENT_TEST(environment)
   std::string envvalue;
   kwiversys::SystemTools::GetEnv( envvar, envvalue );
 
-  if ( ! envvalue.empty() )
+  if ( envvalue.empty() )
   {
     TEST_ERROR("failed to get environment from CTest");
   }


### PR DESCRIPTION
The inversion shouldn't be there. Test will always fail as is, even if the environment is set properly.