### PR TITLE
Disabled MSVC warnings coming from Boost headers

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
@@ -32,12 +32,15 @@
 
 #include <sprokit/python/util/python_gil.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4267)
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/return_internal_reference.hpp>
 #include <boost/python/str.hpp>
+#pragma warning (pop)
 
 #include <sstream>
 

--- a/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
@@ -31,8 +31,11 @@
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/process_cluster.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4244)
 #include <boost/python/class.hpp>
 #include <boost/python/module.hpp>
+#pragma warning (pop)
 
 /**
  * \file pipeline.cxx

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -37,6 +37,9 @@
 #include <sprokit/python/util/python_wrap_const_shared_ptr.h>
 #include <sprokit/python/util/set_indexing_suite.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4244)
+#pragma warning (disable : 4267)
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/args.hpp>
 #include <boost/python/class.hpp>
@@ -44,6 +47,7 @@
 #include <boost/python/implicit.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/operators.hpp>
+#pragma warning (pop)
 
 /**
  * \file process.cxx

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
@@ -35,12 +35,15 @@
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4244)
 #include <boost/python/args.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/implicit.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/override.hpp>
+#pragma warning (pop)
 
 /**
  * \file process_cluster.cxx

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -45,12 +45,15 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/vital_foreach.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4267)
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/object.hpp>
 #include <boost/python/wrapper.hpp>
 #include <boost/python/def.hpp>
+#pragma warning (pop)
 
 #ifdef WIN32
  // Windows get_pointer const volatile workaround

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
@@ -34,10 +34,13 @@
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 
+#pragma warning (push)
+#pragma warning (disable : 4244)
 #include <boost/python/class.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/override.hpp>
 #include <boost/python/pure_virtual.hpp>
+#pragma warning (pop)
 
 /**
  * \file scheduler.cxx

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -42,7 +42,10 @@
 #include <boost/noncopyable.hpp>
 
 #include <boost/cstdint.hpp>
+#pragma warning (push)
+#pragma warning (disable : 4146)
 #include <boost/rational.hpp>
+#pragma warning (pop)
 
 #include <set>
 #include <string>


### PR DESCRIPTION
Visual Studio triggers several warnings coming from within Boost header
files.  We will not fix these warnings in Boost so this patch disables
the warnings just in the offending Boost headers.