### PR TITLE
Improved site-packages implementation

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -105,8 +105,8 @@ function ( _kwiver_python_site_package_dir    var_name)
     endif()
 
     # Cache computed value
-    set(_prev_site_packages "${python_site_packages}" INTERNAL)
-    set(_prev_python_exe "${PYTHON_EXECUTABLE}" INTERNAL)
+    set(_prev_site_packages "${python_site_packages}" CACHE INTERNAL "previous state")
+    set(_prev_python_exe "${PYTHON_EXECUTABLE}" CACHE INTERNAL "previous state")
   endif()
 
   set(${var_name} ${python_site_packages} PARENT_SCOPE )

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -61,48 +61,13 @@ macro (_sprokit_create_safe_modpath    modpath    result)
   string(REPLACE "/" "." "${result}" "${modpath}")
 endmacro ()
 
-###
-#
-# Get canonical directory for python site packages.
-# It varys from system to system.
-#
-function ( _sprokit_python_site_package_dir    var_name)
-
-  #
-  # This is run many times and should produce the same result, which could be cached.
-  # Think about it.
-  execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig; print distutils.sysconfig.get_python_lib(prefix='')"
-  RESULT_VARIABLE proc_success
-  OUTPUT_VARIABLE python_site_packages
-  )
-  # Returns something like "lib/python2.7/dist-packages"
-
-  if(NOT ${proc_success} EQUAL 0)
-    message(FATAL_ERROR "Request for python site-packages location failed with error code: ${proc_success}")
-  else()
-    string(STRIP "${python_site_packages}" python_site_packages)
-  endif()
-
-  # Current usage determines most of the path in alternate ways.
-  # All we need to supply is the '*-packages' directory name.
-  # Customers could be converted to accept a larger part of the path from this function.
-  string( REGEX MATCH "dist-packages" result ${python_site_packages} )
-  if (result)
-    set( python_site_packages dist-packages)
-  else()
-    set( python_site_packages site-packages)
-  endif()
-
-  set( ${var_name} ${python_site_packages} PARENT_SCOPE )
-endfunction()
 
 ###
 #
 function (sprokit_add_python_library    name    modpath)
   _sprokit_create_safe_modpath("${modpath}" safe_modpath)
 
-  _sprokit_python_site_package_dir( python_site_packages )
+  _kwiver_python_site_package_dir( python_site_packages )
 
   set(library_subdir "/${sprokit_python_subdir}")
   set(library_subdir_suffix "/${python_site_packages}/${modpath}")
@@ -143,7 +108,7 @@ endfunction ()
 function (sprokit_add_python_module_int    path     modpath    module)
   _sprokit_create_safe_modpath("${modpath}" safe_modpath)
 
-  _sprokit_python_site_package_dir( python_site_packages )
+  _kwiver_python_site_package_dir( python_site_packages )
   set(python_sitepath /${python_site_packages})
 
   set(python_arch)

--- a/sprokit/tests/bindings/python/CMakeLists.txt
+++ b/sprokit/tests/bindings/python/CMakeLists.txt
@@ -51,7 +51,7 @@ function (sprokit_add_python_test group instance)
     set(python_chdir           "$<CONFIGURATION>")
   endif ()
 
-  _sprokit_python_site_package_dir( site_dir )
+  _kwiver_python_site_package_dir( site_dir )
   sprokit_add_tooled_test(python-${group} ${instance}
     "${python_chdir}" "${python_module_path}/${site_dir}" ${ARGN})
 endfunction ()

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -148,7 +148,7 @@ function (sprokit_add_tooled_run_test group instance)
     if (KWIVER_ENABLE_PYTHON)
       if (scheduler STREQUAL "pythread_per_process" OR
           instance STREQUAL "pysimple_pipeline")
-          _sprokit_python_site_package_dir( python_site_packages )
+          _kwiver_python_site_package_dir( python_site_packages )
 
         set(sprokit_test_environment "PYTHONPATH=${test_python_path}/${python_site_packages}")
       endif ()


### PR DESCRIPTION
Similar to #296, this PR is a small standalone piece of #268.

The work is based on a comment I saw in `_sprokit_python_site_package_dir`

```cmake
#		
# This is run many times and should produce the same result, which could be cached.		
# Think about it.		
```

So, I basically did that. I created an internal cache variable that stores the result of the call. If `PYTHON_EXECUTABLE` is ever changed, this cache is reset. 