### PR TITLE
Don't return rotation quaternion by reference

### DIFF
--- a/vital/types/rotation.h
+++ b/vital/types/rotation.h
@@ -137,7 +137,7 @@ public:
   /**
    * The first component is real, the last 3 are imaginary (i,j,k)
    */
-  const Eigen::Quaternion< T >& quaternion() const { return q_; }
+  Eigen::Quaternion< T > quaternion() const { return q_; }
 
   /// Return the rotation as a Rodrigues vector
   Eigen::Matrix< T, 3, 1 > rodrigues() const;


### PR DESCRIPTION
Change `rotation::quaternion()` to return by value, rather than returning a reference to the internal data member. The latter is a subtle trap for anyone calling the method on a temporary object; if the caller also binds the return value to a reference, the resulting object will be invalidated before it can be used. (In particular, this was causing many of the VXL arrow tests to fail horribly because `arrows/vxl/camera.cxx` was running afoul of this!)