### PR TITLE
Point KWIVER_LIBRARY_DIR to where *.lib files live, no matter the OS

### DIFF
--- a/CMake/kwiver-config-build.cmake.in
+++ b/CMake/kwiver-config-build.cmake.in
@@ -20,14 +20,11 @@ set(KWIVER_TEST_INCLUDE_DIRS
   )
 
 if (WIN32)
-  set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/bin")
   add_definitions(-DBOOST_ALL_NO_LIB)
   add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
-
-else ()
-  set(KWIVER_LIBRARY_DIR    "@KWIVER_BINARY_DIR@/lib")
 endif ()
 
+set(KWIVER_LIBRARY_DIR         "@KWIVER_BINARY_DIR@/lib")
 set(KWIVER_LIBRARIES           @kwiver_libs@)
 set(KWIVER_ENABLE_PYTHON       "@KWIVER_ENABLE_PYTHON@")
 set(KWIVER_LIBRARY_DIRS        "${KWIVER_LIBRARY_DIR}"  "@KWIVER_LIBRARY_DIRS@")


### PR DESCRIPTION
This variable is intended to tell the linker where to find lib files live, not where *.so || *.dll files live