### PR TITLE
Finalize goedesy tests with Google Test

### DIFF
--- a/CMake/future/3.10/GoogleTest.cmake
+++ b/CMake/future/3.10/GoogleTest.cmake
@@ -1,0 +1,440 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+GoogleTest
+----------
+
+This module defines functions to help use the Google Test infrastructure.  Two
+mechanisms for adding tests are provided. :command:`gtest_add_tests` has been
+around for some time, originally via ``find_package(GTest)``.
+:command:`gtest_discover_tests` was introduced in CMake 3.10.
+
+The (older) :command:`gtest_add_tests` scans source files to identify tests.
+This is usually effective, with some caveats, including in cross-compiling
+environments, and makes setting additional properties on tests more convenient.
+However, its handling of parameterized tests is less comprehensive, and it
+requires re-running CMake to detect changes to the list of tests.
+
+The (newer) :command:`gtest_discover_tests` discovers tests by asking the
+compiled test executable to enumerate its tests.  This is more robust and
+provides better handling of parameterized tests, and does not require CMake
+to be re-run when tests change.  However, it may not work in a cross-compiling
+environment, and setting test properties is less convenient.
+
+More details can be found in the documentation of the respective functions.
+
+Both commands are intended to replace use of :command:`add_test` to register
+tests, and will create a separate CTest test for each Google Test test case.
+Note that this is in some cases less efficient, as common set-up and tear-down
+logic cannot be shared by multiple test cases executing in the same instance.
+However, it provides more fine-grained pass/fail information to CTest, which is
+usually considered as more beneficial.  By default, the CTest test name is the
+same as the Google Test name (i.e. ``suite.testcase``); see also
+``TEST_PREFIX`` and ``TEST_SUFFIX``.
+
+.. command:: gtest_add_tests
+
+  Automatically add tests with CTest by scanning source code for Google Test
+  macros::
+
+    gtest_add_tests(TARGET target
+                    [SOURCES src1...]
+                    [EXTRA_ARGS arg1...]
+                    [WORKING_DIRECTORY dir]
+                    [TEST_PREFIX prefix]
+                    [TEST_SUFFIX suffix]
+                    [SKIP_DEPENDENCY]
+                    [TEST_LIST outVar]
+    )
+
+  ``gtest_add_tests`` attempts to identify tests by scanning source files.
+  Although this is generally effective, it uses only a basic regular expression
+  match, which can be defeated by atypical test declarations, and is unable to
+  fully "split" parameterized tests.  Additionally, it requires that CMake be
+  re-run to discover any newly added, removed or renamed tests (by default,
+  this means that CMake is re-run when any test source file is changed, but see
+  ``SKIP_DEPENDENCY``).  However, it has the advantage of declaring tests at
+  CMake time, which somewhat simplifies setting additional properties on tests,
+  and always works in a cross-compiling environment.
+
+  The options are:
+
+  ``TARGET target``
+    Specifies the Google Test executable, which must be a known CMake
+    executable target.  CMake will substitute the location of the built
+    executable when running the test.
+
+  ``SOURCES src1...``
+    When provided, only the listed files will be scanned for test cases.  If
+    this option is not given, the :prop_tgt:`SOURCES` property of the
+    specified ``target`` will be used to obtain the list of sources.
+
+  ``EXTRA_ARGS arg1...``
+    Any extra arguments to pass on the command line to each test case.
+
+  ``WORKING_DIRECTORY dir``
+    Specifies the directory in which to run the discovered test cases.  If this
+    option is not provided, the current binary directory is used.
+
+  ``TEST_PREFIX prefix``
+    Specifies a ``prefix`` to be prepended to the name of each discovered test
+    case.  This can be useful when the same source files are being used in
+    multiple calls to ``gtest_add_test()`` but with different ``EXTRA_ARGS``.
+
+  ``TEST_SUFFIX suffix``
+    Similar to ``TEST_PREFIX`` except the ``suffix`` is appended to the name of
+    every discovered test case.  Both ``TEST_PREFIX`` and ``TEST_SUFFIX`` may
+    be specified.
+
+  ``SKIP_DEPENDENCY``
+    Normally, the function creates a dependency which will cause CMake to be
+    re-run if any of the sources being scanned are changed.  This is to ensure
+    that the list of discovered tests is updated.  If this behavior is not
+    desired (as may be the case while actually writing the test cases), this
+    option can be used to prevent the dependency from being added.
+
+  ``TEST_LIST outVar``
+    The variable named by ``outVar`` will be populated in the calling scope
+    with the list of discovered test cases.  This allows the caller to do
+    things like manipulate test properties of the discovered tests.
+
+  .. code-block:: cmake
+
+    include(GoogleTest)
+    add_executable(FooTest FooUnitTest.cxx)
+    gtest_add_tests(TARGET      FooTest
+                    TEST_SUFFIX .noArgs
+                    TEST_LIST   noArgsTests
+    )
+    gtest_add_tests(TARGET      FooTest
+                    EXTRA_ARGS  --someArg someValue
+                    TEST_SUFFIX .withArgs
+                    TEST_LIST   withArgsTests
+    )
+    set_tests_properties(${noArgsTests}   PROPERTIES TIMEOUT 10)
+    set_tests_properties(${withArgsTests} PROPERTIES TIMEOUT 20)
+
+  For backward compatibility, the following form is also supported::
+
+    gtest_add_tests(exe args files...)
+
+  ``exe``
+    The path to the test executable or the name of a CMake target.
+  ``args``
+    A ;-list of extra arguments to be passed to executable.  The entire
+    list must be passed as a single argument.  Enclose it in quotes,
+    or pass ``""`` for no arguments.
+  ``files...``
+    A list of source files to search for tests and test fixtures.
+    Alternatively, use ``AUTO`` to specify that ``exe`` is the name
+    of a CMake executable target whose sources should be scanned.
+
+  .. code-block:: cmake
+
+    include(GoogleTest)
+    set(FooTestArgs --foo 1 --bar 2)
+    add_executable(FooTest FooUnitTest.cxx)
+    gtest_add_tests(FooTest "${FooTestArgs}" AUTO)
+
+.. command:: gtest_discover_tests
+
+  Automatically add tests with CTest by querying the compiled test executable
+  for available tests::
+
+    gtest_discover_tests(target
+                         [EXTRA_ARGS arg1...]
+                         [WORKING_DIRECTORY dir]
+                         [TEST_PREFIX prefix]
+                         [TEST_SUFFIX suffix]
+                         [NO_PRETTY_TYPES] [NO_PRETTY_VALUES]
+                         [PROPERTIES name1 value1...]
+                         [TEST_LIST var]
+    )
+
+  ``gtest_discover_tests`` sets up a post-build command on the test executable
+  that generates the list of tests by parsing the output from running the test
+  with the ``--gtest_list_tests`` argument.  Compared to the source parsing
+  approach of :command:`gtest_add_tests`, this ensures that the full list of
+  tests, including instantiations of parameterized tests, is obtained.  Since
+  test discovery occurs at build time, it is not necessary to re-run CMake when
+  the list of tests changes.
+  However, it requires that :prop_tgt:`CROSSCOMPILING_EMULATOR` is properly set
+  in order to function in a cross-compiling environment.
+
+  Additionally, setting properties on tests is somewhat less convenient, since
+  the tests are not available at CMake time.  Additional test properties may be
+  assigned to the set of tests as a whole using the ``PROPERTIES`` option.  If
+  more fine-grained test control is needed, custom content may be provided
+  through an external CTest script using the :prop_dir:`TEST_INCLUDE_FILES`
+  directory property.  The set of discovered tests is made accessible to such a
+  script via the ``<target>_TESTS`` variable.
+
+  The options are:
+
+  ``target``
+    Specifies the Google Test executable, which must be a known CMake
+    executable target.  CMake will substitute the location of the built
+    executable when running the test.
+
+  ``EXTRA_ARGS arg1...``
+    Any extra arguments to pass on the command line to each test case.
+
+  ``WORKING_DIRECTORY dir``
+    Specifies the directory in which to run the discovered test cases.  If this
+    option is not provided, the current binary directory is used.
+
+  ``TEST_PREFIX prefix``
+    Specifies a ``prefix`` to be prepended to the name of each discovered test
+    case.  This can be useful when the same test executable is being used in
+    multiple calls to ``gtest_discover_tests()`` but with different
+    ``EXTRA_ARGS``.
+
+  ``TEST_SUFFIX suffix``
+    Similar to ``TEST_PREFIX`` except the ``suffix`` is appended to the name of
+    every discovered test case.  Both ``TEST_PREFIX`` and ``TEST_SUFFIX`` may
+    be specified.
+
+  ``NO_PRETTY_TYPES``
+    By default, the type index of type-parameterized tests is replaced by the
+    actual type name in the CTest test name.  If this behavior is undesirable
+    (e.g. because the type names are unwieldy), this option will suppress this
+    behavior.
+
+  ``NO_PRETTY_VALUES``
+    By default, the value index of value-parameterized tests is replaced by the
+    actual value in the CTest test name.  If this behavior is undesirable
+    (e.g. because the value strings are unwieldy), this option will suppress
+    this behavior.
+
+  ``PROPERTIES name1 value1...``
+    Specifies additional properties to be set on all tests discovered by this
+    invocation of ``gtest_discover_tests``.
+
+  ``TEST_LIST var``
+    Make the list of tests available in the variable ``var``, rather than the
+    default ``<target>_TESTS``.  This can be useful when the same test
+    executable is being used in multiple calls to ``gtest_discover_tests()``.
+    Note that this variable is only available in CTest.
+
+#]=======================================================================]
+
+#------------------------------------------------------------------------------
+function(gtest_add_tests)
+
+  if (ARGC LESS 1)
+    message(FATAL_ERROR "No arguments supplied to gtest_add_tests()")
+  endif()
+
+  set(options
+      SKIP_DEPENDENCY
+  )
+  set(oneValueArgs
+      TARGET
+      WORKING_DIRECTORY
+      TEST_PREFIX
+      TEST_SUFFIX
+      TEST_LIST
+  )
+  set(multiValueArgs
+      SOURCES
+      EXTRA_ARGS
+  )
+  set(allKeywords ${options} ${oneValueArgs} ${multiValueArgs})
+
+  unset(sources)
+  if("${ARGV0}" IN_LIST allKeywords)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(autoAddSources YES)
+  else()
+    # Non-keyword syntax, convert to keyword form
+    if (ARGC LESS 3)
+      message(FATAL_ERROR "gtest_add_tests() without keyword options requires at least 3 arguments")
+    endif()
+    set(ARGS_TARGET     "${ARGV0}")
+    set(ARGS_EXTRA_ARGS "${ARGV1}")
+    if(NOT "${ARGV2}" STREQUAL "AUTO")
+      set(ARGS_SOURCES "${ARGV}")
+      list(REMOVE_AT ARGS_SOURCES 0 1)
+    endif()
+  endif()
+
+  # The non-keyword syntax allows the first argument to be an arbitrary
+  # executable rather than a target if source files are also provided. In all
+  # other cases, both forms require a target.
+  if(NOT TARGET "${ARGS_TARGET}" AND NOT ARGS_SOURCES)
+    message(FATAL_ERROR "${ARGS_TARGET} does not define an existing CMake target")
+  endif()
+  if(NOT ARGS_WORKING_DIRECTORY)
+    unset(workDir)
+  else()
+    set(workDir WORKING_DIRECTORY "${ARGS_WORKING_DIRECTORY}")
+  endif()
+
+  if(NOT ARGS_SOURCES)
+    get_property(ARGS_SOURCES TARGET ${ARGS_TARGET} PROPERTY SOURCES)
+  endif()
+
+  unset(testList)
+
+  set(gtest_case_name_regex ".*\\( *([A-Za-z_0-9]+) *, *([A-Za-z_0-9]+) *\\).*")
+  set(gtest_test_type_regex "(TYPED_TEST|TEST_?[FP]?)")
+
+  foreach(source IN LISTS ARGS_SOURCES)
+    if(NOT ARGS_SKIP_DEPENDENCY)
+      set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${source})
+    endif()
+    file(READ "${source}" contents)
+    string(REGEX MATCHALL "${gtest_test_type_regex} *\\(([A-Za-z_0-9 ,]+)\\)" found_tests ${contents})
+    foreach(hit ${found_tests})
+      string(REGEX MATCH "${gtest_test_type_regex}" test_type ${hit})
+
+      # Parameterized tests have a different signature for the filter
+      if("x${test_type}" STREQUAL "xTEST_P")
+        string(REGEX REPLACE ${gtest_case_name_regex}  "*/\\1.\\2/*" gtest_test_name ${hit})
+      elseif("x${test_type}" STREQUAL "xTEST_F" OR "x${test_type}" STREQUAL "xTEST")
+        string(REGEX REPLACE ${gtest_case_name_regex} "\\1.\\2" gtest_test_name ${hit})
+      elseif("x${test_type}" STREQUAL "xTYPED_TEST")
+        string(REGEX REPLACE ${gtest_case_name_regex} "\\1/*.\\2" gtest_test_name ${hit})
+      else()
+        message(WARNING "Could not parse GTest ${hit} for adding to CTest.")
+        continue()
+      endif()
+
+      # Make sure tests disabled in GTest get disabled in CTest
+      if(gtest_test_name MATCHES "(^|\\.)DISABLED_")
+        # Add the disabled test if CMake is new enough
+        # Note that this check is to allow backwards compatibility so this
+        # module can be copied locally in projects to use with older CMake
+        # versions
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.8.20170401)
+          string(REGEX REPLACE
+                 "(^|\\.)DISABLED_" "\\1"
+                 orig_test_name "${gtest_test_name}"
+          )
+          set(ctest_test_name
+              ${ARGS_TEST_PREFIX}${orig_test_name}${ARGS_TEST_SUFFIX}
+          )
+          add_test(NAME ${ctest_test_name}
+                   ${workDir}
+                   COMMAND ${ARGS_TARGET}
+                     --gtest_also_run_disabled_tests
+                     --gtest_filter=${gtest_test_name}
+                     ${ARGS_EXTRA_ARGS}
+          )
+          set_tests_properties(${ctest_test_name} PROPERTIES DISABLED TRUE)
+          list(APPEND testList ${ctest_test_name})
+        endif()
+      else()
+        set(ctest_test_name ${ARGS_TEST_PREFIX}${gtest_test_name}${ARGS_TEST_SUFFIX})
+        add_test(NAME ${ctest_test_name}
+                 ${workDir}
+                 COMMAND ${ARGS_TARGET}
+                   --gtest_filter=${gtest_test_name}
+                   ${ARGS_EXTRA_ARGS}
+        )
+        list(APPEND testList ${ctest_test_name})
+      endif()
+    endforeach()
+  endforeach()
+
+  if(ARGS_TEST_LIST)
+    set(${ARGS_TEST_LIST} ${testList} PARENT_SCOPE)
+  endif()
+
+endfunction()
+
+#------------------------------------------------------------------------------
+function(gtest_discover_tests TARGET)
+  cmake_parse_arguments(
+    ""
+    "NO_PRETTY_TYPES;NO_PRETTY_VALUES"
+    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST"
+    "EXTRA_ARGS;PROPERTIES"
+    ${ARGN}
+  )
+
+  if(NOT _WORKING_DIRECTORY)
+    set(_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+  if(NOT _TEST_LIST)
+    set(_TEST_LIST ${TARGET}_TESTS)
+  endif()
+
+  # Define rule to generate test list for aforementioned test executable
+  set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_include.cmake")
+  set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_tests.cmake")
+  get_property(crosscompiling_emulator
+    TARGET ${TARGET}
+    PROPERTY CROSSCOMPILING_EMULATOR
+  )
+  add_custom_command(
+    TARGET ${TARGET} POST_BUILD
+    BYPRODUCTS "${ctest_tests_file}"
+    COMMAND "${CMAKE_COMMAND}"
+            -D "TEST_TARGET=${TARGET}"
+            -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
+            -D "TEST_EXECUTOR=${crosscompiling_emulator}"
+            -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
+            -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
+            -D "TEST_PROPERTIES=${_PROPERTIES}"
+            -D "TEST_PREFIX=${_TEST_PREFIX}"
+            -D "TEST_SUFFIX=${_TEST_SUFFIX}"
+            -D "NO_PRETTY_TYPES=${_NO_PRETTY_TYPES}"
+            -D "NO_PRETTY_VALUES=${_NO_PRETTY_VALUES}"
+            -D "TEST_LIST=${_TEST_LIST}"
+            -D "CTEST_FILE=${ctest_tests_file}"
+            -P "${_GOOGLETEST_DISCOVER_TESTS_SCRIPT}"
+    VERBATIM
+  )
+
+  file(WRITE "${ctest_include_file}"
+    "if(EXISTS \"${ctest_tests_file}\")\n"
+    "  include(\"${ctest_tests_file}\")\n"
+    "else()\n"
+    "  add_test(${TARGET}_NOT_BUILT ${TARGET}_NOT_BUILT)\n"
+    "endif()\n"
+  )
+
+  # Set name of our tests include file
+  set(
+    gtest_test_include
+    "${CMAKE_CURRENT_BINARY_DIR}/gtest_discovered_tests.cmake"
+  )
+
+  # Have we processed this directory yet?
+  get_property(
+    dir_gtest_test_include
+    DIRECTORY PROPERTY GTEST_TEST_INCLUDE_FILE
+  )
+  if(NOT dir_gtest_test_include)
+    # If not, remove any old all_tests.cmake...
+    file(REMOVE "${gtest_test_include}")
+    # ...and set directory GTEST_TEST_INCLUDE_FILE
+    set_property(
+      DIRECTORY PROPERTY GTEST_TEST_INCLUDE_FILE "${gtest_test_include}"
+    )
+  endif()
+
+  # Ensure that our discovered tests will be processed
+  get_property(dir_test_include DIRECTORY PROPERTY TEST_INCLUDE_FILE)
+  if(NOT dir_test_include STREQUAL "${gtest_test_include}")
+    # If TEST_INCLUDE_FILE was previously set, include the previously specified
+    # file in our own include file
+    if(dir_test_include)
+      file(APPEND "${gtest_test_include}" "include(\"${dir_test_include}\")\n")
+    endif()
+    # Set directory TEST_INCLUDE_FILE
+    set_property(DIRECTORY PROPERTY TEST_INCLUDE_FILE "${gtest_test_include}")
+  endif()
+
+  # Add tests to current directory's all_tests list
+  file(APPEND "${gtest_test_include}" "include(\"${ctest_include_file}\")\n")
+
+endfunction()
+
+###############################################################################
+
+set(_GOOGLETEST_DISCOVER_TESTS_SCRIPT
+  ${CMAKE_CURRENT_LIST_DIR}/GoogleTestAddTests.cmake
+)

--- a/CMake/future/3.10/GoogleTestAddTests.cmake
+++ b/CMake/future/3.10/GoogleTestAddTests.cmake
@@ -1,0 +1,100 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+set(prefix "${TEST_PREFIX}")
+set(suffix "${TEST_SUFFIX}")
+set(extra_args ${TEST_EXTRA_ARGS})
+set(properties ${TEST_PROPERTIES})
+set(script)
+set(suite)
+set(tests)
+
+function(add_command NAME)
+  set(_args "")
+  foreach(_arg ${ARGN})
+    if(_arg MATCHES "[^-./:a-zA-Z0-9_]")
+      set(_args "${_args} [==[${_arg}]==]")
+    else()
+      set(_args "${_args} ${_arg}")
+    endif()
+  endforeach()
+  set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
+endfunction()
+
+# Run test executable to get list of available tests
+if(NOT EXISTS "${TEST_EXECUTABLE}")
+  message(FATAL_ERROR
+    "Specified test executable '${TEST_EXECUTABLE}' does not exist"
+  )
+endif()
+execute_process(
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --gtest_list_tests
+  OUTPUT_VARIABLE output
+  RESULT_VARIABLE result
+)
+if(NOT ${result} EQUAL 0)
+  message(FATAL_ERROR
+    "Error running test executable '${TEST_EXECUTABLE}':\n"
+    "  Result: ${result}\n"
+    "  Output: ${output}\n"
+  )
+endif()
+
+string(REPLACE "\n" ";" output "${output}")
+
+# Parse output
+foreach(line ${output})
+  # Skip header
+  if(NOT line MATCHES "gtest_main\\.cc")
+    # Do we have a module name or a test name?
+    if(NOT line MATCHES "^  ")
+      # Module; remove trailing '.' to get just the name...
+      string(REGEX REPLACE "\\.( *#.*)?" "" suite "${line}")
+      if(line MATCHES "#" AND NOT NO_PRETTY_TYPES)
+        string(REGEX REPLACE "/[0-9]\\.+ +#.*= +" "/" pretty_suite "${line}")
+      else()
+        set(pretty_suite "${suite}")
+      endif()
+      string(REGEX REPLACE "^DISABLED_" "" pretty_suite "${pretty_suite}")
+    else()
+      # Test name; strip spaces and comments to get just the name...
+      string(REGEX REPLACE " +" "" test "${line}")
+      if(test MATCHES "#" AND NOT NO_PRETTY_VALUES)
+        string(REGEX REPLACE "/[0-9]+#GetParam..=" "/" pretty_test "${test}")
+      else()
+        string(REGEX REPLACE "#.*" "" pretty_test "${test}")
+      endif()
+      string(REGEX REPLACE "^DISABLED_" "" pretty_test "${pretty_test}")
+      string(REGEX REPLACE "#.*" "" test "${test}")
+      # ...and add to script
+      add_command(add_test
+        "${prefix}${pretty_suite}.${pretty_test}${suffix}"
+        ${TEST_EXECUTOR}
+        "${TEST_EXECUTABLE}"
+        "--gtest_filter=${suite}.${test}"
+        "--gtest_also_run_disabled_tests"
+        ${extra_args}
+      )
+      if(suite MATCHES "^DISABLED" OR test MATCHES "^DISABLED")
+        add_command(set_tests_properties
+          "${prefix}${pretty_suite}.${pretty_test}${suffix}"
+          PROPERTIES DISABLED TRUE
+        )
+      endif()
+      add_command(set_tests_properties
+        "${prefix}${pretty_suite}.${pretty_test}${suffix}"
+        PROPERTIES
+        WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+        ${properties}
+      )
+     list(APPEND tests "${prefix}${pretty_suite}.${pretty_test}${suffix}")
+    endif()
+  endif()
+endforeach()
+
+# Create a list of all discovered tests, which users may use to e.g. set
+# properties on the tests
+add_command(set ${TEST_LIST} ${tests})
+
+# Write CTest script
+file(WRITE "${CTEST_FILE}" "${script}")

--- a/CMake/future/3.9/FindGTest.cmake
+++ b/CMake/future/3.9/FindGTest.cmake
@@ -1,0 +1,209 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindGTest
+# ---------
+#
+# Locate the Google C++ Testing Framework.
+#
+# Imported targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` targets:
+#
+# ``GTest::GTest``
+#   The Google Test ``gtest`` library, if found; adds Thread::Thread
+#   automatically
+# ``GTest::Main``
+#   The Google Test ``gtest_main`` library, if found
+#
+#
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``GTEST_FOUND``
+#   Found the Google Testing framework
+# ``GTEST_INCLUDE_DIRS``
+#   the directory containing the Google Test headers
+#
+# The library variables below are set as normal variables.  These
+# contain debug/optimized keywords when a debugging library is found.
+#
+# ``GTEST_LIBRARIES``
+#   The Google Test ``gtest`` library; note it also requires linking
+#   with an appropriate thread library
+# ``GTEST_MAIN_LIBRARIES``
+#   The Google Test ``gtest_main`` library
+# ``GTEST_BOTH_LIBRARIES``
+#   Both ``gtest`` and ``gtest_main``
+#
+# Cache variables
+# ^^^^^^^^^^^^^^^
+#
+# The following cache variables may also be set:
+#
+# ``GTEST_ROOT``
+#   The root directory of the Google Test installation (may also be
+#   set as an environment variable)
+# ``GTEST_MSVC_SEARCH``
+#   If compiling with MSVC, this variable can be set to ``MT`` or
+#   ``MD`` (the default) to enable searching a GTest build tree
+#
+#
+# Example usage
+# ^^^^^^^^^^^^^
+#
+# ::
+#
+#     enable_testing()
+#     find_package(GTest REQUIRED)
+#
+#     add_executable(foo foo.cc)
+#     target_link_libraries(foo GTest::GTest GTest::Main)
+#
+#     add_test(AllTestsInFoo foo)
+#
+#
+# Deeper integration with CTest
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# See :module:`GoogleTest` for information on the :command:`gtest_add_tests`
+# command.
+
+include(GoogleTest)
+
+function(_gtest_append_debugs _endvar _library)
+    if(${_library} AND ${_library}_DEBUG)
+        set(_output optimized ${${_library}} debug ${${_library}_DEBUG})
+    else()
+        set(_output ${${_library}})
+    endif()
+    set(${_endvar} ${_output} PARENT_SCOPE)
+endfunction()
+
+function(_gtest_find_library _name)
+    find_library(${_name}
+        NAMES ${ARGN}
+        HINTS
+            ENV GTEST_ROOT
+            ${GTEST_ROOT}
+        PATH_SUFFIXES ${_gtest_libpath_suffixes}
+    )
+    mark_as_advanced(${_name})
+endfunction()
+
+#
+
+if(NOT DEFINED GTEST_MSVC_SEARCH)
+    set(GTEST_MSVC_SEARCH MD)
+endif()
+
+set(_gtest_libpath_suffixes lib)
+if(MSVC)
+    if(GTEST_MSVC_SEARCH STREQUAL "MD")
+        list(APPEND _gtest_libpath_suffixes
+            msvc/gtest-md/Debug
+            msvc/gtest-md/Release
+            msvc/x64/Debug
+            msvc/x64/Release
+            )
+    elseif(GTEST_MSVC_SEARCH STREQUAL "MT")
+        list(APPEND _gtest_libpath_suffixes
+            msvc/gtest/Debug
+            msvc/gtest/Release
+            msvc/x64/Debug
+            msvc/x64/Release
+            )
+    endif()
+endif()
+
+
+find_path(GTEST_INCLUDE_DIR gtest/gtest.h
+    HINTS
+        $ENV{GTEST_ROOT}/include
+        ${GTEST_ROOT}/include
+)
+mark_as_advanced(GTEST_INCLUDE_DIR)
+
+if(MSVC AND GTEST_MSVC_SEARCH STREQUAL "MD")
+    # The provided /MD project files for Google Test add -md suffixes to the
+    # library names.
+    _gtest_find_library(GTEST_LIBRARY            gtest-md  gtest)
+    _gtest_find_library(GTEST_LIBRARY_DEBUG      gtest-mdd gtestd)
+    _gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main-md  gtest_main)
+    _gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_main-mdd gtest_maind)
+else()
+    _gtest_find_library(GTEST_LIBRARY            gtest)
+    _gtest_find_library(GTEST_LIBRARY_DEBUG      gtestd)
+    _gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main)
+    _gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_maind)
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTest DEFAULT_MSG GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY)
+
+if(GTEST_FOUND)
+    set(GTEST_INCLUDE_DIRS ${GTEST_INCLUDE_DIR})
+    _gtest_append_debugs(GTEST_LIBRARIES      GTEST_LIBRARY)
+    _gtest_append_debugs(GTEST_MAIN_LIBRARIES GTEST_MAIN_LIBRARY)
+    set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
+
+    include(CMakeFindDependencyMacro)
+    find_dependency(Threads)
+
+    if(NOT TARGET GTest::GTest)
+        add_library(GTest::GTest UNKNOWN IMPORTED)
+        set_target_properties(GTest::GTest PROPERTIES
+            INTERFACE_LINK_LIBRARIES "Threads::Threads")
+        if(GTEST_INCLUDE_DIRS)
+            set_target_properties(GTest::GTest PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}")
+        endif()
+        if(EXISTS "${GTEST_LIBRARY}")
+            set_target_properties(GTest::GTest PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+                IMPORTED_LOCATION "${GTEST_LIBRARY}")
+        endif()
+        if(EXISTS "${GTEST_LIBRARY_RELEASE}")
+            set_property(TARGET GTest::GTest APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(GTest::GTest PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+                IMPORTED_LOCATION_RELEASE "${GTEST_LIBRARY_RELEASE}")
+        endif()
+        if(EXISTS "${GTEST_LIBRARY_DEBUG}")
+            set_property(TARGET GTest::GTest APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(GTest::GTest PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+                IMPORTED_LOCATION_DEBUG "${GTEST_LIBRARY_DEBUG}")
+        endif()
+      endif()
+      if(NOT TARGET GTest::Main)
+          add_library(GTest::Main UNKNOWN IMPORTED)
+          set_target_properties(GTest::Main PROPERTIES
+              INTERFACE_LINK_LIBRARIES "GTest::GTest")
+          if(EXISTS "${GTEST_MAIN_LIBRARY}")
+              set_target_properties(GTest::Main PROPERTIES
+                  IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+                  IMPORTED_LOCATION "${GTEST_MAIN_LIBRARY}")
+          endif()
+          if(EXISTS "${GTEST_MAIN_LIBRARY_RELEASE}")
+            set_property(TARGET GTest::Main APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(GTest::Main PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+                IMPORTED_LOCATION_RELEASE "${GTEST_MAIN_LIBRARY_RELEASE}")
+          endif()
+          if(EXISTS "${GTEST_MAIN_LIBRARY_DEBUG}")
+            set_property(TARGET GTest::Main APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(GTest::Main PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+                IMPORTED_LOCATION_DEBUG "${GTEST_MAIN_LIBRARY_DEBUG}")
+          endif()
+    endif()
+endif()

--- a/CMake/kwiver-cmake-future.cmake
+++ b/CMake/kwiver-cmake-future.cmake
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------
+function(kwiver_import_cmake_future BASE_PATH)
+  message(STATUS "Import CMake future from '${BASE_PATH}'")
+  file(GLOB _cmake_future_versions RELATIVE ${BASE_PATH} "${BASE_PATH}/*/")
+  foreach(_version ${_cmake_future_versions})
+    message(STATUS "Import CMake future '${_version}'")
+    if(IS_DIRECTORY "${BASE_PATH}/${_version}")
+      if(CMAKE_VERSION VERSION_LESS ${_version})
+        list(APPEND CMAKE_MODULE_PATH "${BASE_PATH}/${_version}")
+      endif()
+    endif()
+  endforeach()
+
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+endfunction()
+
+###############################################################################
+
+message(STATUS "Current path: '${CMAKE_MODULE_PATH}'")
+kwiver_import_cmake_future(${CMAKE_CURRENT_LIST_DIR}/future)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.3)
 
 project(KWIVER)
 
-include(CMakeDependentOption)
-
 ###
 # KWIVER version
 set(KWIVER_VERSION_MAJOR 1)
@@ -52,7 +50,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
   endif()
 endif()
 
-LIST( INSERT CMAKE_MODULE_PATH  0         ${KWIVER_CMAKE_DIR} ) # prepend out cmake resources
+# prepend our CMake resources
+list(INSERT CMAKE_MODULE_PATH 0 ${KWIVER_CMAKE_DIR})
+
+# import CMake future modules
+include(kwiver-cmake-future)
 
 # ================================================================
 # project global includes
@@ -74,6 +76,8 @@ include_directories( SYSTEM ${CMAKE_CURRENT_SOURCE_DIR} )
 # ================================================================
 ###
 # User options
+include(CMakeDependentOption)
+
 OPTION(KWIVER_BUILD_SHARED     "Build KWIVER components shared or not" TRUE )
 MARK_AS_ADVANCED( KWIVER_BUILD_SHARED )
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -130,6 +130,13 @@ Sprokit
 
      $plugin_explorer --fact instrumentation
 
+Unit Tests
+
+ * KWIVER is in the process of transitioning to Google Test as its primary
+   testing framework.  This means that Google Test is now a hard dependency
+   when KWIVER_ENABLE_TESTS is ON.  (Recent versions of Fletch include Google
+   Test.)  The Sprokit tests will continue to use their own framework.
+
 
 Fixes since v1.1.0
 ------------------

--- a/tests/test_eigen.h
+++ b/tests/test_eigen.h
@@ -1,0 +1,66 @@
+/*ckwg +29
+ * Copyright 2011-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *
+ * \brief Google Test utilities for Eigen types
+ *
+ * This adds some utilities that improve working with Eigen types in Google
+ * Test.
+ */
+
+#ifndef KWIVER_TEST_TEST_EIGEN_H_
+#define KWIVER_TEST_TEST_EIGEN_H_
+
+#include <Eigen/Core>
+
+// ----------------------------------------------------------------------------
+//
+// Testing helper functions
+//
+
+namespace Eigen
+{
+
+// ----------------------------------------------------------------------------
+void
+PrintTo( Vector2d const& v, ::std::ostream* os )
+{
+  // This function exists because a) it produces better formatting, and
+  // b) Google Test needs an exact match or it will fall back to the generic
+  // value printer...
+  // TODO move this to a shared header
+  (*os) << v[0] << ", " << v[1];
+}
+
+} // end namespace Eigen
+
+#endif // KWIVER_TEST_TEST_EIGEN_H_

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -17,7 +17,6 @@ kwiver_discover_tests(core_config             test_libraries test_config.cxx )
 kwiver_discover_tests(core_enumerate_matrix   test_libraries test_enumerate_matrix.cxx )
 kwiver_discover_tests(core_essential_matrix   test_libraries test_essential_matrix.cxx )
 kwiver_discover_tests(core_fundamental_matrix test_libraries test_fundamental_matrix.cxx )
-kwiver_discover_tests(core_geo_point          test_libraries test_geo_point.cxx)
 kwiver_discover_tests(core_homography         test_libraries test_homography.cxx)
 kwiver_discover_tests(core_image              test_libraries test_image.cxx)
 kwiver_discover_tests(core_rotation           test_libraries test_rotation.cxx)
@@ -41,4 +40,5 @@ kwiver_discover_tests(core_detected_object          test_libraries    test_detec
 kwiver_discover_tests(core_detected_object_set      test_libraries    test_detected_object_set.cxx)
 
 kwiver_discover_gtests(core     geodesy       LIBRARIES ${test_libraries})
+kwiver_discover_gtests(core     geo_point     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core     geo_polygon   LIBRARIES ${test_libraries})

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -40,4 +40,5 @@ kwiver_discover_tests(core_detected_object_type     test_libraries    test_detec
 kwiver_discover_tests(core_detected_object          test_libraries    test_detected_object.cxx)
 kwiver_discover_tests(core_detected_object_set      test_libraries    test_detected_object_set.cxx)
 
+kwiver_discover_gtests(core     geodesy       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core     geo_polygon   LIBRARIES ${test_libraries})

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ kwiver_discover_tests(core_enumerate_matrix   test_libraries test_enumerate_matr
 kwiver_discover_tests(core_essential_matrix   test_libraries test_essential_matrix.cxx )
 kwiver_discover_tests(core_fundamental_matrix test_libraries test_fundamental_matrix.cxx )
 kwiver_discover_tests(core_geo_point          test_libraries test_geo_point.cxx)
-kwiver_discover_tests(core_geo_polygon        test_libraries test_geo_polygon.cxx)
 kwiver_discover_tests(core_homography         test_libraries test_homography.cxx)
 kwiver_discover_tests(core_image              test_libraries test_image.cxx)
 kwiver_discover_tests(core_rotation           test_libraries test_rotation.cxx)
@@ -38,3 +37,8 @@ kwiver_discover_tests(core_algorithm_capabilities  test_libraries test_algorithm
 kwiver_discover_tests(core_detected_object_type     test_libraries    test_detected_object_type.cxx)
 kwiver_discover_tests(core_detected_object          test_libraries    test_detected_object.cxx)
 kwiver_discover_tests(core_detected_object_set      test_libraries    test_detected_object_set.cxx)
+
+find_package(GTest REQUIRED)
+add_executable(test-core_geo_polygon test_geo_polygon.cxx)
+target_link_libraries(test-core_geo_polygon vital vital_vpm GTest::GTest)
+gtest_add_tests(test-core_geo_polygon "" AUTO)

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_core_tests)
 
+find_package(GTest REQUIRED)
+
 include(kwiver-test-setup)
 
 set( test_libraries vital vital_vpm vital_algo )
@@ -38,7 +40,4 @@ kwiver_discover_tests(core_detected_object_type     test_libraries    test_detec
 kwiver_discover_tests(core_detected_object          test_libraries    test_detected_object.cxx)
 kwiver_discover_tests(core_detected_object_set      test_libraries    test_detected_object_set.cxx)
 
-find_package(GTest REQUIRED)
-add_executable(test-core_geo_polygon test_geo_polygon.cxx)
-target_link_libraries(test-core_geo_polygon vital vital_vpm GTest::GTest)
-gtest_add_tests(test-core_geo_polygon "" AUTO)
+kwiver_discover_gtests(core     geo_polygon   LIBRARIES ${test_libraries})

--- a/vital/tests/test_geo_polygon.cxx
+++ b/vital/tests/test_geo_polygon.cxx
@@ -33,27 +33,28 @@
  * \brief core geo_polygon class tests
  */
 
-#include <test_common.h>
-
 #include <vital/types/geo_polygon.h>
 #include <vital/types/geodesy.h>
 #include <vital/types/polygon.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
-#define TEST_ARGS ()
+#include <gtest/gtest.h>
 
-DECLARE_TEST_MAP();
 
 // "It's a magical place." -- P.C.
 static auto const loc_ll = kwiver::vital::vector_2d{ -149.484444, -17.619482 };
 static auto const loc_utm = kwiver::vital::vector_2d{ 236363.98, 8050181.74 };
 
+static auto const loc2_ll = kwiver::vital::vector_2d{ -73.759291, 42.849631 };
+
 static auto constexpr crs_ll = kwiver::vital::SRID::lat_lon_WGS84;
 static auto constexpr crs_utm_6s = kwiver::vital::SRID::UTM_WGS84_south + 6;
 
+namespace kwiver {
+namespace vital {
+
 // ----------------------------------------------------------------------------
-bool operator==( kwiver::vital::polygon const& a,
-                 kwiver::vital::polygon const& b )
+bool operator==( polygon const& a, polygon const& b )
 {
   auto const k = a.num_vertices();
   if ( b.num_vertices() != k )
@@ -72,95 +73,121 @@ bool operator==( kwiver::vital::polygon const& a,
   return true;
 }
 
-// ----------------------------------------------------------------------------
-bool operator!=( kwiver::vital::polygon const& a,
-                 kwiver::vital::polygon const& b )
+} } // end namespace
+
+namespace Eigen
 {
-  return !( a == b );
+
+// ----------------------------------------------------------------------------
+void
+PrintTo( Vector2d const& v, ::std::ostream* os )
+{
+  // This function exists because a) it produces better formatting, and
+  // b) Google Test needs an exact match or it will fall back to the generic
+  // value printer...
+  // TODO move this to a shared header
+  (*os) << v[0] << ", " << v[1];
 }
+
+} // end namespace
 
 // ----------------------------------------------------------------------------
 int
-main(int argc, char* argv[])
+main( int argc, char* argv[] )
 {
-  CHECK_ARGS(1);
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
 }
 
 // ----------------------------------------------------------------------------
-IMPLEMENT_TEST(default_constructor)
+TEST(geo_polygon, default_constructor)
 {
   kwiver::vital::geo_polygon p;
-
-  if ( ! p.is_empty() )
-  {
-    TEST_ERROR("The default polygon is not empty");
-  }
+  EXPECT_TRUE( p.is_empty() );
 }
 
 // ----------------------------------------------------------------------------
-IMPLEMENT_TEST(constructor_point)
+TEST(geo_polygon, constructor_polygon)
 {
   kwiver::vital::geo_polygon p{ { loc_ll }, crs_ll };
-
-  if ( p.is_empty() )
-  {
-    TEST_ERROR("The constructed polygon is empty");
-  }
+  EXPECT_FALSE( p.is_empty() );
 }
 
 // ----------------------------------------------------------------------------
-IMPLEMENT_TEST(assignment)
+TEST(geo_polygon, assignment)
 {
   kwiver::vital::geo_polygon p;
   kwiver::vital::geo_polygon const p1{ { loc_ll }, crs_ll };
   kwiver::vital::geo_polygon const p2;
 
-  if ( ! p.is_empty() )
-  {
-    TEST_ERROR("The default polygon is not empty");
-  }
+  // Paranoia-check initial state
+  EXPECT_TRUE( p.is_empty() );
 
+  // Check assignment from non-empty geo_polygon
   p = p1;
 
-  if ( p.is_empty() )
-  {
-    TEST_ERROR("The polygon is empty after assignment from non-empty polygon");
-  }
+  EXPECT_FALSE( p.is_empty() );
+  EXPECT_EQ( p1.polygon(), p.polygon() );
+  EXPECT_EQ( p1.crs(), p.crs() );
 
-  if ( p.polygon() != p1.polygon() )
-  {
-    TEST_ERROR("The polygon has the wrong location after assignment");
-  }
-
-  if ( p.crs() != p1.crs() )
-  {
-    TEST_ERROR("The polygon has the wrong CRS after assignment");
-  }
-
+  // Check assignment from empty geo_polygon
   p = p2;
 
-  if ( ! p.is_empty() )
+  EXPECT_TRUE( p.is_empty() );
+}
+
+// ----------------------------------------------------------------------------
+TEST(geo_polygon, api)
+{
+  kwiver::vital::geo_polygon p{ { loc_ll }, crs_ll };
+
+  // Test values of the point as originally constructed
+  [=]() {
+    ASSERT_EQ( 1, p.polygon().num_vertices() );
+    EXPECT_EQ( loc_ll, p.polygon().at( 0 ) );
+    EXPECT_EQ( crs_ll, p.crs() );
+    EXPECT_EQ( loc_ll, p.polygon( crs_ll ).at( 0 ) );
+  }();
+
+  // Modify the location and test the new values
+  p.set_polygon( { loc2_ll }, crs_ll );
+
+  [=]() {
+    ASSERT_EQ( 1, p.polygon().num_vertices() );
+    EXPECT_EQ( crs_ll, p.crs() );
+    EXPECT_EQ( loc2_ll, p.polygon().at( 0 ) );
+    EXPECT_EQ( loc2_ll, p.polygon( crs_ll ).at( 0 ) );
+  }();
+
+  // Modify the location again and test the new values
+  p.set_polygon( { loc_utm }, crs_utm_6s );
+
+  [=]() {
+    ASSERT_EQ( 1, p.polygon().num_vertices() );
+    EXPECT_EQ( crs_utm_6s, p.crs() );
+    EXPECT_EQ( loc_utm, p.polygon().at( 0 ) );
+    EXPECT_EQ( loc_utm, p.polygon( crs_utm_6s ).at( 0 ) );
+  }();
+
+  // Test that the old location is not cached
+  try
   {
-    TEST_ERROR("The polygon is not empty after assignment from polygon point");
+    EXPECT_NE( loc2_ll, p.polygon( crs_ll ).at( 0 ) )
+      << "Changing the location did not clear the location cache";
+  }
+  catch (...)
+  {
+    // If no conversion functor is registered, the conversion will fail; that
+    // is okay, since we are only checking here that the point isn't still
+    // caching the old location, which it isn't if it needed to attempt a
+    // conversion
   }
 }
 
 // ----------------------------------------------------------------------------
-IMPLEMENT_TEST(api)
-{
-  // TODO: Implement these tests
-  // This test case should replicate the geo_point api test case, but doing it
-  // well with the current test framework is awkward... it would be much easier
-  // with Google Test!
-}
-
-// ----------------------------------------------------------------------------
-IMPLEMENT_TEST(conversion)
+TEST(geo_polygon, conversion)
 {
   kwiver::vital::geo_polygon p_ll{ { loc_ll }, crs_ll };
   kwiver::vital::geo_polygon p_utm{ { loc_utm }, crs_utm_6s };
@@ -170,19 +197,12 @@ IMPLEMENT_TEST(conversion)
   auto const d2 =
     p_utm.polygon( p_ll.crs() ).at( 0 ) - p_ll.polygon().at( 0 );
 
-  auto const e1 = d1.squaredNorm();
-  auto const e2 = d2.squaredNorm();
+  auto const epsilon_ll_to_utm = d1.squaredNorm();
+  auto const epsilon_utm_to_ll = d2.squaredNorm();
 
-  if ( e1 > 1e-4 )
-  {
-    TEST_ERROR("Result of LL->UTM conversion exceeds tolerance");
-  }
+  EXPECT_LT( epsilon_ll_to_utm, 1e-4 );
+  EXPECT_LT( epsilon_utm_to_ll, 1e-13 );
 
-  if ( e2 > 1e-13 )
-  {
-    TEST_ERROR("Result of UTM->LL conversion exceeds tolerance");
-  }
-
-  std::cout << "LL->UTM epsilon: " << e1 << std::endl;
-  std::cout << "UTM->LL epsilon: " << e2 << std::endl;
+  std::cout << "LL->UTM epsilon: " << epsilon_ll_to_utm << std::endl;
+  std::cout << "UTM->LL epsilon: " << epsilon_utm_to_ll << std::endl;
 }

--- a/vital/tests/test_geo_polygon.cxx
+++ b/vital/tests/test_geo_polygon.cxx
@@ -33,6 +33,8 @@
  * \brief core geo_polygon class tests
  */
 
+#include <test_eigen.h>
+
 #include <vital/types/geo_polygon.h>
 #include <vital/types/geodesy.h>
 #include <vital/types/polygon.h>
@@ -74,22 +76,6 @@ bool operator==( polygon const& a, polygon const& b )
 }
 
 } } // end namespace
-
-namespace Eigen
-{
-
-// ----------------------------------------------------------------------------
-void
-PrintTo( Vector2d const& v, ::std::ostream* os )
-{
-  // This function exists because a) it produces better formatting, and
-  // b) Google Test needs an exact match or it will fall back to the generic
-  // value printer...
-  // TODO move this to a shared header
-  (*os) << v[0] << ", " << v[1];
-}
-
-} // end namespace
 
 // ----------------------------------------------------------------------------
 int
@@ -146,8 +132,8 @@ TEST(geo_polygon, api)
   // Test values of the point as originally constructed
   [=]() {
     ASSERT_EQ( 1, p.polygon().num_vertices() );
-    EXPECT_EQ( loc_ll, p.polygon().at( 0 ) );
     EXPECT_EQ( crs_ll, p.crs() );
+    EXPECT_EQ( loc_ll, p.polygon().at( 0 ) );
     EXPECT_EQ( loc_ll, p.polygon( crs_ll ).at( 0 ) );
   }();
 

--- a/vital/tests/test_geodesy.cxx
+++ b/vital/tests/test_geodesy.cxx
@@ -1,0 +1,93 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief core geodesy tests
+ */
+
+#include <vital/types/geodesy.h>
+
+#include <gtest/gtest.h>
+
+
+static auto const loc1 = kwiver::vital::vector_2d{ -73.759291,  42.849631 };
+static auto const loc2 = kwiver::vital::vector_2d{   4.857878,  45.777158 };
+static auto const loc3 = kwiver::vital::vector_2d{ -62.557243,  82.505337 };
+static auto const loc4 = kwiver::vital::vector_2d{ -12.150267,  85.407630 };
+static auto const loc5 = kwiver::vital::vector_2d{ 166.644316, -77.840078 };
+static auto const loc6 = kwiver::vital::vector_2d{ 107.646964, -83.921037 };
+
+// ----------------------------------------------------------------------------
+int
+main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(geodesy, utm_ups_zones)
+{
+  auto const z1 = kwiver::vital::utm_ups_zone( loc1 );
+  EXPECT_EQ( 18, z1.number );
+  EXPECT_EQ( true, z1.north );
+
+  auto const z2 = kwiver::vital::utm_ups_zone( loc2 );
+  EXPECT_EQ( 31, z2.number );
+  EXPECT_EQ( true, z2.north );
+
+  auto const z3 = kwiver::vital::utm_ups_zone( loc3 );
+  EXPECT_EQ( 20, z3.number );
+  EXPECT_EQ( true, z3.north );
+
+  auto const z4 = kwiver::vital::utm_ups_zone( loc4 );
+  EXPECT_EQ( 0, z4.number );
+  EXPECT_EQ( true, z4.north );
+
+  auto const z5 = kwiver::vital::utm_ups_zone( loc5 );
+  EXPECT_EQ( 58, z5.number );
+  EXPECT_EQ( false, z5.north );
+
+  auto const z6 = kwiver::vital::utm_ups_zone( loc6 );
+  EXPECT_EQ( 0, z6.number );
+  EXPECT_EQ( false, z6.north );
+}
+
+// ----------------------------------------------------------------------------
+TEST(geodesy, utm_ups_zone_range_error)
+{
+  EXPECT_THROW(
+    kwiver::vital::utm_ups_zone( { 0.0, -100.0 } ),
+    std::range_error );
+  EXPECT_THROW(
+    kwiver::vital::utm_ups_zone( { 0.0, +100.0 } ),
+    std::range_error );
+}


### PR DESCRIPTION
See #277 for major background.

This is the first in a series of PR's to port kwiver's unit tests to [Google Test](https://github.com/google/googletest). This PR implements missing bits of the `geo_polygon` test (which was the impetus for using Google Test in the first place), ports the `geo_point` test, and adds the CMake infrastructure for using Google Test.

As noted in #277, the porting is being split into multiple PR's in order to make review easier.