### PR TITLE
refactored module/test adding to use loops

### DIFF
--- a/sprokit/tests/bindings/python/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/CMakeLists.txt
@@ -1,80 +1,49 @@
 project(sprokit_test_python_sprokit_pipeline)
 
-##############################
-# Config tests
-##############################
-sprokit_discover_python_tests(config test-config.py)
+# Simple testables require no pytest paramatarization
+set(__simple_testable_modnames
+  config
+  datum
+  edge
+  modules
+  pipeline
+  process
+  process_cluster
+  process_registry
+  scheduler
+  scheduler_registry
+  stamp
+  utils
+  version
+  )
 
-##############################
-# Datum tests
-##############################
-sprokit_discover_python_tests(datum test-datum.py)
 
-##############################
-# Edge tests
-##############################
-sprokit_discover_python_tests(edge test-edge.py)
+###
+# Setup simple tests with no parameters
 
-##############################
-# Modules tests
-##############################
-sprokit_discover_python_tests(modules test-modules.py)
+# KWIVER_ENABLE_TESTS is always true for now (because we are in the test
+# subdir), but the python tests should be moved to the python source dir.
+if (KWIVER_ENABLE_TESTS)
+  include(kwiver-test-setup)
+  # Register individual tests with ctest
+  foreach (group IN LISTS __simple_testable_modnames)
+    # SeeAlso:
+    #     # defines sprokit_discover_python_tests
+    #     sprokit/conf/sprokit-macro-python-tests.cmake
+    sprokit_discover_python_tests(${group} test-${group}.py)
+  endforeach()
+endif()
 
-##############################
-# Pipeline tests
-##############################
-sprokit_discover_python_tests(pipeline test-pipeline.py)
 
-##############################
-# Process tests
-##############################
-sprokit_discover_python_tests(process test-process.py)
-
-##############################
-# Process cluster tests
-##############################
-sprokit_discover_python_tests(process_cluster test-process_cluster.py)
-
-##############################
-# Process registry tests
-##############################
-sprokit_discover_python_tests(process_registry test-process_registry.py)
-
-##############################
-# Scheduler tests
-##############################
-sprokit_discover_python_tests(scheduler test-scheduler.py)
-
-##############################
-# Scheduler registry tests
-##############################
-sprokit_discover_python_tests(scheduler_registry test-scheduler_registry.py)
-
-##############################
-# Stamp tests
-##############################
-sprokit_discover_python_tests(stamp test-stamp.py)
-
-##############################
-# Utils tests
-##############################
-sprokit_discover_python_tests(utils test-utils.py)
-
-##############################
-# Version tests
-##############################
-sprokit_discover_python_tests(version test-version.py)
-
-##############################
-# Run tests
-##############################
-sprokit_build_python_test(run test-run.py)
+###
+# Setup tests with parameters
 
 set(schedulers
   pythread_per_process
   sync
   thread_per_process)
 
+sprokit_build_python_test(run test-run.py)
 function (sprokit_add_python_run_test group instance)
   foreach (scheduler IN LISTS schedulers)
     sprokit_add_python_test(${group} ${instance}-${scheduler})

--- a/sprokit/tests/bindings/python/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/tests/bindings/python/sprokit/pipeline_util/CMakeLists.txt
@@ -3,20 +3,17 @@ project(sprokit_test_python_sprokit_pipeline_util)
 set(sprokit_test_pipelines_directory
   "${sprokit_test_data_directory}/pipelines")
 
-##############################
-# Bake tests
-##############################
-sprokit_discover_python_tests(bake test-bake.py
-  "${sprokit_test_pipelines_directory}")
+set(__modnames
+  bake
+  export_
+  load
+  )
 
-##############################
-# Export tests
-##############################
-sprokit_discover_python_tests(export_ test-export_.py
-  "${sprokit_test_pipelines_directory}")
-
-##############################
-# Load tests
-##############################
-sprokit_discover_python_tests(load test-load.py
-  "${sprokit_test_pipelines_directory}")
+# For now this is always enabled (because we are in the test-dir)
+# but the goal is to move python tests into the python source dir soon
+if (KWIVER_ENABLE_TESTS)
+  foreach (group IN LISTS __modnames)
+    sprokit_discover_python_tests(${group} test-${group}.py
+      ${sprokit_test_pipelines_directory})
+  endforeach()
+endif()

--- a/vital/bindings/python/vital/tests/CMakeLists.txt
+++ b/vital/bindings/python/vital/tests/CMakeLists.txt
@@ -2,91 +2,40 @@
 # Python support
 #
 
-# Add python modules
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/helpers.py
-  vital/tests
-  helpers )
+# Define modules with tests in them
+set(__testable_modnames
+  test_algo_convert_image
+  test_camera
+  test_camera_intrinsics
+  test_camera_map
+  test_color
+  test_config_block
+  test_covariance
+  test_descriptor
+  test_eigen_numpy
+  test_feature
+  test_find_vital_library
+  test_homography
+  test_image
+  test_image_container
+  test_landmark
+  test_rotation
+  test_similarity
+  test_track
+  test_track_set
+  test_track_state
+  )
 
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_algo_convert_image.py
-  vital/tests
-  test_algo_convert_image )
+# All python filenames_we in the vital.tests module
+set(__all_modnames
+  __init__
+  helpers
+  ${__testable_modnames}
+  )
 
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_camera.py
-  vital/tests
-  test_camera )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_camera_intrinsics.py
-  vital/tests
-  test_camera_intrinsics )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_camera_map.py
-  vital/tests
-  test_camera_map )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_color.py
-  vital/tests
-  test_color )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_config_block.py
-  vital/tests
-  test_config_block )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_covariance.py
-  vital/tests
-  test_covariance )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_descriptor.py
-  vital/tests
-  test_descriptor )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_eigen_numpy.py
-  vital/tests
-  test_eigen_numpy )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_feature.py
-  vital/tests
-  test_feature )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_find_vital_library.py
-  vital/tests
-  test_find_vital_library )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_homography.py
-  vital/tests
-  test_homography )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_image.py
-  vital/tests
-  test_image )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_image_container.py
-  vital/tests
-  test_image_container )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_landmark.py
-  vital/tests
-  test_landmark )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_rotation.py
-  vital/tests
-  test_rotation )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_similarity.py
-  vital/tests
-  test_similarity )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_track.py
-  vital/tests
-  test_track )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_track_set.py
-  vital/tests
-  test_track_set )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_track_state.py
-  vital/tests
-  test_track_state )
-
-kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
-  vital/tests
-  __init__ )
+# Add files to the vital.tests python module
+foreach (modname IN LISTS __all_modnames)
+  kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/${modname}.py
+    vital/tests
+    ${modname})
+endforeach()


### PR DESCRIPTION
This is part of #268. Took very long files with repetitive function calls, put the arguments in a list and called the function in a loop. 

Note, in the last file there are two lists `__all_modnames` and `__testable_modnames` that are only split up to support code in a future PR where I will call `add_python_test` on the `__testable_modnames`
