### PR TITLE
Fix a Visual Studio warning about an extra ';'

### DIFF
--- a/vital/bindings/c/types/landmark.cxx
+++ b/vital/bindings/c/types/landmark.cxx
@@ -235,7 +235,7 @@ vital_landmark_##S##_set_loc( vital_landmark_t *l, \
     REINTERP_TYPE( matrix_t const, loc, loc_ptr ); \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     l_ptr->set_loc( *loc_ptr ); \
   ); \
 } \
@@ -249,7 +249,7 @@ vital_landmark_##S##_set_scale( vital_landmark_t *l, T scale, \
     "vital_landmark_" #S "_set_scale", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     l_ptr->set_scale( scale );\
   ); \
 } \
@@ -265,7 +265,7 @@ vital_landmark_##S##_set_normal( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_normal", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     REINTERP_TYPE( matrix_t const, normal, n_ptr ); \
     l_ptr->set_normal( *n_ptr ); \
   ); \
@@ -282,7 +282,7 @@ vital_landmark_##S##_set_covar( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_covar", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     REINTERP_TYPE( covar_t const, covar, covar_ptr ); \
     l_ptr->set_covar( *covar_ptr ); \
   ); \
@@ -298,7 +298,7 @@ vital_landmark_##S##_set_color( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_color", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     REINTERP_TYPE( vital::rgb_color const, c, c_ptr ); \
     l_ptr->set_color( *c_ptr ); \
   ); \
@@ -314,7 +314,7 @@ vital_landmark_##S##_set_observations( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_observations", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ); \
+                      l_ptr ){} \
     l_ptr->set_observations( observations ); \
   ); \
 }

--- a/vital/bindings/c/types/landmark.cxx
+++ b/vital/bindings/c/types/landmark.cxx
@@ -235,7 +235,12 @@ vital_landmark_##S##_set_loc( vital_landmark_t *l, \
     REINTERP_TYPE( matrix_t const, loc, loc_ptr ); \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     l_ptr->set_loc( *loc_ptr ); \
   ); \
 } \
@@ -249,7 +254,12 @@ vital_landmark_##S##_set_scale( vital_landmark_t *l, T scale, \
     "vital_landmark_" #S "_set_scale", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     l_ptr->set_scale( scale );\
   ); \
 } \
@@ -265,7 +275,12 @@ vital_landmark_##S##_set_normal( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_normal", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     REINTERP_TYPE( matrix_t const, normal, n_ptr ); \
     l_ptr->set_normal( *n_ptr ); \
   ); \
@@ -282,7 +297,12 @@ vital_landmark_##S##_set_covar( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_covar", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     REINTERP_TYPE( covar_t const, covar, covar_ptr ); \
     l_ptr->set_covar( *covar_ptr ); \
   ); \
@@ -298,7 +318,12 @@ vital_landmark_##S##_set_color( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_color", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     REINTERP_TYPE( vital::rgb_color const, c, c_ptr ); \
     l_ptr->set_color( *c_ptr ); \
   ); \
@@ -314,7 +339,12 @@ vital_landmark_##S##_set_observations( vital_landmark_t *l, \
     "vital_landmark_" #S "_set_observations", eh, \
     TRY_DYNAMIC_CAST( vital::landmark_<T>, \
                       vital_c::LANDMARK_SPTR_CACHE.get( l ).get(), \
-                      l_ptr ){} \
+                      l_ptr ) \
+    { \
+      POPULATE_EH( eh, 1, "Failed to dynamic cast to '" #S "' type for data " \
+                          "access method." ); \
+      return; \
+    } \
     l_ptr->set_observations( observations ); \
   ); \
 }

--- a/vital/bindings/c/types/landmark.h
+++ b/vital/bindings/c/types/landmark.h
@@ -198,6 +198,9 @@ vital_landmark_##S##_new_default( vital_error_handle_t *eh ); \
 /**
  * Set 3D location of a landmark instance
  *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
+ *
  * \param l landmark instance
  * \param loc New 3D location for the landmark
  * \param eh Vital error handle instance
@@ -211,6 +214,9 @@ vital_landmark_##S##_set_loc( vital_landmark_t *l, \
 /**
  * Set the scale of the landmark
  *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
+ *
  * \param l landmark instance
  * \param scale New scale of the landmark
  * \param eh Vital error handle instance
@@ -222,6 +228,9 @@ vital_landmark_##S##_set_scale( vital_landmark_t *l, T scale, \
 \
 /**
  * Set the normal vector of the landmark
+ *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
  *
  * \param l landmark instance
  * \param normal New 3D normal vector of the landmark
@@ -236,6 +245,9 @@ vital_landmark_##S##_set_normal( vital_landmark_t *l, \
 /**
  * Set the covariance of the landmark
  *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
+ *
  * \param l landmark instance
  * \param covar New 3D covariance of the landmark
  * \param eh Vital error handle instance
@@ -249,6 +261,9 @@ vital_landmark_##S##_set_covar( vital_landmark_t *l, \
 /**
  * Set the color of the landmark
  *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
+ *
  * \param l landmark instance
  * \param c New color of the landmark
  * \param eh Vital error handle instance
@@ -261,6 +276,9 @@ vital_landmark_##S##_set_color( vital_landmark_t *l, \
 \
 /**
  * Set the observations of the landmark
+ *
+ * This may error if the underlying landmark cannot be dynamic cast to the
+ * requested type (error code 1).
  *
  * \param l landmark instance
  * \param observations New observations value for the landmark

--- a/vital/bindings/python/vital/types/landmark.py
+++ b/vital/bindings/python/vital/types/landmark.py
@@ -37,6 +37,7 @@ import ctypes
 
 import numpy
 
+from vital.exceptions.base import VitalDynamicCastException
 from vital.types import Covariance
 from vital.types import EigenArray
 from vital.types import RGBColor
@@ -150,7 +151,10 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_loc'.format(self._tchar),
             [self.C_TYPE_PTR, EigenArray.c_ptr_type(3, ctype=self._datatype)],
-            [self, new_loc]
+            [self, new_loc],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )
 
     @property
@@ -166,7 +170,10 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_scale'.format(self._tchar),
             [self.C_TYPE_PTR, self._datatype],
-            [self, s]
+            [self, s],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )
 
     @property
@@ -184,7 +191,10 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_normal'.format(self._tchar),
             [self.C_TYPE_PTR, EigenArray.c_ptr_type(3, ctype=self._datatype)],
-            [self, n]
+            [self, n],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )
 
     @property
@@ -209,7 +219,10 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_covar'.format(self._tchar),
             [self.C_TYPE_PTR, expected_covar_type],
-            [self, c]
+            [self, c],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )
 
     @property
@@ -226,7 +239,10 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_color'.format(self._tchar),
             [self.C_TYPE_PTR, RGBColor.c_ptr_type()],
-            [self, c]
+            [self, c],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )
 
     @property
@@ -245,5 +261,8 @@ class Landmark (VitalObject):
         self._call_cfunc(
             'vital_landmark_{}_set_observations'.format(self._tchar),
             [self.C_TYPE_PTR, ctypes.c_uint],
-            [self, o]
+            [self, o],
+            exception_map={
+                1: VitalDynamicCastException
+            }
         )

--- a/vital/bindings/python/vital/util/error_handle.py
+++ b/vital/bindings/python/vital/util/error_handle.py
@@ -100,8 +100,9 @@ class VitalErrorHandle (VitalObject):
         Extend the current return code to exception mapping.
 
         :param ec_exception_map: Dictionary mapping integer return code to an
-            exception, or function returning an exception instance, that should
-            be raised.
+            exception type, or function returning an exception instance, that
+            should be raised. If a function is provided it should accept one
+            positional argument that is the string message of the exception.
         :type ec_exception_map: dict[int, BaseException | types.FunctionType]
 
         """


### PR DESCRIPTION
These macros expand to something like

    if(var == NULL);

Visual Studio doesn't like conditionals followed by a ';' so
this commit uses '{}' instead.  While this works, it does not seem
to be using the macro as intended, a better fix would actually
do something in the '{}', like throw an exception.