### PR TITLE
Update build instructions for Google Test

### DIFF
--- a/doc/manuals/install_guide.rst
+++ b/doc/manuals/install_guide.rst
@@ -77,6 +77,11 @@ the last couple of steps, Fletch should build without any issues.
 
 `make`
 
+.. note::
+
+  If you are on Windows, you should ensure that both KWIVER and Fletch use the
+  same values of `CMAKE_BUILD_TYPE` and `BUILD_SHARED_LIBS`. If these do not
+  match, you may experience link errors or other issues.
 
 Install Kwiver
 **************

--- a/doc/manuals/install_guide.rst
+++ b/doc/manuals/install_guide.rst
@@ -40,10 +40,10 @@ download.
   cd ~/Downloads
   tar zxfv cmake-3.6.1.tar.gz
   cd cmake-3.6.1
-  ./bootstrap --system-curl --no-system-libs
+  ./bootstrap --system-curl --no-system-libs --prefix=/opt/kitware/cmake/3.6.1
   make
   sudo make install
-  sudo ln -s /usr/local/bin/cmake /bin/cmake`
+  sudo ln -s /opt/kitware/cmake/3.6.1/bin/cmake /bin/cmake
 
 These instructions build the source code into a working executable,
 installs the executable into a personal directory, and then lets the

--- a/doc/manuals/install_guide.rst
+++ b/doc/manuals/install_guide.rst
@@ -16,16 +16,17 @@ Linux distributions may have different packages already installed, or
 may use a different package manager than apt, but even on Ubuntu this
 should help to provide a starting point.
 
-`sudo apt-get install git zlib1g-dev libcurl4-openssl-dev libexpat1-dev dh-autoreconf liblapack-dev libxt-dev`
+.. code::
 
-`sudo apt-get build-dep libboost-all-dev qt5-default`
+  sudo apt-get install git zlib1g-dev libcurl4-openssl-dev libexpat1-dev dh-autoreconf liblapack-dev libxt-dev
+  sudo apt-get build-dep libboost-all-dev qt5-default
 
 Install CMAKE
 =============
 
 The version of cmake you currently get with apt is too old to use for
 kwiver, so you need to do a manual install. Go to the cmake website,
-`https://cmake.org/download`, and download the appropriate binary
+https://cmake.org/download, and download the appropriate binary
 distribution (for Ubuntu, this would be something like
 cmake-3.6.1-Linux-x86_64.sh, depending on version). Download the
 source code, cmake-3.6.1.tar.gz (or just download and use the
@@ -34,19 +35,15 @@ following set of commands. Keep in mind that if you're not using
 version 3.6.1, you'll need to update the version number to match your
 download.
 
-`cd ~/Downloads`
+.. code::
 
-`tar zxfv cmake-3.6.1.tar.gz`
-
-`cd cmake-3.6.1`
-
-`./bootstrap --system-curl --no-system-libs`
-
-`make`
-
-`sudo make install`
-
-`sudo ln -s /usr/local/bin/cmake /bin/cmake`
+  cd ~/Downloads
+  tar zxfv cmake-3.6.1.tar.gz
+  cd cmake-3.6.1
+  ./bootstrap --system-curl --no-system-libs
+  make
+  sudo make install
+  sudo ln -s /usr/local/bin/cmake /bin/cmake`
 
 These instructions build the source code into a working executable,
 installs the executable into a personal directory, and then lets the
@@ -63,46 +60,38 @@ code and builds. I personally like to use ~/Work and then set up a new
 directory for each repo. With all dependencies for Fletch installed in
 the last couple of steps, Fletch should build without any issues.
 
-`mkdir fletch`
+::
 
-`cd fletch`
-
-`git clone https://github.com/kitware/fletch.git`
-
-`mkdir build`
-
-`cd build`
-
-`cmake -Dfletch_ENABLE_ALL_PACKAGES:bool=on ../fletch`
-
-`make`
+  mkdir fletch
+  cd fletch
+  git clone https://github.com/kitware/fletch.git
+  mkdir build
+  cd build
+  cmake -Dfletch_ENABLE_ALL_PACKAGES:bool=on ../fletch
+  make
 
 .. note::
 
   If you are on Windows, you should ensure that both KWIVER and Fletch use the
-  same values of `CMAKE_BUILD_TYPE` and `BUILD_SHARED_LIBS`. If these do not
-  match, you may experience link errors or other issues.
+  same values of ``CMAKE_BUILD_TYPE`` and ``BUILD_SHARED_LIBS``. If these do
+  not match, you may experience link errors or other issues.
 
 Install Kwiver
 **************
 
 After Fletch is built, you should have everything necessary to build
 Kwiver. Navigate back to the directory you want to put Kwiver in (if
-you followed the directions above, the command to return is `cd
-../..`). In the cmake step, make sure to fill in your Fletch build
+you followed the directions above, the command to return is ``cd ../..``).
+In the cmake step, make sure to fill in your Fletch build
 directory so Kwiver knows where to find its dependencies. For example,
-I would use `cmake -Dfletch_DIR:path=/home/dave/Work/fletch/build ../kwiver`.
+I would use ``cmake -Dfletch_DIR:path=/home/dave/Work/fletch/build ../kwiver``.
 
-`mkdir kwiver`
+::
 
-`cd kwiver`
-
-`git clone https://github.com/kitware/kwiver.git`
-
-`mkdir build`
-
-`cd build`
-
-`cmake -Dfletch_DIR:path=<fletch_build_directory> ../kwiver`
-
-`make`
+  mkdir kwiver
+  cd kwiver
+  git clone https://github.com/kitware/kwiver.git
+  mkdir build
+  cd build
+  cmake -Dfletch_DIR:path=<fletch_build_directory> ../kwiver
+  make


### PR DESCRIPTION
Add a note that `CMAKE_BUILD_TYPE` and `BUILD_SHARED_LIBS` must match between Fletch and KWIVER in order to use Google Test on Windows.

Possibly this should wait until https://github.com/Kitware/fletch/pull/213 lands? (Strictly speaking, until that does, Fletch's `BUILD_SHARED_LIBS` doesn't matter and KWIVER must be built with `BUILD_SHARED_LIBS=OFF` in order to use Google Test from Fletch.)