### PR TITLE
Dev/macros in include

### DIFF
--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -34,6 +34,9 @@
 #include <vital/config/config_block_exception.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/util/string.h>
+#include <vital/util/token_expander.h>
+#include <vital/util/token_type_sysenv.h>
+#include <vital/util/token_type_env.h>
 #include <kwiversys/SystemTools.hxx>
 
 #include <sprokit/pipeline_util/load_pipe_exception.h>
@@ -218,6 +221,8 @@ public:
 
   // file search path list
   kwiver::vital::config_path_list_t m_search_path;
+
+  kwiver::vital::token_expander m_token_expander;
 };
 
 
@@ -388,6 +393,9 @@ get_next_token()
 
       std::string file_name( m_priv->m_cur_char, m_priv->m_input_line.end() );
       m_priv->trim_string( file_name );
+
+      // Perform macro substitutions first
+      file_name = m_priv->m_token_expander.expand_token( file_name );
 
       kwiver::vital::config_path_t resolv_filename = m_priv->resolve_file_name( file_name );
       if ( "" == resolv_filename ) // could not resolve
@@ -583,6 +591,9 @@ priv()
 
   m_keyword_table["::"]           = TK_DOUBLE_COLON;
   m_keyword_table[":="]           = TK_LOCAL_ASSIGN;
+
+  m_token_expander.add_token_type( new kwiver::vital::token_type_env() );
+  m_token_expander.add_token_type( new kwiver::vital::token_type_sysenv() );
 }
 
 

--- a/sprokit/tests/data/pipelines/config_block.pipe
+++ b/sprokit/tests/data/pipelines/config_block.pipe
@@ -3,4 +3,4 @@ config myblock
   :mykey myvalue
 
 # new style config entry
-otherkey = value
+  otherkey = value

--- a/sprokit/tests/data/pipelines/include.pipe
+++ b/sprokit/tests/data/pipelines/include.pipe
@@ -1,1 +1,1 @@
-!include config_block.pipe
+include config_block.pipe

--- a/sprokit/tests/data/pipelines/include_env.pipe
+++ b/sprokit/tests/data/pipelines/include_env.pipe
@@ -1,0 +1,1 @@
+include $ENV{FoO}_block.pipe

--- a/sprokit/tests/sprokit/pipeline_util/test_load_pipe.cxx
+++ b/sprokit/tests/sprokit/pipeline_util/test_load_pipe.cxx
@@ -35,6 +35,7 @@
 #include <sprokit/pipeline_util/pipe_declaration_types.h>
 
 #include <vital/config/config_block.h>
+#include <kwiversys/SystemTools.hxx>
 
 #include <boost/variant.hpp>
 
@@ -294,6 +295,22 @@ IMPLEMENT_TEST(connected_processes_notalnum)
 // ------------------------------------------------------------------
 IMPLEMENT_TEST(include)
 {
+  sprokit::pipe_blocks const blocks = sprokit::load_pipe_blocks_from_file(pipe_file);
+
+  test_visitor v;
+
+  std::for_each(blocks.begin(), blocks.end(), boost::apply_visitor(v));
+
+  v.expect(1, 0, 0, 0);
+}
+
+
+// ------------------------------------------------------------------
+IMPLEMENT_TEST(include_env)
+{
+  // Supply part of file name
+  kwiversys::SystemTools::PutEnv( "FoO=config" );
+
   sprokit::pipe_blocks const blocks = sprokit::load_pipe_blocks_from_file(pipe_file);
 
   test_visitor v;


### PR DESCRIPTION
Add environment expansion to include file names.
    
Apply macro expander to raw file name from include name
before it is resolved any further. This provides the ability
dynamically change the file name based on environment contents.