### PR TITLE
Fixed a Visual Studio linking error.

### DIFF
--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -252,12 +252,6 @@ history_entry( const uint64_t& ts,
 }
 
 
-track_descriptor::history_entry::
-~history_entry()
-{
-}
-
-
 uint64_t
 track_descriptor::history_entry::
 get_timestamp() const

--- a/vital/types/track_descriptor.h
+++ b/vital/types/track_descriptor.h
@@ -85,7 +85,7 @@ public:
     typedef bounding_box< double > world_bbox_t;
 
     /// Constructors
-    ~history_entry();
+    ~history_entry() VITAL_DEFAULT_DTOR
 
     /**
      * Create new object.


### PR DESCRIPTION
Visual Studio was giving a linking error when trying to find the
empty destructor for the track_descriptor::history_entry class.
Its not clear why it was failing, but moving the destructor
definition to the header fixes the error.