### PR TITLE
Refactor track_set 

### DIFF
--- a/arrows/ceres/tests/test_optimize_cameras.cxx
+++ b/arrows/ceres/tests/test_optimize_cameras.cxx
@@ -107,7 +107,7 @@ IMPLEMENT_TEST(empty_input)
 
   camera_map_sptr cam_map(new simple_camera_map());
   landmark_map_sptr lm_map(new simple_landmark_map());
-  feature_track_set_sptr trk_set(new simple_feature_track_set());
+  feature_track_set_sptr trk_set(new feature_track_set());
 
   ceres::optimize_cameras optimizer;
   config_block_sptr cfg = optimizer.get_configuration();

--- a/arrows/core/close_loops_bad_frames_only.cxx
+++ b/arrows/core/close_loops_bad_frames_only.cxx
@@ -197,13 +197,13 @@ close_loops_bad_frames_only
     last_frame_to_test = frame_to_test - max_search_length_;
   }
 
-  auto stitch_frame_set = std::make_shared<vital::simple_feature_track_set>(
+  auto stitch_frame_set = std::make_shared<vital::feature_track_set>(
                               input->active_tracks( frame_to_stitch ) );
 
 
   for( ; frame_to_test > last_frame_to_test; frame_to_test-- )
   {
-    auto test_frame_set = std::make_shared<vital::simple_feature_track_set>(
+    auto test_frame_set = std::make_shared<vital::feature_track_set>(
                               input->active_tracks( frame_to_test ) );
 
     // run matcher alg
@@ -240,7 +240,7 @@ close_loops_bad_frames_only
         );
       }
 
-      return std::make_shared<simple_feature_track_set>( all_tracks );
+      return std::make_shared<feature_track_set>( all_tracks );
     }
   }
 

--- a/arrows/core/close_loops_exhaustive.cxx
+++ b/arrows/core/close_loops_exhaustive.cxx
@@ -169,7 +169,7 @@ close_loops_exhaustive
   }
 
   std::vector< vital::track_sptr > all_tracks = input->tracks();
-  auto current_set = std::make_shared<vital::simple_feature_track_set>(
+  auto current_set = std::make_shared<vital::feature_track_set>(
                          input->active_tracks( frame_number ) );
 
   std::vector<vital::track_sptr> current_tracks = current_set->tracks();

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -220,7 +220,7 @@ close_loops_keyframe
 
   // extract the subset of tracks on the current frame and their
   // features and descriptors
-  auto current_set = std::make_shared<vital::simple_feature_track_set>(
+  auto current_set = std::make_shared<vital::feature_track_set>(
                          input->active_tracks( frame_number ) );
   std::vector<vital::track_sptr> current_tracks = current_set->tracks();
   vital::descriptor_set_sptr current_descriptors =

--- a/arrows/core/filter_tracks.cxx
+++ b/arrows/core/filter_tracks.cxx
@@ -147,7 +147,7 @@ filter_tracks
         good_trks.push_back(t);
       }
     }
-    tracks = std::make_shared<kwiver::vital::simple_track_set>(good_trks);
+    tracks = std::make_shared<kwiver::vital::track_set>(good_trks);
   }
 
   if( d_->min_mm_importance > 0 )
@@ -172,7 +172,7 @@ filter_tracks
       }
     }
 
-    tracks = std::make_shared<kwiver::vital::simple_track_set>(good_trks);
+    tracks = std::make_shared<kwiver::vital::track_set>(good_trks);
   }
   return tracks;
 }

--- a/arrows/core/initialize_cameras_landmarks.cxx
+++ b/arrows/core/initialize_cameras_landmarks.cxx
@@ -339,7 +339,7 @@ initialize_cameras_landmarks::priv
 
   landmark_map_sptr lm_map = std::make_shared<simple_landmark_map>(init_lms);
   camera_map_sptr cam_map = std::make_shared<simple_camera_map>(cams);
-  auto tracks = std::make_shared<simple_feature_track_set>(trks);
+  auto tracks = std::make_shared<feature_track_set>(trks);
   this->lm_triangulator->triangulate(cam_map, tracks, lm_map);
 
   // detect and remove landmarks with large triangulation error
@@ -1008,7 +1008,7 @@ initialize_cameras_landmarks
     }
 
     // get the subset of tracks that have features on frame f
-    auto ftracks = std::make_shared<simple_feature_track_set>(
+    auto ftracks = std::make_shared<feature_track_set>(
                        tracks->active_tracks(static_cast<int>(f)));
 
     // find existing landmarks for tracks also having features on the other frame
@@ -1071,7 +1071,7 @@ initialize_cameras_landmarks
       opt_cam_map[f] = cams[f];
       camera_map_sptr opt_cams = std::make_shared<simple_camera_map>(opt_cam_map);
       landmark_map_sptr landmarks = std::make_shared<simple_landmark_map>(flms);
-      auto tracks = std::make_shared<simple_feature_track_set>(trks);
+      auto tracks = std::make_shared<feature_track_set>(trks);
       d_->camera_optimizer->optimize(opt_cams, tracks, landmarks, metadata);
       cams[f] = opt_cams->cameras()[f];
     }
@@ -1125,7 +1125,7 @@ initialize_cameras_landmarks
       remove_landmarks(to_remove, lms);
       std::vector<track_sptr> all_trks = tracks->tracks();
       remove_tracks(to_remove, all_trks);
-      tracks = std::make_shared<simple_feature_track_set>(all_trks);
+      tracks = std::make_shared<feature_track_set>(all_trks);
       double final_rmse = kwiver::arrows::reprojection_rmse(cams, lms, trks);
       LOG_INFO(d_->m_logger, "final reprojection RMSE: " << final_rmse);
       LOG_DEBUG(d_->m_logger, "updated focal length "

--- a/arrows/core/merge_tracks.cxx
+++ b/arrows/core/merge_tracks.cxx
@@ -52,7 +52,7 @@ match_tracks( vital::algo::match_features_sptr matcher,
               vital::frame_id_t target_frame )
 {
   // extract the subset of tracks on the current frame
-  auto current_tracks = std::make_shared<simple_feature_track_set>(
+  auto current_tracks = std::make_shared<feature_track_set>(
                             all_tracks->active_tracks(current_frame) );
   // extract the set of features on the current frame
   feature_set_sptr current_features = current_tracks->frame_features(current_frame);
@@ -75,7 +75,7 @@ match_tracks( vital::algo::match_features_sptr matcher,
               vital::frame_id_t target_frame )
 {
   // extract the subset of tracks on the target frame
-  auto target_tracks = std::make_shared<simple_feature_track_set>(
+  auto target_tracks = std::make_shared<feature_track_set>(
                            all_tracks->active_tracks(target_frame) );
   // extract the set of features on the target frame
   feature_set_sptr target_features = target_tracks->frame_features(target_frame);
@@ -178,7 +178,7 @@ remove_replaced_tracks( vital::feature_track_set_sptr all_tracks,
     at.end()
   );
   // recreate the track set with the new filtered tracks
-  return std::make_shared<simple_feature_track_set>( at );
+  return std::make_shared<feature_track_set>( at );
 }
 
 

--- a/arrows/core/projected_track_set.cxx
+++ b/arrows/core/projected_track_set.cxx
@@ -66,7 +66,7 @@ projected_tracks(landmark_map_sptr landmarks, camera_map_sptr cameras)
       t->append( fts );
     }
   }
-  return std::make_shared<simple_feature_track_set>( tracks );
+  return std::make_shared<feature_track_set>( tracks );
 }
 
 

--- a/arrows/core/track_features_core.cxx
+++ b/arrows/core/track_features_core.cxx
@@ -267,7 +267,7 @@ track_features_core
   // see if there are already existing tracks on this frame
   if( prev_tracks )
   {
-    existing_set = std::make_shared<simple_feature_track_set>(
+    existing_set = std::make_shared<feature_track_set>(
                        prev_tracks->active_tracks(frame_number));
     if( existing_set && existing_set->size() > 0 )
     {
@@ -381,10 +381,10 @@ track_features_core
       // call loop closure on the first frame to establish this
       // frame as the first frame for loop closing purposes
       return d_->closer->stitch(frame_number,
-                                std::make_shared<simple_feature_track_set>(new_tracks),
+                                std::make_shared<feature_track_set>(new_tracks),
                                 image_data, mask);
     }
-    return std::make_shared<simple_feature_track_set>(new_tracks);
+    return std::make_shared<feature_track_set>(new_tracks);
   }
 
   // get the last track id in the existing set of tracks and increment it
@@ -398,7 +398,7 @@ track_features_core
   // and prefer those over the last frame (i.e. largest frame number)
   if( prev_frame >= frame_number && frame_number > 0 )
   {
-    active_set = std::make_shared<simple_feature_track_set>(
+    active_set = std::make_shared<feature_track_set>(
                      prev_tracks->active_tracks(frame_number - 1) );
     if( active_set && active_set->size() > 0 )
     {
@@ -407,7 +407,7 @@ track_features_core
   }
   if( !active_set )
   {
-    active_set = std::make_shared<simple_feature_track_set>(
+    active_set = std::make_shared<feature_track_set>(
                      prev_tracks->active_tracks(prev_frame) );
   }
 
@@ -488,7 +488,7 @@ track_features_core
       all_tracks.back()->append(fts);
       all_tracks.back()->set_id(next_track_id++);
     }
-    updated_track_set = std::make_shared<simple_feature_track_set>(all_tracks);
+    updated_track_set = std::make_shared<feature_track_set>(all_tracks);
   }
 
   // run loop closure if enabled

--- a/arrows/vxl/close_loops_homography_guided.cxx
+++ b/arrows/vxl/close_loops_homography_guided.cxx
@@ -351,11 +351,11 @@ close_loops_homography_guided
     const frame_id_t prior_frame = best_frame_to_test->fid;
 
     // Get all tracks on target frame
-    auto prior_set = std::make_shared<simple_feature_track_set>(
+    auto prior_set = std::make_shared<feature_track_set>(
                          input->active_tracks( prior_frame ) );
 
     // Get all tracks on the current frame
-    auto current_set = std::make_shared<simple_feature_track_set>(
+    auto current_set = std::make_shared<feature_track_set>(
                            input->active_tracks( frame_number ) );
 
     // Perform matching operation
@@ -402,7 +402,7 @@ close_loops_homography_guided
       }
 
       // Return updated set
-      return std::make_shared<simple_feature_track_set>( all_tracks );
+      return std::make_shared<feature_track_set>( all_tracks );
     }
   }
 

--- a/arrows/vxl/tests/test_optimize_cameras.cxx
+++ b/arrows/vxl/tests/test_optimize_cameras.cxx
@@ -106,7 +106,7 @@ IMPLEMENT_TEST(empty_input)
 
   camera_map_sptr cam_map(new simple_camera_map());
   landmark_map_sptr lm_map(new simple_landmark_map());
-  auto trk_set = std::make_shared<simple_feature_track_set>();
+  auto trk_set = std::make_shared<feature_track_set>();
 
   vxl::optimize_cameras optimizer;
 

--- a/sprokit/processes/core/matcher_process.cxx
+++ b/sprokit/processes/core/matcher_process.cxx
@@ -174,7 +174,7 @@ matcher_process
     // call loop closure on the first frame to establish this
     // frame as the first frame for loop closing purposes
     d->m_curr_tracks = d->m_closer->stitch( frame_number,
-                                            std::make_shared<vital::simple_feature_track_set>( new_tracks ),
+                                            std::make_shared<vital::feature_track_set>( new_tracks ),
                                             image_data );
   }
   else
@@ -216,7 +216,7 @@ matcher_process
     }
 
     d->m_curr_tracks = d->m_closer->stitch( frame_number,
-                  std::make_shared<vital::simple_feature_track_set>( all_tracks ),
+                  std::make_shared<vital::feature_track_set>( all_tracks ),
                   image_data );
   }
 

--- a/tests/test_scene.h
+++ b/tests/test_scene.h
@@ -230,7 +230,7 @@ subset_tracks( kwiver::vital::feature_track_set_sptr in_tracks, double keep_frac
     std::cout << std::endl;
     new_tracks.push_back( nt );
   }
-  return std::make_shared<simple_feature_track_set>( new_tracks );
+  return std::make_shared<feature_track_set>( new_tracks );
 }
 
 
@@ -260,7 +260,7 @@ noisy_tracks( kwiver::vital::feature_track_set_sptr in_tracks, double stdev = 1.
     }
     new_tracks.push_back(nt);
   }
-  return std::make_shared<simple_feature_track_set>( new_tracks );
+  return std::make_shared<feature_track_set>( new_tracks );
 }
 
 
@@ -306,7 +306,7 @@ add_outliers_to_tracks(kwiver::vital::feature_track_set_sptr in_tracks,
     std::cout << std::endl;
     new_tracks.push_back( nt );
   }
-  return std::make_shared<simple_feature_track_set>( new_tracks );
+  return std::make_shared<feature_track_set>( new_tracks );
 }
 
 

--- a/vital/bindings/c/types/track_set.cxx
+++ b/vital/bindings/c/types/track_set.cxx
@@ -71,7 +71,7 @@ vital_trackset_new( size_t length, vital_track_t **tracks,
       track_vec.push_back( vital_c::TRACK_SPTR_CACHE.get( tracks[i] ) );
     }
 
-    kwiver::vital::track_set_sptr ts_sptr( new kwiver::vital::simple_track_set( track_vec )
+    kwiver::vital::track_set_sptr ts_sptr( new kwiver::vital::track_set( track_vec )
                                          );
 
     kwiver::vital_c::TRACK_SET_SPTR_CACHE.store( ts_sptr );

--- a/vital/io/track_set_io.cxx
+++ b/vital/io/track_set_io.cxx
@@ -206,7 +206,7 @@ read_feature_track_file( path_t const& file_path )
     t->append( ftsd );
   }
 
-  return std::make_shared<simple_feature_track_set>( tracks );
+  return std::make_shared<feature_track_set>( tracks );
 } // read_track_file
 
 

--- a/vital/io/track_set_io.cxx
+++ b/vital/io/track_set_io.cxx
@@ -103,7 +103,7 @@ read_track_file( path_t const& file_path )
     t->append( std::make_shared<track_state>( fid ) );
   }
 
-  return track_set_sptr( new simple_track_set( tracks ) );
+  return track_set_sptr( new track_set( tracks ) );
 } // read_track_file
 
 

--- a/vital/tests/test_track_set.cxx
+++ b/vital/tests/test_track_set.cxx
@@ -84,7 +84,7 @@ IMPLEMENT_TEST(accessor_functions)
   test_tracks[1]->append( test_state2->clone() );
   test_tracks[2]->append( test_state3->clone() );
 
-  track_set_sptr test_set( new simple_track_set( test_tracks ) );
+  track_set_sptr test_set( new track_set( test_tracks ) );
 
   TEST_EQUAL("Total set size", test_set->size(), 4);
 

--- a/vital/types/feature_track_set.cxx
+++ b/vital/types/feature_track_set.cxx
@@ -43,6 +43,32 @@
 namespace kwiver {
 namespace vital {
 
+typedef std::unique_ptr<track_set_implementation> tsi_uptr;
+
+
+/// Default Constructor
+feature_track_set
+::feature_track_set()
+  : track_set(tsi_uptr(new simple_track_set_implementation))
+{
+}
+
+
+/// Constructor specifying the implementation
+feature_track_set
+::feature_track_set(std::unique_ptr<track_set_implementation> impl)
+  : track_set(std::move(impl))
+{
+}
+
+
+/// Constructor from a vector of tracks
+feature_track_set
+::feature_track_set(std::vector< track_sptr > const& tracks)
+  : track_set(tsi_uptr(new simple_track_set_implementation(tracks)))
+{
+}
+
 
 /// Return the set of features in tracks on the last frame
 feature_set_sptr

--- a/vital/types/feature_track_set.h
+++ b/vital/types/feature_track_set.h
@@ -31,8 +31,7 @@
 /**
  * \file
  * \brief Header file for \link kwiver::vital::feature_track_set feature_track_set
- *        \endlink and a concrete \link kwiver::vital::simple_feature_track_set
- *        simple_feature_track_set \endlink
+ *        \endlink
  */
 
 #ifndef VITAL_FEATURE_TRACK_SET_H_
@@ -85,6 +84,21 @@ typedef std::shared_ptr< feature_track_set > feature_track_set_sptr;
 class VITAL_EXPORT feature_track_set : public track_set
 {
 public:
+  /// Default Constructor
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  feature_track_set();
+
+  /// Constructor specifying the implementation
+  feature_track_set(std::unique_ptr<track_set_implementation> impl);
+
+  /// Constructor from a vector of tracks
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  feature_track_set(std::vector< track_sptr > const& tracks);
+
   /// Destructor
   virtual ~feature_track_set() VITAL_DEFAULT_DTOR
 
@@ -118,31 +132,6 @@ public:
    */
   virtual descriptor_set_sptr frame_descriptors( frame_id_t offset = -1 ) const;
 
-};
-
-
-/// A concrete feature track set that simply wraps a vector of tracks.
-class simple_feature_track_set :
-  public feature_track_set
-{
-public:
-  /// Default Constructor
-  simple_feature_track_set() VITAL_DEFAULT_CTOR
-
-  /// Constructor from a vector of tracks
-  explicit simple_feature_track_set( const std::vector< track_sptr >& tracks )
-    : data_( tracks ) { }
-
-  /// Return the number of tracks in the set
-  virtual size_t size() const { return data_.size(); }
-
-  /// Return a vector of track shared pointers
-  virtual std::vector< track_sptr > tracks() const { return data_; }
-
-
-protected:
-  /// The vector of tracks
-  std::vector< track_sptr > data_;
 };
 
 

--- a/vital/types/object_track_set.cxx
+++ b/vital/types/object_track_set.cxx
@@ -43,7 +43,31 @@
 namespace kwiver {
 namespace vital {
 
-//TODO add object_track_set implementations here
+typedef std::unique_ptr<track_set_implementation> tsi_uptr;
+
+
+/// Default Constructor
+object_track_set
+::object_track_set()
+  : track_set(tsi_uptr(new simple_track_set_implementation))
+{
+}
+
+
+/// Constructor specifying the implementation
+object_track_set
+::object_track_set(std::unique_ptr<track_set_implementation> impl)
+  : track_set(std::move(impl))
+{
+}
+
+
+/// Constructor from a vector of tracks
+object_track_set
+::object_track_set(std::vector< track_sptr > const& tracks)
+  : track_set(tsi_uptr(new simple_track_set_implementation(tracks)))
+{
+}
 
 
 } } // end namespace vital

--- a/vital/types/object_track_set.h
+++ b/vital/types/object_track_set.h
@@ -75,34 +75,23 @@ typedef std::shared_ptr< object_track_set > object_track_set_sptr;
 class VITAL_EXPORT object_track_set : public track_set
 {
 public:
+  /// Default Constructor
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  object_track_set();
+
+  /// Constructor specifying the implementation
+  object_track_set(std::unique_ptr<track_set_implementation> impl);
+
+  /// Constructor from a vector of tracks
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  object_track_set(std::vector< track_sptr > const& tracks);
 
   /// Destructor
   virtual ~object_track_set() VITAL_DEFAULT_DTOR
-};
-
-
-/// A concrete object track set that simply wraps a vector of tracks.
-class simple_object_track_set :
-  public object_track_set
-{
-public:
-  /// Default Constructor
-  simple_object_track_set() VITAL_DEFAULT_CTOR
-
-  /// Constructor from a vector of tracks
-  explicit simple_object_track_set( const std::vector< track_sptr >& tracks )
-    : data_( tracks ) { }
-
-  /// Return the number of tracks in the set
-  virtual size_t size() const { return data_.size(); }
-
-  /// Return a vector of track shared pointers
-  virtual std::vector< track_sptr > tracks() const { return data_; }
-
-
-protected:
-  /// The vector of tracks
-  std::vector< track_sptr > data_;
 };
 
 

--- a/vital/types/track_set.cxx
+++ b/vital/types/track_set.cxx
@@ -45,7 +45,7 @@ namespace vital {
 
 /// Return the number of tracks in the set
 size_t
-track_set
+track_set_implementation
 ::size() const
 {
   return this->tracks().size();
@@ -54,7 +54,7 @@ track_set
 
 /// Return whether or not there are any tracks in the set
 bool
-track_set
+track_set_implementation
 ::empty() const
 {
   return this->tracks().empty();
@@ -63,7 +63,7 @@ track_set
 
 /// Return the set of all frame IDs covered by these tracks
 std::set<frame_id_t>
-track_set
+track_set_implementation
 ::all_frame_ids() const
 {
   std::set<frame_id_t> ids;
@@ -81,7 +81,7 @@ track_set
 
 /// Return the set of all track IDs in this track set
 std::set<track_id_t>
-track_set
+track_set_implementation
 ::all_track_ids() const
 {
   std::set<track_id_t> ids;
@@ -98,7 +98,7 @@ track_set
 
 /// Return the last (largest) frame number containing tracks
 frame_id_t
-track_set
+track_set_implementation
 ::last_frame() const
 {
   frame_id_t last_frame = 0;
@@ -120,7 +120,7 @@ track_set
 
 /// Return the first (smallest) frame number containing tracks
 frame_id_t
-track_set
+track_set_implementation
 ::first_frame() const
 {
   frame_id_t first_frame = std::numeric_limits<frame_id_t>::max();
@@ -149,7 +149,7 @@ track_set
 
 /// Return the track in the set with the specified id.
 track_sptr const
-track_set
+track_set_implementation
 ::get_track(track_id_t tid) const
 {
   const std::vector<track_sptr> all_tracks = this->tracks();
@@ -167,8 +167,8 @@ track_set
 
 /// Return all tracks active on a frame.
 std::vector< track_sptr >
-track_set
-::active_tracks(frame_id_t offset)
+track_set_implementation
+::active_tracks(frame_id_t offset) const
 {
   frame_id_t frame_number = offset_to_frame(offset);
   const std::vector<track_sptr> all_tracks = this->tracks();
@@ -188,8 +188,8 @@ track_set
 
 /// Return all tracks active on a frame.
 std::vector< track_sptr >
-track_set
-::inactive_tracks(frame_id_t offset)
+track_set_implementation
+::inactive_tracks(frame_id_t offset) const
 {
   frame_id_t frame_number = offset_to_frame(offset);
   const std::vector<track_sptr> all_tracks = this->tracks();
@@ -209,8 +209,8 @@ track_set
 
 /// Return all new tracks on a given frame.
 std::vector< track_sptr >
-track_set
-::new_tracks(frame_id_t offset)
+track_set_implementation
+::new_tracks(frame_id_t offset) const
 {
   frame_id_t frame_number = offset_to_frame(offset);
   const std::vector<track_sptr> all_tracks = this->tracks();
@@ -230,8 +230,8 @@ track_set
 
 /// Return all new tracks on a given frame.
 std::vector< track_sptr >
-track_set
-::terminated_tracks(frame_id_t offset)
+track_set_implementation
+::terminated_tracks(frame_id_t offset) const
 {
   frame_id_t frame_number = offset_to_frame(offset);
   const std::vector<track_sptr> all_tracks = this->tracks();
@@ -251,8 +251,8 @@ track_set
 
 /// Return the percentage of tracks successfully tracked to the next frame.
 double
-track_set
-::percentage_tracked(frame_id_t offset1, frame_id_t offset2)
+track_set_implementation
+::percentage_tracked(frame_id_t offset1, frame_id_t offset2) const
 {
   const frame_id_t frame_number1 = offset_to_frame(offset1);
   const frame_id_t frame_number2 = offset_to_frame(offset2);
@@ -279,7 +279,7 @@ track_set
 
 /// Return a vector of state data corresponding to the tracks on the given frame.
 std::vector<track_state_sptr>
-track_set
+track_set_implementation
 ::frame_states( frame_id_t offset ) const
 {
   const frame_id_t frame_number = offset_to_frame(offset);
@@ -301,7 +301,7 @@ track_set
 
 /// Convert an offset number to an absolute frame number
 frame_id_t
-track_set
+track_set_implementation
 ::offset_to_frame(frame_id_t offset) const
 {
   if( offset >= 0 )
@@ -317,5 +317,32 @@ track_set
   }
   return frame_number;
 }
+
+
+
+/// Default Constructor
+track_set
+::track_set()
+  : impl_(new simple_track_set_implementation)
+{
+}
+
+
+/// Constructor specifying the implementation
+track_set
+::track_set(std::unique_ptr<track_set_implementation> impl)
+  : impl_(std::move(impl))
+{
+}
+
+
+/// Constructor from a vector of tracks
+track_set
+::track_set(std::vector< track_sptr > const& tracks)
+  : impl_(new simple_track_set_implementation(tracks))
+{
+}
+
+
 
 } } // end namespace vital

--- a/vital/types/track_set.h
+++ b/vital/types/track_set.h
@@ -51,45 +51,50 @@
 namespace kwiver {
 namespace vital {
 
+
+
 class track_set;
 /// Shared pointer for base track_set type
 typedef std::shared_ptr< track_set > track_set_sptr;
 
-/// A collection of tracks
-class VITAL_EXPORT track_set
+/// Abstract interface for a collection of tracks
+class VITAL_EXPORT track_set_interface
 {
 public:
   /// Destructor
-  virtual ~track_set() VITAL_DEFAULT_DTOR
+  virtual ~track_set_interface() VITAL_DEFAULT_DTOR
 
   /// Return the number of tracks in the set
-  virtual size_t size() const;
+  virtual size_t size() const = 0;
 
   /// Return whether or not there are any tracks in the set
-  virtual bool empty() const;
+  virtual bool empty() const = 0;
+
+  /// Assign a vector of track shared pointers to this container
+  virtual void set_tracks( std::vector< track_sptr > const& tracks ) = 0;
 
   /// Return a vector of track shared pointers
   virtual std::vector< track_sptr > tracks() const = 0;
 
   /// Return the set of all frame IDs covered by these tracks
-  virtual std::set< frame_id_t > all_frame_ids() const;
+  virtual std::set< frame_id_t > all_frame_ids() const = 0;
 
   /// Return the set of all track IDs in this track set
-  virtual std::set< track_id_t > all_track_ids() const;
+  virtual std::set< track_id_t > all_track_ids() const = 0;
 
   /// Return the first (smallest) frame number containing tracks
   /**
    * If there are no tracks in this set, or no tracks have states, this returns
    * 0.
    */
-  virtual frame_id_t first_frame() const;
+  virtual frame_id_t first_frame() const = 0;
 
   /// Return the last (largest) frame number containing tracks
   /**
    * If there are no tracks in this set, or no tracks have states, this returns
    * 0.
    */
-  virtual frame_id_t last_frame() const;
+  virtual frame_id_t last_frame() const = 0;
 
   /// Return the track in this set with the specified id.
   /**
@@ -99,7 +104,7 @@ public:
    *
    * \returns a pointer to the track with the given id.
    */
-  virtual track_sptr const get_track( track_id_t tid ) const;
+  virtual track_sptr const get_track( track_id_t tid ) const = 0;
 
   /// Return all tracks active on a frame.
   /**
@@ -113,7 +118,7 @@ public:
    *
    * \returns a vector of tracks that is the subset of tracks that are active.
    */
-  virtual std::vector< track_sptr> active_tracks( frame_id_t offset = -1 );
+  virtual std::vector< track_sptr> active_tracks( frame_id_t offset = -1 ) const = 0;
 
   /// Return all tracks inactive on a frame.
   /**
@@ -127,7 +132,7 @@ public:
    *
    * \returns a vector of tracks that is the subset of tracks that are inactive.
    */
-  virtual std::vector< track_sptr > inactive_tracks( frame_id_t offset = -1 );
+  virtual std::vector< track_sptr > inactive_tracks( frame_id_t offset = -1 ) const = 0;
 
   /// Return all tracks newly initialized on the given frame.
   /**
@@ -141,7 +146,7 @@ public:
    *
    * \returns a vector of tracks containing all new tracks for the given frame.
    */
-  virtual std::vector< track_sptr > new_tracks( frame_id_t offset = -1 );
+  virtual std::vector< track_sptr > new_tracks( frame_id_t offset = -1 ) const = 0;
 
   /// Return all tracks terminated on the given frame.
   /**
@@ -155,7 +160,7 @@ public:
    *
    * \returns a vector of tracks containing all terminated tracks for the given frame.
    */
-  virtual std::vector< track_sptr > terminated_tracks( frame_id_t offset = -1 );
+  virtual std::vector< track_sptr > terminated_tracks( frame_id_t offset = -1 ) const = 0;
 
   /// Return the percentage of tracks successfully tracked between the two frames.
   /**
@@ -176,7 +181,7 @@ public:
    *
    * \returns a floating point percent value (between 0.0 and 1.0).
    */
-  virtual double percentage_tracked( frame_id_t offset1 = -2, frame_id_t offset2 = -1 );
+  virtual double percentage_tracked( frame_id_t offset1 = -2, frame_id_t offset2 = -1 ) const = 0;
 
   /// Return a vector of state data corresponding to the tracks on the given frame.
   /**
@@ -189,29 +194,227 @@ public:
    * \returns a vector of track_state_sptr corresponding to the tracks
               on this frame and in the same order as active_track(offset)
    */
-  virtual std::vector<track_state_sptr> frame_states( frame_id_t offset = -1 ) const;
+  virtual std::vector<track_state_sptr> frame_states( frame_id_t offset = -1 ) const = 0;
 
-protected:
   /// Convert an offset number to an absolute frame number
-  frame_id_t offset_to_frame( frame_id_t offset ) const;
+  virtual frame_id_t offset_to_frame( frame_id_t offset ) const = 0;
 };
 
 
 
+/// A base class for the implementation of track sets
+/**
+ * This class provides default implementations of most functions which are
+ * written by calling the tracks() function (which is still abstract here)
+ * and operating on the vector of tracks.  These implementations might not
+ * be the most efficent depending on how tracks are stored, but derived
+ * classes can reimplement more efficient overrides as needed.
+ */
+class VITAL_EXPORT track_set_implementation
+  : public track_set_interface
+{
+public:
+  /// Destructor
+  virtual ~track_set_implementation() VITAL_DEFAULT_DTOR
+
+  /// Return the number of tracks in the set
+  virtual size_t size() const;
+
+  /// Return whether or not there are any tracks in the set
+  virtual bool empty() const;
+
+  /// Return the set of all frame IDs covered by these tracks
+  virtual std::set< frame_id_t > all_frame_ids() const;
+
+  /// Return the set of all track IDs in this track set
+  virtual std::set< track_id_t > all_track_ids() const;
+
+  /// Return the first (smallest) frame number containing tracks
+  virtual frame_id_t first_frame() const;
+
+  /// Return the last (largest) frame number containing tracks
+  virtual frame_id_t last_frame() const;
+
+  /// Return the track in this set with the specified id.
+  virtual track_sptr const get_track( track_id_t tid ) const;
+
+  /// Return all tracks active on a frame.
+  virtual std::vector< track_sptr> active_tracks( frame_id_t offset = -1 ) const;
+
+  /// Return all tracks inactive on a frame.
+  virtual std::vector< track_sptr > inactive_tracks( frame_id_t offset = -1 ) const;
+
+  /// Return all tracks newly initialized on the given frame.
+  virtual std::vector< track_sptr > new_tracks( frame_id_t offset = -1 ) const;
+
+  /// Return all tracks terminated on the given frame.
+  virtual std::vector< track_sptr > terminated_tracks( frame_id_t offset = -1 ) const;
+
+  /// Return the percentage of tracks successfully tracked between the two frames.
+  virtual double percentage_tracked( frame_id_t offset1 = -2, frame_id_t offset2 = -1 ) const;
+
+  /// Return a vector of state data corresponding to the tracks on the given frame.
+  virtual std::vector<track_state_sptr> frame_states( frame_id_t offset = -1 ) const;
+
+  /// Convert an offset number to an absolute frame number
+  virtual frame_id_t offset_to_frame( frame_id_t offset ) const;
+};
+
+
+
+/// A collection of tracks
+/**
+ * This class dispatches everything to an implementation class as in the
+ * bridge design pattern.  This pattern allows multiple back end implementations that
+ * store and index track data in different ways.  Each back end can be combined with
+ * any of the derived track_set types like feature_track_set and object_track_set.
+ */
+class VITAL_EXPORT track_set
+ : public track_set_interface
+{
+public:
+  /// Destructor
+  virtual ~track_set() VITAL_DEFAULT_DTOR
+
+  /// Default Constructor
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  track_set();
+
+  /// Constructor specifying the implementation
+  track_set(std::unique_ptr<track_set_implementation> impl);
+
+  /// Constructor from a vector of tracks
+  /**
+   * \note implementation defaults to simple_track_set_implementation
+   */
+  track_set(std::vector< track_sptr > const& tracks);
+
+  /// Return the number of tracks in the set
+  virtual size_t size() const
+  {
+    return impl_->size();
+  }
+
+  /// Return whether or not there are any tracks in the set
+  virtual bool empty() const
+  {
+    return impl_->empty();
+  }
+
+  /// Assign a vector of track shared pointers to this container
+  virtual void set_tracks( std::vector< track_sptr > const& tracks )
+  {
+    impl_->set_tracks(tracks);
+  }
+
+  /// Return a vector of track shared pointers
+  virtual std::vector< track_sptr > tracks() const
+  {
+    return impl_->tracks();
+  }
+
+  /// Return the set of all frame IDs covered by these tracks
+  virtual std::set< frame_id_t > all_frame_ids() const
+  {
+    return impl_->all_frame_ids();
+  }
+
+  /// Return the set of all track IDs in this track set
+  virtual std::set< track_id_t > all_track_ids() const
+  {
+    return impl_->all_track_ids();
+  }
+
+  /// Return the first (smallest) frame number containing tracks
+  virtual frame_id_t first_frame() const
+  {
+    return impl_->first_frame();
+  }
+
+  /// Return the last (largest) frame number containing tracks
+  virtual frame_id_t last_frame() const
+  {
+    return impl_->last_frame();
+  }
+
+  /// Return the track in this set with the specified id.
+  virtual track_sptr const get_track( track_id_t tid ) const
+  {
+    return impl_->get_track(tid);
+  }
+
+  /// Return all tracks active on a frame.
+  virtual std::vector< track_sptr> active_tracks( frame_id_t offset = -1 ) const
+  {
+    return impl_->active_tracks(offset);
+  };
+
+  /// Return all tracks inactive on a frame.
+  virtual std::vector< track_sptr > inactive_tracks( frame_id_t offset = -1 ) const
+  {
+    return impl_->inactive_tracks(offset);
+  }
+
+  /// Return all tracks newly initialized on the given frame.
+  virtual std::vector< track_sptr > new_tracks( frame_id_t offset = -1 ) const
+  {
+    return impl_->new_tracks(offset);
+  }
+
+  /// Return all tracks terminated on the given frame.
+  virtual std::vector< track_sptr > terminated_tracks( frame_id_t offset = -1 ) const
+  {
+    return impl_->terminated_tracks(offset);
+  }
+
+  /// Return the percentage of tracks successfully tracked between the two frames.
+  virtual double percentage_tracked( frame_id_t offset1 = -2, frame_id_t offset2 = -1 ) const
+  {
+    return impl_->percentage_tracked(offset1, offset2);
+  }
+
+  /// Return a vector of state data corresponding to the tracks on the given frame.
+  virtual std::vector<track_state_sptr> frame_states( frame_id_t offset = -1 ) const
+  {
+    return impl_->frame_states(offset);
+  }
+
+  /// Convert an offset number to an absolute frame number
+  virtual frame_id_t offset_to_frame( frame_id_t offset ) const
+  {
+    return impl_->offset_to_frame(offset);
+  }
+
+private:
+  /// The implementation of the track set functions
+  std::unique_ptr<track_set_implementation> impl_;
+};
+
+
+
+
 /// A concrete track set that simply wraps a vector of tracks.
-class simple_track_set :
-  public track_set
+class simple_track_set_implementation :
+  public track_set_implementation
 {
 public:
   /// Default Constructor
-  simple_track_set() { }
+  simple_track_set_implementation() { }
 
   /// Constructor from a vector of tracks
-  explicit simple_track_set( const std::vector< track_sptr >& tracks )
+  explicit simple_track_set_implementation( const std::vector< track_sptr >& tracks )
     : data_( tracks ) { }
 
   /// Return the number of tracks in the set
   virtual size_t size() const { return data_.size(); }
+
+  /// Return whether or not there are any tracks in the set
+  virtual bool empty() const { return data_.empty(); }
+
+  /// Assign a vector of track shared pointers to this container
+  virtual void set_tracks( std::vector< track_sptr > const& tracks ) { data_ = tracks; }
 
   /// Return a vector of track shared pointers
   virtual std::vector< track_sptr > tracks() const { return data_; }


### PR DESCRIPTION
This branch refactors the `track_set` class using a bridge design pattern.  It separates the interface from the implementation such that derived classes for each can be used interchangeably.  This removes the need for `simple_track_set`, `simple_feature_track_set`, and `simple_object_track_set` and replaces them with a single `simple_track_set_implementation` that works for all cases.  This change also sets the stage for adding more complex `track_set_implementation` classes that will also apply across `track_set`, `feature_track_set`, and `object_track_set`.

This is an extension of PR #155 and the release notes add there are still relevant.