### PR TITLE
fixed xrange and basestring

### DIFF
--- a/vital/bindings/python/vital/apm.py
+++ b/vital/bindings/python/vital/apm.py
@@ -35,6 +35,7 @@ Interface to VITAL algorithm_plugin_manager class.
 """
 # -*- coding: utf-8 -*-
 import ctypes
+from six.moves import range
 from vital.util import VitalObject
 
 
@@ -122,7 +123,7 @@ def registered_module_names():
 
     # Constructing return array
     r = []
-    for i in xrange(length.value):
+    for i in range(length.value):
         r.append(keys[i])
 
     # Free allocated key listing

--- a/vital/bindings/python/vital/bin/maptk_track_features.py
+++ b/vital/bindings/python/vital/bin/maptk_track_features.py
@@ -40,6 +40,7 @@ interface usage.
 import logging
 import os
 import os.path
+from six.moves import range
 
 from vital import (
     apm,
@@ -255,7 +256,7 @@ class TrackFeaturesTool (object):
         test_f.close()
 
         tracks = TrackSet()
-        for frame_num in xrange(len(input_filepaths)):
+        for frame_num in range(len(input_filepaths)):
             input_img = self.algo_convert_img.convert(
                 self.algo_image_io.load(input_filepaths[frame_num])
             )

--- a/vital/bindings/python/vital/config_block.py
+++ b/vital/bindings/python/vital/config_block.py
@@ -49,6 +49,7 @@ from vital.exceptions.config_block_io import (
 from vital.util import VitalObject, VitalErrorHandle, free_void_ptr
 
 import os
+from six.moves import range
 import tempfile
 
 
@@ -422,7 +423,7 @@ class ConfigBlock (VitalObject):
 
         # Constructing return array
         r = []
-        for i in xrange(length.value):
+        for i in range(length.value):
             r.append(keys[i])
 
         # Free allocated key listing

--- a/vital/bindings/python/vital/tests/helpers.py
+++ b/vital/bindings/python/vital/tests/helpers.py
@@ -35,6 +35,7 @@ Helper functions for testing various Vital components
 """
 import logging
 import math
+from six.moves import range
 
 import numpy
 
@@ -91,7 +92,7 @@ def init_landmarks(num_lm, c=None):
     if c is None:
         c = EigenArray.from_iterable([0, 0, 0])
     d = {}
-    for i in xrange(num_lm):
+    for i in range(num_lm):
         d[i] = Landmark(loc=c)
     return LandmarkMap.from_dict(d)
 
@@ -123,7 +124,7 @@ def camera_seq(num_cams=20, k=None):
         k = CameraIntrinsics(1000, [640, 480])
     d = {}
     r = Rotation()  # identity
-    for i in xrange(num_cams):
+    for i in range(num_cams):
         frac = float(i) / num_cams
         x = 4 * math.cos(2*frac)
         y = 3 * math.sin(2*frac)

--- a/vital/bindings/python/vital/tests/test_eigen_numpy.py
+++ b/vital/bindings/python/vital/tests/test_eigen_numpy.py
@@ -38,6 +38,7 @@ import unittest
 
 import nose.tools as ntools
 import numpy
+from six.moves import range
 
 from vital.exceptions.eigen import VitalInvalidStaticEigenShape
 from vital.types import EigenArray
@@ -105,7 +106,7 @@ class TestVitalEigenMatrix (unittest.TestCase):
     def test_mutability(self):
         a = EigenArray(2, 3)
         d = a.base.base  # The data pointer
-        for i in xrange(6):
+        for i in range(6):
             d[i] = 0
         numpy.testing.assert_array_equal(a, [[0, 0, 0],
                                              [0, 0, 0]])

--- a/vital/bindings/python/vital/tests/test_track_set.py
+++ b/vital/bindings/python/vital/tests/test_track_set.py
@@ -34,6 +34,7 @@ Tests for Python interface to vital::track_set
 
 """
 import ctypes
+from six.moves import range
 
 from vital.types import Track, TrackState
 from vital.types import TrackSet
@@ -57,7 +58,7 @@ class TestVitalTrackSet (object):
 
     def test_new_nonempty(self):
         n = 10
-        tracks = [Track(i) for i in xrange(n)]
+        tracks = [Track(i) for i in range(n)]
         ts = TrackSet(tracks)
         nt.assert_true(ts, "Invalid track set instance constructed")
         nt.assert_equal(len(ts), n)
@@ -65,7 +66,7 @@ class TestVitalTrackSet (object):
 
     def test_tracklist_accessor(self):
         n = 10
-        tracks = [Track(i) for i in xrange(n)]
+        tracks = [Track(i) for i in range(n)]
         ts = TrackSet(tracks)
         ts_tracks = ts.tracks()
 
@@ -78,7 +79,7 @@ class TestVitalTrackSet (object):
         # (same C/C++ instances).
         ts2 = TrackSet(ts_tracks)
         ts2_tracks = ts2.tracks()
-        for i in xrange(n):
+        for i in range(n):
             ctypes.addressof(ts2_tracks[0].c_pointer.contents) \
                 == ctypes.addressof(ts2_tracks[0].c_pointer.contents)
 

--- a/vital/bindings/python/vital/types/camera_map.py
+++ b/vital/bindings/python/vital/types/camera_map.py
@@ -37,6 +37,7 @@ Interface to vital::camera_map class.
 
 import ctypes
 
+from six.moves import range
 from vital.types import Camera
 from vital.util import VitalObject, VitalErrorHandle
 
@@ -128,7 +129,7 @@ class CameraMap (VitalObject):
                        eh)
 
         m = {}
-        for i in xrange(length.value):
+        for i in range(length.value):
             # copy camera cptr so we don't
             cptr = Camera.c_ptr_type()(cameras[i].contents)
             m[frame_numbers[i]] = Camera(from_cptr=cptr)

--- a/vital/bindings/python/vital/types/descriptor_set.py
+++ b/vital/bindings/python/vital/types/descriptor_set.py
@@ -35,6 +35,7 @@ Interface to the VITAL descriptor_set class.
 """
 import ctypes
 
+from six.moves import range
 from vital.types import Descriptor
 from vital.util import VitalObject, free_void_ptr
 

--- a/vital/bindings/python/vital/types/homography.py
+++ b/vital/bindings/python/vital/types/homography.py
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Interface to vital::homography
 
 """
+import six
 import ctypes
 import collections
 import numpy
@@ -45,13 +46,13 @@ from vital.util import VitalObject, TYPE_NAME_MAP
 
 
 class Homography (VitalObject):
-    
+
     @classmethod
     def from_matrix(cls, m, datatype=ctypes.c_double):
         """
         Create a homography from an existing 3x3 matrix.
 
-        If the data type of the matrix given is not the same as ``datatype``, 
+        If the data type of the matrix given is not the same as ``datatype``,
         it will be automatically converted.
 
         :param m: Matrix to base the new homography on. This should be a 3x3
@@ -75,63 +76,63 @@ class Homography (VitalObject):
             Homography.c_ptr_type()
         )
         return Homography(from_cptr=cptr)
-    
+
     @classmethod
     def from_translation(cls, dx, dy, datatype=ctypes.c_double):
         """
         Return homography that represents a translation.
-        
-        :param dx: Homography will displace input points by this amount along 
+
+        :param dx: Homography will displace input points by this amount along
             the x-axis.
         :type dx: float | double | int
-        
-        :param dy: Homography will displace input points by this value along 
+
+        :param dy: Homography will displace input points by this value along
             the y-axis.
         :type dy: float | double | int
-        
+
         :return: New homography instance.
         :rtype: Homography
-        
+
         """
         m = numpy.matrix([[1, 0, dx], [0, 1, dy], [0, 0, 1]])
         return cls.from_matrix(m, datatype=datatype)
-    
+
     @classmethod
     def from_scale(cls, scale, datatype=ctypes.c_double):
         """
         Return homography that scales inputs.
-        
+
         :param scale: Homography will scale input vectors by this multiple.
         :type s: float | double | int
-        
+
         :return: New homography instance.
         :rtype: Homography
-        
+
         """
-        m = numpy.matrix([[scale, 0, 0], [0, scale, 0], [0, 0, 1]]) 
+        m = numpy.matrix([[scale, 0, 0], [0, scale, 0], [0, 0, 1]])
         return cls.from_matrix(m, datatype=datatype)
-    
+
     @classmethod
     def read_from_file(cls, fin, datatype=ctypes.c_double):
         """
         Read homography from ASCII file.
-        
-        If fin is an open file object, the homography will be read from the 
-        next three valid lines of the file, and it will remain open upon 
-        return. If fout is the str full path to a file, the file will be 
+
+        If fin is an open file object, the homography will be read from the
+        next three valid lines of the file, and it will remain open upon
+        return. If fout is the str full path to a file, the file will be
         opened, read from, and closed.
-        
+
         If a valid 3x3 matrix can not be extracted, None will be returned.
-        
+
         :param fin: open file object or str filename to read from.
         :type fin: file or str
-        
+
         :param datatype: Type to store data in the homography.
         :type datatype: ctypes.c_float | ctypes.c_double
-        
+
         :return: New homography instance read from file.
         :rtype: Homography | None
-        
+
         """
         if hasattr(fin, 'read'):
             # Must be an open file.
@@ -139,27 +140,27 @@ class Homography (VitalObject):
             h = numpy.zeros((3,3), dtype=numpy.float64)
             for line in fin:
                 linev = numpy.fromstring(line, dtype=numpy.float64, sep=' ')
-                
+
                 if len(linev) == 3:
                     h[l] = linev
                     l += 1
-                
+
                 if l == 3:
                     return Homography.from_matrix(h)
-            
+
             return None
-        
-        elif isinstance(fin, basestring):
+
+        elif isinstance(fin, six.string_types):
             with open(fin, 'r') as f:
                 return cls.read_from_file(f)
         else:
             raise ValueError("fin must be of type file or str.")
-    
+
     @classmethod
     def random(cls, datatype=ctypes.c_double):
         """
-        Create a normzlied random homography.
-        
+        Create a normalized random homography.
+
         :param datatype: Type to store data in the homography.
         :type datatype: ctypes._SimpleCData
 
@@ -230,7 +231,7 @@ class Homography (VitalObject):
 
     def __ne__(self, other):
         return not (self == other)
-    
+
     def __repr__(self):
         cls_name = self.__class__.__name__
         s = numpy.array2string(self.as_matrix(), separator=',')
@@ -327,27 +328,27 @@ class Homography (VitalObject):
                 1: PointMapsToInfinityException
             }
         )
-        return EigenArray(2, dtype=self._datatype, from_cptr=p_cptr)    
-        
+        return EigenArray(2, dtype=self._datatype, from_cptr=p_cptr)
+
     def write_to_file(self, fout):
         """
         Write homography in ASCII to file.
-        
-        If fout is an open file object, the homography will be written to the 
+
+        If fout is an open file object, the homography will be written to the
         file, and it will remain open upon return. If fout is the str full path
         to a file, the file will be opened, written to, and closed.
-        
+
         :param fout: open file object or str filename to write to.
         :type fout: file or str
-        
-        """    
+
+        """
         if hasattr(fout, 'write'):
             h = self.as_matrix().tolist()
             str_rep = ''.join(["%.12g %.12g %.12g\n" % tuple(h[0]),
                                "%.12g %.12g %.12g\n" % tuple(h[1]),
                                "%.12g %.12g %.12g\n" % tuple(h[2])])
             fout.write(str_rep)
-        elif isinstance(fout, basestring):
+        elif isinstance(fout, six.string_types):
             with open(fout, 'w') as f:
                 self.write_to_file(f)
         else:

--- a/vital/bindings/python/vital/types/rotation.py
+++ b/vital/bindings/python/vital/types/rotation.py
@@ -35,6 +35,7 @@ Interface to the vital::rotation_ class
 """
 import collections
 import ctypes
+from six.moves import range
 
 import numpy
 
@@ -339,7 +340,7 @@ class Rotation (VitalObject):
         with VitalErrorHandle() as eh:
             r_arr_ptr = r_interp(a, b, n, eh)
         r_list = []
-        for i in xrange(n):
+        for i in range(n):
             # Have to create a new pointer instance and copy the pointer value
             # at r_arr_ptr[i] into it.
             # the pointer content at index `i` in the ptr array

--- a/vital/bindings/python/vital/types/track.py
+++ b/vital/bindings/python/vital/types/track.py
@@ -34,6 +34,7 @@ Interface to VITAL track class.
 
 """
 import ctypes
+from six.moves import range
 
 from vital.util import VitalObject, free_void_ptr
 
@@ -235,7 +236,7 @@ class Track (VitalObject):
             ctypes.POINTER(ctypes.c_int64)
         )
         r = set()
-        for i in xrange(n.value):
+        for i in range(n.value):
             r.add(s[i])
         free_void_ptr(s)
         return r


### PR DESCRIPTION
This is a cherry-pick from one of my work branches. It consists of small changes to increase compatibility with python3. 

The first changes is that every `xrange` was replaced with `range`, but `from six.moves import range` (which evaluates as `xrange` in python2) was added to these files. 

The second change is that `basestring` (which no longer exists in python3) was replaced with six.string_types, which evaluates to `basestring` in python2. 

So overall there should be no functional changes, and it allows python3 code to at least run without SyntaxErrors. 