### PR TITLE
Port logger test to Google Test

### DIFF
--- a/vital/logger/logger.h
+++ b/vital/logger/logger.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -241,9 +241,10 @@ logger_handle_t VITAL_LOGGER_EXPORT get_logger( std::string const& name );
  */
 #define LOG_ASSERT( logger, cond, msg ) do {                   \
     if ( ! ( cond ) ) {                                        \
-      std::stringstream _oss_; _oss_  << "ASSERTION FAILED: (" \
-                                      << # cond ")\n"  << msg; \
-      logger->log_error( _oss_.str(), KWIVER_LOGGER_SITE );     \
+      std::stringstream _oss_;                                 \
+      _oss_  << "ASSERTION FAILED: (" << # cond ")\n"  << msg; \
+      logger->log_error( _oss_.str(), KWIVER_LOGGER_SITE );    \
+    }                                                          \
 } while ( 0 )
 
 

--- a/vital/logger/tests/CMakeLists.txt
+++ b/vital/logger/tests/CMakeLists.txt
@@ -8,4 +8,4 @@ set( test_libraries vital_logger )
 # Logger tests
 ##############################
 
-kwiver_discover_tests(vital-logger             test_libraries test_logger.cxx)
+kwiver_discover_gtests(vital logger LIBRARIES ${test_libraries})

--- a/vital/logger/tests/test_logger.cxx
+++ b/vital/logger/tests/test_logger.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,76 +28,62 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tests/test_common.h>
-
 #include <vital/logger/logger.h>
 
-#include <functional>
+#include <gtest/gtest.h>
+
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
+#include <functional>
 
-#define TEST_ARGS ()
+using namespace kwiver::vital;
 
-DECLARE_TEST_MAP();
-
-int
-main(int argc, char* argv[])
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
 {
-  CHECK_ARGS(1);
-
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
 }
 
 //
 // Assume basic logger
 //
 
-// ------------------------------------------------------------------
-IMPLEMENT_TEST(check_levels)
+// ----------------------------------------------------------------------------
+TEST(logger, levels)
 {
-  kwiver::vital::logger_handle_t log2 = kwiver::vital::get_logger( "main.logger2" );
+  logger_handle_t log2 = get_logger( "main.logger2" );
 
-  log2->set_level(kwiver::vital::kwiver_logger::LEVEL_WARN);
+  log2->set_level( kwiver_logger::LEVEL_WARN );
 
-  TEST_EQUAL ("Trace level enabled",  IS_TRACE_ENABLED(log2), false );
-  TEST_EQUAL ("Debug level enabled",  IS_DEBUG_ENABLED(log2), false );
-  TEST_EQUAL ("Info level enabled",   IS_INFO_ENABLED(log2), false );
-  TEST_EQUAL ("Warn level enabled",   IS_WARN_ENABLED(log2), true );
-  TEST_EQUAL ("Error level  enabled", IS_ERROR_ENABLED(log2), true );
-  TEST_EQUAL ("Fatal level enabled",  IS_FATAL_ENABLED(log2), true );
+  EXPECT_FALSE( IS_TRACE_ENABLED( log2 ) );
+  EXPECT_FALSE( IS_DEBUG_ENABLED( log2 ) );
+  EXPECT_FALSE( IS_INFO_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_WARN_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_ERROR_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_FATAL_ENABLED( log2 ) );
 
-  TEST_EQUAL ("Logger name", log2->get_name(), "main.logger2" );
+  EXPECT_EQ( "main.logger2", log2->get_name() );
 
-  TEST_EQUAL ("Get logger2 level(1)", log2->get_level(), kwiver::vital::kwiver_logger::LEVEL_WARN );
+  EXPECT_EQ( kwiver_logger::LEVEL_WARN, log2->get_level() );
 
-  log2->set_level(kwiver::vital::kwiver_logger::LEVEL_DEBUG);
+  log2->set_level( kwiver_logger::LEVEL_DEBUG );
 
-  TEST_EQUAL ("Trace level enabled",  IS_TRACE_ENABLED(log2), false );
-  TEST_EQUAL ("Debug level enabled",  IS_DEBUG_ENABLED(log2), true );
-  TEST_EQUAL ("Info level enabled",   IS_INFO_ENABLED(log2), true );
-  TEST_EQUAL ("Warn level enabled",   IS_WARN_ENABLED(log2), true );
-  TEST_EQUAL ("Error level  enabled", IS_ERROR_ENABLED(log2), true );
-  TEST_EQUAL ("Fatal level enabled",  IS_FATAL_ENABLED(log2), true );
-/*
-  // a compiler check, mostly
+  EXPECT_FALSE( IS_TRACE_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_DEBUG_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_INFO_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_WARN_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_ERROR_ENABLED( log2 ) );
+  EXPECT_TRUE( IS_FATAL_ENABLED( log2 ) );
 
-  LOG_ASSERT( log2, true, "This should compile." );
-  LOG_ASSERT( log2, false, "This should generate ERROR message." );
-*/
-  TEST_EQUAL ("Get logger2 level(2)", log2->get_level(), kwiver::vital::kwiver_logger::LEVEL_DEBUG );
+  EXPECT_EQ( kwiver_logger::LEVEL_DEBUG, log2->get_level() );
 
   // test to see if we get the same logger back
-  kwiver::vital::logger_handle_t log = kwiver::vital::get_logger( "main.logger2" );
-
-  TEST_EQUAL ("Get logger level(3)", log->get_level(), kwiver::vital::kwiver_logger::LEVEL_DEBUG );
-
+  EXPECT_EQ( log2, get_logger( "main.logger2" ) );
 }
 
-
-// ------------------------------------------------------------------
-IMPLEMENT_TEST(logger_factory)
+// ----------------------------------------------------------------------------
+TEST(logger, factory)
 {
   // Need to unset any logger factory specification so we will use the
   // default factory
@@ -107,23 +93,23 @@ IMPLEMENT_TEST(logger_factory)
   unsetenv( "VITAL_LOGGER_FACTORY" );
 #endif
 
-  kwiver::vital::logger_handle_t log2 = kwiver::vital::get_logger( "main.logger" );
+  logger_handle_t log2 = get_logger( "main.logger" );
 
-  TEST_EQUAL( "default logger factory name", log2->get_factory_name(), "default_logger factory" );
+  EXPECT_EQ( "default_logger factory", log2->get_factory_name() );
 }
 
-
-// ------------------------------------------------------------------
-IMPLEMENT_TEST(logger_output)
+// ----------------------------------------------------------------------------
+TEST(logger, output)
 {
-  kwiver::vital::logger_handle_t log2 = kwiver::vital::get_logger( "main.logger2" );
+  logger_handle_t log2 = get_logger( "main.logger2" );
 
-  log2->set_level(kwiver::vital::kwiver_logger::LEVEL_TRACE);
+  log2->set_level( kwiver_logger::LEVEL_TRACE );
 
   LOG_DEBUG( log2, "Test message" );
 
+  LOG_ASSERT( log2, true, "This should pass." );
+  LOG_ASSERT( log2, false, "This should generate an ERROR message." );
 }
-
 
 //
 // Need to test


### PR DESCRIPTION
Fix broken `LOG_ASSERT` macro. Port logger test to Google Test and re-enable tests of `LOG_ASSERT` macro.