### PR TITLE
Don't return rotation quaternion by reference

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -29,6 +29,11 @@ Vital
     base method, allowing it to be called with one parameter from an instance
     whose static type is simple_camera.
 
+  * rotation::quaternion no longer returns the quaternion by reference.  This
+    fixes a potential dangling reference problem if this method is called on a
+    temporary object.  (In particular, this was causing several VXL arrow tests
+    to fail.)
+
 Sprokit
 
  * Previously the Python path used in Sprokit Python tests was incorrect due to

--- a/vital/types/rotation.h
+++ b/vital/types/rotation.h
@@ -137,7 +137,7 @@ public:
   /**
    * The first component is real, the last 3 are imaginary (i,j,k)
    */
-  const Eigen::Quaternion< T >& quaternion() const { return q_; }
+  Eigen::Quaternion< T > quaternion() const { return q_; }
 
   /// Return the rotation as a Rodrigues vector
   Eigen::Matrix< T, 3, 1 > rodrigues() const;


### PR DESCRIPTION
Change `rotation::quaternion()` to return by value, rather than returning a reference to the internal data member. The latter is a subtle trap for anyone calling the method on a temporary object; if the caller also binds the return value to a reference, the resulting object will be invalidated before it can be used. (In particular, this was causing many of the VXL arrow tests to fail horribly because `arrows/vxl/camera.cxx` was running afoul of this!)

This is a backport of #270 to the release branch.