### PR TITLE
Removed missing file from the install list

### DIFF
--- a/CMake/kwiver-install-utils.cmake
+++ b/CMake/kwiver-install-utils.cmake
@@ -18,7 +18,6 @@ install(
         "${utils_dir}/kwiver-configcheck.cmake"
         "${utils_dir}/CommonFindMacros.cmake"
         "${utils_dir}/FindEigen3.cmake"
-        "${utils_dir}/FindLog4cplus.cmake"
         "${utils_dir}/FindLog4cxx.cmake"
         "${utils_dir}/FindPROJ.cmake"
         "${utils_dir}/FindTinyXML.cmake"


### PR DESCRIPTION
Installation was failing to not being able to find FindLog4cplus.cmake
to install, but that file has been removed.