### PR TITLE
Revert sprokit to use boost pointers

### DIFF
--- a/sprokit/processes/adapters/adapter_data_set.cxx
+++ b/sprokit/processes/adapters/adapter_data_set.cxx
@@ -35,13 +35,14 @@
 
 #include "adapter_data_set.h"
 
+#include <boost/make_shared.hpp>
 
 namespace kwiver {
 namespace adapter {
 
 namespace {
 
-// Hack to allow std::make_shared<> work when CTOR is private.
+// Hack to allow boost::make_shared<> work when CTOR is private.
 struct local_ads : public adapter_data_set {
   local_ads( data_set_type type ) : adapter_data_set(type) {}
 };
@@ -66,7 +67,7 @@ adapter_data_set_t
 adapter_data_set
 ::create( data_set_type type )
 {
-  adapter_data_set_t set = std::make_shared<local_ads>( type );
+  adapter_data_set_t set = boost::make_shared<local_ads>( type );
   return set;
 }
 

--- a/sprokit/processes/adapters/adapter_types.h
+++ b/sprokit/processes/adapters/adapter_types.h
@@ -55,8 +55,8 @@ template <class T> class bounded_buffer;
 namespace adapter{
 
 class adapter_data_set;
-typedef std::shared_ptr< adapter_data_set > adapter_data_set_t;
-typedef std::shared_ptr< kwiver::vital::bounded_buffer< kwiver::adapter::adapter_data_set_t > > interface_ref_t;
+typedef boost::shared_ptr< adapter_data_set > adapter_data_set_t;
+typedef boost::shared_ptr< kwiver::vital::bounded_buffer< kwiver::adapter::adapter_data_set_t > > interface_ref_t;
 typedef std::map< sprokit::process::port_t, sprokit::process::port_info_t > ports_info_t;
 
 } } // end namespace

--- a/sprokit/processes/bindings/c/vital_type_converters.cxx
+++ b/sprokit/processes/bindings/c/vital_type_converters.cxx
@@ -56,10 +56,10 @@ more python friendly types.
 #include <string>
 
 typedef std::vector< double >  double_vector;
-typedef std::shared_ptr< double_vector > double_vector_sptr;
+typedef boost::shared_ptr< double_vector > double_vector_sptr;
 
 typedef std::vector< std::string > string_vector;
-typedef std::shared_ptr< string_vector > string_vector_sptr;
+typedef boost::shared_ptr< string_vector > string_vector_sptr;
 
 static kwiver::vital::logger_handle_t logger( kwiver::vital::get_logger( "vital.type_converters" ) );
 

--- a/sprokit/processes/kwiver_type_traits.h
+++ b/sprokit/processes/kwiver_type_traits.h
@@ -62,9 +62,9 @@ namespace vital {
   class f2f_homography;
 
   typedef std::vector< double >  double_vector;
-  typedef std::shared_ptr< double_vector > double_vector_sptr;
+  typedef boost::shared_ptr< double_vector > double_vector_sptr;
   typedef std::vector< std::string > string_vector;
-  typedef std::shared_ptr< string_vector > string_vector_sptr;
+  typedef boost::shared_ptr< string_vector > string_vector_sptr;
 
 } }
 

--- a/sprokit/processes/matlab/matlab_process.cxx
+++ b/sprokit/processes/matlab/matlab_process.cxx
@@ -98,7 +98,7 @@ public:
   std::string m_program_file;
 
   // MatLab support. The engine is allocated at the latest time.
-  std::shared_ptr< kwiver::arrows::matlab::matlab_engine > m_matlab_engine;
+  boost::shared_ptr< kwiver::arrows::matlab::matlab_engine > m_matlab_engine;
 
 }; // end priv class
 
@@ -132,7 +132,7 @@ matlab_process
 ::_configure()
 {
   // Need to delay creating engine because it is heavyweight
-  d->m_matlab_engine = std::make_shared< kwiver::arrows::matlab::matlab_engine >();
+  d->m_matlab_engine = boost::make_shared< kwiver::arrows::matlab::matlab_engine >();
 
   d->m_program_file = config_value_using_trait( program_file );
 

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -260,7 +260,7 @@ BOOST_PYTHON_MODULE(process)
     .def_readonly("frequency", &sprokit::process::port_info::frequency)
   ;
 
-  implicitly_convertible<std::shared_ptr<sprokit::process::port_info>, sprokit::process::port_info_t>();
+  implicitly_convertible<boost::shared_ptr<sprokit::process::port_info>, sprokit::process::port_info_t>();
 
   class_<sprokit::process::conf_info, sprokit::process::conf_info_t>("ConfInfo"
     , "Information about a configuration on a process."
@@ -271,7 +271,7 @@ BOOST_PYTHON_MODULE(process)
     .def_readonly("tunable", &sprokit::process::conf_info::tunable)
   ;
 
-  implicitly_convertible<std::shared_ptr<sprokit::process::conf_info>, sprokit::process::conf_info_t>();
+  implicitly_convertible<boost::shared_ptr<sprokit::process::conf_info>, sprokit::process::conf_info_t>();
 
   class_<sprokit::process::data_info, sprokit::process::data_info_t>("DataInfo"
     , "Information about a set of data packets from edges."
@@ -288,7 +288,7 @@ BOOST_PYTHON_MODULE(process)
     .value("valid", sprokit::process::check_valid)
   ;
 
-  implicitly_convertible<std::shared_ptr<sprokit::process::data_info>, sprokit::process::data_info_t>();
+  implicitly_convertible<boost::shared_ptr<sprokit::process::data_info>, sprokit::process::data_info_t>();
 
   class_<wrap_process, boost::noncopyable>("PythonProcess"
     , "The base class for Python processes."

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
@@ -349,7 +349,7 @@ wrap_process_cluster
 object
 cluster_from_process(sprokit::process_t const& process)
 {
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(process);
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(process);
 
   if (!cluster)
   {

--- a/sprokit/src/schedulers/sync_scheduler.cxx
+++ b/sprokit/src/schedulers/sync_scheduler.cxx
@@ -46,6 +46,7 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/bind.hpp>
+#include <boost/make_shared.hpp>
 
 #include <deque>
 #include <iterator>
@@ -182,7 +183,7 @@ sync_scheduler::priv
   VITAL_FOREACH (process::name_t const& name, names)
   {
     process_t const proc = pipe->process_by_name(name);
-    edge_t const monitor_edge = std::make_shared<edge>(edge_conf);
+    edge_t const monitor_edge = boost::make_shared<edge>(edge_conf);
 
     proc->connect_output_port(process::port_heartbeat, monitor_edge);
     monitor_edges[name] = monitor_edge;

--- a/sprokit/src/schedulers/thread_per_process_scheduler.cxx
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.cxx
@@ -42,6 +42,7 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/make_shared.hpp>
 
 #include <memory>
 
@@ -178,7 +179,7 @@ thread_per_process_scheduler::priv
   kwiver::vital::config_block_sptr const edge_conf = monitor_edge_config();
 
   name_thread(process->name());
-  edge_t monitor_edge = std::make_shared<edge>(edge_conf);
+  edge_t monitor_edge = boost::make_shared<edge>(edge_conf);
 
   process->connect_output_port(process::port_heartbeat, monitor_edge);
 

--- a/sprokit/src/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/sprokit/pipeline/edge.cxx
@@ -108,7 +108,7 @@ class edge::priv
     priv(bool depends_, size_t capacity_, bool blocking_);
     ~priv();
 
-    typedef std::weak_ptr<process> process_ref_t;
+    typedef boost::weak_ptr<process> process_ref_t;
 
     bool full_of_data() const;
     void complete_check() const;

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -46,6 +46,7 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/functional.hpp>
+#include <boost/make_shared.hpp>
 
 #include <functional>
 #include <map>
@@ -247,7 +248,7 @@ pipeline
 
   d->check_duplicate_name(name);
 
-  process_cluster_t const cluster = std::dynamic_pointer_cast<process_cluster>(process);
+  process_cluster_t const cluster = boost::dynamic_pointer_cast<process_cluster>(process);
 
   process::name_t parent;
 
@@ -1819,7 +1820,7 @@ pipeline::priv
     }
 
     // Create a new edge
-    edge_t const e = std::make_shared<edge>(edge_config);
+    edge_t const e = boost::make_shared<edge>(edge_config);
 
     edge_map[i] = e;
 

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -44,6 +44,7 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/optional.hpp>
+#include <boost/make_shared.hpp>
 
 #include <map>
 #include <utility>
@@ -1029,7 +1030,7 @@ process
                      port_description_t const& description_,
                      port_frequency_t const& frequency_)
 {
-  declare_input_port(port, std::make_shared<port_info>(
+  declare_input_port(port, boost::make_shared<port_info>(
     type_,
     flags_,
     description_,
@@ -1093,7 +1094,7 @@ process
                       port_description_t const& description_,
                       port_frequency_t const& frequency_)
 {
-  declare_output_port(port, std::make_shared<port_info>(
+  declare_output_port(port, boost::make_shared<port_info>(
     type_,
     flags_,
     description_,
@@ -1263,7 +1264,7 @@ process
                             kwiver::vital::config_block_description_t const& description_,
                             bool tunable_)
 {
-  declare_configuration_key(key, std::make_shared<conf_info>(
+  declare_configuration_key(key, boost::make_shared<conf_info>(
     def_,
     description_,
     tunable_));
@@ -1549,7 +1550,7 @@ process
     }
   }
 
-  return std::make_shared<data_info>(in_sync, max_type);
+  return boost::make_shared<data_info>(in_sync, max_type);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -220,7 +220,7 @@ class SPROKIT_PIPELINE_EXPORT process
         port_frequency_t const frequency;
     };
     /// Type for information about a port.
-    typedef std::shared_ptr<port_info const> port_info_t;
+    typedef boost::shared_ptr<port_info const> port_info_t;
 
     /**
      * \class conf_info process.h <sprokit/pipeline/process.h>
@@ -253,7 +253,7 @@ class SPROKIT_PIPELINE_EXPORT process
         bool const tunable;
     };
     /// Type for information about a configuration parameter.
-    typedef std::shared_ptr<conf_info const> conf_info_t;
+    typedef boost::shared_ptr<conf_info const> conf_info_t;
 
     /**
      * \class data_info process.h <sprokit/pipeline/process.h>
@@ -285,7 +285,7 @@ class SPROKIT_PIPELINE_EXPORT process
         datum::type_t const max_status;
     };
     /// Type for information about a set of data.
-    typedef std::shared_ptr<data_info const> data_info_t;
+    typedef boost::shared_ptr<data_info const> data_info_t;
 
     /**
      * \brief Data checking levels. All levels include lower levels.
@@ -1322,7 +1322,7 @@ class SPROKIT_PIPELINE_EXPORT process
     SPROKIT_PIPELINE_NO_EXPORT void reconfigure_with_provides(kwiver::vital::config_block_sptr const& conf);
 
     class SPROKIT_PIPELINE_NO_EXPORT priv;
-    std::shared_ptr<priv> d;
+    boost::shared_ptr<priv> d;
 };
 
 template <typename T>

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -44,6 +44,8 @@
 
 #include <sprokit/pipeline/process.h>
 
+#include <boost/make_shared.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -69,7 +71,7 @@ process_t
 create_new_process(kwiver::vital::config_block_sptr const& conf)
 {
   // Note boost pointer
-  return std::make_shared<T>(conf);
+  return boost::make_shared<T>(conf);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -42,6 +42,8 @@
 
 #include <sprokit/pipeline/scheduler.h>
 
+#include <boost/make_shared.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -67,7 +69,7 @@ scheduler_t
 create_new_scheduler( pipeline_t const& pipe,
                       kwiver::vital::config_block_sptr const& conf)
 {
-  return std::make_shared<T>(pipe, conf);
+  return boost::make_shared<T>(pipe, conf);
 }
 
 

--- a/sprokit/src/sprokit/pipeline/types.h
+++ b/sprokit/src/sprokit/pipeline/types.h
@@ -44,6 +44,8 @@
 #include <string>
 #include <memory>
 
+#include <boost/shared_ptr.hpp>
+
 /**
  * \brief The namespace for all sprokit-related symbols.
  */
@@ -59,31 +61,31 @@ typedef std::string module_t;
 
 class datum;
 /// A typedef used to handle \link datum edge data\endlink.
-typedef std::shared_ptr<datum const> datum_t;
+typedef boost::shared_ptr<datum const> datum_t;
 
 class edge;
 /// A typedef used to handle \link edge edges\endlink.
-typedef std::shared_ptr<edge> edge_t;
+typedef boost::shared_ptr<edge> edge_t;
 
 class pipeline;
 /// A typedef used to handle \link pipeline pipelines\endlink.
-typedef std::shared_ptr<pipeline> pipeline_t;
+typedef boost::shared_ptr<pipeline> pipeline_t;
 
 class process;
 /// A typedef used to handle \link process processes\endlink.
-typedef std::shared_ptr<process> process_t;
+typedef boost::shared_ptr<process> process_t;
 
 class process_cluster;
 /// A typedef used to handle \link process_cluster process clusters\endlink.
-typedef std::shared_ptr<process_cluster> process_cluster_t;
+typedef boost::shared_ptr<process_cluster> process_cluster_t;
 
 class scheduler;
 /// A typedef used to handle \link scheduler schedulers\endlink.
-typedef std::shared_ptr<scheduler> scheduler_t;
+typedef boost::shared_ptr<scheduler> scheduler_t;
 
 class stamp;
 /// A typedef used to handle \link stamp stamps\endlink.
-typedef std::shared_ptr<stamp const> stamp_t;
+typedef boost::shared_ptr<stamp const> stamp_t;
 
 /**
  * \class pipeline_exception types.h <sprokit/pipeline/types.h>

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
@@ -45,6 +45,8 @@
 
 #include <kwiversys/SystemTools.hxx>
 
+#include <boost/make_shared.hpp>
+
 namespace sprokit {
 
 namespace {
@@ -102,7 +104,7 @@ bakery_base
   , m_ref_config( kwiver::vital::config_block::empty_config() )
   , m_logger( kwiver::vital::get_logger( "sprokit.bakery_base" ) )
 {
-  m_token_expander = std::make_shared < expander_bakery >(m_logger);
+  m_token_expander = boost::make_shared < expander_bakery >(m_logger);
   m_token_expander->add_token_type( new kwiver::vital::token_type_env() );
   m_token_expander->add_token_type( new kwiver::vital::token_type_sysenv() );
   m_token_expander->add_token_type( m_symtab );

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.h
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.h
@@ -115,7 +115,7 @@ protected:
 private:
 
   // macro provider
-  std::shared_ptr< kwiver::vital::token_expander > m_token_expander;
+  boost::shared_ptr< kwiver::vital::token_expander > m_token_expander;
   kwiver::vital::token_type_symtab* m_symtab;
   kwiver::vital::config_block_sptr m_ref_config;
 

--- a/sprokit/src/sprokit/pipeline_util/cluster_creator.cxx
+++ b/sprokit/src/sprokit/pipeline_util/cluster_creator.cxx
@@ -41,6 +41,8 @@
 #include <vital/vital_foreach.h>
 #include <vital/util/tokenize.h>
 
+#include <boost/make_shared.hpp>
+
 #include <algorithm>
 #include <memory>
 
@@ -116,13 +118,13 @@ cluster_creator
 
   kwiver::vital::config_block_sptr const full_config = bakery_base::extract_configuration_from_decls( all_configs );
 
-  typedef std::shared_ptr< loaded_cluster > loaded_cluster_t;
+  typedef boost::shared_ptr< loaded_cluster > loaded_cluster_t;
 
   // Pull out the main config block to the top-level.
   kwiver::vital::config_block_sptr const cluster_config = full_config->subblock_view( type );
   full_config->merge_config( cluster_config );
 
-  loaded_cluster_t const cluster = std::make_shared< loaded_cluster > ( full_config );
+  loaded_cluster_t const cluster = boost::make_shared< loaded_cluster > ( full_config );
 
   cluster_bakery::opt_cluster_component_info_t const& opt_info = m_bakery.m_cluster;
 

--- a/sprokit/src/sprokit/pipeline_util/cluster_info.h
+++ b/sprokit/src/sprokit/pipeline_util/cluster_info.h
@@ -80,7 +80,7 @@ class SPROKIT_PIPELINE_UTIL_EXPORT cluster_info
 };
 
 /// A handle to information about a cluster.
-typedef std::shared_ptr<cluster_info> cluster_info_t;
+typedef boost::shared_ptr<cluster_info> cluster_info_t;
 
 } // end namespace sprokit
 

--- a/sprokit/src/sprokit/pipeline_util/export_dot.cxx
+++ b/sprokit/src/sprokit/pipeline_util/export_dot.cxx
@@ -41,6 +41,7 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/ref.hpp>
+#include <boost/make_shared.hpp>
 
 #include <map>
 #include <ostream>
@@ -216,7 +217,7 @@ export_dot(std::ostream& ostr, process_cluster_t const& cluster, std::string con
     throw null_cluster_export_dot_exception();
   }
 
-  pipeline_t const pipe = std::make_shared<pipeline>();
+  pipeline_t const pipe = boost::make_shared<pipeline>();
 
   pipe->add_process(cluster);
 

--- a/sprokit/src/sprokit/pipeline_util/export_pipe.cxx
+++ b/sprokit/src/sprokit/pipeline_util/export_pipe.cxx
@@ -50,6 +50,7 @@
 #include <string>
 #include <cstdlib>
 
+#include <boost/make_shared.hpp>
 
 namespace sprokit {
 
@@ -198,7 +199,7 @@ config_printer
     }
 
     sprokit::process_cluster_t const cluster = m_pipe->cluster_by_name( name );
-    sprokit::process_t const proc = std::static_pointer_cast< sprokit::process > ( cluster );
+    sprokit::process_t const proc = boost::static_pointer_cast< sprokit::process > ( cluster );
 
     static std::string const kind = "cluster";
 
@@ -242,7 +243,7 @@ config_printer
       {
         sprokit::process_cluster_t const cluster = m_pipe->cluster_by_name( name );
 
-        proc = std::static_pointer_cast< sprokit::process > ( cluster );
+        proc = boost::static_pointer_cast< sprokit::process > ( cluster );
       }
       catch ( sprokit::no_such_process_exception const& /*e*/ )
       {

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -46,6 +46,8 @@
 #include <sstream>
 #include <set>
 
+#include <boost/make_shared.hpp>
+
 namespace sprokit {
 
 namespace {
@@ -65,7 +67,7 @@ public:
     : m_fstream( file_name ) // open file stream
     , m_stream( &m_fstream )
     , m_reader( m_fstream ) // assign stream to reader
-    , m_filename( std::make_shared< std::string >(file_name) )
+    , m_filename( boost::make_shared< std::string >(file_name) )
   {
     if ( ! m_stream )
     {
@@ -77,7 +79,7 @@ public:
   include_context( std::istream& str, const std::string& file_name )
     : m_stream( &str ) // open file stream
     , m_reader( *m_stream ) // assign stream to reader
-    , m_filename( std::make_shared< std::string >(file_name) )
+    , m_filename( boost::make_shared< std::string >(file_name) )
   {
   }
 
@@ -100,7 +102,7 @@ public:
   // This reader operates on the above stream to provide trimmed input
   // with no comments or blank lines
   kwiver::vital::data_stream_reader m_reader;
-  std::shared_ptr< std::string > m_filename;
+  boost::shared_ptr< std::string > m_filename;
 };
 
 } // end namespace
@@ -203,7 +205,7 @@ public:
    * stack at end of file and the previous file is resumed, unless it
    * is the last entry on the stack when a real EOF token is retrned.
    */
-  std::vector< std::shared_ptr< include_context > > m_include_stack;
+  std::vector< boost::shared_ptr< include_context > > m_include_stack;
 
   /**
    * This is used to remove leading and trailing strings.
@@ -236,7 +238,7 @@ lex_processor::
 open_file( const std::string& file_name )
 {
   // open file, throw error if open error
-  m_priv->m_include_stack.push_back( std::make_shared< include_context >( file_name ) );
+  m_priv->m_include_stack.push_back( boost::make_shared< include_context >( file_name ) );
 }
 
 
@@ -245,7 +247,7 @@ void
 lex_processor::
 open_stream( std::istream& input, const std::string& file_name )
 {
-  m_priv->m_include_stack.push_back( std::make_shared< include_context >( input, file_name ) );
+  m_priv->m_include_stack.push_back( boost::make_shared< include_context >( input, file_name ) );
 }
 
 
@@ -342,7 +344,7 @@ get_next_token()
   if ( m_priv->m_include_stack.empty() )
   {
     // return EOF token
-    return std::make_shared< token > ( TK_EOF, "E-O-F" );
+    return boost::make_shared< token > ( TK_EOF, "E-O-F" );
   }
 
   if ( m_priv->m_cur_char == m_priv->m_input_line.end() )
@@ -357,7 +359,7 @@ get_next_token()
       if ( m_priv->m_include_stack.empty() )
       {
         // return EOF token
-        return std::make_shared< token > ( TK_EOF, "E-O-F" );
+        return boost::make_shared< token > ( TK_EOF, "E-O-F" );
       }
     } // end while
 
@@ -392,7 +394,7 @@ get_next_token()
       m_priv->flush_line();
 
       // Push the current location onto the include stack
-      m_priv->m_include_stack.push_back( std::make_shared< include_context >( resolv_filename ) );
+      m_priv->m_include_stack.push_back( boost::make_shared< include_context >( resolv_filename ) );
 
       // Get first line from included file.
       m_priv->get_line();
@@ -400,7 +402,7 @@ get_next_token()
 
     if ( ! m_priv->m_absorb_eol )
     {
-      auto t = std::make_shared< token > ( TK_EOL, "" );
+      auto t = boost::make_shared< token > ( TK_EOL, "" );
       t->set_location( m_priv->current_loc() );
       return t;
     }
@@ -422,7 +424,7 @@ get_next_token()
       {
         // generate a whitespace token collecting all whitespace at
         // this point
-        t = std::make_shared< token > ( TK_WHITESPACE, " " );
+        t = boost::make_shared< token > ( TK_WHITESPACE, " " );
         t->set_location( current_location() );
 
         // Skip over all whitespace. No need to generate more tokens.
@@ -447,7 +449,7 @@ get_next_token()
         // Collect description text from after token to EOL
         std::string text( m_priv->m_cur_char + 1, m_priv->m_input_line.end() );
         m_priv->trim_string( text );
-        t = std::make_shared< token > ( TK_CLUSTER_DESC, text );
+        t = boost::make_shared< token > ( TK_CLUSTER_DESC, text );
         t->set_location( current_location() );
 
         m_priv->flush_line();
@@ -457,7 +459,7 @@ get_next_token()
       // look for "::"
       if ( c == ':' && n == ':' )
       {
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
+        token_sptr t = boost::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
         t->set_location( current_location() );
 
         return t;
@@ -468,7 +470,7 @@ get_next_token()
         // Collect rest of line as text
         std::string text( m_priv->m_cur_char + 1, m_priv->m_input_line.end() );
         m_priv->trim_string( text );
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
+        token_sptr t = boost::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
         t->set_location( current_location() );
 
         m_priv->flush_line();
@@ -485,7 +487,7 @@ get_next_token()
       // Collect rest of line as text
       std::string text( m_priv->m_cur_char, m_priv->m_input_line.end() );
       m_priv->trim_string( text );
-      t = std::make_shared< token > ( TK_ASSIGN, text );
+      t = boost::make_shared< token > ( TK_ASSIGN, text );
       t->set_location( m_priv->current_loc() );
 
       m_priv->flush_line();
@@ -494,7 +496,7 @@ get_next_token()
 
     if ( ':' == c )  // old style config line
     {
-      t = std::make_shared< token > ( TK_COLON, ":" );
+      t = boost::make_shared< token > ( TK_COLON, ":" );
       t->set_location( m_priv->current_loc() );
       return t;
     }
@@ -512,7 +514,7 @@ get_next_token()
 
     // At this point,just pass all single characters
     // as tokens.  Let the parser decide what to do.
-    t = std::make_shared< token > ( c );
+    t = boost::make_shared< token > ( c );
     t->set_location( m_priv->current_loc() );
     return t;
   }   // end while
@@ -605,7 +607,7 @@ process_id()
 
   // Check ident against list of keywords
   // Create the new token
-  token_sptr t = std::make_shared< token > ( find_res_word( ident ), ident );
+  token_sptr t = boost::make_shared< token > ( find_res_word( ident ), ident );
   t->set_location( current_loc() );
 
   return t;
@@ -637,7 +639,7 @@ lex_processor::priv::
 current_loc() const
 {
   // Get current location from the include file stack top element
-  return kwiver::vital::source_location( m_include_stack.back()->m_filename,
+  return kwiver::vital::source_location( std::make_shared< std::string >( *(m_include_stack.back()->m_filename) ),
            static_cast<int>(m_include_stack.back()->m_reader.line_number()) );
 }
 

--- a/sprokit/src/sprokit/pipeline_util/pipe_bakery.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipe_bakery.cxx
@@ -109,7 +109,7 @@ bake_pipe_blocks( pipe_blocks const& blocks )
   // Create pipeline.
   kwiver::vital::config_block_sptr const pipeline_conf = global_conf->subblock_view( config_pipeline_key );
 
-  pipe = std::make_shared< pipeline > ( pipeline_conf );
+  pipe = boost::make_shared< pipeline > ( pipeline_conf );
 
   // Create processes.
   {
@@ -194,7 +194,7 @@ bake_cluster_blocks( cluster_blocks const& blocks )
   process::description_t const& description = bakery.m_description;
   process_factory_func_t const ctor = cluster_creator( bakery );
 
-  cluster_info_t const info = std::make_shared< cluster_info > ( type, description, ctor );
+  cluster_info_t const info = boost::make_shared< cluster_info > ( type, description, ctor );
 
   return info;
 }

--- a/sprokit/src/sprokit/pipeline_util/token.h
+++ b/sprokit/src/sprokit/pipeline_util/token.h
@@ -44,6 +44,8 @@
 #include <string>
 #include <memory>
 
+#include <boost/shared_ptr.hpp>
+
 namespace sprokit {
 
 /**
@@ -135,7 +137,7 @@ inline std::ostream&
 operator<<( std::ostream& str, const token& obj )
 { return obj.format( str ); }
 
-typedef std::shared_ptr< token > token_sptr;
+typedef boost::shared_ptr< token > token_sptr;
 
 } // end namespace
 

--- a/sprokit/src/sprokit/python/util/python_wrap_const_shared_ptr.h
+++ b/sprokit/src/sprokit/python/util/python_wrap_const_shared_ptr.h
@@ -46,13 +46,13 @@ namespace python
 template <typename T>
 inline
 T*
-get_pointer(std::shared_ptr<T const> const& p)
+get_pointer(boost::shared_ptr<T const> const& p)
 {
   return const_cast<T*>(p.get());
 }
 
 template <typename T>
-struct pointee<std::shared_ptr<T const> >
+struct pointee<boost::shared_ptr<T const> >
 {
   typedef T type;
 };

--- a/sprokit/src/sprokit/scoring/statistics.h
+++ b/sprokit/src/sprokit/scoring/statistics.h
@@ -36,6 +36,8 @@
 #include <memory>
 #include <vector>
 
+#include <boost/shared_ptr.hpp>
+
 /**
  * \file statistics.h
  *
@@ -149,7 +151,7 @@ class SPROKIT_SCORING_EXPORT statistics
 };
 
 /// A handle to statistics class.
-typedef std::shared_ptr<statistics> statistics_t;
+typedef boost::shared_ptr<statistics> statistics_t;
 
 }
 

--- a/sprokit/src/sprokit/tools/tool_io.cxx
+++ b/sprokit/src/sprokit/tools/tool_io.cxx
@@ -34,6 +34,8 @@
 #include <fstream>
 #include <stdexcept>
 
+#include <boost/shared_ptr.hpp>
+
 namespace sprokit {
 
 namespace {

--- a/sprokit/src/sprokit/tools/tool_io.h
+++ b/sprokit/src/sprokit/tools/tool_io.h
@@ -39,10 +39,12 @@
 #include <ostream>
 #include <memory>
 
+#include <boost/shared_ptr.hpp>
+
 namespace sprokit {
 
-typedef std::shared_ptr<std::istream> istream_t;
-typedef std::shared_ptr<std::ostream> ostream_t;
+typedef boost::shared_ptr<std::istream> istream_t;
+typedef boost::shared_ptr<std::ostream> ostream_t;
 
 SPROKIT_TOOLS_EXPORT istream_t open_istream(kwiver::vital::path_t const& path);
 SPROKIT_TOOLS_EXPORT ostream_t open_ostream(kwiver::vital::path_t const& path);

--- a/sprokit/src/tools/pipe_to_dot.cxx
+++ b/sprokit/src/tools/pipe_to_dot.cxx
@@ -126,14 +126,14 @@ sprokit_tool_main(int argc, char const* argv[])
       conf->set_value(sprokit::process::config_name, graph_name);
 
       sprokit::process_t const proc = info->ctor(conf);
-      cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+      cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
     }
     else if (have_cluster_type)
     {
       sprokit::process::type_t const type = vm["cluster-type"].as<sprokit::process::type_t>();
 
       sprokit::process_t const proc = sprokit::create_process(type, graph_name, conf);
-      cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+      cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
       if (!cluster)
       {

--- a/sprokit/tests/sprokit/pipeline/test_edge.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_edge.cxx
@@ -136,7 +136,7 @@ IMPLEMENT_TEST(null_config)
   kwiver::vital::config_block_sptr const config;
 
   EXPECT_EXCEPTION(sprokit::null_edge_config_exception,
-                   std::make_shared<sprokit::edge>(config),
+                   boost::make_shared<sprokit::edge>(config),
                    "when passing a NULL config to an edge");
 }
 
@@ -144,7 +144,7 @@ IMPLEMENT_TEST(makes_dependency)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   if (!edge->makes_dependency())
   {
@@ -153,7 +153,7 @@ IMPLEMENT_TEST(makes_dependency)
 
   config->set_value(sprokit::edge::config_dependency, "false");
 
-  sprokit::edge_t const edge2 = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge2 = boost::make_shared<sprokit::edge>(config);
 
   if (edge2->makes_dependency())
   {
@@ -166,7 +166,7 @@ IMPLEMENT_TEST(new_has_no_data)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   if (edge->has_data())
   {
@@ -178,7 +178,7 @@ IMPLEMENT_TEST(new_is_not_full)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   if (edge->full_of_data())
   {
@@ -190,7 +190,7 @@ IMPLEMENT_TEST(new_has_count_zero)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   if (edge->datum_count())
   {
@@ -202,7 +202,7 @@ IMPLEMENT_TEST(push_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -230,7 +230,7 @@ IMPLEMENT_TEST(peek_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -260,7 +260,7 @@ IMPLEMENT_TEST(peek_datum_index)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -301,7 +301,7 @@ IMPLEMENT_TEST(pop_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -324,7 +324,7 @@ IMPLEMENT_TEST(get_datum)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -354,7 +354,7 @@ IMPLEMENT_TEST(null_upstream_process)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::process_t const process;
 
@@ -367,7 +367,7 @@ IMPLEMENT_TEST(null_downstream_process)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::process_t const process;
 
@@ -384,7 +384,7 @@ IMPLEMENT_TEST(set_upstream_process)
 
   sprokit::process_t const process = sprokit::create_process(proc_type, sprokit::process::name_t());
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
 
   edge->set_upstream_process(process);
 
@@ -401,7 +401,7 @@ IMPLEMENT_TEST(set_downstream_process)
 
   sprokit::process_t const process = sprokit::create_process(proc_type, sprokit::process::name_t());
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
 
   edge->set_downstream_process(process);
 
@@ -414,7 +414,7 @@ IMPLEMENT_TEST(push_data_into_complete)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -444,7 +444,7 @@ IMPLEMENT_TEST(get_data_from_complete)
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   edge->mark_downstream_as_complete();
 
@@ -484,7 +484,7 @@ IMPLEMENT_TEST(capacity)
 
   config->set_value(sprokit::edge::config_capacity, value_capacity);
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -536,7 +536,7 @@ IMPLEMENT_TEST(try_push_datum)
 
   config->set_value(sprokit::edge::config_capacity, 1);
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   sprokit::stamp::increment_t const inc = sprokit::stamp::increment_t(1);
 
@@ -575,7 +575,7 @@ IMPLEMENT_TEST(try_push_datum)
 
 IMPLEMENT_TEST(try_get_datum)
 {
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>();
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>();
 
   time_point_t const start = time_clock_t::now();
 

--- a/sprokit/tests/sprokit/pipeline/test_modules.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_modules.cxx
@@ -85,7 +85,7 @@ IMPLEMENT_TEST(envvar)
 
   sprokit::scheduler::type_t const sched_type = sprokit::scheduler::type_t("test");
 
-  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>();
 
   sprokit::create_scheduler(sched_type, pipeline);
 }

--- a/sprokit/tests/sprokit/pipeline/test_pipeline.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_pipeline.cxx
@@ -71,7 +71,7 @@ IMPLEMENT_TEST( null_config )
   kwiver::vital::config_block_sptr const config;
 
   EXPECT_EXCEPTION( sprokit::null_pipeline_config_exception,
-                    std::make_shared< sprokit::pipeline > ( config ),
+                    boost::make_shared< sprokit::pipeline > ( config ),
                     "passing a NULL config to the pipeline" );
 }
 
@@ -1825,7 +1825,7 @@ IMPLEMENT_TEST( reconfigure_before_setup )
 
   sprokit::process_t const expect = create_process( proc_type, proc_name );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( expect );
 
@@ -1868,9 +1868,9 @@ IMPLEMENT_TEST( reconfigure )
   conf->set_value( check_reconfigure_process::config_should_reconfigure, "true" );
   conf->set_value( sprokit::process::config_name, proc_name );
 
-  sprokit::process_t const check = std::make_shared< check_reconfigure_process > ( conf );
+  sprokit::process_t const check = boost::make_shared< check_reconfigure_process > ( conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( check );
   pipeline->setup_pipeline();
@@ -1912,18 +1912,18 @@ IMPLEMENT_TEST( reconfigure_only_top_level )
   conf->set_value( check_reconfigure_process::config_should_reconfigure, "false" );
   conf->set_value( sprokit::process::config_name, proc_name );
 
-  typedef std::shared_ptr< sample_cluster > sample_cluster_t;
+  typedef boost::shared_ptr< sample_cluster > sample_cluster_t;
 
   const auto cluster_conf = kwiver::vital::config_block::empty_config();
   const auto cluster_name = sprokit::process::name_t( "cluster" );
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   cluster->_add_process( proc_name, proc_type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -1958,7 +1958,7 @@ create_process( sprokit::process::type_t const&   type,
 sprokit::pipeline_t
 create_pipeline()
 {
-  return std::make_shared< sprokit::pipeline > ();
+  return boost::make_shared< sprokit::pipeline > ();
 }
 
 
@@ -1981,7 +1981,7 @@ create_scheduler( sprokit::pipeline_t const& pipe )
 {
   kwiver::vital::config_block_sptr const config = kwiver::vital::config_block::empty_config();
 
-  return std::make_shared< dummy_scheduler > ( pipe, config );
+  return boost::make_shared< dummy_scheduler > ( pipe, config );
 }
 
 

--- a/sprokit/tests/sprokit/pipeline/test_process.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process.cxx
@@ -171,9 +171,9 @@ IMPLEMENT_TEST(connect_after_init)
 
   const auto config = kwiver::vital::config_block::empty_config();
 
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
-  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>(config);
+  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>(config);
 
   // Only the pipeline can properly initialize a process.
   pipe->add_process(process);
@@ -878,7 +878,7 @@ IMPLEMENT_TEST(reconfigure_tunable)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -911,7 +911,7 @@ IMPLEMENT_TEST(reconfigure_non_tunable)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -945,7 +945,7 @@ IMPLEMENT_TEST(reconfigure_extra_parameters)
 
   sprokit::process_t const expect = create_process(proc_type, proc_name, conf);
 
-  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
+  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>(kwiver::vital::config_block::empty_config());
 
   pipeline->add_process(expect);
   pipeline->setup_pipeline();
@@ -978,7 +978,7 @@ sprokit::edge_t
 create_edge()
 {
   const auto config = kwiver::vital::config_block::empty_config();
-  sprokit::edge_t const edge = std::make_shared<sprokit::edge>(config);
+  sprokit::edge_t const edge = boost::make_shared<sprokit::edge>(config);
 
   return edge;
 }

--- a/sprokit/tests/sprokit/pipeline/test_process_cluster.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_cluster.cxx
@@ -41,6 +41,7 @@
 #include <sprokit/pipeline/process_exception.h>
 
 #include <memory>
+#include <boost/make_shared.hpp>
 
 #define TEST_ARGS ()
 
@@ -70,7 +71,7 @@ public:
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( configure )
 {
-  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
 
   cluster->configure();
 }
@@ -79,7 +80,7 @@ IMPLEMENT_TEST( configure )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( init )
 {
-  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
 
   cluster->configure();
   cluster->init();
@@ -89,7 +90,7 @@ IMPLEMENT_TEST( init )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( step )
 {
-  sprokit::process_cluster_t const cluster = std::make_shared< empty_cluster > ();
+  sprokit::process_cluster_t const cluster = boost::make_shared< empty_cluster > ();
 
   cluster->configure();
   cluster->init();
@@ -121,13 +122,13 @@ public:
   void _connect( name_t const& upstream_name, port_t const& upstream_port,
                  name_t const& downstream_name, port_t const& downstream_port );
 };
-typedef std::shared_ptr< sample_cluster > sample_cluster_t;
+typedef boost::shared_ptr< sample_cluster > sample_cluster_t;
 
 
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( add_process )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "orphan" );
@@ -169,7 +170,7 @@ IMPLEMENT_TEST( add_process )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( duplicate_name )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "orphan" );
@@ -187,7 +188,7 @@ IMPLEMENT_TEST( duplicate_name )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_config )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -199,7 +200,7 @@ IMPLEMENT_TEST( map_config )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_config_after_process )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -220,7 +221,7 @@ IMPLEMENT_TEST( map_config_no_exist )
 {
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -241,7 +242,7 @@ IMPLEMENT_TEST( map_config_read_only )
 
   sprokit::process::name_t const cluster_name = sprokit::process::name_t( "cluster" );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -282,7 +283,7 @@ IMPLEMENT_TEST( map_config_ignore_override )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -312,7 +313,7 @@ IMPLEMENT_TEST( map_config_ignore_override )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -336,7 +337,7 @@ IMPLEMENT_TEST( map_input )
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "print_number" );
@@ -400,7 +401,7 @@ IMPLEMENT_TEST( map_input )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_twice )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "print_number" );
@@ -423,7 +424,7 @@ IMPLEMENT_TEST( map_input_twice )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -437,7 +438,7 @@ IMPLEMENT_TEST( map_input_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_input_port_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "no_such_port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -462,7 +463,7 @@ IMPLEMENT_TEST( map_output )
 
   conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "numbers" );
@@ -526,7 +527,7 @@ IMPLEMENT_TEST( map_output )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_twice )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -550,7 +551,7 @@ IMPLEMENT_TEST( map_output_twice )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -564,7 +565,7 @@ IMPLEMENT_TEST( map_output_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( map_output_port_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::port_t const port = sprokit::process::port_t( "no_such_port" );
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
@@ -581,7 +582,7 @@ IMPLEMENT_TEST( map_output_port_no_exist )
 
 IMPLEMENT_TEST( connect )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -648,7 +649,7 @@ IMPLEMENT_TEST( connect )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_upstream_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -668,7 +669,7 @@ IMPLEMENT_TEST( connect_upstream_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_upstream_port_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -691,7 +692,7 @@ IMPLEMENT_TEST( connect_upstream_port_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_downstream_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -711,7 +712,7 @@ IMPLEMENT_TEST( connect_downstream_no_exist )
 // ------------------------------------------------------------------
 IMPLEMENT_TEST( connect_downstream_port_no_exist )
 {
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ();
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ();
 
   sprokit::process::name_t const name1 = sprokit::process::name_t( "name1" );
   sprokit::process::name_t const name2 = sprokit::process::name_t( "name2" );
@@ -742,7 +743,7 @@ IMPLEMENT_TEST( reconfigure_pass_tunable_mappings )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -770,7 +771,7 @@ IMPLEMENT_TEST( reconfigure_pass_tunable_mappings )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -794,7 +795,7 @@ IMPLEMENT_TEST( reconfigure_no_pass_untunable_mappings )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -821,7 +822,7 @@ IMPLEMENT_TEST( reconfigure_no_pass_untunable_mappings )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -847,7 +848,7 @@ IMPLEMENT_TEST( reconfigure_pass_extra )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "expect" );
@@ -864,7 +865,7 @@ IMPLEMENT_TEST( reconfigure_pass_extra )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -888,7 +889,7 @@ IMPLEMENT_TEST( reconfigure_tunable_only_if_mapped )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   sprokit::process::name_t const name = sprokit::process::name_t( "name" );
   sprokit::process::type_t const type = sprokit::process::type_t( "expect" );
@@ -906,7 +907,7 @@ IMPLEMENT_TEST( reconfigure_tunable_only_if_mapped )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -933,7 +934,7 @@ IMPLEMENT_TEST( reconfigure_mapped_untunable )
 
   cluster_conf->set_value( sprokit::process::config_name, cluster_name );
 
-  sample_cluster_t const cluster = std::make_shared< sample_cluster > ( cluster_conf );
+  sample_cluster_t const cluster = boost::make_shared< sample_cluster > ( cluster_conf );
 
   kwiver::vital::config_block_key_t const key = kwiver::vital::config_block_key_t( "key" );
 
@@ -961,7 +962,7 @@ IMPLEMENT_TEST( reconfigure_mapped_untunable )
 
   cluster->_add_process( name, type, conf );
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();

--- a/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
@@ -270,7 +270,7 @@ test_process_input_ports( sprokit::process_t const process )
                   "(" << process->type() << "." << port << ")" );
     }
 
-    sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
 
     process->connect_input_port( port, edge );
 
@@ -334,8 +334,8 @@ test_process_output_ports( sprokit::process_t const process )
                   "(" << process->type() << "." << port << ")" );
     }
 
-    sprokit::edge_t edge1 = std::make_shared< sprokit::edge > ( config );
-    sprokit::edge_t edge2 = std::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge1 = boost::make_shared< sprokit::edge > ( config );
+    sprokit::edge_t edge2 = boost::make_shared< sprokit::edge > ( config );
 
     process->connect_output_port( port, edge1 );
     process->connect_output_port( port, edge2 );
@@ -366,7 +366,7 @@ test_process_invalid_input_port( sprokit::process_t const process )
                     process->input_port_info( non_existent_port ),
                     "requesting the info for a non-existent input port" );
 
-  sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
+  sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
 
   EXPECT_EXCEPTION( sprokit::no_such_port_exception,
                     process->connect_input_port( non_existent_port, edge ),
@@ -386,7 +386,7 @@ test_process_invalid_output_port( sprokit::process_t const process )
                     process->output_port_info( non_existent_port ),
                     "requesting the info for a non-existent output port" );
 
-  sprokit::edge_t edge = std::make_shared< sprokit::edge > ( config );
+  sprokit::edge_t edge = boost::make_shared< sprokit::edge > ( config );
 
   EXPECT_EXCEPTION( sprokit::no_such_port_exception,
                     process->connect_output_port( non_existent_port, edge ),

--- a/sprokit/tests/sprokit/pipeline/test_process_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_registry.cxx
@@ -164,7 +164,7 @@ IMPLEMENT_TEST(register_cluster)
 
   sprokit::process_t const cluster_from_reg = sprokit::create_process(cluster_type, sprokit::process::name_t(), config);
 
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(cluster_from_reg);
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(cluster_from_reg);
 
   if (!cluster)
   {
@@ -175,7 +175,7 @@ IMPLEMENT_TEST(register_cluster)
 
   sprokit::process_t const not_a_cluster_from_reg = sprokit::create_process(type, sprokit::process::name_t(), config);
 
-  sprokit::process_cluster_t const not_a_cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(not_a_cluster_from_reg);
+  sprokit::process_cluster_t const not_a_cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(not_a_cluster_from_reg);
 
   if (not_a_cluster)
   {

--- a/sprokit/tests/sprokit/pipeline/test_run.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_run.cxx
@@ -630,5 +630,5 @@ create_process(sprokit::process::type_t const& type, sprokit::process::name_t co
 sprokit::pipeline_t
 create_pipeline()
 {
-  return std::make_shared<sprokit::pipeline>();
+  return boost::make_shared<sprokit::pipeline>();
 }

--- a/sprokit/tests/sprokit/pipeline/test_scheduler.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler.cxx
@@ -254,7 +254,7 @@ IMPLEMENT_TEST(restart)
   sched->start();
   sched->stop();
 
-  std::shared_ptr<null_scheduler> const null_sched = std::dynamic_pointer_cast<null_scheduler>(sched);
+  boost::shared_ptr<null_scheduler> const null_sched = boost::dynamic_pointer_cast<null_scheduler>(sched);
 
   null_sched->reset_pipeline();
 
@@ -265,7 +265,7 @@ IMPLEMENT_TEST(restart)
 sprokit::scheduler_t
 create_scheduler(sprokit::scheduler::type_t const& type)
 {
-  sprokit::pipeline_t const pipeline = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipeline = boost::make_shared<sprokit::pipeline>();
 
   return sprokit::create_scheduler(type, pipeline);
 }
@@ -282,14 +282,14 @@ create_minimal_scheduler()
 
   sprokit::process_t const proc = sprokit::create_process(type, name);
 
-  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
 
   pipe->add_process(proc);
   pipe->setup_pipeline();
 
   kwiver::vital::config_block_sptr const conf = kwiver::vital::config_block::empty_config();
 
-  sprokit::scheduler_t const sched = std::make_shared<null_scheduler>(pipe, conf);
+  sprokit::scheduler_t const sched = boost::make_shared<null_scheduler>(pipe, conf);
 
   return sched;
 }

--- a/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
@@ -92,7 +92,7 @@ IMPLEMENT_TEST(load_schedulers)
 
   auto factories =  kwiver::vital::plugin_manager::instance().get_factories<sprokit::scheduler>();
 
-  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
 
   VITAL_FOREACH( auto fact, factories )
   {
@@ -172,7 +172,7 @@ IMPLEMENT_TEST(unknown_types)
 {
   sprokit::scheduler::type_t const non_existent_scheduler = sprokit::scheduler::type_t("no_such_scheduler");
 
-  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
 
   EXPECT_EXCEPTION(sprokit::no_such_scheduler_type_exception,
                    sprokit::create_scheduler(non_existent_scheduler, pipe),

--- a/sprokit/tests/sprokit/pipeline_util/test_export_dot.cxx
+++ b/sprokit/tests/sprokit/pipeline_util/test_export_dot.cxx
@@ -91,7 +91,7 @@ IMPLEMENT_TEST(pipeline_empty_name)
   sprokit::process::type_t const type = sprokit::process::type_t("orphan");
   sprokit::process_t const proc = sprokit::create_process(type, sprokit::process::name_t());
 
-  sprokit::pipeline_t const pipe = std::make_shared<sprokit::pipeline>();
+  sprokit::pipeline_t const pipe = boost::make_shared<sprokit::pipeline>();
 
   pipe->add_process(proc);
 
@@ -166,7 +166,7 @@ IMPLEMENT_TEST(cluster_empty_name)
   const auto conf = kwiver::vital::config_block::empty_config();
 
   sprokit::process_t const proc = info->ctor(conf);
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   std::ostringstream sstr;
 
@@ -188,7 +188,7 @@ IMPLEMENT_TEST(cluster_multiplier)
   conf->set_value(sprokit::process::config_name, name);
 
   sprokit::process_t const proc = info->ctor(conf);
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast<sprokit::process_cluster>(proc);
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast<sprokit::process_cluster>(proc);
 
   std::ostringstream sstr;
 

--- a/sprokit/tests/sprokit/pipeline_util/test_pipe_bakery.cxx
+++ b/sprokit/tests/sprokit/pipeline_util/test_pipe_bakery.cxx
@@ -579,7 +579,7 @@ IMPLEMENT_TEST( cluster_multiplier )
 
   sprokit::process_t const proc = ctor( config );
 
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast< sprokit::process_cluster > ( proc );
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast< sprokit::process_cluster > ( proc );
 
   if ( ! cluster )
   {
@@ -731,7 +731,7 @@ IMPLEMENT_TEST( cluster_map_config )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -759,7 +759,7 @@ IMPLEMENT_TEST( cluster_map_config_tunable )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -790,7 +790,7 @@ DONT_IMPLEMENT_TEST( cluster_map_config_redirect )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -828,7 +828,7 @@ DONT_IMPLEMENT_TEST( cluster_map_config_modified )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -866,7 +866,7 @@ IMPLEMENT_TEST( cluster_map_config_not_read_only )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -902,7 +902,7 @@ IMPLEMENT_TEST( cluster_map_config_only_provided )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -939,7 +939,7 @@ IMPLEMENT_TEST( cluster_map_config_only_conf_provided )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -978,7 +978,7 @@ IMPLEMENT_TEST( cluster_map_config_to_non_process )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -1014,7 +1014,7 @@ IMPLEMENT_TEST( cluster_map_config_not_from_cluster )
     return;
   }
 
-  sprokit::pipeline_t const pipeline = std::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
+  sprokit::pipeline_t const pipeline = boost::make_shared< sprokit::pipeline > ( kwiver::vital::config_block::empty_config() );
 
   pipeline->add_process( cluster );
   pipeline->setup_pipeline();
@@ -1187,7 +1187,7 @@ create_process( sprokit::process::type_t const& type, sprokit::process::name_t c
 sprokit::pipeline_t
 create_pipeline()
 {
-  return std::make_shared< sprokit::pipeline > ();
+  return boost::make_shared< sprokit::pipeline > ();
 }
 
 
@@ -1206,7 +1206,7 @@ setup_map_config_cluster( sprokit::process::name_t const& name, kwiver::vital::p
 
   sprokit::process_t const proc = ctor( config );
 
-  sprokit::process_cluster_t const cluster = std::dynamic_pointer_cast< sprokit::process_cluster > ( proc );
+  sprokit::process_cluster_t const cluster = boost::dynamic_pointer_cast< sprokit::process_cluster > ( proc );
 
   return cluster;
 }


### PR DESCRIPTION
As sad as it makes me, I think we need to temporarily switch back to boost shared pointer.  The intent is to make this release of KWIVER functional and then @hughed2 will revert the commit as part of his branch to switch to pybind11.  Thanks to @mattdawkins for providing the patch.