### PR TITLE
Travis CI select Fletch build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 cache:
   directories:
   - $HOME/deps
-  - /opt/fletch
+  - /opt/kitware
 
 before_script:
   - bash .travis/install-deps.sh
@@ -44,7 +44,7 @@ script:
   - cmake -DCMAKE_C_COMPILER=$C_COMPILER
           -DCMAKE_CXX_COMPILER=$CXX_COMPILER
           -DCMAKE_INSTALL_PREFIX=$HOME/install
-          -Dfletch_DIR=/opt/fletch
+          -Dfletch_DIR=/opt/kitware/fletch
           -DKWIVER_ENABLE_ARROWS=ON
           -DKWIVER_ENABLE_CERES=ON
           -DKWIVER_ENABLE_C_BINDINGS=ON

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -24,7 +24,14 @@ fi
 # download and unpack Fletch
 HASH_FILE="$HASH_DIR/fletch.sha512"
 cd /tmp
-TAR_FILE_ID=59822a8e8d777f16d01ea140
+if [ -f $TRAVIS_BUILD_DIR/doc/release-notes/master.txt ]; then
+  TAR_FILE_ID=599c39468d777f7d33e9cbe5
+  echo "Using master branch of Fletch"
+else
+  TAR_FILE_ID=59822a8e8d777f16d01ea140
+  echo "Using release branch of Fletch"
+fi
+
 wget https://data.kitware.com/api/v1/file/$TAR_FILE_ID/hashsum_file/sha512 -O fletch.sha512
 RHASH=`cat fletch.sha512`
 echo "Current Fletch tarball hash: " $RHASH

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -29,7 +29,7 @@ if [ -f $TRAVIS_BUILD_DIR/doc/release-notes/master.txt ]; then
   TAR_FILE_ID=599c39468d777f7d33e9cbe5
   echo "Using master branch of Fletch"
 else
-  TAR_FILE_ID=59822a8e8d777f16d01ea140
+  TAR_FILE_ID=599f2db18d777f7d33e9cc9e
   echo "Using release branch of Fletch"
 fi
 

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -2,9 +2,10 @@
 set -e
 
 INSTALL_DIR=$HOME/deps
-FLETCH_DIR=/opt/fletch
+FLETCH_DIR=/opt/kitware/fletch
 export PATH=$INSTALL_DIR/bin:$FLETCH_DIR/bin:$PATH
-HASH_DIR=$FLETCH_DIR/hashes
+HASH_DIR=/opt/kitware/hashes
+mkdir -p $FLETCH_DIR
 mkdir -p $HASH_DIR
 mkdir -p $INSTALL_DIR
 

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -41,6 +41,6 @@ if [ -f $HASH_FILE ] && [ -n "$RHASH" ] && grep -q $RHASH $HASH_FILE ; then
 else
   wget https://data.kitware.com/api/v1/file/$TAR_FILE_ID/download -O fletch.tgz
   rm -rf $FLETCH_DIR/*
-  tar -xzf fletch.tgz -C $FLETCH_DIR
+  tar -xzf fletch.tgz -C /opt/kitware
   cp fletch.sha512 $HASH_FILE
 fi


### PR DESCRIPTION
Fletch builds in Travis CI now go into /opt/kitware/fletch and the selected build of Fletch depends on whether this is a branch of release or master.