### PR TITLE
Fix Windows build errors from #241

### DIFF
--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -37,6 +37,7 @@
 #include "geodesy.h"
 
 #include <algorithm>
+#include <cctype>
 #include <iomanip>
 #include <numeric>
 #include <stdexcept>

--- a/vital/video_metadata/convert_0104_metadata.cxx
+++ b/vital/video_metadata/convert_0104_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ empty_vector()
 // ----------------------------------------------------------------------------
 template < int N = 2 >
 bool
-is_empty( Eigen::Matrix< double, N, 1 > const& vec )
+is_empty( Eigen::Matrix< double, N, 1, 0, N, 1 > const& vec )
 {
   for ( int i = 0; i < N; ++i )
   {

--- a/vital/video_metadata/convert_0601_metadata.cxx
+++ b/vital/video_metadata/convert_0601_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,7 +69,7 @@ empty_vector()
 // ----------------------------------------------------------------------------
 template < int N = 2 >
 bool
-is_empty( Eigen::Matrix< double, N, 1 > const& vec )
+is_empty( Eigen::Matrix< double, N, 1, 0, N, 1 > const& vec )
 {
   for ( int i = 0; i < N; ++i )
   {


### PR DESCRIPTION
Fix Windows build errors introduced by #241; one case of a missing header (which apparently is transitively included on Linux from something else), and another case of MSVC being stupid about template argument deduction.