### PR TITLE
Fix formatting of inline literals in documentation

### DIFF
--- a/doc/manuals/sprokit/getting-started.rst
+++ b/doc/manuals/sprokit/getting-started.rst
@@ -137,10 +137,10 @@ Factories that create type "sprokit::process"
     Process type: pyprint_number          A Python process which prints numbers
 
 This is the list of modules that can be included in a Sprokit
-pipeline.  We're going to use the `numbers` module and the the
-`print_number` module to create a very simple pipeline.  To learn more
-about the `numbers` module we'll again use `plugin_explorer` this time
-to get details on a particular module.  For `numbers` we'll use the
+pipeline.  We're going to use the ``numbers`` module and the the
+``print_number`` module to create a very simple pipeline.  To learn more
+about the ``numbers`` module we'll again use ``plugin_explorer`` this time
+to get details on a particular module.  For ``numbers`` we'll use the
 following command::
 
     $ plugin_explorer --process --type numbers -d --config
@@ -169,7 +169,7 @@ following command::
         Flags      : _required,
         Description: Where the numbers will be available.
 
-And for `print_number`, we'll use::
+And for ``print_number``, we'll use::
 
     $ plugin_explorer --process --type print_number -d --config
 
@@ -202,17 +202,17 @@ output "Ports").
 
 KWIVER comes with a sample
 [sprokit/pipelines/number_flow.pipe](sprokit/pipelines/number_flow.pipe)
-file that configures and connects the pipeline so that the `numbers`
+file that configures and connects the pipeline so that the ``numbers``
 process will generate a set of integers from 1 to 99 and the
-`print_number` process will write those to a file called
-`numbers.txt`.  Of particular interest is the section at the end of
+``print_number`` process will write those to a file called
+``numbers.txt``.  Of particular interest is the section at the end of
 the file that actually "hooks up" the pipeline.
 
-To run the pipeline, we'll use the Sprokit `pipeline_runner` command::
+To run the pipeline, we'll use the Sprokit ``pipeline_runner`` command::
 
     $ pipeline_runner -p </path/to/kwiver/source>/sprokit/pipelines/number_flow.pipe
 
-After the pipeline completes, you should find a file, `numbers.txt`, in your working directory.
+After the pipeline completes, you should find a file, ``numbers.txt``, in your working directory.
 
 
 Python Processes
@@ -222,8 +222,8 @@ One of KWIVER's great strengths (as provided by sprokit) is the
 ability to create hybrid pipelines which combine C++ and Python
 processes in the same pipeline.  This greatly facilitates prototyping
 complex processing pipelines.  To test this out we'll still use the
-`numbers` process, but we'll use a Python version of the
-`print_number` process called `kw_print_number_process` the code for
+``numbers`` process, but we'll use a Python version of the
+``print_number`` process called ``kw_print_number_process`` the code for
 which can be seen in
 [sprokit/processes/python/kw_print_number_process.py](sprokit/processes/python/kw_print_number_process.py).
 As usual, we can lean about this process with the following command::
@@ -247,16 +247,16 @@ As usual, we can lean about this process with the following command::
 
     Output ports:
 
-As you can see, the process is very similar to the C++ `print_number`
+As you can see, the process is very similar to the C++ ``print_number``
 process.  As a result, the [".pipe" file is very
 similar](sprokit/pipelines/number_flow_python.pipe).
 
 In order to get around limitations imposed by the Python Global
 Interpreter Lock, we'll use a different Sprokit scheduler for this
-pipeline.  The `pythread_per_process` scheduler which does essentially
+pipeline.  The ``pythread_per_process`` scheduler which does essentially
 what it says: it creates a Python thread for every process in the
 pipeline::
 
 	pipeline_runner -S pythread_per_process -p </path/to/kwiver/source>/sprokit/pipelines/number_flow_python.pipe>
 
-As with the previous pipeline, the numbers will be written to an output file, this time `numbers_from_python.txt`
+As with the previous pipeline, the numbers will be written to an output file, this time ``numbers_from_python.txt``

--- a/doc/manuals/sprokit/pipeline_declaration.rst
+++ b/doc/manuals/sprokit/pipeline_declaration.rst
@@ -137,7 +137,7 @@ For example::
   config foo
     bar = baz
 
-makes the value available by specifying `$CONFIG{foo:bar}` to following lines in the config file
+makes the value available by specifying ``$CONFIG{foo:bar}`` to following lines in the config file
 as shown below.::
 
    value = mode-$CONFIG{foo:bar}ify

--- a/doc/manuals/vital/config_file_format.rst
+++ b/doc/manuals/vital/config_file_format.rst
@@ -163,7 +163,7 @@ OS/X Apple Platform
 - /usr/local/share/<app-name>[/<app-version>]/config
 - /usr/share/<app-name>[/<app-version>]/config
 
-If <install-dir> is not `/usr` or `/usr/local`:
+If <install-dir> is not ``/usr`` or ``/usr/local``:
 
 - <install-dir>/share/<app-name>[/<app-version>]/config
 - <install-dir>/share/config
@@ -181,7 +181,7 @@ Other Posix Platforms (e.g. Linux)
 - /usr/local/share/<app-name>[/<app-version>]/config
 - /usr/share/<app-name>[/<app-version>]/config
 
-If <install-dir> is not `/usr` or `/usr/local`:
+If <install-dir> is not ``/usr`` or ``/usr/local``:
 
 - <install-dir>/share/<app-name>[/<app-version>]/config
 - <install-dir>/share/config
@@ -189,13 +189,13 @@ If <install-dir> is not `/usr` or `/usr/local`:
 
 The environment variable \c KWIVER_CONFIG_PATH can be set with a list
 of one or more directories, in the same manner as the native execution
-`PATH` variable, to be searched for config files.
+``PATH`` variable, to be searched for config files.
 
 Macro Substitution
 ------------------
 The values for configuration elements can be composed from static text
 in the config file and dynamic text supplied by macro providers. The
-format of a macro specification is `$TYPE{name}` where **TYPE** is the
+format of a macro specification is ``$TYPE{name}`` where **TYPE** is the
 name of macro provider and **name** requests a particular value to be
 supplied. The **name** entry is specific to each provider.
 
@@ -217,8 +217,8 @@ LOCAL Macro Provider
 ''''''''''''''''''''
 This macro provider supplies values that have been stored previously
 in the config file.  Local values are specified in the config file
-using the ":=" operator. For example the config entry `mode := online`
-makes `$LOCAL{mode}` available in subsequent configuration
+using the ":=" operator. For example the config entry ``mode := online``
+makes ``$LOCAL{mode}`` available in subsequent configuration
 entries.::
 
   mode := online
@@ -233,7 +233,7 @@ ENV Macro Provider
 ''''''''''''''''''
 This macro provides gives access to the current program
 environment. The values of environment variables such as "HOME" can be
-used by specifying `$ENV{HOME}` in the config file.
+used by specifying ``$ENV{HOME}`` in the config file.
 
 CONFIG Macro Provider
 '''''''''''''''''''''
@@ -242,7 +242,7 @@ entries. For example::
 
   foo:bar = baz
 
-makes the value available by specifying `$CONFIG{foo:bar}` to following lines in the config file
+makes the value available by specifying ``$CONFIG{foo:bar}`` to following lines in the config file
 as shown below.::
 
   value = mode-$CONFIG{foo:bar}ify

--- a/doc/manuals/vital/config_usage.rst
+++ b/doc/manuals/vital/config_usage.rst
@@ -14,7 +14,7 @@ document/section at the end.
 
 Introduction
 ------------
-The vital `config_block` supports general configuration tasks where a
+The vital ``config_block`` supports general configuration tasks where a
 general purpose key/value pair is needed.
 
 Configuration Features


### PR DESCRIPTION
Fix several reST documentation files that were using single-back-tick to mark up literal text. This specifies "default interpreted text role", which may happen to work in some contexts, but is not correct according to plain reST, and results in the text being unstyled when viewed in Github. Instead, use double-back-tick, which is the markup for inline literals.

Note that this does not affect the install guide; that is addressed in #318.