### PR TITLE
Added cmake option to symlink python files

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -120,14 +120,29 @@ function (kwiver_add_python_module_int    path     modpath    module)
     set(kwiver_configure_extra_dests
       "${kwiver_python_output_path}/${python_noarchdir}\${config}/${python_sitename}/${modpath}/${module}.py")
   endif ()
-  kwiver_configure_file("python${python_arch}-${safe_modpath}-${module}"
-    "${path}"
-    "${kwiver_python_output_path}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py"
-    PYTHON_EXECUTABLE)
 
+  set(pyfile_src "${path}")
+  set(pyfile_dst "${kwiver_python_output_path}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py")
+  # installation path for this module
+  set(pypkg_install_path "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}")
+
+  # copy and configure the source file into the binary directory
+  if (KWIVER_SYMLINK_PYTHON)
+    kwiver_symlink_file("python${python_arch}-${safe_modpath}-${module}"
+      "${pyfile_src}"
+      "${pyfile_dst}"
+      PYTHON_EXECUTABLE)
+  else()
+    kwiver_configure_file("python${python_arch}-${safe_modpath}-${module}"
+      "${pyfile_src}"
+      "${pyfile_dst}"
+      PYTHON_EXECUTABLE)
+  endif()
+
+  # install the configured binary to the kwiver python install path
   kwiver_install(
-    FILES       "${kwiver_python_output_path}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py"
-    DESTINATION "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}"
+    FILES       "${pyfile_dst}"
+    DESTINATION "${pypkg_install_path}"
     COMPONENT   runtime)
 
   add_dependencies(python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,11 @@ CMAKE_DEPENDENT_OPTION( KWIVER_ENABLE_PYTHON    "Enable python code" OFF
   KWIVER_ENABLE_C_BINDINGS OFF )
 
 if (KWIVER_ENABLE_PYTHON)
+
+  if (NOT WIN32)
+    OPTION(KWIVER_SYMLINK_PYTHON "Symlink python files instead of copying. Allows for more dynamic python development." Off)
+  endif()
+
   if ( NOT KWIVER_ENABLE_C_BINDINGS )
     message( SEND_ERROR  "Python can not be enabled unless KWIVER_ENABLE_C_BINDINGS is also enabled." )
   endif()

--- a/sprokit/conf/sprokit-macro-configure.cmake
+++ b/sprokit/conf/sprokit-macro-configure.cmake
@@ -105,6 +105,61 @@ function (sprokit_configure_file_w_uid uid name source dest)
   endif ()
 endfunction ()
 
+
+###
+#
+# Mimics a sprokit_configure_file_w_uid, but will symlink `source` to `dest`
+# directly without any configureation. This should only be used for interpreted
+# languages like python to prevent the need to re-make the project after making
+# small changes to these interpreted files.
+#
+# TODO: this should be eventually replaced by `kwiver_symlink_file`. Either the
+# kwiver version should take a uid, or the uid is not necessary.
+#
+# SeeAlso:
+#     kwiver/CMake/utils/kwiver-utils-configuration.cmake
+#
+function (sprokit_symlink_file_w_uid uid name source dest)
+
+  if(EXISTS ${dest} AND NOT IS_SYMLINK ${dest})
+    # If our target it not a symlink, then remove it so we can replace it
+    file(REMOVE ${dest})
+  endif()
+
+  # Need to ensure the directory exists before we create a symlink there
+  get_filename_component(dest_dir ${dest} DIRECTORY)
+  add_custom_command(
+    OUTPUT  "${dest_dir}"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory ${dest_dir}
+    )
+
+  add_custom_command(
+    OUTPUT  "${dest}"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink ${source} ${dest}
+    DEPENDS "${source}" "${dest_dir}"
+    COMMENT "Symlink-configuring ${name} file \"${source}\" -> \"${dest}\""
+    )
+
+  if (NOT no_configure_target)
+    add_custom_target(configure-${uid} ${all}
+      DEPENDS "${dest}"
+      SOURCES "${source}")
+    source_group("Configured Files"
+      FILES "${source}")
+    add_dependencies(configure
+      configure-${uid})
+  endif()
+endfunction ()
+
+
+###
+# Mirrors sprokit_configure_file. Simply calls sprokit_symlink_file_w_uid with
+# the name being the uid
+function (sprokit_symlink_file name source dest)
+  sprokit_symlink_file_w_uid(${name} ${name} "${source}" "${dest}" ${ARGN})
+endfunction ()
+
+
 function (sprokit_configure_file name source dest)
   sprokit_configure_file_w_uid(${name} ${name} "${source}" "${dest}" ${ARGN})
 endfunction ()

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -128,16 +128,32 @@ function (sprokit_add_python_module_int    path     modpath    module)
     set(python_module_id "python${python_arch}-${safe_modpath}-${module}")
   endif()
 
-  sprokit_configure_file_w_uid("${python_configure_id}"
-    "${python_module_id}"
-    "${path}"
-    "${sprokit_python_output_path}/${kwiver_python_subdir}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py"
-    PYTHON_EXECUTABLE)
+  set(pyfile_src "${path}")
+  set(pyfile_dst "${sprokit_python_output_path}/${kwiver_python_subdir}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py")
+  set(pypkg_install_path "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}")
 
+  if (KWIVER_SYMLINK_PYTHON)
+      sprokit_symlink_file_w_uid("${python_configure_id}"
+        "${python_module_id}"
+        "${pyfile_src}"
+        "${pyfile_dst}"
+        PYTHON_EXECUTABLE)
+  else()
+      sprokit_configure_file_w_uid("${python_configure_id}"
+        "${python_module_id}"
+        "${pyfile_src}"
+        "${pyfile_dst}"
+        PYTHON_EXECUTABLE)
+  endif()
+
+  # Force installation of the test into the tests module
+  # FIXME: (there was a merge conflict between sprokit_install/install, which
+  # should this be?)
   sprokit_install(
-    FILES       "${sprokit_python_output_path}/${kwiver_python_subdir}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py"
-    DESTINATION "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}"
-    COMPONENT   runtime)
+      FILES       "${pyfile_dst}"
+      DESTINATION "${pypkg_install_path}"
+      COMPONENT   runtime
+      )
 
   add_dependencies(python
     "configure-${python_configure_id}")

--- a/sprokit/tests/bindings/python/modules/test-pymodules.py
+++ b/sprokit/tests/bindings/python/modules/test-pymodules.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2012-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-config.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-config.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-datum.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-datum.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-edge.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-edge.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-modules.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-modules.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-pipeline.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-pipeline.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-process.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-process.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-process_cluster.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-process_cluster.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2012-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-process_registry.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-process_registry.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-run.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-run.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-scheduler.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-scheduler.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-scheduler_registry.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-scheduler_registry.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-stamp.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-stamp.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-utils.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-utils.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-version.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-version.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2012-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline_util/test-bake.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline_util/test-bake.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline_util/test-export_.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline_util/test-export_.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/sprokit/pipeline_util/test-load.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline_util/test-load.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2011-2013 by Kitware, Inc.
 # All rights reserved.

--- a/sprokit/tests/bindings/python/test/test-test.py
+++ b/sprokit/tests/bindings/python/test/test-test.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python
 #ckwg +28
 # Copyright 2012-2013 by Kitware, Inc.
 # All rights reserved.


### PR DESCRIPTION
This is an attempt to move some of the functionality out of  #268 and into standalone components. 

This PR adds the option `KWIVER_SYMLINK_PYTHON` (defaulting to Off), which makes it so Python files can be optionally symlinked to the build/install directories on unix systems. 

By default, this PR is cause no change to existing functionality. However, by turning symlinks on, instead of having to run cmake every time you change a python file, you can simply edit it and the changes will immediately be reflected in the build files.  While this make python development easier and more dynamic, it is not always a desirable behavior, which is why it is optional and defaulted to false (also it wont work on systems without symlink support). 


#### The first commit
The first commit  adds the CMAKE helper functions `kwiver_symlink_file`, `sprokit_symlink_file`, `sprokit_symlink_file_with_uid` (eventually I think all the sprokit versions should simply be replaced with the kwiver versions, but somebody correct me if I'm wrong about that). 

It modifies the file `kwiver_add_python_module_int` and `sprokit_add_python_module_int` to use the symlink function instead of the corresponding configure option if `KWIVER_SYMLINK_PYTHON` is enabled.

Currently, there are very few configuration variables actually used in python files so the actual configure step is (almost) equivalent to a copy. Most all instances of configure variables in Python files refer to the `PYTHON_EXECUTABLE` cmake variable to setup a shebang (e.g. `#!@PYTHON_EXECUTABLE@` ) However, this is not necessary and should be replaced with `#!/usr/bin/env python`. 

The only other configuration variable that is used is a comment in the `test-pymodules.py` file 

```
# TEST_PROPERTY(ENVIRONMENT, PYTHONPATH=@CMAKE_CURRENT_SOURCE_DIR@)
def test_pythonpath():
```

This test will fail if symlinks are on in this branch. However, these comment-based macros will be replaced by `pytest` configurations once the move to `pytest` is complete (hopefully breaking PRs like this out of #268, will make that easier), and then this test will pass even with symlinks on (note because symlinks are off by default and should only be enabled when developing python code, this will not cause dashboard failures). 


#### The second commit
The second commit replaces the configured shebangs with the previously mentioned static ones. It touches a lot of files, but is a very small and repetitive change. The main change only touches 4 files. 