### PR TITLE
Visual Studio needs optional template parameters spelled out

### DIFF
--- a/vital/io/eigen_io.h
+++ b/vital/io/eigen_io.h
@@ -77,8 +77,8 @@ operator>>( std::istream& s, Matrix< T, M, N >& m )
 
 
 /// Serialization of fixed Eigen matrices
-template < typename Archive, typename T, int M, int N >
-void serialize(Archive & archive, Matrix< T, M, N >& m)
+template < typename Archive, typename T, int M, int N, int O, int MM, int NN >
+void serialize(Archive & archive, Matrix< T, M, N, O, MM, NN >& m)
 {
   for ( int i = 0; i < M; ++i )
   {


### PR DESCRIPTION
This change resolve build errors on Visual Studio 2013 and 2015 in
which Cereal can't resolve the Eigen::Matrix serialize function
unless all optional template parameters of Eigen::Matrix are
explicitly spelled out.