### PR TITLE
Fix location of Sprokit Python files on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ if (KWIVER_ENABLE_PYTHON)
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "\n# set to suppress loading python modules/processes\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "# export SPROKIT_NO_PYTHON_MODULES\n\n" )
 
-  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set PYTHONPATH=%~dp0/lib/python2.7/%config%/site-packages\n" )
+  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set PYTHONPATH=%~dp0/lib/%config%/python2.7/site-packages\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n:: additional python mudules to load, separated by ':'\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set SPROKIT_PYTHON_MODULES=kwiver.processes\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n:: set to suppress loading python modules/processes\n" )

--- a/sprokit/cmake/snippets/python.cmake
+++ b/sprokit/cmake/snippets/python.cmake
@@ -4,7 +4,7 @@ cmake_dependent_option(SPROKIT_ENABLE_PYTHON3 "Use Python3" OFF
   KWIVER_ENABLE_PYTHON OFF)
 if (KWIVER_ENABLE_PYTHON)
   set(sprokit_python_subdir "python${PYTHON_VERSION}${PYTHON_ABIFLAGS}")
-  set(sprokit_python_output_path "${KWIVER_BINARY_DIR}/lib/${sprokit_python_subdir}")
+  set(sprokit_python_output_path "${KWIVER_BINARY_DIR}/lib")
 
   set(PYTHON_VERSION "2.7"
     CACHE STRING "The version of python to use for bindings")

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -169,7 +169,7 @@ function (sprokit_add_python_module_int    path     modpath    module)
     set(sprokit_configure_cmake_args
       "\"-Dconfig=${CMAKE_CFG_INTDIR}/\"")
     set(sprokit_configure_extra_dests
-      "${sprokit_python_output_path}/${python_noarchdir}\${config}${python_sitepath}/${modpath}/${module}.py")
+      "${sprokit_python_output_path}/\${config}/${sprokit_python_subdir}${python_noarchdir}${python_sitepath}/${modpath}/${module}.py")
   endif ()
 
   if( WIN32 )
@@ -184,11 +184,11 @@ function (sprokit_add_python_module_int    path     modpath    module)
   sprokit_configure_file_w_uid("${python_configure_id}"
     "${python_module_id}"
     "${path}"
-    "${sprokit_python_output_path}${python_noarchdir}${python_sitepath}/${modpath}/${module}.py"
+    "${sprokit_python_output_path}/${sprokit_python_subdir}${python_noarchdir}${python_sitepath}/${modpath}/${module}.py"
     PYTHON_EXECUTABLE)
 
   sprokit_install(
-    FILES       "${sprokit_python_output_path}${python_noarchdir}${python_sitepath}/${modpath}/${module}.py"
+    FILES       "${sprokit_python_output_path}/${sprokit_python_subdir}${python_noarchdir}${python_sitepath}/${modpath}/${module}.py"
     DESTINATION "${python_install_path}/${sprokit_python_subdir}${python_sitepath}/${modpath}"
     COMPONENT   runtime)
 


### PR DESCRIPTION
This change makes Sprokit consistently use lib/${config}/python2.7
instead of lib/python2.7/${config}.