### PR TITLE
Fix minor build issues on macOS

### DIFF
--- a/tests/test_tmpfn.h
+++ b/tests/test_tmpfn.h
@@ -39,7 +39,8 @@
 
 #include <string>
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdlib>
 
 #ifdef _WIN32
 #define tempnam(d, p) _tempnam(d, p)

--- a/vital/types/image.cxx
+++ b/vital/types/image.cxx
@@ -43,14 +43,17 @@ namespace vital {
 template <typename T> VITAL_EXPORT
 image_pixel_traits::pixel_type const image_pixel_traits_of<T>::static_type;
 
-template struct image_pixel_traits_of<uint8_t>;
-template struct image_pixel_traits_of<int8_t>;
-template struct image_pixel_traits_of<uint16_t>;
-template struct image_pixel_traits_of<int16_t>;
-template struct image_pixel_traits_of<uint32_t>;
-template struct image_pixel_traits_of<int32_t>;
-template struct image_pixel_traits_of<uint64_t>;
-template struct image_pixel_traits_of<int64_t>;
+template struct image_pixel_traits_of<char>;
+template struct image_pixel_traits_of<signed char>;
+template struct image_pixel_traits_of<unsigned char>;
+template struct image_pixel_traits_of<signed short>;
+template struct image_pixel_traits_of<unsigned short>;
+template struct image_pixel_traits_of<signed int>;
+template struct image_pixel_traits_of<unsigned int>;
+template struct image_pixel_traits_of<signed long>;
+template struct image_pixel_traits_of<unsigned long>;
+template struct image_pixel_traits_of<signed long long>;
+template struct image_pixel_traits_of<unsigned long long>;
 template struct image_pixel_traits_of<float>;
 template struct image_pixel_traits_of<double>;
 


### PR DESCRIPTION
Change the list of types for which we explicitly instantiate image pixel traits to use the core type names, rather than `cstdint` type names. This is necessary to ensure that both `long` and `long long` variants are exported, which is important in case the `cstdint` types and VXL types are not the same, as is the case on macOS. See also 3339294b3e82.

Add missing include of `cstdlib`, which is needed because some platforms might not implicitly include a header which declares `free()`. (In particular, this was broken on macOS.)

Along with kitware/fletch#229, this should fix the current issues with the macOS CI build. (FYI @hughed2...)


