### PR TITLE
Use NDEBUG to reduce lexer output of individual tokens.

### DIFF
--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -48,6 +48,10 @@
 
 #include <boost/make_shared.hpp>
 
+// Make value evaluate to true to enable low level lexer debugging of
+// token traffic
+#define LEX_DEBUG 0
+
 namespace sprokit {
 
 namespace {
@@ -312,7 +316,7 @@ unget_token( token_sptr token )
 {
   m_priv->m_token_stack.push_back( token );
 
-#if !defined NDEBUG
+#if LEX_DEBUG
   LOG_TRACE( m_logger, "Ungetting " << *token );
 #endif
 }
@@ -325,7 +329,7 @@ get_token()
 {
   auto t = get_next_token();
 
-#if !defined NDEBUG
+#if LEX_DEBUG
   LOG_TRACE( m_logger, *t );
 #endif
 

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -311,7 +311,10 @@ lex_processor::
 unget_token( token_sptr token )
 {
   m_priv->m_token_stack.push_back( token );
+
+#if !defined NDEBUG
   LOG_TRACE( m_logger, "Ungetting " << *token );
+#endif
 }
 
 
@@ -321,7 +324,10 @@ lex_processor::
 get_token()
 {
   auto t = get_next_token();
+
+#if !defined NDEBUG
   LOG_TRACE( m_logger, *t );
+#endif
 
   return t;
 }


### PR DESCRIPTION
The token trace is only interesting when debugging the lexer.
Sometimes when there is a permissive logger configuration, the lexer trace is overwhelming.