### PR TITLE
Add iterator interface to descriptors

### DIFF
--- a/vital/types/descriptor.h
+++ b/vital/types/descriptor.h
@@ -148,6 +148,11 @@ public:
   virtual const T* raw_data() const = 0;
 
 
+  // Iterator interface
+  T const* begin() const { return this->raw_data(); }
+  T const* end() const { return this->raw_data() + this->size(); }
+
+
   /// Equality operator
   bool operator==( descriptor_array_of<T> const& other ) const
   {


### PR DESCRIPTION
Add an iterator/range (i.e. `begin` and `end` methods) to descriptors. This allows them to be use in more ways, including standard algorithms and range-based for, and since they are essentially arrays anyway, it is unnecessarily awkward to not have these interfaces.