### PR TITLE
Fix simple_camera::clone_look_at override

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -23,6 +23,12 @@ Testing
 Fixes since v1.1.0
 ------------------
 
+Vital
+
+  * The simple_camera::clone_look_at now has the same parameter default as the
+    base method, allowing it to be called with one parameter from an instance
+    whose static type is simple_camera.
+
 Sprokit
 
  * Previously the Python path used in Sprokit Python tests was incorrect due to

--- a/vital/types/camera.cxx
+++ b/vital/types/camera.cxx
@@ -143,7 +143,7 @@ simple_camera
 camera_sptr
 simple_camera
 ::clone_look_at( const vector_3d &stare_point,
-                 const vector_3d &up_direction = vector_3d::UnitZ() ) const
+                 const vector_3d &up_direction ) const
 {
   camera_sptr c_sptr = this->clone();
   dynamic_cast<simple_camera *>(c_sptr.get())->look_at( stare_point,

--- a/vital/types/camera.h
+++ b/vital/types/camera.h
@@ -206,8 +206,9 @@ public:
    * \param up_direction the vector which is "up" in the world (defaults to Z-axis)
    * \returns New clone, but set to look at the given point.
    */
-  virtual camera_sptr clone_look_at( const vector_3d &stare_point,
-                                     const vector_3d &up_direction ) const;
+  virtual camera_sptr clone_look_at(
+    const vector_3d &stare_point,
+    const vector_3d &up_direction = vector_3d::UnitZ() ) const override;
 
   /// Accessor for the camera center of projection using underlying data type
   const vector_3d& get_center() const { return center_; }


### PR DESCRIPTION
Fix the declaration of `simple_camera::clone_look_at`, which was missing the default parameter from the base declaration. This prevented calling the method with a single parameter from a `simple_camera` instance. Also, remove the useless default value from the definition of the same method.