### PR TITLE
Port VXL image test to Google Test

### DIFF
--- a/arrows/vxl/tests/CMakeLists.txt
+++ b/arrows/vxl/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ kwiver_discover_tests(vxl_estimate_essential_matrix    test_libraries test_estim
 kwiver_discover_tests(vxl_estimate_fundamental_matrix  test_libraries test_estimate_fundamental_matrix.cxx)
 kwiver_discover_tests(vxl_estimate_homography          test_libraries test_estimate_homography.cxx)
 kwiver_discover_tests(vxl_estimate_similarity          test_libraries test_estimate_similarity.cxx)
-kwiver_discover_tests(vxl_image                        test_libraries test_image.cxx)
+kwiver_discover_gtests(vxl image                       LIBRARIES ${test_libraries})
 kwiver_discover_tests(vxl_optimize_cameras             test_libraries test_optimize_cameras.cxx)
 kwiver_discover_tests(vxl_triangulate_landmarks        test_libraries test_triangulate_landmarks.cxx)
 kwiver_discover_tests(vxl_polygon                      test_libraries test_polygon.cxx)

--- a/arrows/vxl/tests/test_image.cxx
+++ b/arrows/vxl/tests/test_image.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,51 +33,45 @@
  * \brief test VXL image class functionality
  */
 
-#include <test_common.h>
-#include <vital/plugin_loader/plugin_manager.h>
+#include <test_tmpfn.h>
 
 #include <arrows/vxl/image_container.h>
 #include <arrows/vxl/image_io.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/transform_image.h>
 
 #include <vil/vil_crop.h>
 
-#define TEST_ARGS ()
-
-DECLARE_TEST_MAP();
-
-int
-main(int argc, char* argv[])
-{
-  CHECK_ARGS(1);
-
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
-}
+#include <gtest/gtest.h>
 
 using namespace kwiver::vital;
+using namespace kwiver::arrows;
 
-IMPLEMENT_TEST(factory)
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
 {
-  using namespace kwiver::arrows;
-  kwiver::vital::plugin_manager::instance().load_all_plugins();
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
 
-  kwiver::vital::algo::image_io_sptr img_io = kwiver::vital::algo::image_io::create("vxl");
-  if (!img_io)
-  {
-    TEST_ERROR("Unable to create image_io algorithm of type vxl");
-  }
+// ----------------------------------------------------------------------------
+TEST(image, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  std::shared_ptr<algo::image_io> img_io;
+  ASSERT_NE(nullptr, img_io = algo::image_io::create("vxl"));
+
   algo::image_io* img_io_ptr = img_io.get();
-  if (typeid(*img_io_ptr) != typeid(vxl::image_io))
-  {
-    TEST_ERROR("Factory method did not construct the correct type");
-  }
+  EXPECT_EQ(typeid(vxl::image_io), typeid(*img_io_ptr))
+    << "Factory method did not construct the correct type";
 }
 
 namespace {
 
-// helper functor for use in transform_image
+// ----------------------------------------------------------------------------
+// Helper functor for use in transform_image
 template <typename T>
 class scale_offset {
 private:
@@ -93,9 +87,9 @@ public:
   }
 };
 
-
-// helper functor for use in transform_image
-// This funcion mimics the vil_convert_stretch_range_limited operation
+// ----------------------------------------------------------------------------
+// Helper functor for use in transform_image; mimics the
+// vil_convert_stretch_range_limited operation
 template <typename T>
 class range_to_byte {
 private:
@@ -112,10 +106,9 @@ public:
   }
 };
 
-
-
-// helper function to populate the image with a pattern
-// the dynamic range is stretched between minv and maxv
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern; the dynamic range is
+// stretched between minv and maxv
 template <typename T>
 void
 populate_vil_image(vil_image_view<T>& img, T minv, T maxv)
@@ -136,8 +129,8 @@ populate_vil_image(vil_image_view<T>& img, T minv, T maxv)
   }
 }
 
-
-// helper function to populate the image with a pattern
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern
 template <typename T>
 void
 populate_vil_image(vil_image_view<T>& img)
@@ -147,9 +140,9 @@ populate_vil_image(vil_image_view<T>& img)
   populate_vil_image(img, minv, maxv);
 }
 
-
-// helper function to populate the image with a pattern
-// the dynamic range is stretched between minv and maxv
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern; the dynamic range is
+// stretched between minv and maxv
 template <typename T>
 void
 populate_vital_image(kwiver::vital::image& img, T minv, T maxv)
@@ -170,7 +163,7 @@ populate_vital_image(kwiver::vital::image& img, T minv, T maxv)
   }
 }
 
-
+// ----------------------------------------------------------------------------
 // helper function to populate the image with a pattern
 template <typename T>
 void
@@ -181,325 +174,359 @@ populate_vital_image(kwiver::vital::image& img)
   populate_vital_image<T>(img, minv, maxv);
 }
 
+// ----------------------------------------------------------------------------
+// TODO replace with template variable when we require C++14
+template <typename T> constexpr size_t depth_for_type() { return 3; }
 
-template <typename T>
-void
-run_image_io_tests(kwiver::vital::image_of<T> const& img, std::string const& type_str)
-{
-  using namespace kwiver::arrows;
-  const std::string image_path = "test_"+type_str+".tiff";
-  image_container_sptr c(new simple_image_container(img));
-  vxl::image_io io;
-  io.save(image_path, c);
-  image_container_sptr c2 = io.load(image_path);
-  kwiver::vital::image img2 = c2->get_image();
-  TEST_EQUAL("Image of type "+type_str+" has same type after saving and loading",
-             img.pixel_traits(), img2.pixel_traits());
-  TEST_EQUAL("Image of type "+type_str+" has same content after saving and loading",
-             equal_content(img, img2), true);
-  if( std::remove(image_path.c_str()) != 0 )
-  {
-    TEST_ERROR("Unable to delete temporary image file.");
-  }
-}
+// currently VXL support only single channel double TIFFs
+template <> constexpr size_t depth_for_type<double>() { return 1; }
+
+// currently VXL support only single channel boolean TIFFs
+template <> constexpr size_t depth_for_type<bool>() { return 1; }
 
 } // end anonymous namespace
 
-
-IMPLEMENT_TEST(image_io_types)
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_io : public ::testing::Test
 {
-  {
-    kwiver::vital::image_of<kwiver::vital::byte> img(200,300,3);
-    populate_vital_image<kwiver::vital::byte>(img);
-    run_image_io_tests(img, "uint8");
-  }
-  {
-    kwiver::vital::image_of<float> img(200,300,3);
-    populate_vital_image<float>(img);
-    run_image_io_tests(img, "float");
-  }
-  {
-    // currently VXL support only single channel double TIFFs
-    kwiver::vital::image_of<double> img(200,300,1);
-    populate_vital_image<double>(img);
-    run_image_io_tests(img, "double");
-  }
-  {
-    kwiver::vital::image_of<uint16_t> img(200,300,3);
-    populate_vital_image<uint16_t>(img);
-    run_image_io_tests(img, "uint16_t");
-  }
-  {
-    // currently VXL support only single channel boolean TIFFs
-    kwiver::vital::image_of<bool> img(200,300,1);
-    populate_vital_image<bool>(img);
-    run_image_io_tests(img, "bool");
-  }
+};
+
+using io_types =
+  ::testing::Types<kwiver::vital::byte, float, double, uint16_t, bool>;
+TYPED_TEST_CASE(image_io, io_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_io, type)
+{
+  constexpr auto depth = depth_for_type<TypeParam>();
+  kwiver::vital::image_of<TypeParam> img( 200, 300, depth );
+  populate_vital_image<TypeParam>( img );
+
+  auto const image_path = kwiver::testing::temp_file_name( "test-", ".tiff" );
+
+  auto c = std::make_shared<simple_image_container>( img );
+  vxl::image_io io;
+  io.save( image_path, c );
+  image_container_sptr c2 = io.load( image_path );
+  kwiver::vital::image img2 = c2->get_image();
+  EXPECT_EQ( img.pixel_traits(), img2.pixel_traits() );
+  EXPECT_EQ( img.depth(), img2.depth() );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( 0, std::remove( image_path.c_str() ) )
+    << "Failed to delete temporary image file.";
 }
 
+// ----------------------------------------------------------------------------
+class image_io_stretch : public ::testing::Test
+{
+public:
+  image_io_stretch() :
+    img12{ 200, 300, 3 },
+    img12_path{ kwiver::testing::temp_file_name( "test-", ".tiff" ) }
+    {}
 
-IMPLEMENT_TEST(image_io_stretch)
+  void SetUp();
+  void TearDown();
+
+  kwiver::arrows::vxl::image_io io;
+  kwiver::vital::image_of<uint16_t> img12;
+  std::string const img12_path;
+};
+
+// ----------------------------------------------------------------------------
+void image_io_stretch::SetUp()
+{
+  // Create an image with 12-bit data in a 16-bit image
+  populate_vital_image<uint16_t>( img12, 0, 4095 );
+  auto c = std::make_shared<simple_image_container>( img12 );
+
+  // Save 12-bit image
+  io.save( img12_path, c );
+  std::cout << "wrote 12-bit test image" << std::endl;
+}
+
+// ----------------------------------------------------------------------------
+void image_io_stretch::TearDown()
+{
+  EXPECT_EQ( 0, std::remove( img12_path.c_str() ) )
+    << "Failed to delete temporary image file.";
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(image_io_stretch, auto_stretch)
 {
   using namespace kwiver;
 
-  // an image with 12-bit data in a 16-bit image
-  vital::image_of<uint16_t> img12(200,300,3);
-  populate_vital_image<uint16_t>(img12, 0, 4095);
-  image_container_sptr c(new simple_image_container(img12));
+  vital::image_of<uint16_t> img16{ 200, 300, 3 };
+  img16.copy_from( img12 );
+  auto const scale = ( 65536.0 - 1e-6 ) / 4095.0;
+  vital::transform_image( img16, scale_offset<uint16_t>( scale, 0 ) );
 
-  vital::image_of<uint8_t> img8(200,300,3);
-  vital::image_of<uint16_t> img16(200,300,3);
-  img16.copy_from(img12);
-  double scale = 255.0 / 4095.0;
-  vital::transform_image(img16, scale_offset<uint16_t>(scale, 0));
-  cast_image(img16, img8);
-  img16.copy_from(img12);
-  scale = (65536.0 - 1e-6) / 4095.0;
-  vital::transform_image(img16, scale_offset<uint16_t>(scale, 0));
-
-  // save a 12-bit image
-  arrows::vxl::image_io io;
-  io.save("test12.tiff", c);
-  std::cout << "wrote 12-bit test image" <<std::endl;
-
+  // Load as a 16-bit image
   vital::config_block_sptr config = vital::config_block::empty_config();
-  config->set_value("auto_stretch", true);
-  io.set_configuration(config);
-  c = io.load("test12.tiff");
-  vital::image img_loaded = c->get_image();
-  TEST_EQUAL("12-bit image is represented as 16-bits after saving and loading",
-             img16.pixel_traits(), img_loaded.pixel_traits());
-  TEST_EQUAL("12-bit image is automatically stretched to 16-bit range",
-             equal_content(img_loaded, img16), true);
+  config->set_value( "auto_stretch", true );
+  io.set_configuration( config );
 
-  // load as an 8-bit image
-  config->set_value("force_byte", true);
-  io.set_configuration(config);
-  c = io.load("test12.tiff");
-  img_loaded = c->get_image();
-  TEST_EQUAL("12-bit image is compressed to 8-bits when loading with force_byte",
-             img8.pixel_traits(), img_loaded.pixel_traits());
-  TEST_EQUAL("12-bit image is automatically stretched to 8-bit range with force_byte",
-             equal_content(img_loaded, img8), true);
+  auto const& c = io.load( img12_path );
+  auto const& img_loaded = c->get_image();
 
-  // load as an 8-bit image without stretching
-  vital::image_of<uint8_t> img8t(200,300,3);
-  vital::cast_image(img12, img8t);
-  config->set_value("auto_stretch", false);
-  io.set_configuration(config);
-  c = io.load("test12.tiff");
-  img_loaded = c->get_image();
-  TEST_EQUAL("12-bit image is truncated to 8-bits when loading with force_byte",
-             img8t.pixel_traits(), img_loaded.pixel_traits());
-  TEST_EQUAL("12-bit image is truncated to 8-bit range with force_byte",
-             equal_content(img_loaded, img8t), true);
-
-  // load as an 8-bit image custom stretching
-  vital::image_of<uint8_t> img8m(200,300,3);
-  vital::transform_image(img12, img8m, range_to_byte<uint16_t>(100, 4000));
-  config->set_value("manual_stretch", true);
-  config->set_value("intensity_range", "100 4000");
-  io.set_configuration(config);
-  c = io.load("test12.tiff");
-  img_loaded = c->get_image();
-  TEST_EQUAL("12-bit image is compressed to 8-bits when loading with force_byte",
-             img8m.pixel_traits(), img_loaded.pixel_traits());
-  TEST_EQUAL("12-bit image is manually stretched to 8-bit range with force_byte",
-             equal_content(img_loaded, img8m), true);
-
-  if( std::remove("test12.tiff") != 0 )
-  {
-    TEST_ERROR("Unable to delete temporary image file.");
-  }
-
-  // test the range stretching at save time
-  c = std::make_shared<simple_image_container>(img12);
-  config->set_value("auto_stretch", true);
-  config->set_value("manual_stretch", false);
-  config->set_value("force_byte", true);
-  io.set_configuration(config);
-  io.save("test8.tiff", c);
-  config->set_value("auto_stretch", false);
-  config->set_value("force_byte", false);
-  io.set_configuration(config);
-  c = io.load("test8.tiff");
-  img_loaded = c->get_image();
-  TEST_EQUAL("12-bit image is compressed to 8-bits when saving with force_byte",
-             img8.pixel_traits(), img_loaded.pixel_traits());
-  TEST_EQUAL("8-bit image has correct content (stretched automatically when saved)",
-             equal_content(img_loaded, img8), true);
-
-  if( std::remove("test8.tiff") != 0 )
-  {
-    TEST_ERROR("Unable to delete temporary image file.");
-  }
+  EXPECT_EQ( img16.pixel_traits(), img_loaded.pixel_traits() );
+  EXPECT_TRUE( equal_content( img16, img_loaded ) );
 }
 
+// ----------------------------------------------------------------------------
+TEST_F(image_io_stretch, as_byte_auto_stretch)
+{
+  using namespace kwiver;
+
+  vital::image_of<uint8_t> img8{ 200, 300,3 };
+  vital::image_of<uint16_t> img16{ 200, 300, 3 };
+  img16.copy_from( img12 );
+  auto const scale = 255.0 / 4095.0;
+  vital::transform_image( img16, scale_offset<uint16_t>( scale, 0 ) );
+  cast_image( img16, img8 );
+
+  // Load as an 8-bit image
+  vital::config_block_sptr config = vital::config_block::empty_config();
+  config->set_value( "auto_stretch", true );
+  config->set_value( "force_byte", true );
+  io.set_configuration( config );
+
+  auto const& c = io.load( img12_path );
+  auto const& img_loaded = c->get_image();
+
+  EXPECT_EQ( img8.pixel_traits(), img_loaded.pixel_traits() );
+  EXPECT_TRUE( equal_content( img8, img_loaded ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(image_io_stretch, as_byte_no_stretch)
+{
+  using namespace kwiver;
+
+  // load as an 8-bit image without stretching
+  vital::image_of<uint8_t> img8t{ 200, 300, 3 };
+  vital::cast_image( img12, img8t );
+
+  vital::config_block_sptr config = vital::config_block::empty_config();
+  config->set_value( "auto_stretch", false );
+  config->set_value( "force_byte", true );
+  io.set_configuration( config );
+
+  auto const& c = io.load( img12_path );
+  auto const& img_loaded = c->get_image();
+
+  EXPECT_EQ( img8t.pixel_traits(), img_loaded.pixel_traits() );
+  EXPECT_TRUE( equal_content( img8t, img_loaded ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(image_io_stretch, as_byte_manual_stretch)
+{
+  using namespace kwiver;
+
+  // load as an 8-bit image custom stretching
+  vital::image_of<uint8_t> img8m{ 200, 300, 3 };
+  vital::transform_image( img12, img8m, range_to_byte<uint16_t>( 100, 4000 ) );
+
+  vital::config_block_sptr config = vital::config_block::empty_config();
+  config->set_value( "auto_stretch", false );
+  config->set_value( "force_byte", true );
+  config->set_value( "manual_stretch", true );
+  config->set_value( "intensity_range", "100 4000" );
+  io.set_configuration( config );
+
+  auto const& c = io.load( img12_path );
+  auto const& img_loaded = c->get_image();
+
+  EXPECT_EQ( img8m.pixel_traits(), img_loaded.pixel_traits() );
+  EXPECT_TRUE( equal_content( img8m, img_loaded ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(image_io_stretch, stretch_on_save)
+{
+  using namespace kwiver;
+
+  vital::image_of<uint8_t> img8{ 200, 300,3 };
+  vital::image_of<uint16_t> img16{ 200, 300, 3 };
+  img16.copy_from( img12 );
+  auto const scale = 255.0 / 4095.0;
+  vital::transform_image( img16, scale_offset<uint16_t>( scale, 0 ) );
+  cast_image( img16, img8 );
+
+  // Test the range stretching at save time
+  auto cs = std::make_shared<simple_image_container>( img12 );
+
+  vital::config_block_sptr config = vital::config_block::empty_config();
+  config->set_value( "auto_stretch", true );
+  config->set_value( "force_byte", true );
+  io.set_configuration( config );
+
+  auto const& image_path = kwiver::testing::temp_file_name( "test-", ".tiff" );
+  io.save( image_path, cs );
+
+  config->set_value( "auto_stretch", false );
+  config->set_value( "force_byte", false );
+  io.set_configuration( config );
+
+  auto const& cl = io.load( image_path );
+  auto const& img_loaded = cl->get_image();
+
+  EXPECT_EQ( img8.pixel_traits(), img_loaded.pixel_traits() );
+  EXPECT_TRUE( equal_content( img8, img_loaded ) );
+
+  EXPECT_EQ( 0, std::remove( image_path.c_str() ) )
+    << "Failed to delete temporary image file.";
+}
 
 namespace {
 
+// ----------------------------------------------------------------------------
 template <typename T>
 void
-run_vil_conversion_tests(const vil_image_view<T>& img, const std::string& type_str)
+run_vil_conversion_tests( vil_image_view<T> const& img )
 {
-  using namespace kwiver::arrows;
-  // convert to a vital image and verify that the properties are correct
-  kwiver::vital::image vimg =  vxl::image_container::vxl_to_vital(img);
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the correct bit depth",
-             vimg.pixel_traits().num_bytes, sizeof(T));
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the correct pixel type",
-             vimg.pixel_traits().type, image_pixel_traits_of<T>::static_type);
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the correct number of planes",
-             vimg.depth(), img.nplanes());
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the correct width",
-             vimg.height(), img.nj());
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the correct height",
-             vimg.width(), img.ni());
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the same memory",
-             vimg.first_pixel(), img.top_left_ptr());
-  bool equal_data = true;
-  for( unsigned int p=0; equal_data && p<img.nplanes(); ++p )
-  {
-    for( unsigned int j=0; equal_data && j<img.nj(); ++j )
+  // Convert to a vital image and verify that the properties are correct
+  image const& vimg = vxl::image_container::vxl_to_vital( img );
+  EXPECT_EQ( sizeof(T), vimg.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, vimg.pixel_traits().type );
+  EXPECT_EQ( img.nplanes(), vimg.depth() );
+  EXPECT_EQ( img.nj(), vimg.height() );
+  EXPECT_EQ( img.ni(), vimg.width() );
+  EXPECT_EQ( img.top_left_ptr(), vimg.first_pixel() )
+    << "vital::image should share memory with vil_image_view";
+
+  // Don't try to compare images if they don't have the same layout!
+  ASSERT_FALSE( ::testing::Test::HasNonfatalFailure() );
+
+  [&]{
+    for( unsigned int p = 0; p < img.nplanes(); ++p )
     {
-      for( unsigned int i=0; equal_data && i<img.ni(); ++i )
+      for( unsigned int j = 0; j < img.nj(); ++j )
       {
-        if( img(i,j,p) != vimg.at<T>(i,j,p) )
+        for( unsigned int i = 0; i < img.ni(); ++i )
         {
-          equal_data = false;
+          ASSERT_EQ( img( i, j, p ), vimg.at<T>( i, j, p ) );
         }
       }
     }
-  }
-  TEST_EQUAL("VXL image conversion of type "+type_str+" has the same values",
-             equal_data, true);
+  }();
 
-  // convert back to VXL and test again
-  vil_image_view<T> img2 = vxl::image_container::vital_to_vxl(vimg);
-  if( !img2 )
-  {
-    TEST_ERROR("VXL image re-conversion of type "+type_str+" did not produce a valid vil_image_view");
-    return;
-  }
+  // Convert back to VXL and test again
+  vil_image_view<T> img2 = vxl::image_container::vital_to_vxl( vimg );
+  ASSERT_TRUE( !!img2 )
+    << "vil_image_view re-conversion did not produce a valid vil_image_view";
 
-  TEST_EQUAL("VXL image re-conversion of type "+type_str+" has the correct pixel format",
-             img.pixel_format(), img2.pixel_format());
-  TEST_EQUAL("VXL image re-conversion of type "+type_str+" is identical",
-             vil_image_view_deep_equality(img, img2), true);
-  TEST_EQUAL("VXL image re-conversion of type "+type_str+" has the same memory",
-             img.top_left_ptr(), img2.top_left_ptr());
+  EXPECT_EQ( img2.pixel_format(), img.pixel_format() );
+  EXPECT_TRUE( vil_image_view_deep_equality( img, img2 ) );
+  EXPECT_EQ( img2.top_left_ptr(), img.top_left_ptr() )
+    << "re-converted vil_image_view should share memory with original";
 }
 
-
+// ----------------------------------------------------------------------------
 template <typename T>
 void
-run_vital_conversion_tests(const kwiver::vital::image_of<T>& img, const std::string& type_str)
+run_vital_conversion_tests( kwiver::vital::image_of<T> const& img )
 {
-  using namespace kwiver::arrows;
-  // convert to a vil image and verify that the properties are correct
-  vil_image_view<T> vimg =  vxl::image_container::vital_to_vxl(img);
-  if( !vimg )
-  {
-    TEST_ERROR("Vital image conversion of type "+type_str+" did not produce a valid vil_image_view");
-    return;
-  }
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct pixel format",
-             vimg.pixel_format(), vil_pixel_format_of(T()));
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct number of planes",
-             vimg.nplanes(), img.depth());
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct width",
-             vimg.nj(), img.height());
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct height",
-             vimg.ni(), img.width());
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the same memory",
-             vimg.top_left_ptr(), img.first_pixel());
-  bool equal_data = true;
-  for( unsigned int p=0; equal_data && p<vimg.nplanes(); ++p )
-  {
-    for( unsigned int j=0; equal_data && j<vimg.nj(); ++j )
+  // Convert to a vil image and verify that the properties are correct
+  vil_image_view<T> vimg = vxl::image_container::vital_to_vxl( img );
+  ASSERT_TRUE( !!vimg )
+    << "vital::image conversion did not produce a valid vil_image_view";
+
+  EXPECT_EQ( vil_pixel_format_of( T() ), vimg.pixel_format() );
+  EXPECT_EQ( img.depth(), vimg.nplanes() );
+  EXPECT_EQ( img.height(), vimg.nj() );
+  EXPECT_EQ( img.width(), vimg.ni() );
+  EXPECT_EQ( img.first_pixel(), vimg.top_left_ptr() )
+    << "vil_image_view should share memory with vital::image";
+
+  // Don't try to compare images if they don't have the same layout!
+  ASSERT_FALSE( ::testing::Test::HasNonfatalFailure() );
+
+  [&]{
+    for( unsigned int p = 0; p < vimg.nplanes(); ++p )
     {
-      for( unsigned int i=0; equal_data && i<vimg.ni(); ++i )
+      for( unsigned int j = 0; j < vimg.nj(); ++j )
       {
-        if( img(i,j,p) != vimg(i,j,p) )
+        for( unsigned int i = 0; i < vimg.ni(); ++i )
         {
-          std::cout << "Pixel "<<i<<", "<<j<<", "<<p<<" has values "
-                    <<img(i,j,p)<<" != "<<vimg(i,j,p)<<std::endl;
-          equal_data = false;
+          ASSERT_EQ( img( i, j, p ), vimg( i, j, p ) )
+            << "Pixels differ at " << i << ", " << j << ", " << p;
         }
       }
     }
-  }
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the same values",
-             equal_data, true);
+  }();
 
-  // convert back to VXL and test again
-  kwiver::vital::image img2 = vxl::image_container::vxl_to_vital(vimg);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the correct bit depth",
-             img2.pixel_traits().num_bytes, sizeof(T));
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the correct pixel type",
-             img2.pixel_traits().type, image_pixel_traits_of<T>::static_type);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" is identical",
-             kwiver::vital::equal_content(img, img2), true);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the same memory",
-             img.first_pixel(), img2.first_pixel());
-}
-
-
-template <typename T>
-void
-test_conversion(const std::string& type_str)
-{
-  // create vil_image_view and convert to an from vital images
-  {
-    vil_image_view<T> img(100,200,3);
-    populate_vil_image(img);
-    run_vil_conversion_tests(img, type_str);
-  }
-
-  {
-    vil_image_view<T> img(100,200,3,true);
-    populate_vil_image(img);
-    run_vil_conversion_tests(img, type_str+" (interleaved)");
-  }
-
-  {
-    vil_image_view<T> img(200,300,3);
-    populate_vil_image(img);
-    vil_image_view<T> img_crop = vil_crop(img, 50, 100, 40, 200);
-    run_vil_conversion_tests(img_crop, type_str+" (cropped)");
-  }
-
-  // create vital images and convert to an from vil_image_view
-  // Note: different code paths are taken depending on whether the image
-  // is natively created as vil or vital, so we need to test both ways.
-  {
-    kwiver::vital::image_of<T> img(200, 300, 3);
-    populate_vital_image<T>(img);
-    run_vital_conversion_tests(img, type_str);
-  }
-
-  {
-    kwiver::vital::image_of<T> img(200, 300, 3, true);
-    populate_vital_image<T>(img);
-    run_vital_conversion_tests(img, type_str+" (interleaved)");
-  }
+  // Convert back to vital::image and test again
+  image img2 = vxl::image_container::vxl_to_vital( vimg );
+  EXPECT_EQ( sizeof(T), img2.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, img2.pixel_traits().type );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( img.first_pixel(), img2.first_pixel() )
+    << "re-converted vital::image should share memory with original";
 }
 
 } // end anonymous namespace
 
-
-IMPLEMENT_TEST(image_convert)
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_conversion : public ::testing::Test
 {
-  using namespace kwiver::arrows;
-  test_conversion<vxl_byte>("byte");
-  test_conversion<vxl_sbyte>("signed byte");
-  test_conversion<vxl_uint_16>("uint_16");
-  test_conversion<vxl_int_16>("int_16");
-  test_conversion<vxl_uint_32>("uint_32");
-  test_conversion<vxl_int_32>("int_32");
-  test_conversion<vxl_uint_64>("uint_64");
-  test_conversion<vxl_int_64>("int_64");
-  test_conversion<float>("float");
-  test_conversion<double>("double");
-  test_conversion<bool>("bool");
+};
+
+using conversion_types =
+  ::testing::Types<vxl_byte, vxl_sbyte, vxl_uint_16, vxl_int_16, vxl_uint_32,
+                   vxl_uint_64, vxl_int_64, float, double, bool>;
+TYPED_TEST_CASE(image_conversion, conversion_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vxl_to_vital)
+{
+  // Create vil_image_view and convert to and from vital images
+  vil_image_view<TypeParam> img{ 100, 200, 3 };
+  populate_vil_image( img );
+  run_vil_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vxl_to_vital_interleaved)
+{
+  // Create interleaved vil_image_view and convert to and from vital images
+  vil_image_view<TypeParam> img{ 100, 200, 3, true };
+  populate_vil_image( img );
+  run_vil_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vxl_to_vital_cropped)
+{
+  // Create cropped vil_image_view and convert to and from vital images
+  vil_image_view<TypeParam> img{ 200, 300, 3 };
+  populate_vil_image(img);
+  vil_image_view<TypeParam> img_crop = vil_crop( img, 50, 100, 40, 200 );
+  run_vil_conversion_tests( img_crop );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_vxl)
+{
+  // Create vital images and convert to and from vil_image_view
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as vil or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_vxl_interleaved)
+{
+  // Create vital images and convert to and from vil_image_view
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as vil or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3, true };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
 }

--- a/tests/test_tmpfn.h
+++ b/tests/test_tmpfn.h
@@ -1,0 +1,70 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *
+ * \brief Supplemental macro definitions for test cases
+ */
+
+#ifndef KWIVER_TEST_TEST_TMPFN_H_
+#define KWIVER_TEST_TEST_TMPFN_H_
+
+#include <string>
+
+#include <stdio.h>
+
+#ifdef _WIN32
+#define tempnam(d, p) _tempnam(d, p)
+#endif
+
+namespace kwiver {
+namespace testing {
+
+// ----------------------------------------------------------------------------
+/** @brief Generate a unique file name in the current working directory.
+ *
+ * @param prefix Prefix for generated file name.
+ * @param suffix Suffix for generated file name.
+ */
+std::string
+temp_file_name( char const* prefix, char const* suffix )
+{
+  auto const n = tempnam(".", prefix);
+  auto const s = std::string(n);
+  free(n);
+
+  return s + suffix;
+}
+
+} // end namespace testing
+} // end namespace kwiver
+
+#endif

--- a/vital/types/image.cxx
+++ b/vital/types/image.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,25 @@
 
 namespace kwiver {
 namespace vital {
+
+template <typename T> VITAL_EXPORT
+image_pixel_traits::pixel_type const image_pixel_traits_of<T>::static_type;
+
+template struct image_pixel_traits_of<uint8_t>;
+template struct image_pixel_traits_of<int8_t>;
+template struct image_pixel_traits_of<uint16_t>;
+template struct image_pixel_traits_of<int16_t>;
+template struct image_pixel_traits_of<uint32_t>;
+template struct image_pixel_traits_of<int32_t>;
+template struct image_pixel_traits_of<uint64_t>;
+template struct image_pixel_traits_of<int64_t>;
+template struct image_pixel_traits_of<float>;
+template struct image_pixel_traits_of<double>;
+
+VITAL_EXPORT
+image_pixel_traits::pixel_type const image_pixel_traits_of<bool>::static_type;
+
+template <> struct image_pixel_traits_of<bool>;
 
 /// Output stream operator for image_pixel_traits::pixel_type
 std::ostream& operator<<(std::ostream& os, image_pixel_traits::pixel_type pt)


### PR DESCRIPTION
Add helper for creating temporary file names in tests. Modify config_block_io test to use this. Port VXL image test to Google Test, also using the new helper. The image test cases have also been split into smaller parts and, in one case, into paramaterized cases.