### PR TITLE
Prevent the empty string from being considered a python module

### DIFF
--- a/sprokit/src/bindings/python/modules/modules.py
+++ b/sprokit/src/bindings/python/modules/modules.py
@@ -59,9 +59,9 @@ def load_python_modules():
 
     envvar = 'SPROKIT_PYTHON_MODULES'
 
-    if envvar in os.environ:
-        extra_modules = os.environ[envvar]
-        packages += extra_modules.split(os.pathsep)
+    extra_modules = os.environ.get(envvar, '').split(os.pathsep)
+    # ensure the empty string is not considered as a module
+    packages.extend([p for p in extra_modules if p])
 
     loader = loaders.ModuleLoader()
     all_modules = []


### PR DESCRIPTION
This PR is a small standalone piece of #268.

This is a bug fix for an issue that occurs when the empty string is part of your `SPROKIT_PYTHON_MODULES` environment variable. 

I discovered this when running the python tests, and each time a test ran my browser would open this webpage [page](https://xkcd.com/353/). This led to a lot of web pages being opened. 

After quite a bit of debugging, I found that when given a path, sprokit.modules.loaders.load will import all modules in that path to check for `__sprokit_register__` function.  When given the empty string, it seems sprokit considers anything in `PYTHONPATH` as fair game, which means that every single python module is imported, including `antigravity`, hence symptomatic behavior. 

The fix is to simply filter out the empty string before calling load. 