### PR TITLE
Add sprokit plugin directory to KWIVER_PLUGIN_PATH

### DIFF
--- a/CMake/setup_KWIVER.sh.in
+++ b/CMake/setup_KWIVER.sh.in
@@ -6,7 +6,7 @@ this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export VG_PLUGIN_PATH=$this_dir
 export PATH=$this_dir/bin:$PATH
 export LD_LIBRARY_PATH=$this_dir/lib:$LD_LIBRARY_PATH
-export KWIVER_PLUGIN_PATH=$this_dir/lib/modules:$KWIVER_PLUGIN_PATH
+export KWIVER_PLUGIN_PATH=$this_dir/lib/modules:$this_dir/lib/sprokit:$KWIVER_PLUGIN_PATH
 
 # Set default log reporting level for default logger.
 # export KWIVER_DEFAULT_LOG_LEVEL=info


### PR DESCRIPTION
The setup_KWIVER.sh file did not specify the directory for sprokit
plugins when wetting default search path.