### PR TITLE
Update future-imported FindGTest.cmake

### DIFF
--- a/CMake/future/3.10/FindGTest.cmake
+++ b/CMake/future/3.10/FindGTest.cmake
@@ -71,11 +71,11 @@
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # See :module:`GoogleTest` for information on the :command:`gtest_add_tests`
-# command.
+# and :command:`gtest_discover_tests` commands.
 
 include(GoogleTest)
 
-function(_gtest_append_debugs _endvar _library)
+function(__gtest_append_debugs _endvar _library)
     if(${_library} AND ${_library}_DEBUG)
         set(_output optimized ${${_library}} debug ${${_library}_DEBUG})
     else()
@@ -84,7 +84,7 @@ function(_gtest_append_debugs _endvar _library)
     set(${_endvar} ${_output} PARENT_SCOPE)
 endfunction()
 
-function(_gtest_find_library _name)
+function(__gtest_find_library _name)
     find_library(${_name}
         NAMES ${ARGN}
         HINTS
@@ -93,6 +93,56 @@ function(_gtest_find_library _name)
         PATH_SUFFIXES ${_gtest_libpath_suffixes}
     )
     mark_as_advanced(${_name})
+endfunction()
+
+macro(__gtest_determine_windows_library_type _var)
+    if(EXISTS "${${_var}}")
+        file(TO_NATIVE_PATH "${${_var}}" _lib_path)
+        get_filename_component(_name "${${_var}}" NAME_WE)
+        file(STRINGS "${${_var}}" _match REGEX "${_name}\\.dll" LIMIT_COUNT 1)
+        if(NOT _match STREQUAL "")
+            set(${_var}_TYPE SHARED PARENT_SCOPE)
+        else()
+            set(${_var}_TYPE UNKNOWN PARENT_SCOPE)
+        endif()
+        return()
+    endif()
+endmacro()
+
+function(__gtest_determine_library_type _var)
+    if(WIN32)
+        # For now, at least, only Windows really needs to know the library type
+        __gtest_determine_windows_library_type(${_var})
+        __gtest_determine_windows_library_type(${_var}_RELEASE)
+        __gtest_determine_windows_library_type(${_var}_DEBUG)
+    endif()
+    # If we get here, no determination was made from the above checks
+    set(${_var}_TYPE UNKNOWN PARENT_SCOPE)
+endfunction()
+
+function(__gtest_import_library _target _var _config)
+    if(_config)
+        set(_config_suffix "_${_config}")
+    else()
+        set(_config_suffix "")
+    endif()
+
+    set(_lib "${${_var}${_config_suffix}}")
+    if(EXISTS "${_lib}")
+        if(_config)
+            set_property(TARGET ${_target} APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS ${_config})
+        endif()
+        set_target_properties(${_target} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES${_config_suffix} "CXX")
+        if(WIN32 AND ${_var}_TYPE STREQUAL SHARED)
+            set_target_properties(${_target} PROPERTIES
+                IMPORTED_IMPLIB${_config_suffix} "${_lib}")
+        else()
+            set_target_properties(${_target} PROPERTIES
+                IMPORTED_LOCATION${_config_suffix} "${_lib}")
+        endif()
+    endif()
 endfunction()
 
 #
@@ -131,15 +181,15 @@ mark_as_advanced(GTEST_INCLUDE_DIR)
 if(MSVC AND GTEST_MSVC_SEARCH STREQUAL "MD")
     # The provided /MD project files for Google Test add -md suffixes to the
     # library names.
-    _gtest_find_library(GTEST_LIBRARY            gtest-md  gtest)
-    _gtest_find_library(GTEST_LIBRARY_DEBUG      gtest-mdd gtestd)
-    _gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main-md  gtest_main)
-    _gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_main-mdd gtest_maind)
+    __gtest_find_library(GTEST_LIBRARY            gtest-md  gtest)
+    __gtest_find_library(GTEST_LIBRARY_DEBUG      gtest-mdd gtestd)
+    __gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main-md  gtest_main)
+    __gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_main-mdd gtest_maind)
 else()
-    _gtest_find_library(GTEST_LIBRARY            gtest)
-    _gtest_find_library(GTEST_LIBRARY_DEBUG      gtestd)
-    _gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main)
-    _gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_maind)
+    __gtest_find_library(GTEST_LIBRARY            gtest)
+    __gtest_find_library(GTEST_LIBRARY_DEBUG      gtestd)
+    __gtest_find_library(GTEST_MAIN_LIBRARY       gtest_main)
+    __gtest_find_library(GTEST_MAIN_LIBRARY_DEBUG gtest_maind)
 endif()
 
 include(FindPackageHandleStandardArgs)
@@ -147,63 +197,38 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTest DEFAULT_MSG GTEST_LIBRARY GTEST_INCLUDE_
 
 if(GTEST_FOUND)
     set(GTEST_INCLUDE_DIRS ${GTEST_INCLUDE_DIR})
-    _gtest_append_debugs(GTEST_LIBRARIES      GTEST_LIBRARY)
-    _gtest_append_debugs(GTEST_MAIN_LIBRARIES GTEST_MAIN_LIBRARY)
+    __gtest_append_debugs(GTEST_LIBRARIES      GTEST_LIBRARY)
+    __gtest_append_debugs(GTEST_MAIN_LIBRARIES GTEST_MAIN_LIBRARY)
     set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
+    find_package(Threads QUIET)
 
     if(NOT TARGET GTest::GTest)
-        add_library(GTest::GTest UNKNOWN IMPORTED)
-        set_target_properties(GTest::GTest PROPERTIES
-            INTERFACE_LINK_LIBRARIES "Threads::Threads")
+        __gtest_determine_library_type(GTEST_LIBRARY)
+        add_library(GTest::GTest ${GTEST_LIBRARY_TYPE} IMPORTED)
+        if(TARGET Threads::Threads)
+            set_target_properties(GTest::GTest PROPERTIES
+                INTERFACE_LINK_LIBRARIES Threads::Threads)
+        endif()
+        if(GTEST_LIBRARY_TYPE STREQUAL "SHARED")
+            set_target_properties(GTest::GTest PROPERTIES
+                INTERFACE_COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+        endif()
         if(GTEST_INCLUDE_DIRS)
             set_target_properties(GTest::GTest PROPERTIES
                 INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}")
         endif()
-        if(EXISTS "${GTEST_LIBRARY}")
-            set_target_properties(GTest::GTest PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-                IMPORTED_LOCATION "${GTEST_LIBRARY}")
-        endif()
-        if(EXISTS "${GTEST_LIBRARY_RELEASE}")
-            set_property(TARGET GTest::GTest APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS RELEASE)
-            set_target_properties(GTest::GTest PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
-                IMPORTED_LOCATION_RELEASE "${GTEST_LIBRARY_RELEASE}")
-        endif()
-        if(EXISTS "${GTEST_LIBRARY_DEBUG}")
-            set_property(TARGET GTest::GTest APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS DEBUG)
-            set_target_properties(GTest::GTest PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
-                IMPORTED_LOCATION_DEBUG "${GTEST_LIBRARY_DEBUG}")
-        endif()
-      endif()
-      if(NOT TARGET GTest::Main)
-          add_library(GTest::Main UNKNOWN IMPORTED)
-          set_target_properties(GTest::Main PROPERTIES
-              INTERFACE_LINK_LIBRARIES "GTest::GTest")
-          if(EXISTS "${GTEST_MAIN_LIBRARY}")
-              set_target_properties(GTest::Main PROPERTIES
-                  IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-                  IMPORTED_LOCATION "${GTEST_MAIN_LIBRARY}")
-          endif()
-          if(EXISTS "${GTEST_MAIN_LIBRARY_RELEASE}")
-            set_property(TARGET GTest::Main APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS RELEASE)
-            set_target_properties(GTest::Main PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
-                IMPORTED_LOCATION_RELEASE "${GTEST_MAIN_LIBRARY_RELEASE}")
-          endif()
-          if(EXISTS "${GTEST_MAIN_LIBRARY_DEBUG}")
-            set_property(TARGET GTest::Main APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS DEBUG)
-            set_target_properties(GTest::Main PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
-                IMPORTED_LOCATION_DEBUG "${GTEST_MAIN_LIBRARY_DEBUG}")
-          endif()
+        __gtest_import_library(GTest::GTest GTEST_LIBRARY "")
+        __gtest_import_library(GTest::GTest GTEST_LIBRARY "RELEASE")
+        __gtest_import_library(GTest::GTest GTEST_LIBRARY "DEBUG")
+    endif()
+    if(NOT TARGET GTest::Main)
+        __gtest_determine_library_type(GTEST_MAIN_LIBRARY)
+        add_library(GTest::Main ${GTEST_MAIN_LIBRARY_TYPE} IMPORTED)
+        set_target_properties(GTest::Main PROPERTIES
+            INTERFACE_LINK_LIBRARIES "GTest::GTest")
+        __gtest_import_library(GTest::Main GTEST_MAIN_LIBRARY "")
+        __gtest_import_library(GTest::Main GTEST_MAIN_LIBRARY "RELEASE")
+        __gtest_import_library(GTest::Main GTEST_MAIN_LIBRARY "DEBUG")
     endif()
 endif()


### PR DESCRIPTION
Update our imported-from-the-future copy of `FindGTest.cmake` to include changes from https://gitlab.kitware.com/cmake/cmake/merge_requests/1267. This resolves a link issue with some tests on Windows.