### PR TITLE
Fix config_block_set_value_cast<geo_polygon>

### DIFF
--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -174,8 +174,10 @@ config_block_set_value_cast( geo_polygon const& value )
     []( double cur, vector_2d const& p ) {
       return std::max( { cur, std::fabs( p[0] ), std::fabs( p[1] ) } );
     });
+  auto const idigits =
+    static_cast<int>( std::floor( std::log10( magnitude ) ) ) + 1;
 
-  str_result.precision( 20 - static_cast<int>( std::ceil( magnitude ) ) );
+  str_result.precision( std::max( 0, 20 - idigits ) );
   str_result.setf( std::ios::fixed );
 
   // Write vertex coordinates


### PR DESCRIPTION
Fix algorithm to compute the correct number of decimal digits when serializing a `geo_polygon` for output to a `config_block`. The previous algorithm was failing to take the logarithm of the polygon magnitude, such that we were setting the decimal digits precision to some screwy value. For whatever reason, this apparently just happened to work on Linux (possibly because it was producing a negative number that libstdc++ ignored), but was causing Windows to output an empty string instead of the coordinate value numbers.

Thanks go to the failing unit test for noticing that something was wrong!