### PR TITLE
Removing *add_python_module_int

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -93,10 +93,28 @@ function (kwiver_add_python_library    name    modpath)
 
 endfunction ()
 
+
 ###
-# - internal implementation -
 #
-function (kwiver_add_python_module_int    path     modpath    module)
+# kwiver_add_python_module(path modpath module)
+#
+# Installs a pure-Python module into the 'modpath' and puts it into the
+# correct place in the build tree so that it may be used with any built
+# libraries in any build configuration.
+#
+# Args:
+#     path: Path to the python source (e.g. kwiver_process.py)
+#     modpath: Python module path (e.g. kwiver/processes)
+#     module: Python module name. This is the name used to import the code.
+#         (e.g. kwiver_process)
+#
+# SeeAlso:
+#     kwiver/CMake/utils/kwiver-utils-configuration.cmake
+#     ../../sprokit/conf/sprokit-macro-python.cmake
+#     ../../vital/bindings/python/vital/CMakeLists.txt
+#     ../../sprokit/processes/bindings/python/kwiver/CMakeLists.txt
+#     ../../sprokit/processes/bindings/python/kwiver/util/CMakeLists.txt
+function (kwiver_add_python_module path     modpath    module)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
 
   set(python_arch)
@@ -154,7 +172,7 @@ function (kwiver_add_python_module_int    path     modpath    module)
 
     if (NOT WIN32)
       # this looks recursive
-      kwiver_add_python_module_int(
+      kwiver_add_python_module(
         "${path}"
         "${modpath}"
         "${module}")
@@ -162,30 +180,12 @@ function (kwiver_add_python_module_int    path     modpath    module)
   endif ()
 endfunction ()
 
-###
-# kwiver_add_python_module
-#
-#     Installs a pure-Python module into the 'modpath' and puts it into the
-#     correct place in the build tree so that it may be used with any built
-#     libraries in any build configuration.
-#
-# \param path Path to the python source
-#
-# \param modpath Python module path (e.g. kwiver/processes)
-#
-# \param module Python module name. This is the name used to import the code.
-#
-function (kwiver_add_python_module   path   modpath   module)
-  kwiver_add_python_module_int("${path}"
-    "${modpath}"
-    "${module}")
-endfunction ()
 
 ###
 #   kwiver_create_python_init(modpath [module ...])
 #
-#     Creates an __init__.py package file which imports the modules in the
-#     arguments for the package.
+#     Creates an __init__.py file for a core package which imports the modules
+#     in the arguments for the package.
 #
 function (kwiver_create_python_init    modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
@@ -202,12 +202,15 @@ function (kwiver_create_python_init    modpath)
     file(APPEND "${init_template}"      "from ${module} import *\n")
   endforeach ()
 
-  kwiver_add_python_module_int("${init_template}"
+  kwiver_add_python_module("${init_template}"
     "${modpath}"
     __init__)
 endfunction ()
 
+
 ###
+# Creates a default __init__.py file for a plugin package in the build
+# directory.
 #
 function (kwiver_create_python_plugin_init modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
@@ -222,7 +225,7 @@ function (kwiver_create_python_plugin_init modpath)
   file(APPEND "${init_template}"    "from pkgutil import extend_path\n")
   file(APPEND "${init_template}"    "__path__ = extend_path(__path__, __name__)\n")
 
-  kwiver_add_python_module_int("${init_template}"
+  kwiver_add_python_module("${init_template}"
     "${modpath}"
     __init__)
 endfunction ()

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -88,9 +88,14 @@ function (sprokit_add_python_library    name    modpath)
 
 endfunction ()
 
+
 ###
 #
-function (sprokit_add_python_module_int    path     modpath    module)
+# SeeAlso:
+#     kwiver/CMake/utils/kwiver-utils-python.cmake
+#
+function (sprokit_add_python_module    path     modpath    module)
+
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
 
   set(python_arch)
@@ -159,15 +164,9 @@ function (sprokit_add_python_module_int    path     modpath    module)
     "configure-${python_configure_id}")
 endfunction ()
 
-###
-#
-function (sprokit_add_python_module   path   modpath   module)
-  sprokit_add_python_module_int("${path}"
-    "${modpath}"
-    "${module}")
-endfunction ()
 
 ###
+# Creates a default __init__.py file for a core package in the build directory.
 #
 function (sprokit_create_python_init    modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
@@ -191,12 +190,15 @@ function (sprokit_create_python_init    modpath)
       "from ${module} import *\n")
   endforeach ()
 
-  sprokit_add_python_module_int("${init_template}"
+  sprokit_add_python_module("${init_template}"
     "${modpath}"
     __init__)
 endfunction ()
 
+
 ###
+# Creates a default __init__.py file for a plugin package in the build
+# directory.
 #
 function (sprokit_create_python_plugin_init modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
@@ -219,7 +221,7 @@ function (sprokit_create_python_plugin_init modpath)
   file(APPEND "${init_template}"
     "__path__ = extend_path(__path__, __name__)\n")
 
-  sprokit_add_python_module_int("${init_template}"
+  sprokit_add_python_module("${init_template}"
     "${modpath}"
     __init__)
 endfunction ()


### PR DESCRIPTION
This PR is a small standalone piece of #268.
In both the sprokit and kwiver python utils (which should likely be consolidated and merged), there were two functions `{kwiver,sprokit}_add_python_module_int` that were only used internally to each file. The functions  `{kwiver,sprokit}_add_python_module` were called elsewhere, but all they did was call the `_int` functions. 

I essentially removed these do-nothing functions and renamed the `_int` functions to `{kwiver,sprokit}_add_python_module` to reduce code clutter. 

Also,  I added a TODO comment to remove these lines 
```
  file(APPEND "${init_template}"    "from pkgutil import extend_path\n")
  file(APPEND "${init_template}"    "__path__ = extend_path(__path__, __name__)\n")
```

from python plugin init files, as I don't believe they are necessary (unless someone can correct me). 