### PR TITLE
Fix python tests

### DIFF
--- a/vital/bindings/c/algorithm.h
+++ b/vital/bindings/c/algorithm.h
@@ -162,7 +162,7 @@ vital_algorithm_check_impl_configuration( vital_algorithm_t *algo,
   VITAL_C_EXPORT                                                                \
   void                                                                          \
   vital_algorithm_##type##_set_type_config( char const *name,                   \
-                                            vital_config_block_t const *cb,           \
+                                            vital_config_block_t const *cb,     \
                                             vital_algorithm_t **algo,           \
                                             vital_error_handle_t *eh );         \
                                                                                 \
@@ -171,23 +171,7 @@ vital_algorithm_check_impl_configuration( vital_algorithm_t *algo,
   bool                                                                          \
   vital_algorithm_##type##_check_type_config( char const *name,                 \
                                               vital_config_block_t const *cb,   \
-                                              vital_error_handle_t *eh );       \
-                                                                                \
-  /* ==================================================================== */    \
-  /* Functions on algorithm instances                                     */    \
-  /*                                                                      */    \
-  /* These will error if the incorrect algorithm pointer was given.       */    \
-  /* -------------------------------------------------------------------- */    \
-                                                                                \
-  /* Clone the given algorithm instance */                                      \
-  /**
-   * If a NULL algorithm pointer is given, a null pointer is returned.
-   */                                                                           \
-  VITAL_C_EXPORT                                                                \
-  vital_algorithm_t*                                                            \
-  vital_algorithm_##type##_clone( vital_algorithm_t const *algo,                \
-                                  vital_error_handle_t *eh );
-  // TODO: description() method
+                                              vital_error_handle_t *eh );
 
 
 #ifdef __cplusplus

--- a/vital/bindings/c/helpers/algorithm.h
+++ b/vital/bindings/c/helpers/algorithm.h
@@ -194,7 +194,7 @@ public:
   /** Check the configuration with respect to this algorithm type */    \
   bool                                                                  \
   vital_algorithm_##type##_check_type_config( char const *name,         \
-                                              vital_config_block_t *cb, \
+                                              vital_config_block_t const *cb, \
                                               vital_error_handle_t *eh ) \
   {                                                                     \
     STANDARD_CATCH(                                                     \

--- a/vital/bindings/python/requirements.txt
+++ b/vital/bindings/python/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.13.0
+pillow==4.0.0
+
+# For Testing
+nose==1.3.7
+coverage==4.4.1

--- a/vital/bindings/python/vital/algo/algorithm.py
+++ b/vital/bindings/python/vital/algo/algorithm.py
@@ -205,22 +205,6 @@ class VitalAlgorithm (VitalObject):
         else:
             return None
 
-    def clone(self, new_name=None):
-        """
-        :param new_name: An optional new instance name for the cloned algorithm
-        :type new_name: str
-
-        :return: A new copy of this algorithm
-        :rtype: VitalAlgorithm
-        """
-        clone_cptr = self._call_cfunc(
-            'vital_algorithm_%s_clone' % self.type_name(),
-            [self.C_TYPE_PTR], [self],
-            self.C_TYPE_PTR
-        )
-        return self.__class__(name=(new_name or self.name),
-                              from_cptr=clone_cptr)
-
     def get_config(self, cb=None):
         """
         Return this algorithm's current configuration.

--- a/vital/bindings/python/vital/tests/test_algo_convert_image.py
+++ b/vital/bindings/python/vital/tests/test_algo_convert_image.py
@@ -37,10 +37,7 @@ Tests for vital::algo::convert_image and general algorithm tests
 
 import ctypes
 
-from vital import (
-    apm,
-    config_block,
-)
+from vital import ConfigBlock
 from vital.algo import ConvertImage
 from vital.exceptions.base import VitalNullPointerException
 
@@ -112,22 +109,6 @@ class TestVitalAlgoConvertImage (object):
         ci_empty = ConvertImage('ci')
         nt.assert_is_none(ci_empty.impl_name())
 
-    def test_clone_empty(self):
-        ci_empty = ConvertImage('ci')
-        ci_empty2 = ci_empty.clone()
-        nt.assert_false(ci_empty)
-        nt.assert_false(ci_empty2)
-
-    def test_clone(self):
-        # inst_ptr will be null for both
-        ci1 = ConvertImage('ci')
-        ci2 = ci1.clone()
-        nt.assert_false(ci1)
-        nt.assert_false(ci2)
-        nt.assert_not_equal(ci1.c_pointer, ci2.c_pointer)
-        # They should both be null
-        nt.assert_equal(mem_address(ci1.c_pointer), mem_address(ci2.c_pointer))
-
     def test_get_conf(self):
         ci = ConvertImage('ci')
         c = ci.get_config()
@@ -142,7 +123,7 @@ class TestVitalAlgoConvertImage (object):
 
     def test_check_conf(self):
         ci = ConvertImage('ci')
-        c = config_block()
+        c = ConfigBlock()
         nt.assert_false(ci.check_config(c))
 
         c.set_value('ci:type', '')

--- a/vital/bindings/python/vital/tests/test_config_block.py
+++ b/vital/bindings/python/vital/tests/test_config_block.py
@@ -36,41 +36,41 @@ Tests for the Python interface to VITAL class config_block.
 import nose.tools
 import os
 
-from vital import config_block
+from vital import ConfigBlock
 from vital.exceptions.config_block import *
 from vital.exceptions.config_block_io import *
 from vital.tests import TEST_DATA_DIR
 
 
 # noinspection PyMethodMayBeStatic
-class TestVitalconfig_block (object):
+class TestVitalConfigBlock (object):
     """
     Python version of test_config_block.cxx
     """
 
     def test_block_set_size(self):
-        nose.tools.assert_equal(len(config_block.BLOCK_SEP), 1)
+        nose.tools.assert_equal(len(ConfigBlock.BLOCK_SEP), 1)
 
     def test_construction(self):
-        cb1 = config_block()
+        cb1 = ConfigBlock()
         nose.tools.assert_true(cb1._inst_ptr, "Received null pointer from "
-                                              "config_block construction")
-        cb2 = config_block("A Name")
+                                              "ConfigBlock construction")
+        cb2 = ConfigBlock("A Name")
         nose.tools.assert_true(cb2._inst_ptr, "Received a null pointer "
-                                              "from named config_block "
+                                              "from named ConfigBlock "
                                               "construction.")
 
     def test_name_access(self):
-        cb = config_block()
+        cb = ConfigBlock()
         nose.tools.assert_equal(cb.name, "",
                                 "Default constructor should have an empty "
                                 "string name.")
-        cb = config_block("FooBar")
+        cb = ConfigBlock("FooBar")
         nose.tools.assert_equal(cb.name, "FooBar",
                                 "Named constructor didn't seem to retain name")
 
     def test_set_value(self):
-        cb = config_block()
+        cb = ConfigBlock()
         # Basic value string
         cb.set_value('foo', 'bar')
         # Should attempt casting non-string to string
@@ -79,7 +79,7 @@ class TestVitalconfig_block (object):
         cb.set_value('baz', 'a', "This is a description")
 
     def test_has_value(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         cb.set_value('foo', 'bar')
         cb.set_value('bar', 124789)
@@ -93,7 +93,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_false(cb.has_value('not a value'))
 
     def test_get_value(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         cb.set_value('a', 'b')
         cb.set_value('longer_value:foo', "BarBazThing")
@@ -103,7 +103,7 @@ class TestVitalconfig_block (object):
                                 'BarBazThing')
 
     def test_get_value_bool(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         cb.set_value('a', 'true')
         nose.tools.assert_true(cb.get_value_bool('a'))
@@ -118,10 +118,10 @@ class TestVitalconfig_block (object):
         nose.tools.assert_false(cb.get_value_bool('b'))
 
     def test_get_value_bool_default(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         nose.tools.assert_raises(
-            Vitalconfig_blockNoSuchValueException,
+            VitalConfigBlockNoSuchValueException,
             cb.get_value_bool, 'not-a-key'
         )
 
@@ -133,33 +133,33 @@ class TestVitalconfig_block (object):
         )
 
     def test_get_value_nested(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         k1 = 'a'
         k2 = 'b'
         v = 'c'
 
-        cb.set_value(k1 + config_block.BLOCK_SEP + k2, v)
-        nose.tools.assert_equal(cb.get_value(k1 + config_block.BLOCK_SEP + k2),
+        cb.set_value(k1 + ConfigBlock.BLOCK_SEP + k2, v)
+        nose.tools.assert_equal(cb.get_value(k1 + ConfigBlock.BLOCK_SEP + k2),
                                 v)
 
         sb = cb.subblock(k1)
         nose.tools.assert_equal(sb.get_value(k2), v)
 
     def test_get_value_no_exist(self):
-        cb = config_block()
+        cb = ConfigBlock()
         k1 = 'a'
         k2 = 'b'
         v2 = '2'
 
         nose.tools.assert_raises(
-            Vitalconfig_blockNoSuchValueException,
+            VitalConfigBlockNoSuchValueException,
             cb.get_value, k1
         )
         nose.tools.assert_equal(cb.get_value(k2, v2), v2)
 
     def test_unset_value(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         cb.set_value('a', '1')
         cb.set_value('b', '2')
@@ -168,7 +168,7 @@ class TestVitalconfig_block (object):
 
         nose.tools.assert_false(cb.has_value('a'))
         nose.tools.assert_raises(
-            Vitalconfig_blockNoSuchValueException,
+            VitalConfigBlockNoSuchValueException,
             cb.get_value, 'a'
         )
 
@@ -176,7 +176,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_true(cb.has_value('b'))
 
     def test_available_keys(self):
-        cb = config_block()
+        cb = ConfigBlock()
         cb.set_value("foo", 1)
         cb.set_value('bar', 'baz')
         r = cb.available_keys()
@@ -185,31 +185,31 @@ class TestVitalconfig_block (object):
                                     "Returned key list was incorrect.")
 
     def test_read_only(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         cb.set_value('a', '1')
         cb.mark_read_only('a')
         nose.tools.assert_equal(cb.get_value('a'), '1')
 
         nose.tools.assert_raises(
-            Vitalconfig_blockReadOnlyException,
+            VitalConfigBlockReadOnlyException,
             cb.set_value, 'a', '2'
         )
         nose.tools.assert_equal(cb.get_value('a'), '1')
 
     def test_read_only_unset(self):
-        cb = config_block()
+        cb = ConfigBlock()
         cb.set_value('a', '1')
         cb.mark_read_only('a')
         nose.tools.assert_raises(
-            Vitalconfig_blockReadOnlyException,
+            VitalConfigBlockReadOnlyException,
             cb.unset_value, 'a'
         )
         nose.tools.assert_true(cb.has_value('a'))
         nose.tools.assert_equal(cb.get_value('a'), '1')
 
     def test_subblock(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         block_name = 'block'
         other_name = 'other_block'
@@ -220,9 +220,9 @@ class TestVitalconfig_block (object):
         vb = 'vb'
         vc = 'vc'
 
-        cb.set_value(block_name + config_block.BLOCK_SEP + ka, va)
-        cb.set_value(block_name + config_block.BLOCK_SEP + kb, vb)
-        cb.set_value(other_name + config_block.BLOCK_SEP + kc, vc)
+        cb.set_value(block_name + ConfigBlock.BLOCK_SEP + ka, va)
+        cb.set_value(block_name + ConfigBlock.BLOCK_SEP + kb, vb)
+        cb.set_value(other_name + ConfigBlock.BLOCK_SEP + kc, vc)
 
         sb = cb.subblock(block_name)
 
@@ -233,19 +233,19 @@ class TestVitalconfig_block (object):
         nose.tools.assert_false(sb.has_value(kc))
 
     def test_subblock_nested(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         block_name = 'block'
         other_name = 'other'
-        nestd_name = block_name + config_block.BLOCK_SEP + other_name
+        nestd_name = block_name + ConfigBlock.BLOCK_SEP + other_name
 
         ka = 'ka'
         kb = 'kb'
         va = 'va'
         vb = 'vb'
 
-        cb.set_value(nestd_name + config_block.BLOCK_SEP + ka, va)
-        cb.set_value(nestd_name + config_block.BLOCK_SEP + kb, vb)
+        cb.set_value(nestd_name + ConfigBlock.BLOCK_SEP + ka, va)
+        cb.set_value(nestd_name + ConfigBlock.BLOCK_SEP + kb, vb)
 
         sb = cb.subblock(nestd_name)
 
@@ -255,7 +255,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(sb.get_value(kb), vb)
 
     def test_subblock_match(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         b_name = 'block'
         va = 'va'
@@ -266,7 +266,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(len(keys), 0)
 
     def test_subblock_prefix_match(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         b_name = 'block'
         ka = 'ka'
@@ -279,7 +279,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(len(keys), 0)
 
     def test_subblock_view(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         b_name = 'block'
         o_name = 'other_block'
@@ -290,32 +290,32 @@ class TestVitalconfig_block (object):
         vb = 'vb'
         vc = 'vc'
 
-        cb.set_value(b_name + config_block.BLOCK_SEP + ka, va)
-        cb.set_value(b_name + config_block.BLOCK_SEP + kb, vb)
-        cb.set_value(o_name + config_block.BLOCK_SEP + kc, vc)
+        cb.set_value(b_name + ConfigBlock.BLOCK_SEP + ka, va)
+        cb.set_value(b_name + ConfigBlock.BLOCK_SEP + kb, vb)
+        cb.set_value(o_name + ConfigBlock.BLOCK_SEP + kc, vc)
         sb = cb.subblock_view(b_name)
 
         nose.tools.assert_true(sb.has_value(ka))
         nose.tools.assert_false(sb.has_value(kc))
 
-        cb.set_value(b_name + config_block.BLOCK_SEP + ka, vb)
+        cb.set_value(b_name + ConfigBlock.BLOCK_SEP + ka, vb)
         nose.tools.assert_equal(sb.get_value(ka), vb)
         sb.set_value(ka, va)
-        nose.tools.assert_equal(cb.get_value(b_name + config_block.BLOCK_SEP + ka), va)
+        nose.tools.assert_equal(cb.get_value(b_name + ConfigBlock.BLOCK_SEP + ka), va)
 
         sb.unset_value(kb)
-        nose.tools.assert_false(cb.has_value(b_name + config_block.BLOCK_SEP + kb))
+        nose.tools.assert_false(cb.has_value(b_name + ConfigBlock.BLOCK_SEP + kb))
 
-        cb.set_value(b_name + config_block.BLOCK_SEP + kc, vc)
+        cb.set_value(b_name + ConfigBlock.BLOCK_SEP + kc, vc)
         sb_keys = sb.available_keys()
         nose.tools.assert_set_equal(set(sb_keys), {ka, kc})
 
     def test_subblock_view_nested(self):
-        cb = config_block()
+        cb = ConfigBlock()
 
         b_name = 'block'
         o_name = 'other_block'
-        n_name = b_name + config_block.BLOCK_SEP + o_name
+        n_name = b_name + ConfigBlock.BLOCK_SEP + o_name
         ka = 'ka'
         kb = 'kb'
         kc = 'kc'
@@ -323,28 +323,28 @@ class TestVitalconfig_block (object):
         vb = 'vb'
         vc = 'vc'
 
-        cb.set_value(n_name + config_block.BLOCK_SEP + ka, va)
-        cb.set_value(n_name + config_block.BLOCK_SEP + kb, vb)
-        cb.set_value(o_name + config_block.BLOCK_SEP + kc, vc)
+        cb.set_value(n_name + ConfigBlock.BLOCK_SEP + ka, va)
+        cb.set_value(n_name + ConfigBlock.BLOCK_SEP + kb, vb)
+        cb.set_value(o_name + ConfigBlock.BLOCK_SEP + kc, vc)
         sb = cb.subblock_view(n_name)
 
         nose.tools.assert_true(sb.has_value(ka))
         nose.tools.assert_false(sb.has_value(kc))
 
-        cb.set_value(n_name + config_block.BLOCK_SEP + ka, vb)
+        cb.set_value(n_name + ConfigBlock.BLOCK_SEP + ka, vb)
         nose.tools.assert_equal(sb.get_value(ka), vb)
         sb.set_value(ka, va)
-        nose.tools.assert_equal(cb.get_value(n_name + config_block.BLOCK_SEP + ka), va)
+        nose.tools.assert_equal(cb.get_value(n_name + ConfigBlock.BLOCK_SEP + ka), va)
 
         sb.unset_value(kb)
-        nose.tools.assert_false(cb.has_value(n_name + config_block.BLOCK_SEP + kb))
+        nose.tools.assert_false(cb.has_value(n_name + ConfigBlock.BLOCK_SEP + kb))
 
-        cb.set_value(n_name + config_block.BLOCK_SEP + kc, vc)
+        cb.set_value(n_name + ConfigBlock.BLOCK_SEP + kc, vc)
         sb_keys = sb.available_keys()
         nose.tools.assert_set_equal(set(sb_keys), {ka, kc})
 
     def test_subblock_view_match(self):
-        cb = config_block()
+        cb = ConfigBlock()
         bname = 'block'
         va = 'va'
         cb.set_value(bname, va)
@@ -353,7 +353,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(len(keys), 0)
 
     def test_subblock_view_prefix_match(self):
-        cb = config_block()
+        cb = ConfigBlock()
         bname = 'block'
         ka = 'ka'
         va = 'va'
@@ -364,8 +364,8 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(len(keys), 0)
 
     def test_merge_config(self):
-        cb1 = config_block()
-        cb2 = config_block()
+        cb1 = ConfigBlock()
+        cb2 = ConfigBlock()
         ka = 'ka'
         kb = 'kb'
         kc = 'kc'
@@ -385,7 +385,7 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(cb1.get_value(kc), vc)
 
     def test_set_value_description(self):
-        cb = config_block()
+        cb = ConfigBlock()
         bname = 'sub'
         ka = 'ka'
         kb = 'kb'
@@ -397,7 +397,7 @@ class TestVitalconfig_block (object):
         db = 'db'
 
         cb.set_value(ka, va, da)
-        cb.set_value(bname + config_block.BLOCK_SEP + kb, vb, db)
+        cb.set_value(bname + ConfigBlock.BLOCK_SEP + kb, vb, db)
         cb.set_value(kc, vc)
         sb = cb.subblock('sub')
 
@@ -406,12 +406,12 @@ class TestVitalconfig_block (object):
         nose.tools.assert_equal(cb.get_description(kc), "")
 
     def test_read_no_file(self):
-        nose.tools.assert_raises(Vitalconfig_blockIoFileNotFoundException,
-                                 config_block.from_file,
+        nose.tools.assert_raises(VitalConfigBlockIoFileNotFoundException,
+                                 ConfigBlock.from_file,
                                  'not-a-file.foobar')
 
     def test_read_valid_file(self):
-        c = config_block.from_file(os.path.join(TEST_DATA_DIR,
+        c = ConfigBlock.from_file(os.path.join(TEST_DATA_DIR,
                                                'test_config-valid_file.txt'))
 
         nose.tools.assert_equal(len(c.available_keys()), 25)
@@ -444,9 +444,9 @@ class TestVitalconfig_block (object):
                                 os.path.join(TEST_DATA_DIR, 'inputs.txt'))
 
     def test_write_fail(self):
-        cb = config_block()
+        cb = ConfigBlock()
         cb.set_value('foo', 'bar')
 
-        nose.tools.assert_raises(Vitalconfig_blockIoException,
+        nose.tools.assert_raises(VitalConfigBlockIoException,
                                  cb.write,
                                  '/not/valid')

--- a/vital/bindings/python/vital/tests/test_find_vital_library.py
+++ b/vital/bindings/python/vital/tests/test_find_vital_library.py
@@ -57,7 +57,7 @@ if sys.platform == 'linux2':
 
             # c library should exist since on a linux system
             self.lib_re = re.compile(
-                fvl.__LIBRARY_NAME_RE_BASE__ % "c"
+                fvl.__LIBRARY_FILE_RE_BASE__ % "c"
             )
 
         def tearDown(self):
@@ -81,7 +81,7 @@ if sys.platform == 'linux2':
 
             # Library name that should not exist
             r = re.compile(
-                fvl.__LIBRARY_NAME_RE_BASE__
+                fvl.__LIBRARY_FILE_RE_BASE__
                 % "not_actually_a_library_probably.6"
             )
             p = fvl._search_up_directory("/usr/local", r)

--- a/vital/bindings/python/vital/tests/test_image.py
+++ b/vital/bindings/python/vital/tests/test_image.py
@@ -99,7 +99,6 @@ class TestVitalImage (object):
         val2 = img[0,0,0]
         nose.tools.assert_equal(val1, val2)
 
-
     def test_pil_L(self):
         # test uint8 image
         img = Image(720, 480)

--- a/vital/bindings/python/vital/tests/test_rotation.py
+++ b/vital/bindings/python/vital/tests/test_rotation.py
@@ -44,7 +44,7 @@ from vital.types import Rotation
 
 
 def array_normalize(a, dtype=None):
-    a = numpy.asarray(a, None)
+    a = numpy.asarray(a, dtype)
     return a / numpy.linalg.norm(a)
 
 

--- a/vital/bindings/python/vital/tests/test_rotation.py
+++ b/vital/bindings/python/vital/tests/test_rotation.py
@@ -43,6 +43,11 @@ import numpy
 from vital.types import Rotation
 
 
+def array_normalize(a, dtype=None):
+    a = numpy.asarray(a, None)
+    return a / numpy.linalg.norm(a)
+
+
 class TestVitalRotation (unittest.TestCase):
 
     def test_new_default(self):
@@ -69,15 +74,14 @@ class TestVitalRotation (unittest.TestCase):
         r2 = Rotation(ctypes.c_float)
         # r2 should get converted into a double instance for checking
         nose.tools.assert_equal(r1, r2)
-        
+
         r1 = Rotation.from_quaternion([1,2,3,4], ctype=ctypes.c_double)
         r2 = Rotation.from_quaternion([1,2,3,4], ctype=ctypes.c_double)
         nose.tools.assert_equal(r1, r2)
-        
+
         r1 = Rotation.from_quaternion([1,2,3,4], ctype=ctypes.c_double)
         r2 = Rotation.from_quaternion([-1,-2,-3,-4], ctype=ctypes.c_double)
         assert r1.angle_from(r2) < 1e-12
-        
 
     def test_to_matrix(self):
         # Default value should be identity
@@ -156,13 +160,13 @@ class TestVitalRotation (unittest.TestCase):
         )
 
     def test_from_quaternion(self):
-        q_list = [[+2],
-                  [-1],
-                  [-3],
-                  [+0]]
-        r = Rotation.from_quaternion(q_list)
+        q = array_normalize([[+2],
+                             [-1],
+                             [-3],
+                             [+0]], float)
+        r = Rotation.from_quaternion(q)
         numpy.testing.assert_equal(
-            r.quaternion(), q_list
+            r.quaternion(), q
         )
 
     def test_from_rodrigues(self):
@@ -179,7 +183,7 @@ class TestVitalRotation (unittest.TestCase):
         rod2 = numpy.array([[  2],
                             [ -1],
                             [0.5]])
-        nod2_normed = rod2 / numpy.linalg.norm(rod2)
+        nod2_normed = array_normalize(rod2)
         print 'r2 2-norm:', numpy.linalg.norm(rod2)
         print 'r2-normed:', nod2_normed
 
@@ -195,7 +199,7 @@ class TestVitalRotation (unittest.TestCase):
         axis = numpy.array([[-3],
                             [2],
                             [1]])
-        axis_norm = axis / numpy.linalg.norm(axis)
+        axis_norm = array_normalize(axis)
 
         r = Rotation.from_axis_angle(axis, angle)
         nose.tools.assert_equal(angle, r.angle())
@@ -273,7 +277,7 @@ class TestVitalRotation (unittest.TestCase):
                                           [+0]])
         mat = pre_r.matrix()
         r = Rotation.from_matrix(mat)
-        numpy.testing.assert_equal(mat, r.matrix())
+        numpy.testing.assert_allclose(mat, r.matrix(), 1e-15)
 
     def test_inverse(self):
         # quaternion calc from:
@@ -283,12 +287,14 @@ class TestVitalRotation (unittest.TestCase):
                                       [-3],
                                       [+0]], ctype=ctypes.c_double)
         r_inv = r.inverse()
-        numpy.testing.assert_equal(
+        e_inv = array_normalize([[-1/7.],
+                                 [+1/14.],
+                                 [+3/14.],
+                                 [0]])
+        numpy.testing.assert_allclose(
             r_inv.quaternion(),
-            [[-1/7.],
-             [+1/14.],
-             [+3/14.],
-             [0]]
+            e_inv,
+            1e-15
         )
 
         r = Rotation.from_quaternion([[+2],
@@ -296,19 +302,19 @@ class TestVitalRotation (unittest.TestCase):
                                       [-3],
                                       [+0]], ctype=ctypes.c_float)
         r_inv = r.inverse()
-        numpy.testing.assert_equal(
+        numpy.testing.assert_allclose(
             r_inv.quaternion(),
-            [[numpy.float32(-1/7.)],
-             [numpy.float32(+1/14.)],
-             [numpy.float32(+3/14.)],
-             [0]]
+            e_inv,
+            1e-7
         )
 
     def test_compose(self):
-        expected_quat = [[+2],
-                         [-1],
-                         [-3],
-                         [+0]]
+        # Normalize quaternaion vector.
+        expected_quat = array_normalize([[+2.],
+                                         [-1.],
+                                         [-3.],
+                                         [+0.]])
+
         r_ident_d = Rotation(ctypes.c_double)
         r_ident_f = Rotation(ctypes.c_float)
         r_other_d = Rotation.from_quaternion(expected_quat, ctypes.c_double)
@@ -322,7 +328,8 @@ class TestVitalRotation (unittest.TestCase):
         r_res_f = r_ident_f.compose(r_other_f)
         nose.tools.assert_is_not(r_other_f, r_res_f)
         numpy.testing.assert_equal(r_res_f, r_other_f)
-        numpy.testing.assert_equal(r_res_f.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_f.quaternion(), expected_quat,
+                                      1e-7)
 
         # Should also work with multiply operator
         r_res_d = r_ident_d * r_other_d
@@ -333,32 +340,42 @@ class TestVitalRotation (unittest.TestCase):
         r_res_f = r_ident_f * r_other_f
         nose.tools.assert_is_not(r_other_f, r_res_f)
         numpy.testing.assert_equal(r_res_f, r_other_f)
-        numpy.testing.assert_equal(r_res_f.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_f.quaternion(), expected_quat,
+                                      1e-7)
 
         # Rotation of non-congruent types should be converted automatically
         r_res_d = r_ident_d.compose(r_other_f)
         nose.tools.assert_is_not(r_res_d, r_other_f)
-        numpy.testing.assert_equal(r_res_d.quaternion(),
-                                   r_other_f.quaternion())
-        numpy.testing.assert_equal(r_res_d.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_d.quaternion(),
+                                      r_other_f.quaternion(),
+                                      1e-7)
+        numpy.testing.assert_allclose(r_res_d.quaternion(), expected_quat,
+                                      1e-7)
 
         r_res_f = r_ident_f.compose(r_other_d)
         nose.tools.assert_is_not(r_res_f, r_other_f)
-        numpy.testing.assert_equal(r_res_f.quaternion(),
-                                   r_other_f.quaternion())
-        numpy.testing.assert_equal(r_res_f.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_f.quaternion(),
+                                      r_other_f.quaternion(),
+                                      1e-7)
+        numpy.testing.assert_allclose(r_res_f.quaternion(), expected_quat,
+                                      1e-7)
 
+        # Equality check between types should pass due to integrety resolution
+        # inside function.
         r_res_d = r_ident_d * r_other_f
         nose.tools.assert_is_not(r_res_d, r_other_f)
-        numpy.testing.assert_equal(r_res_d.quaternion(),
-                                   r_other_f.quaternion())
-        numpy.testing.assert_equal(r_res_d.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_d.quaternion(),
+                                      r_other_f.quaternion(),
+                                      1e-7)
+        numpy.testing.assert_allclose(r_res_d.quaternion(), expected_quat,
+                                      1e-7)
 
         r_res_f = r_ident_f * r_other_d
         nose.tools.assert_is_not(r_res_f, r_other_f)
         numpy.testing.assert_equal(r_res_f.quaternion(),
                                    r_other_f.quaternion())
-        numpy.testing.assert_equal(r_res_f.quaternion(), expected_quat)
+        numpy.testing.assert_allclose(r_res_f.quaternion(), expected_quat,
+                                      1e-7)
 
     def test_rotation_vector(self):
         vec = [[1],

--- a/vital/bindings/python/vital/types/__init__.py
+++ b/vital/bindings/python/vital/types/__init__.py
@@ -50,17 +50,17 @@ from .image_container import ImageContainer
 from .rotation import Rotation
 
 # Requires EigenArray
-#from .homography import Homography
+from .homography import Homography
 
 # Requires EigenArray and RGBColor
 from .feature import Feature
 
 # Requires EigenArray and Rotation
-#from .similarity import Similarity
+from .similarity import Similarity
 
 # Requires Covariance
-#from .landmark import Landmark
-#from .landmark_map import LandmarkMap
+from .landmark import Landmark
+from .landmark_map import LandmarkMap
 
 # Requires Descriptor, Feature
 from .track import TrackState, Track

--- a/vital/bindings/python/vital/types/image.py
+++ b/vital/bindings/python/vital/types/image.py
@@ -41,13 +41,47 @@ from vital.util import VitalObject
 
 
 def _pil_image_to_bytes(p_img):
-    # In recent version of PIL, the tobytes function is the correct thing to
-    # call, but some older versions of PIL do not have this function.
+    """
+    Get the component bytes from the given PIL Image.
+
+    In recent version of PIL, the tobytes function is the correct thing to
+    call, but some older versions of PIL do not have this function.
+
+    :param p_img: PIL Image to get the bytes from.
+    :type p_img: PIL.Image.Image
+
+    :returns: Byte string.
+    :rtype: bytes
+
+    """
     if hasattr(p_img, 'tobytes'):
         return p_img.tobytes()
     else:
         # Older version of the function.
         return p_img.tostring()
+
+
+def _pil_image_from_bytes(mode, size, data, decoder_name='raw', *args):
+    """
+    Creates a copy of an image memory from pixel data in a buffer.
+
+    In recent versionf of PIL, the frombytes function is the correct thing to
+    call, but older version fo PIL only have a fromstring, which is equivalent
+    in function.
+
+    :param mode: The image mode. See: :ref:`concept-modes`.
+    :param size: The image size.
+    :param data: A byte buffer containing raw data for the given mode.
+    :param decoder_name: What decoder to use.
+    :param args: Additional parameters for the given decoder.
+    :returns: An :py:class:`~PIL.Image.Image` object.
+
+    """
+    import PIL.Image
+    if hasattr(PIL.Image, 'frombytes'):
+        return PIL.Image.frombytes(mode, size, data, decoder_name, *args)
+    else:
+        return PIL.Image.fromstring(mode, size, data, decoder_name, *args)
 
 
 class Image (VitalObject):
@@ -361,8 +395,6 @@ class Image (VitalObject):
         :return: array containing image
         :rtype: pil image
         """
-        import PIL.Image as PIM
-
         def pil_mode_from_image(img):
             """
             Determine image format from pixel properties
@@ -410,9 +442,9 @@ class Image (VitalObject):
         pixels.restype = ctypes.py_object
         img_pixels = pixels( img_first_byte, size )
 
-        return PIM.frombytes(mode, (img.width(), img.height()), img_pixels,
-                             "raw", mode,
-                             img.h_step() * img.pixel_num_bytes(), 1)
+        return _pil_image_from_bytes(mode, (img.width(), img.height()),
+                                     img_pixels, "raw", mode,
+                                     img.h_step() * img.pixel_num_bytes(), 1)
 
     # ------------------------------------------------------------------
     # return image as a numpy array

--- a/vital/bindings/python/vital/types/image.py
+++ b/vital/bindings/python/vital/types/image.py
@@ -70,12 +70,23 @@ class Image (VitalObject):
     @classmethod
     def from_pil(cls, pil_image):
         """
-        Construct Image from supplied PIL image object
+        Construct Image from supplied PIL image object.
+
+        :param pil_image: PIL image object
+        :type pil_image: PIL.Image.Image
+
+        :raises RuntimeError: If the PIL Image provided is not in a recognized
+            mode.
+
+        :returns: New Image instance using the given image's pixels.
+        :rtype: Image
+
         """
 
         (img_width, img_height) = pil_image.size
         mode = pil_image.mode
 
+        # TODO(paul.tunison): Extract this logic out into a utility function.
         if mode == "1":  # boolean
             img_depth = 1
             img_w_step = 1
@@ -128,7 +139,7 @@ class Image (VitalObject):
                             ctypes.c_int32, ctypes.c_size_t]
         img_new.restype = cls.C_TYPE_PTR
 
-        img_data = pil_image.tostring()
+        img_data = pil_image.tobytes()
         # this constructor create a wrapper around img_data which will be invalid
         # when img_data goes out of scope and is deleted
         vital_img = Image(from_cptr=img_new(img_data,

--- a/vital/bindings/python/vital/types/image.py
+++ b/vital/bindings/python/vital/types/image.py
@@ -329,6 +329,14 @@ class Image (VitalObject):
         img_equal_content.restype = ctypes.c_bool
         return img_equal_content(self, other)
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.equal_content(other)
+        return False
+
+    def __ne__(self, other):
+        # inverse of __eq__ result.
+        return not (self == other)
 
 
     # ------------------------------------------------------------------
@@ -346,7 +354,11 @@ class Image (VitalObject):
         import PIL.Image as PIM
 
         def pil_mode_from_image(img):
-            """ determine image format from pixel properties
+            """
+            Determine image format from pixel properties
+
+            May return None if our current encoding does not map to a PIL image
+            mode.
             """
             if img.pixel_type() == img.PIXEL_UNSIGNED and img.pixel_num_bytes() == 1:
                 if img.depth() == 3 and img.d_step() == 1 and img.w_step() == 3:
@@ -384,13 +396,13 @@ class Image (VitalObject):
             size = (img.h_step() * img.height()) * img.pixel_num_bytes()
         # get buffer from image
         pixels = ctypes.pythonapi.PyBuffer_FromReadWriteMemory
-        pixels.argtypes = [ ctypes.c_void_p, ctypes.c_int ]
+        pixels.argtypes = [ ctypes.c_void_p, ctypes.c_ssize_t ]
         pixels.restype = ctypes.py_object
         img_pixels = pixels( img_first_byte, size )
 
         return PIM.frombytes(mode, (img.width(), img.height()), img_pixels,
-                             "raw", mode, img.h_step() * img.pixel_num_bytes(), 1 )
-
+                             "raw", mode,
+                             img.h_step() * img.pixel_num_bytes(), 1)
 
     # ------------------------------------------------------------------
     # return image as a numpy array

--- a/vital/bindings/python/vital/types/image.py
+++ b/vital/bindings/python/vital/types/image.py
@@ -40,6 +40,16 @@ import numpy
 from vital.util import VitalObject
 
 
+def _pil_image_to_bytes(p_img):
+    # In recent version of PIL, the tobytes function is the correct thing to
+    # call, but some older versions of PIL do not have this function.
+    if hasattr(p_img, 'tobytes'):
+        return p_img.tobytes()
+    else:
+        # Older version of the function.
+        return p_img.tostring()
+
+
 class Image (VitalObject):
     """
     vital::image interface class
@@ -139,7 +149,7 @@ class Image (VitalObject):
                             ctypes.c_int32, ctypes.c_size_t]
         img_new.restype = cls.C_TYPE_PTR
 
-        img_data = pil_image.tobytes()
+        img_data = _pil_image_to_bytes(pil_image)
         # this constructor create a wrapper around img_data which will be invalid
         # when img_data goes out of scope and is deleted
         vital_img = Image(from_cptr=img_new(img_data,

--- a/vital/bindings/python/vital/types/rotation.py
+++ b/vital/bindings/python/vital/types/rotation.py
@@ -82,7 +82,7 @@ class Rotation (VitalObject):
     def from_quaternion(cls, q_vec, ctype=ctypes.c_double):
         """
         Create rotation based on the given 4x1 (column-vector) quaternion
-        representation whose format, `[x, y, z, w]`, represents the 
+        representation whose format, `[x, y, z, w]`, represents the
         `w+xi+yj+zk` formula (see Eigen's `Quaternion` class).
 
         Input data is copied.
@@ -98,7 +98,7 @@ class Rotation (VitalObject):
 
         :raises ValueError: The input array-like data did not conform to the
             specified target shape.
-        
+
         """
         q_vec = EigenArray.from_iterable(q_vec, ctype, (4, 1))
         q_vec /= q_vec.norm()
@@ -230,15 +230,15 @@ class Rotation (VitalObject):
         with VitalErrorHandle() as eh:
             r_ptr = r_from_mat(mat, eh)
         return Rotation(ctype, r_ptr)
-    
+
     @classmethod
     def random(cls, ctype=ctypes.c_double):
         """
         Create a random rotation.
-        
-        Note: this is not uniformly random in S03. Eigen has a UnitRandom 
+
+        Note: this is not uniformly random in S03. Eigen has a UnitRandom
         method for Quaternion.
-        
+
         :param datatype: Type to store data in the homography.
         :type datatype: ctypes._SimpleCData
 
@@ -384,18 +384,18 @@ class Rotation (VitalObject):
     def __eq__(self, other):
         """
         Check whether two rotations are equivalent.
-        
+
         :param other: Rotation to compare this rotation to.
         :type other: vital.types.Rotation
-        
+
         :return: Whether this rotation is equal to other.
         :rtype: bool
-        
-        NOTE: the C++ code called by this method compares the two quaternions 
-        elementwise to determine equality. However, it is possible for two 
+
+        NOTE: the C++ code called by this method compares the two quaternions
+        elementwise to determine equality. However, it is possible for two
         quaternions to have different elements but represent the same rotation.
         """
-        
+
         if isinstance(other, Rotation):
             if self._ctype != other._ctype:
                 # raise ValueError("Cannot test equality of two rotations of "
@@ -505,7 +505,6 @@ class Rotation (VitalObject):
         """
         :return: This rotation as a Rodrigues vector.
         :rtype: vital.types.EigenArray
-        
         """
         r2rod = self._get_c_function(self._spec, "rodrigues")
         r2rod.argtypes = [self.C_TYPE_PTR, VitalErrorHandle.C_TYPE_PTR]
@@ -549,7 +548,7 @@ class Rotation (VitalObject):
         """
         Compose this rotation with another (multiply).
 
-        This rotation is considered the left-hand operand and the given 
+        This rotation is considered the left-hand operand and the given
         rotation is considered the right-hand operand.
 
         Result rotation will have the same data type as this rotation.
@@ -575,7 +574,8 @@ class Rotation (VitalObject):
             self._log.debug("Converting input rotation of type %s into "
                             "compatible type %s",
                             other_rot._ctype, self._ctype)
-            other_rot = Rotation.from_quaternion(other_rot.quaternion(), self._ctype)
+            other_rot = Rotation.from_quaternion(other_rot.quaternion(),
+                                                 self._ctype)
 
         r_compose = self._get_c_function(self._spec, "compose")
         r_compose.argtypes = [self.C_TYPE_PTR, other_rot.C_TYPE_PTR,
@@ -617,13 +617,13 @@ class Rotation (VitalObject):
     def angle_from(self, other):
         """
         Return angle between rotations
-        
+
         :param other: the other rotation to compare this rotation to.
         :type other: vital.types.Rotation
-        
+
         :return: This rotation's angle of rotation (radians).
         :rtype: float
-        
+
         """
         # For some reason, the angle method can return negative values.
         return abs((self.inverse()*other).angle())


### PR DESCRIPTION
Fix VITAL python tests (`./vital/bindings/python/run_tests.sh`) that are failing since the last time they were checked.

Really, these tests need to be run via CTest tests, but that is out of the scope of this particular branch.

There is still one failing python test with the `Image` binding when converting from/to PIL images when the type is boolean (PIL image mode "1"). PIL uses a 1-bit encoding for memory storage where-as kwiver/vital uses 1 **byte** per boolean value. Thus, just extracting the vital Image memory buffer and sticking it into a mode "1" PIL image views incorrect results. Transitively, going back and forth between from-PIL/to-PIL functions compounds the issue.