### PR TITLE
Fix missing headers in timer

### DIFF
--- a/vital/util/timer.h
+++ b/vital/util/timer.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,9 @@
 
 #include <vital/vital_config.h>
 #include <vital/vital_export.h>
+
+#include <iostream>
+#include <string>
 
 namespace kwiver {
 namespace vital {


### PR DESCRIPTION
Add missing includes to `timer.h` for `std::string`, `std::cerr`, which are used in this header, but did not have the necessary includes.