### PR TITLE
Install KWIVER CMake future for use in external projects

### DIFF
--- a/CMake/kwiver-install-utils.cmake
+++ b/CMake/kwiver-install-utils.cmake
@@ -16,6 +16,7 @@ install(
         "${utils_dir}/kwiver-flags-msvc.cmake"
         "${utils_dir}/kwiver-flags-clang.cmake"
         "${utils_dir}/kwiver-configcheck.cmake"
+        "${utils_dir}/kwiver-cmake-future.cmake"
         "${utils_dir}/CommonFindMacros.cmake"
         "${utils_dir}/FindEigen3.cmake"
         "${utils_dir}/FindLog4cxx.cmake"
@@ -29,5 +30,6 @@ install(
             "${utils_dir}/tools"
             "${utils_dir}/configcheck"
             "${utils_dir}/templates"
+            "${utils_dir}/future"
   DESTINATION "${kwiver_cmake_install_dir}"
   )


### PR DESCRIPTION
@mwoehlke-kitware recently added kwiver-cmake-future.cmake which back-ports CMake modules from more recently releases of CMake to make them accessible to KWIVER when building with older CMake versions.  Specifically this adds support for finding GoogleTest.  In order to use these same modules in external projects that build against KWIVER, we need to install the KWIVER CMake Future stuff.