### PR TITLE
Add include to define free() on MacOS and others.

### DIFF
--- a/tests/test_tmpfn.h
+++ b/tests/test_tmpfn.h
@@ -38,7 +38,7 @@
 #define KWIVER_TEST_TEST_TMPFN_H_
 
 #include <string>
-
+#include <cstdlib>
 #include <stdio.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
Add include needed by MacOS to define free() function