### PR TITLE
Fixed inconsistent DLL linkage on MSVC

### DIFF
--- a/sprokit/processes/adapters/CMakeLists.txt
+++ b/sprokit/processes/adapters/CMakeLists.txt
@@ -3,35 +3,6 @@
 #
 project( kwiver_adapter_processes )
 
-set( proc_sources
-  register_processes.cxx
-
-  adapter_data_set.cxx   adapter_data_set.h
-  adapter_base.cxx
-  input_adapter_process.cxx
-  output_adapter_process.cxx
-  )
-
-set( private_headers
-  adapter_base.h
-  input_adapter_process.h
-  output_adapter_process.h
-  )
-
-kwiver_private_header_group( ${private_headers} )
-
-include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
-
-###
-# make processes plugin
-kwiver_add_plugin( kwiver_processes_adapter
-  SUBDIR          sprokit
-  SOURCES         ${proc_sources}
-                  ${private_headers}
-  PRIVATE         sprokit_pipeline
-                  vital vital_vpm vital_logger vital_config
-)
-
 ###
 # library components
 set( lib_sources
@@ -42,17 +13,22 @@ set( lib_sources
   embedded_pipeline.cxx
 
   adapter_base.h             adapter_base.cxx
-  input_adapter_process.h    input_adapter_process.cxx
-  output_adapter_process.h   output_adapter_process.cxx
+  input_adapter_process.cxx
+  output_adapter_process.cxx
   )
 
 set( public_headers
   adapter_types.h
   adapter_data_set.h
   input_adapter.h
+  input_adapter_process.h
   output_adapter.h
+  output_adapter_process.h
   embedded_pipeline.h
   )
+
+
+include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
 ###
 # Make external interface library
@@ -75,6 +51,22 @@ kwiver_install_headers(
   SUBDIR     sprokit/processes/adapters
   NOPATH
 )
+
+###
+# process components
+set( proc_sources
+  register_processes.cxx
+  )
+
+###
+# make processes plugin
+kwiver_add_plugin( kwiver_processes_adapter
+  SUBDIR          sprokit
+  SOURCES         ${proc_sources}
+  PRIVATE         kwiver_adapter sprokit_pipeline
+                  vital_config
+)
+
 
 if (KWIVER_ENABLE_TESTS)
   add_subdirectory( tests )

--- a/sprokit/processes/adapters/input_adapter_process.h
+++ b/sprokit/processes/adapters/input_adapter_process.h
@@ -36,7 +36,7 @@
 #ifndef PROCESS_INPUT_ADAPTER_PROCESS_H
 #define PROCESS_INPUT_ADAPTER_PROCESS_H
 
-#include <sprokit/processes/adapters/kwiver_processes_adapter_export.h>
+#include <sprokit/processes/adapters/kwiver_adapter_export.h>
 
 #include <sprokit/pipeline/process.h>
 
@@ -45,7 +45,7 @@
 namespace kwiver {
 
 // ----------------------------------------------------------------
-class KWIVER_PROCESSES_ADAPTER_NO_EXPORT input_adapter_process
+class KWIVER_ADAPTER_EXPORT input_adapter_process
   : public sprokit::process,
     public adapter::adapter_base
 {

--- a/sprokit/processes/adapters/output_adapter_process.h
+++ b/sprokit/processes/adapters/output_adapter_process.h
@@ -36,7 +36,7 @@
 #ifndef KWIVER_OUTPUT_ADAPTER_PROCESS_H
 #define KWIVER_OUTPUT_ADAPTER_PROCESS_H
 
-#include <sprokit/processes/adapters/kwiver_processes_adapter_export.h>
+#include <sprokit/processes/adapters/kwiver_adapter_export.h>
 
 #include <sprokit/pipeline/process.h>
 
@@ -45,7 +45,7 @@
 namespace kwiver {
 
 // ----------------------------------------------------------------
-class KWIVER_PROCESSES_ADAPTER_NO_EXPORT output_adapter_process
+class KWIVER_ADAPTER_EXPORT output_adapter_process
   : public sprokit::process,
     public adapter::adapter_base
 {


### PR DESCRIPTION
There were multiple source files recompiled into a plugin
and a library.  This change removes the duplicates from the
plugin and make it link to the library instead.