### PR TITLE
Can now load .py files in PYTHONPATH as plugins

### DIFF
--- a/sprokit/src/bindings/python/modules/loaders.py
+++ b/sprokit/src/bindings/python/modules/loaders.py
@@ -134,11 +134,12 @@ class ModuleLoader(Loader):
                 base = namespace_path
                 if base not in already_seen:
                     for ext in py_exts:
-                        mod_fpath = base + '.py'
+                        mod_fpath = base + ext
                         if os.path.isfile(mod_fpath):
                             already_seen.add(base)
-                            mod_rel_path = namespace_rel_path + '.py'
+                            mod_rel_path = namespace_rel_path + ext
                             yield mod_rel_path
+                            # Dont test remaining pyo / pyc extensions.
                             break
 
     def _findPluginModules(self, namespace):

--- a/sprokit/src/bindings/python/modules/modules.py
+++ b/sprokit/src/bindings/python/modules/modules.py
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from __future__ import print_function
 try:
     from . import loaders
 except:
@@ -53,6 +54,14 @@ def _load_python_module(mod):
 
 
 def load_python_modules():
+    """
+    Loads Sprokit python plugins
+
+    Searches for modules specified in the `SPROKIT_PYTHON_MODULES` environment
+    variable that are importable from `PYTHONPATH`. Then these modules are
+    imported and their `__sprokit_register__` function is called to register
+    them with the C++ backend.
+    """
     import os
 
     packages = ['sprokit.processes',

--- a/sprokit/src/bindings/python/modules/modules.py
+++ b/sprokit/src/bindings/python/modules/modules.py
@@ -48,14 +48,15 @@ def _load_python_module(mod):
             mod.__sprokit_register__()
 
     else:
-        print "[WARN] Python module", mod, "does not have __sprokit_register__ method"
+        print(('[WARN] Python module {} does not have '
+               '__sprokit_register__ method').format(mod))
+
 
 def load_python_modules():
     import os
 
-    packages = [ 'sprokit.processes'
-               , 'sprokit.schedulers'
-               ]
+    packages = ['sprokit.processes',
+                'sprokit.schedulers']
 
     envvar = 'SPROKIT_PYTHON_MODULES'
 
@@ -71,7 +72,7 @@ def load_python_modules():
         all_modules += modules
 
     for module in all_modules:
-        print "[DEBUG] Loading python module:", module
+        print('[DEBUG] Loading python module: {}'.format(module))
 
         try:
             _load_python_module(module)


### PR DESCRIPTION
I ran into an issue where I had defined a Sprokit plugin module and put it in my PYTHONPATH, but the module was just a .py file instead of a package with an __init__ file. From a language perspective python treats these exactly the same, so Sprokit should to. 

Now instead of trying to run `os.listdir` on a file path, Sprokit checks if its a file or a directory and handles each case appropriately. 

This new feature should make prototyping pipelines much easier because you now have the option of working form a single file. 

------

While I was making this change I noticed that the "paths" returned by `_findPluginFilePaths` were not actually paths, but weird mangled half-path-synatx half-module-syntax strings. This went unnoticed because its only called from one function `_findPluginModules`, which transforms it into all module-syntax strings. I changed `_findPluginFilePaths`  to actually return relative paths like it seemed it was originally intended to do. From a functionality perspective nothing is changed by this, but the next person who reads this code may be less confused. 

Lastly, I fixed the `print` statements to be both python2/python3 compatible, fixed a few pep8 issues, and changed quotes to single quotes to be consistent. 