### PR TITLE
Installation support

### DIFF
--- a/CMake/setup_KWIVER.bat.in
+++ b/CMake/setup_KWIVER.bat.in
@@ -1,12 +1,24 @@
 ::
 :: Script to source to setup the KWIVER environment
 ::
+
+:: Check to see if we are in an install directory or a build directory
+:: a build directory structure has dlls in a configuration directory (i.e. bin/release/*.dlls)
+:: where as an install directory does not (bin/*.dlls)
+if exist %~dp0/bin/kwiversys.dll (
+  set config=
+  
+  if not [%1] == [] echo setting up an install directory, ignoring provided configuration.
+  GOTO Start
+)
+:: Not in an install directory, setup the path based on a build configuration
 set config=%1
 if /I (%1)==(debug) GOTO Start
 if /I (%1)==(release) GOTO Start
 echo usage: [debug ^| release]
 echo defaulting to release
 set config=release
+
 :Start
 
 set PATH=%~dp0/bin/%config%;%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%

--- a/sprokit/src/processes/examples/CMakeLists.txt
+++ b/sprokit/src/processes/examples/CMakeLists.txt
@@ -48,7 +48,7 @@ set(examples_private_headers
   take_string_process.h
   tunable_process.h)
 
-set(no_install TRUE)
+set(no_install FALSE)
 
 sprokit_private_header_group(${examples_private_headers})
 sprokit_add_plugin(processes_examples


### PR DESCRIPTION
Install the sprokit example processes, this holds the numbers process, which is easy to run to ensure the system is working as expected
On Windows, the kwiver build folders contains dlls in configuration folders, the install directory does not,  the setup_KWIVER.bat needs to handle both cases