### PR TITLE
The python_noarch flag needs to be turned back off

### DIFF
--- a/sprokit/src/bindings/python/CMakeLists.txt
+++ b/sprokit/src/bindings/python/CMakeLists.txt
@@ -74,6 +74,7 @@ add_subdirectory(processes)
 add_subdirectory(schedulers)
 add_subdirectory(test)
 
+set(python_noarch FALSE)
 sprokit_create_python_init(sprokit)
 set(python_noarch TRUE)
 sprokit_create_python_init(sprokit)

--- a/sprokit/src/bindings/python/modules/CMakeLists.txt
+++ b/sprokit/src/bindings/python/modules/CMakeLists.txt
@@ -7,9 +7,11 @@ set(modules_python_private_headers
   modules-config.h
   )
 
+set(python_noarch FALSE)
 sprokit_create_python_init(sprokit/modules)
 set(python_noarch TRUE)
 sprokit_create_python_init(sprokit/modules)
+set(python_noarch FALSE)
 
 sprokit_private_header_group(${modules_python_private_headers})
 


### PR DESCRIPTION
If not turned back off it will persist and following calls to initialize
Python modules will not produce the arch version.