### PR TITLE
Avoid loading plugins at build time

### DIFF
--- a/tests/test_gtest.h
+++ b/tests/test_gtest.h
@@ -39,6 +39,16 @@
 
 #include <gtest/gtest.h>
 
+#define TEST_LOAD_PLUGINS() \
+  class _test_plugin_helper : public ::testing::EmptyTestEventListener \
+  { \
+  public: \
+    virtual void OnTestProgramStart(::testing::UnitTest const&) override \
+    { kwiver::vital::plugin_manager::instance().load_all_plugins(); } \
+  }; \
+  ::testing::UnitTest::GetInstance()->listeners().Append( \
+    new _test_plugin_helper )
+
 // ----------------------------------------------------------------------------
 /** @brief Consume a required command line argument.
  *

--- a/vital/tests/test_geo_point.cxx
+++ b/vital/tests/test_geo_point.cxx
@@ -34,6 +34,7 @@
  */
 
 #include <test_eigen.h>
+#include <test_gtest.h>
 
 #include <vital/types/geo_point.h>
 #include <vital/types/geodesy.h>
@@ -53,9 +54,8 @@ static auto constexpr crs_utm_18n = kwiver::vital::SRID::UTM_WGS84_north + 18;
 int
 main(int argc, char* argv[])
 {
-  kwiver::vital::plugin_manager::instance().load_all_plugins();
-
   ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
   return RUN_ALL_TESTS();
 }
 

--- a/vital/tests/test_geo_polygon.cxx
+++ b/vital/tests/test_geo_polygon.cxx
@@ -34,6 +34,7 @@
  */
 
 #include <test_eigen.h>
+#include <test_gtest.h>
 
 #include <vital/plugin_loader/plugin_manager.h>
 
@@ -42,8 +43,6 @@
 #include <vital/types/geo_polygon.h>
 #include <vital/types/geodesy.h>
 #include <vital/types/polygon.h>
-
-#include <gtest/gtest.h>
 
 using namespace kwiver::vital;
 
@@ -100,9 +99,8 @@ void PrintTo( polygon const& v, ::std::ostream* os )
 int
 main( int argc, char* argv[] )
 {
-  plugin_manager::instance().load_all_plugins();
-
   ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
   return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
Tweak unit tests that need plugins to do so via a Google Test even listener that fires at the start of test execution, rather than directly in `main()`. This avoids attempting to load plugins when merely listing tests, particularly when this happens at build time as part of test discovery.

FYI @mattdawkins.