### PR TITLE
Disable KLV "test"

### DIFF
--- a/vital/klv/tests/CMakeLists.txt
+++ b/vital/klv/tests/CMakeLists.txt
@@ -8,4 +8,5 @@ set( test_libraries vital vital_vpm )
 # KLV tests
 ##############################
 
-kwiver_discover_tests(KLV             test_libraries test_klv.cxx)
+# TODO implement this test!
+# kwiver_discover_tests(KLV             test_libraries test_klv.cxx)


### PR DESCRIPTION
Disable building of the KLV "test". The test source file is just a skeleton that does not actually test anything. Having this show up as a "passing" test is potentially misleading; it seems better to disable it entirely.