### PR TITLE
Fix CSV parsing.

### DIFF
--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -210,7 +210,7 @@ get_input()
   }
 
   m_input_buffer.clear();
-  kwiver::vital::tokenize( line, m_input_buffer, m_delim, true );
+  kwiver::vital::tokenize( line, m_input_buffer, m_delim, false );
 
   // Test the minimum number of fields.
   if ( m_input_buffer.size() < 7 )


### PR DESCRIPTION
Multiple commas should not be treated as one comma in a CSV file. Thus, trimEmpty should be set to false when running the tokenizer on a line of a CSV file.

When detected_object_set_output_csv.cxx is used to create a CSV file of detections and no image file name is supplied, the second column will be correctly created as an empty column. That is, the file will contain a double comma in each line. When the parser in detected_object_set_input_csv.cxx ignores this column, it triggers the error test on line 224. In summary, the CSV writer and reader in arrows are not compatible with one another before this fix.