### PR TITLE
Use steady_clock for wall_timer

### DIFF
--- a/vital/util/wall_timer.h
+++ b/vital/util/wall_timer.h
@@ -74,7 +74,7 @@ public:
   virtual void start()
   {
     m_active = true;
-    m_start = std::chrono::system_clock::now();
+    m_start = std::chrono::steady_clock::now();
   }
 
 
@@ -87,7 +87,7 @@ public:
   virtual void stop()
   {
     m_active = false;
-    m_end = std::chrono::system_clock::now();
+    m_end = std::chrono::steady_clock::now();
   }
 
 
@@ -104,7 +104,7 @@ public:
     if (m_active)
     {
       // Take a snapshot of the interval.
-      std::chrono::duration< double > elapsed_seconds = std::chrono::system_clock::now() - m_start;
+      std::chrono::duration< double > elapsed_seconds = std::chrono::steady_clock::now() - m_start;
       return elapsed_seconds.count();
     }
     else
@@ -116,8 +116,8 @@ public:
 
 private:
 
-  std::chrono::time_point< std::chrono::system_clock > m_start;
-  std::chrono::time_point< std::chrono::system_clock > m_end;
+  std::chrono::time_point< std::chrono::steady_clock > m_start;
+  std::chrono::time_point< std::chrono::steady_clock > m_end;
 
 }; // end class wall_timer
 


### PR DESCRIPTION
Change `wall_timer` to use `std::chrono::steady_clock` instead of `std::chrono::system_clock`. The latter is great for getting a meaningful "calendar" time, but is subject to random skew in either direction (e.g. due to NTP adjustments or users changing the clock for whatever reason). The former may give a time relative to an arbitrary and meaningless point, but is (at least intended to be) monotonic. Since `wall_timer` only cares about durations, this makes `steady_clock` more appropriate for its use.