### PR TITLE
Add mechanism for geodetic conversions

### DIFF
--- a/arrows/proj/CMakeLists.txt
+++ b/arrows/proj/CMakeLists.txt
@@ -16,6 +16,7 @@ kwiver_install_headers(
   )
 
 set(proj_sources
+  geo_conv.cxx
   geo_map.cxx
   )
 

--- a/arrows/proj/geo_conv.cxx
+++ b/arrows/proj/geo_conv.cxx
@@ -1,0 +1,116 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief PROJ geo_conversion functor implementation
+ */
+
+#include "geo_conv.h"
+
+#include <proj_api.h>
+
+#include <string>
+
+namespace kwiver {
+namespace arrows {
+namespace proj {
+
+// ----------------------------------------------------------------------------
+geo_conversion
+::~geo_conversion()
+{
+  for ( auto i : m_projections )
+  {
+    pj_free( i.second );
+  }
+}
+
+// ----------------------------------------------------------------------------
+vital::vector_2d geo_conversion
+::operator()( vital::vector_2d const& point, int from, int to )
+{
+  auto const proj_from = projection( from );
+  auto const proj_to = projection( to );
+
+  auto x = point[0];
+  auto y = point[1];
+  auto z = 0.0;
+
+  if ( pj_is_latlong( proj_from ) )
+  {
+    x *= DEG_TO_RAD;
+    y *= DEG_TO_RAD;
+  }
+
+  int err = pj_transform( proj_from, proj_to, 1, 1, &x, &y, &z );
+  if ( err )
+  {
+    auto const msg =
+      std::string{ "PROJ conversion failed: error " } + std::to_string( err );
+    throw std::runtime_error( msg );
+  }
+
+  if ( pj_is_latlong( proj_to ) )
+  {
+    x *= RAD_TO_DEG;
+    y *= RAD_TO_DEG;
+  }
+
+  return { x, y };
+}
+
+// ----------------------------------------------------------------------------
+void* geo_conversion
+::projection( int crs )
+{
+  auto const i = m_projections.find( crs );
+
+  if ( i == m_projections.end() )
+  {
+    auto const crs_str = std::to_string( crs );
+    auto const arg = std::string{ "+init=epsg:" } + crs_str;
+    auto const p = pj_init_plus( arg.c_str() );
+
+    if ( ! p )
+    {
+      auto const msg =
+        "Failed to construct PROJ projection for EPSG:" + crs_str;
+      throw std::runtime_error( msg );
+    }
+
+    m_projections.emplace( crs, p );
+    return p;
+  }
+
+  return i->second;
+}
+
+} } } // end namespace

--- a/arrows/proj/geo_conv.cxx
+++ b/arrows/proj/geo_conv.cxx
@@ -54,6 +54,13 @@ geo_conversion
 }
 
 // ----------------------------------------------------------------------------
+char const* geo_conversion
+::id() const
+{
+  return "proj";
+}
+
+// ----------------------------------------------------------------------------
 vital::vector_2d geo_conversion
 ::operator()( vital::vector_2d const& point, int from, int to )
 {

--- a/arrows/proj/geo_conv.h
+++ b/arrows/proj/geo_conv.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,48 +30,41 @@
 
 /**
  * \file
- * \brief PROJ algorithm registration implementation
+ * \brief PROJ geo_conversion functor interface
  */
 
-#include <arrows/proj/geo_conv.h>
-#include <arrows/proj/geo_map.h>
+#ifndef KWIVER_ARROWS_PROJ_GEO_CONV_H_
+#define KWIVER_ARROWS_PROJ_GEO_CONV_H_
 
-#include <arrows/proj/kwiver_algo_proj_plugin_export.h>
-#include <vital/algo/algorithm_factory.h>
+
+#include <vital/vital_config.h>
+#include <arrows/proj/kwiver_algo_proj_export.h>
+
 #include <vital/types/geodesy.h>
+
+#include <unordered_map>
 
 namespace kwiver {
 namespace arrows {
 namespace proj {
 
-extern "C"
-KWIVER_ALGO_PROJ_PLUGIN_EXPORT
-void
-register_factories( kwiver::vital::plugin_loader& vpm )
+/// PROJ implementation of geo_conversion functor
+class KWIVER_ALGO_PROJ_EXPORT geo_conversion : public vital::geo_conversion
 {
-  static auto const module_name = std::string( "arrows.proj" );
-  if (vpm.is_module_loaded( module_name ) )
-  {
-    return;
-  }
+public:
+  geo_conversion() {}
+  virtual ~geo_conversion();
 
-  // register geo-conversion functor
-  static auto geo_conv = kwiver::arrows::proj::geo_conversion{};
-  vital::set_geo_conv( &geo_conv );
+  /// Conversion operator
+  virtual vital::vector_2d operator()( vital::vector_2d const& point,
+                                       int from, int to ) override;
 
-  // add factory               implementation-name       type-to-create
-  auto fact = vpm.ADD_ALGORITHM( "proj", kwiver::arrows::proj::geo_map );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Map geographic coordinates between UTM and latitude/longitude using PROJ4." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
+private:
+  void* projection( int crs );
 
+  std::unordered_map< int, void* > m_projections;
+};
 
-  vpm.mark_module_as_loaded( module_name );
-}
+} } } // end namespace
 
-} // end namespace proj
-} // end namespace arrows
-} // end namespace kwiver
+#endif // KWIVER_ARROWS_PROJ_GEO_CONV_H_

--- a/arrows/proj/geo_conv.h
+++ b/arrows/proj/geo_conv.h
@@ -55,6 +55,8 @@ public:
   geo_conversion() {}
   virtual ~geo_conversion();
 
+  virtual char const* id() const override;
+
   /// Conversion operator
   virtual vital::vector_2d operator()( vital::vector_2d const& point,
                                        int from, int to ) override;

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -137,6 +137,7 @@ set( vital_public_headers
   types/geo_lat_lon.h
   types/geo_point.h
   types/geo_polygon.h
+  types/geodesy.h
   types/homography.h
   types/homography_f2f.h
   types/homography_f2w.h
@@ -198,6 +199,7 @@ set( vital_sources
   types/geo_lat_lon.cxx
   types/geo_point.cxx
   types/geo_polygon.cxx
+  types/geodesy.cxx
   types/homography.cxx
   types/homography_f2f.cxx
   types/homography_f2w.cxx

--- a/vital/types/geo_point.cxx
+++ b/vital/types/geo_point.cxx
@@ -34,6 +34,7 @@
  */
 
 #include "geo_point.h"
+#include "geodesy.h"
 
 #include <iomanip>
 #include <stdexcept>
@@ -85,8 +86,9 @@ geo_raw_point_t geo_point
   auto const i = m_loc.find( crs );
   if ( i == m_loc.end() )
   {
-    // TODO convert to requested CRS and add to m_loc
-    throw std::runtime_error( "conversion is not implemented" );
+    auto const p = geo_conv( location(), m_original_crs, crs );
+    m_loc.emplace( crs, p );
+    return p;
   }
 
   return i->second;

--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -119,10 +119,6 @@ public:
    */
   bool is_empty() const;
 
-
-  bool operator==( const geo_point& rhs ) const;
-  bool operator!=( const geo_point& rhs ) const;
-
 protected:
 
   int m_original_crs;

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -34,6 +34,7 @@
  */
 
 #include "geo_polygon.h"
+#include "geodesy.h"
 
 #include <stdexcept>
 
@@ -84,8 +85,15 @@ geo_raw_polygon_t geo_polygon
   auto const i = m_poly.find( crs );
   if ( i == m_poly.end() )
   {
-    // TODO convert to requested CRS and add to m_poly
-    throw std::runtime_error( "conversion is not implemented" );
+    auto new_poly = geo_raw_polygon_t{};
+    auto const verts = polygon().get_vertices();
+
+    for ( auto& v : verts )
+    {
+      new_poly.push_back( geo_conv( v, m_original_crs, crs ) );
+    }
+    m_poly.emplace( crs, new_poly );
+    return new_poly;
   }
 
   return i->second;

--- a/vital/types/geo_polygon.h
+++ b/vital/types/geo_polygon.h
@@ -86,10 +86,6 @@ public:
    */
   bool is_empty() const;
 
-
-  bool operator==( const geo_polygon& rhs ) const;
-  bool operator!=( const geo_polygon& rhs ) const;
-
 protected:
 
   int m_original_crs;

--- a/vital/types/geodesy.cxx
+++ b/vital/types/geodesy.cxx
@@ -56,6 +56,13 @@ double fmod( double n, double d )
 } // end namespace
 
 // ----------------------------------------------------------------------------
+geo_conversion*
+get_geo_conv()
+{
+  return s_geo_conv.load();
+}
+
+// ----------------------------------------------------------------------------
 void
 set_geo_conv( geo_conversion* c )
 {

--- a/vital/types/geodesy.cxx
+++ b/vital/types/geodesy.cxx
@@ -1,0 +1,67 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief This file contains the implementation of a geo point.
+ */
+
+#include "geodesy.h"
+
+#include <atomic>
+
+namespace kwiver {
+namespace vital {
+
+namespace {
+  static std::atomic< geo_conversion* > s_geo_conv;
+}
+
+// ----------------------------------------------------------------------------
+void
+set_geo_conv( geo_conversion* c )
+{
+  s_geo_conv.store( c );
+}
+
+// ----------------------------------------------------------------------------
+vector_2d
+geo_conv( vector_2d const& point, int from, int to )
+{
+  auto const c = s_geo_conv.load();
+  if ( !c )
+  {
+    throw std::runtime_error( "No geo-conversion functor is registered" );
+  }
+
+  return ( *c )( point, from, to );
+}
+
+} } // end namespace

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -76,11 +76,15 @@ namespace SRID
 class geo_conversion
 {
 public:
+  virtual char const* id() const = 0;
   virtual vector_2d operator()( vector_2d const& point, int from, int to ) = 0;
 
 protected:
   virtual ~geo_conversion() VITAL_DEFAULT_DTOR
 };
+
+/// Get the functor used for performing geodetic conversions. \see geo_conv
+VITAL_EXPORT geo_conversion* get_geo_conv();
 
 /// Set the functor used for performing geodetic conversions. \see geo_conv
 VITAL_EXPORT void set_geo_conv( geo_conversion* );

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -57,14 +57,19 @@ namespace vital {
  * \see https://en.wikipedia.org/wiki/Spatial_reference_system,
  *      http://www.epsg.org/, https://epsg-registry.org/
  */
-enum class SRID : int
+namespace SRID
 {
-  lat_lon_NAD83 = 4269,
-  lat_lon_WGS84 = 4326,
-  UTM_WGS84_north = 32600, // Add zone number to get zoned SRID
-  UTM_WGS84_south = 32700, // Add zone number to get zoned SRID
-  UTM_NAD83_northeast = 3313, // Add zone number (59N - 60N) to get zoned SRID
-  UTM_NAD83_northwest = 26900, // Add zone number (1N - 23N) to get zoned SRID
+  constexpr int lat_lon_NAD83 = 4269;
+  constexpr int lat_lon_WGS84 = 4326;
+
+  // Add zone number to get zoned SRID
+  constexpr int UTM_WGS84_north = 32600;
+  constexpr int UTM_WGS84_south = 32700;
+
+  // Add zone number to get zoned SRID (59N - 60N)
+  constexpr int UTM_NAD83_northeast = 3313;
+  // Add zone number to get zoned SRID (1N - 23N)
+  constexpr int UTM_NAD83_northwest = 26900;
 };
 
 /// Functor for implementing geodetic conversion.

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -36,6 +36,7 @@
 #ifndef KWIVER_VITAL_GEODESY_H_
 #define KWIVER_VITAL_GEODESY_H_
 
+#include "vector.h"
 #include <vital/vital_config.h>
 #include <vital/vital_export.h>
 
@@ -65,6 +66,37 @@ enum class SRID : int
   UTM_NAD83_northeast = 3313, // Add zone number (59N - 60N) to get zoned SRID
   UTM_NAD83_northwest = 26900, // Add zone number (1N - 23N) to get zoned SRID
 };
+
+/// Functor for implementing geodetic conversion.
+class geo_conversion
+{
+public:
+  virtual vector_2d operator()( vector_2d const& point, int from, int to ) = 0;
+
+protected:
+  virtual ~geo_conversion() VITAL_DEFAULT_DTOR
+};
+
+/// Set the functor used for performing geodetic conversions. \see geo_conv
+VITAL_EXPORT void set_geo_conv( geo_conversion* );
+
+/**
+ * \brief Convert geo-coordinate.
+ *
+ * This converts a raw geo-coordinate from one CRS to another. The numeric CRS
+ * values shall correspond to geodetic CRS's as specified by the European
+ * Petroleum Survey Group (EPSG) Spatial Reference System Identifiers (SRID's).
+ *
+ * Note that the underlying values are ordered easting, northing, for
+ * consistency with Euclidean convention (X, Y), and \em not northing, easting
+ * as is sometimes used for geo-coordinates.
+ *
+ * \returns The raw geo-coordinate in the requested CRS.
+ * \throws std::runtime_error
+ *   Thrown if the conversion fails or if no conversion function has been
+ *   registered.
+ */
+VITAL_EXPORT vector_2d geo_conv( vector_2d const& point, int from, int to );
 
 
 } } // end namespace

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -103,6 +103,36 @@ VITAL_EXPORT void set_geo_conv( geo_conversion* );
  */
 VITAL_EXPORT vector_2d geo_conv( vector_2d const& point, int from, int to );
 
+/// UTM/UPS zone specification.
+struct utm_ups_zone_t
+{
+  int number; /// Zone number; 1-60 is UTM, 0 is UPS.
+  bool north; /// Indicates if zone if north or south.
+};
+
+/**
+ * \brief Determine UTM/UPS zone of lat/lon geo-coordinate.
+ *
+ * This determines the appropriate greater UTM or UPS zone given an input
+ * coordinate in a latitude/longitude coordinate system. "Greater zone" here
+ * means that UTM zones are distinguished only by north/south; the irregular
+ * grid zones in northern Europe are not considered.
+ *
+ * The resulting zone will be appropriate for the input datum; for example,
+ * input in NAD83 lat/lon will produce a result suitable for representing in
+ * NAD83 UTM. The user is responsible for ensuring that the input coordinate is
+ * in a lat/lon system.
+ *
+ * Note that the coordinate values are assumed to be in degrees (not radians),
+ * in the order easting (longitude), northing (latitude), for consistency with
+ * geo_point. Out of range longitude values are normalized.
+ *
+ * \returns The UTM/UPS zone information.
+ * \throws std::range_error
+ *   Thrown if the latitude (northing) value is outside of the range
+ *   <code>[-90, 90]</code>.
+ */
+VITAL_EXPORT utm_ups_zone_t utm_ups_zone( vector_2d const& lat_lon );
 
 } } // end namespace
 


### PR DESCRIPTION
Add interface and implementation for requesting geodetic conversions from `vital/types`. The actual implementation, which depends on PROJ, is in an arrow, but the mechanism allows for the plugin to register itself as an implementation on load, which allows users to just request conversions without having to do anything special beyond ensuring that plugins have been loaded.