### PR TITLE
Fixes for windows

### DIFF
--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -117,6 +117,13 @@ function (sprokit_add_python_library    name    modpath)
 
   sprokit_add_library("python-${safe_modpath}-${name}" MODULE
     ${ARGN})
+  
+ if(MSVC)
+  # Issues arise with the msvc compiler with some projects where it cannot 
+  # compile bindings without the optimizer expanding some inline functions (i.e. debug builds)
+  # So always have the optimizer expand the inline functions in the python bindings projects
+  target_compile_options("python-${safe_modpath}-${name}" PUBLIC "/Ob2")
+ endif()
 
   set(pysuffix "${CMAKE_SHARED_MODULE_SUFFIX}")
   if (WIN32 AND NOT CYTWIN)

--- a/sprokit/src/bindings/python/schedulers/CMakeLists.txt
+++ b/sprokit/src/bindings/python/schedulers/CMakeLists.txt
@@ -5,4 +5,4 @@ sprokit_create_python_plugin_init(sprokit/schedulers)
 
 sprokit_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/pythread_per_process_scheduler.py
   sprokit/schedulers
-  pythread_per_process_scheduler)
+  pythread_per_process)


### PR DESCRIPTION
Fixes an issue with the msvc compiler not able to compile some python binding code without some preprocessing (needs /Ob2 flag set for debug)(it is now set to this for ALL configurations when using MSVC)

Shortening the python scheduler target library name, I chose to shorten by removing 'scheduler' from the end of the target name (it's also in the beginning of the name, twice seemed redundant)