### PR TITLE
Added missing library dependencies for tests.

### DIFF
--- a/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
@@ -4,6 +4,8 @@ set(test_libraries
   sprokit_pipeline_util
   sprokit_pipeline
   vital_config
+  vital_vpm
+  kwiversys
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY})
 


### PR DESCRIPTION
These ommisions were causing build errors on MacOS.