### PR TITLE
fixed python3 syntax error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if (KWIVER_ENABLE_PYTHON)
     find_package(PythonLibs)
 
     execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig; print distutils.sysconfig.get_python_lib(prefix='')"
+      COMMAND "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(prefix=''))"
       RESULT_VARIABLE proc_success
       OUTPUT_VARIABLE python_site_packages
       )
@@ -239,7 +239,7 @@ if ( KWIVER_ENABLE_LOG4CXX )
   if(WIN32)
     message(STATUS "Log4CXX is not supported on windows, if no other logger is provided, the default will be used")
   endif()
-  
+
 endif()
 
 ###
@@ -271,7 +271,7 @@ endif()
 
 if ( KWIVER_ENABLE_MATLAB )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export LD_LIBRARY_PATH=${Matlab_LIBRARY_DIR}:$LD_LIBRARY_PATH\n" )
-  
+
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set PATH=%PATH%;${Matlab_LIBRARY_DIR}\n" )
 endif()
 


### PR DESCRIPTION
Small fix of a print without any parens in the CMakeLists. It appears my editor also got rid of some trailing whitespace. 