### PR TITLE
Add default directory to pipeline building calls.

### DIFF
--- a/sprokit/processes/adapters/CMakeLists.txt
+++ b/sprokit/processes/adapters/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries( kwiver_adapter
                    vital_logger
   PRIVATE          sprokit_pipeline
                    sprokit_tools
+                   kwiversys
 
   )
 

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -141,7 +141,7 @@ embedded_pipeline
 {
   // create a pipeline
   sprokit::pipeline_builder builder;
-  builder.load_pipeline( istr, def_dir );
+  builder.load_pipeline( istr, def_dir + "/in-stream" );
 
   // build pipeline
   m_priv->m_pipeline = builder.pipeline();

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -137,11 +137,11 @@ embedded_pipeline
 // ------------------------------------------------------------------
 void
 embedded_pipeline
-::build_pipeline( std::istream& istr )
+::build_pipeline( std::istream& istr, std::string const& def_dir )
 {
   // create a pipeline
   sprokit::pipeline_builder builder;
-  builder.load_pipeline( istr );
+  builder.load_pipeline( istr, def_dir );
 
   // build pipeline
   m_priv->m_pipeline = builder.pipeline();

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -52,6 +52,8 @@
 #include <sprokit/processes/adapters/output_adapter.h>
 #include <sprokit/processes/adapters/output_adapter_process.h>
 
+#include <kwiversys/SystemTools.hxx>
+
 #include <sstream>
 #include <stdexcept>
 
@@ -64,6 +66,8 @@ static kwiver::vital::config_block_key_t const scheduler_block = kwiver::vital::
 
 
 namespace kwiver {
+
+typedef kwiversys::SystemTools ST;
 
 // ----------------------------------------------------------------
 class embedded_pipeline::priv
@@ -141,7 +145,14 @@ embedded_pipeline
 {
   // create a pipeline
   sprokit::pipeline_builder builder;
-  builder.load_pipeline( istr, def_dir + "/in-stream" );
+
+  std::string cur_file( def_dir );
+  if ( def_dir.empty() )
+  {
+    cur_file = ST::GetCurrentWorkingDirectory();
+  }
+
+  builder.load_pipeline( istr, cur_file + "/in-stream" );
 
   // build pipeline
   m_priv->m_pipeline = builder.pipeline();

--- a/sprokit/processes/adapters/embedded_pipeline.h
+++ b/sprokit/processes/adapters/embedded_pipeline.h
@@ -1,4 +1,3 @@
-
 /*ckwg +29
  * Copyright 2016 by Kitware, Inc.
  * All rights reserved.
@@ -141,8 +140,11 @@ public:
    * supplied stream.
    *
    * @param istr Input stream containing the pipeline description.
+   * @param def_dir Directory to be used as the current directory
+   * for the specified input stream. This directory is used to resolve
+   * relpath.
    */
-  void build_pipeline( std::istream& istr );
+  void build_pipeline( std::istream& istr, std::string const& def_dir = "" );
 
   /**
    * @brief Send data set to input adapter.

--- a/sprokit/processes/adapters/embedded_pipeline.h
+++ b/sprokit/processes/adapters/embedded_pipeline.h
@@ -140,9 +140,12 @@ public:
    * supplied stream.
    *
    * @param istr Input stream containing the pipeline description.
-   * @param def_dir Directory to be used as the current directory
-   * for the specified input stream. This directory is used to resolve
-   * relpath.
+   * @param def_dir The directory name used to report errors in the
+   * input stream and is used as the current directory to locate
+   * includes and to resolve relpath. Since the input stream being
+   * processed has no file name, the name "in-stream" is appended to
+   * the directory supplied so that errors in the stream can be
+   * differentiated from errors from other files.
    */
   void build_pipeline( std::istream& istr, std::string const& def_dir = "" );
 

--- a/sprokit/processes/adapters/embedded_pipeline.h
+++ b/sprokit/processes/adapters/embedded_pipeline.h
@@ -145,7 +145,8 @@ public:
    * includes and to resolve relpath. Since the input stream being
    * processed has no file name, the name "in-stream" is appended to
    * the directory supplied so that errors in the stream can be
-   * differentiated from errors from other files.
+   * differentiated from errors from other files. If this parameter is
+   * not supplied, the current directory is used.
    */
   void build_pipeline( std::istream& istr, std::string const& def_dir = "" );
 

--- a/sprokit/src/sprokit/pipeline_util/load_pipe.cxx
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe.cxx
@@ -86,7 +86,7 @@ load_pipe_blocks_from_file( kwiver::vital::path_t const& fname )
 
 // ------------------------------------------------------------------
 pipe_blocks
-load_pipe_blocks( std::istream& istr )
+load_pipe_blocks( std::istream& istr, std::string const& def_dir )
 {
   sprokit::pipe_parser the_parser;
 
@@ -97,7 +97,7 @@ load_pipe_blocks( std::istream& istr )
     the_parser.add_search_path( path_list );
   }
 
-  return the_parser.parse_pipeline( istr );
+  return the_parser.parse_pipeline( istr, def_dir );
 }
 
 
@@ -126,7 +126,7 @@ load_cluster_blocks_from_file( kwiver::vital::path_t const& fname )
 
 // ------------------------------------------------------------------
 cluster_blocks
-load_cluster_blocks( std::istream& istr )
+load_cluster_blocks( std::istream& istr, std::string const& def_dir )
 {
   sprokit::pipe_parser the_parser;
 
@@ -137,7 +137,7 @@ load_cluster_blocks( std::istream& istr )
     the_parser.add_search_path( path_list );
   }
 
-  return the_parser.parse_cluster( istr );
+  return the_parser.parse_cluster( istr, def_dir );
 }
 
 } // end namespace

--- a/sprokit/src/sprokit/pipeline_util/load_pipe.cxx
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe.cxx
@@ -86,7 +86,7 @@ load_pipe_blocks_from_file( kwiver::vital::path_t const& fname )
 
 // ------------------------------------------------------------------
 pipe_blocks
-load_pipe_blocks( std::istream& istr, std::string const& def_dir )
+load_pipe_blocks( std::istream& istr, std::string const& def_file )
 {
   sprokit::pipe_parser the_parser;
 
@@ -97,7 +97,7 @@ load_pipe_blocks( std::istream& istr, std::string const& def_dir )
     the_parser.add_search_path( path_list );
   }
 
-  return the_parser.parse_pipeline( istr, def_dir );
+  return the_parser.parse_pipeline( istr, def_file );
 }
 
 
@@ -126,7 +126,7 @@ load_cluster_blocks_from_file( kwiver::vital::path_t const& fname )
 
 // ------------------------------------------------------------------
 cluster_blocks
-load_cluster_blocks( std::istream& istr, std::string const& def_dir )
+load_cluster_blocks( std::istream& istr, std::string const& def_file )
 {
   sprokit::pipe_parser the_parser;
 
@@ -137,7 +137,7 @@ load_cluster_blocks( std::istream& istr, std::string const& def_dir )
     the_parser.add_search_path( path_list );
   }
 
-  return the_parser.parse_cluster( istr, def_dir );
+  return the_parser.parse_cluster( istr, def_file );
 }
 
 } // end namespace

--- a/sprokit/src/sprokit/pipeline_util/load_pipe.h
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe.h
@@ -60,11 +60,11 @@ SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks_from_file( kwiver::vit
  * \brief Convert a pipeline description into a pipeline.
  *
  * \param istr The stream to load the pipeline from.
- * \param inc_root The root directory to search for includes from.
+ * \param def_dir The root directory to search for includes from.
  *
  * \returns A new set of pipeline blocks.
  */
-SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks(std::istream& istr );
+SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks(std::istream& istr, std::string const& def_dir = "" );
 
 /**
  * \brief Convert a cluster description file into a collection of cluster blocks.
@@ -79,11 +79,11 @@ SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks_from_file( kwive
  * \brief Convert a cluster description into a cluster.
  *
  * \param istr The stream to load the cluster from.
- * \param inc_root The root directory to search for includes from.
+ * \param def_dir The root directory to search for includes from.
  *
  * \returns A new set of cluster blocks.
  */
-SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks(std::istream& istr );
+SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks(std::istream& istr, std::string const& def_dir = "" );
 
 }
 

--- a/sprokit/src/sprokit/pipeline_util/load_pipe.h
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe.h
@@ -60,11 +60,14 @@ SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks_from_file( kwiver::vit
  * \brief Convert a pipeline description into a pipeline.
  *
  * \param istr The stream to load the pipeline from.
- * \param def_dir The root directory to search for includes from.
+ * \param def_file The default file name used when reporting errors
+ * from the stream. The directory portion is used when resolving
+ * included files and relpath specifiers.
  *
  * \returns A new set of pipeline blocks.
  */
-SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks(std::istream& istr, std::string const& def_dir = "" );
+SPROKIT_PIPELINE_UTIL_EXPORT pipe_blocks load_pipe_blocks(std::istream& istr,
+                                                          std::string const& def_file = "" );
 
 /**
  * \brief Convert a cluster description file into a collection of cluster blocks.
@@ -79,11 +82,14 @@ SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks_from_file( kwive
  * \brief Convert a cluster description into a cluster.
  *
  * \param istr The stream to load the cluster from.
- * \param def_dir The root directory to search for includes from.
+ * \param def_file The default file name used when reporting errors
+ * from the stream. The directory portion is used when resolving
+ * included files and relpath specifiers.
  *
  * \returns A new set of cluster blocks.
  */
-SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks(std::istream& istr, std::string const& def_dir = "" );
+SPROKIT_PIPELINE_UTIL_EXPORT cluster_blocks load_cluster_blocks(std::istream& istr,
+                                                                std::string const& def_file = "" );
 
 }
 

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
@@ -66,9 +66,9 @@ pipeline_builder
 // ------------------------------------------------------------------
 void
 pipeline_builder
-::load_pipeline(std::istream& istr)
+::load_pipeline(std::istream& istr, std::string const& def_dir )
 {
-  m_blocks = sprokit::load_pipe_blocks(istr);
+  m_blocks = sprokit::load_pipe_blocks(istr, def_dir);
 }
 
 

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
@@ -66,9 +66,9 @@ pipeline_builder
 // ------------------------------------------------------------------
 void
 pipeline_builder
-::load_pipeline(std::istream& istr, std::string const& def_dir )
+::load_pipeline(std::istream& istr, std::string const& def_file )
 {
-  m_blocks = sprokit::load_pipe_blocks(istr, def_dir);
+  m_blocks = sprokit::load_pipe_blocks(istr, def_file);
 }
 
 

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.h
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.h
@@ -76,9 +76,11 @@ public:
    * to the internal pipeline representation.
    *
    * \param istr Stream containing the textual pipeline definition.
-   * \param def_dir Directory to use for resolving inclues and relativepath specifications.
+   * \param def_file The default file name used when reporting errors
+   * from the stream. The directory portion is used when resolving
+   * included files and relpath specifiers.
    */
-  void load_pipeline(std::istream& istr, std::string const& def_dir = "" );
+  void load_pipeline(std::istream& istr, std::string const& def_file = "" );
 
   /**
    * \brief Load supplemental data into pipeline description.

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.h
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.h
@@ -76,8 +76,9 @@ public:
    * to the internal pipeline representation.
    *
    * \param istr Stream containing the textual pipeline definition.
+   * \param def_dir Directory to use for resolving inclues and relativepath specifications.
    */
-  void load_pipeline(std::istream& istr);
+  void load_pipeline(std::istream& istr, std::string const& def_dir = "" );
 
   /**
    * \brief Load supplemental data into pipeline description.

--- a/sprokit/src/sprokit/tools/build_pipeline_from_options.cxx
+++ b/sprokit/src/sprokit/tools/build_pipeline_from_options.cxx
@@ -49,17 +49,15 @@ build_pipeline_from_options( boost::program_options::variables_map const& vm,
   if (!vm.count("pipeline"))
   {
     std::cerr << "Error: pipeline option not set" << std::endl;
-
     tool_usage(EXIT_FAILURE, desc);
   }
 
   kwiver::vital::path_t const ipath = vm["pipeline"].as<kwiver::vital::path_t>();
-
   istream_t const istr = open_istream(ipath);
 
   /// \todo Include paths?
 
-  this->load_pipeline(*istr);
+  this->load_pipeline(*istr, ipath);
   this->load_from_options(vm);
 }
 


### PR DESCRIPTION
In the case where pipeline specification is passed as an istream,
the current directory is ambiguous when needed to resolve an include
file or relativepath specification. This change adds an optional
default directory to be used for the top level directory.