### PR TITLE
MSVC gprof check and use the standard sleep 

### DIFF
--- a/sprokit/cmake/support/test.cmake
+++ b/sprokit/cmake/support/test.cmake
@@ -53,7 +53,9 @@ if (VALGRIND_EXECUTABLE)
   _sprokit_declare_tool_group(bbv)
 endif ()
 
-find_program(GPROF_EXECUTABLE gprof)
+if(NOT MSVC)
+  find_program(GPROF_EXECUTABLE gprof)
+endif()
 
 if (GPROF_EXECUTABLE)
   _sprokit_declare_tool_group(gprof)

--- a/sprokit/tests/sprokit/pipeline/test_non_blocking.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_non_blocking.cxx
@@ -44,7 +44,7 @@
 #include <sprokit/pipeline_util/literal_pipeline.h>
 
 #include <sstream>
-#include <unistd.h>
+#include <thread>
 
 
 class SPROKIT_NO_EXPORT test_non_blocking
@@ -155,7 +155,7 @@ IMPLEMENT_TEST(non_blocking)
     if ( (i % 10) == 0 )
     {
       // pause to let pipeline ketchup
-      sleep(1);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     std::cout << "sending set: " << i << "\n";
     ep.send( ds );


### PR DESCRIPTION
Replacing the unistd.h with something more C++ spec compliantCMAKE found a Perl version of gprof on my machine and made the gprof projects, I don't think these should be attempted if using MSVC, it has it's own profiler you can use
Maybe we can turn this on for msvc users in the future if there is really a need