### PR TITLE
Return uid as std::string

### DIFF
--- a/vital/types/uid.cxx
+++ b/vital/types/uid.cxx
@@ -68,11 +68,11 @@ is_valid() const
 
 
 // ------------------------------------------------------------------
-const char*
+std::string const&
 uid::
 value() const
 {
-  return m_uid.data();
+  return m_uid;
 }
 
 

--- a/vital/types/uid.h
+++ b/vital/types/uid.h
@@ -93,7 +93,7 @@ public:
    *
    * @return pointer to the data bytes.
    */
-  const char* value() const;
+  std::string const& value() const;
 
   /**
    * @brief Get number of bytes in id


### PR DESCRIPTION
Change `uid::value` to return the internal string directly, rather than the string data. This is more efficient if someone needs to store the `uid` as a `std::string`, and users that need the pointer can still call `data()` or `c_str()` themselves.