### PR TITLE
Dev/doc improvements

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -83,6 +83,9 @@ Vital
    simplifies the select methods that now return a detected_object_set
    rather than a vector of detections.
 
+ * Added method to return a vector of values from a single config
+   entry. The method is templated on the vector element type.
+
 Vital Bindings
 
  * Vital C and Python bindings have been updated with respect the refactoring

--- a/sprokit/processes/ocv/register_processes.cxx
+++ b/sprokit/processes/ocv/register_processes.cxx
@@ -63,7 +63,9 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   fact = vpm.ADD_PROCESS( kwiver::draw_detected_object_boxes_process );
   fact->add_attribute(  kwiver::vital::plugin_factory::PLUGIN_NAME,  "draw_detected_object_boxes" );
   fact->add_attribute(  kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
-  fact->add_attribute(  kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Draw detected object boxes on images." );
+  fact->add_attribute(  kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                        "Draw detected object boxes on images.\n\n"
+                        "Deprecated process - use draw_detected_object_set_process with selected algorithm." );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
 
 // - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Added missing release note on config get as vector. 
Added deprecated note on process draw_detected_object_boxes_process. All that drawing code has been moved to a drawing algo with the wrapper process. The new process `draw_detected_object_set_process` allows the actual drawing algo to be specified in the config.