### PR TITLE
Fix finding PROJ on Windows

### DIFF
--- a/CMake/FindPROJ.cmake
+++ b/CMake/FindPROJ.cmake
@@ -33,7 +33,7 @@ elseif(NOT PROJ_FOUND)
     set(_PROJ_LIB_PATH_HINT HINTS "${proj_lib_dir}" "${proj_lib_dir}64" NO_CMAKE_SYSTEM_PATH)
   endif()
 
-  find_library(PROJ_LIBRARY proj
+  find_library(PROJ_LIBRARY NAMES proj proj_4_9 proj_4_9_d
     ${_PROJ_LIB_PATH_HINT}
     ${PROJ_FIND_OPTS}
     DOC "Path to the PROJ library."


### PR DESCRIPTION
Since fletch upgraded to PROJ 4.9.3, the name of the PROJ library on Windows has changed. Tweak our find module to also find the new name.

Note: This also requires https://github.com/Kitware/fletch/pull/203.