### PR TITLE
Remove use of VITAL_NOTHROW

### DIFF
--- a/arrows/core/close_loops_exhaustive.cxx
+++ b/arrows/core/close_loops_exhaustive.cxx
@@ -87,7 +87,7 @@ close_loops_exhaustive
 
 /// Destructor
 close_loops_exhaustive
-::~close_loops_exhaustive() VITAL_NOTHROW
+::~close_loops_exhaustive() noexcept
 {
 }
 

--- a/arrows/core/close_loops_exhaustive.h
+++ b/arrows/core/close_loops_exhaustive.h
@@ -65,7 +65,7 @@ public:
   close_loops_exhaustive();
 
   /// Destructor
-  virtual ~close_loops_exhaustive() VITAL_NOTHROW;
+  virtual ~close_loops_exhaustive() noexcept;
 
   /// Returns implementation description
   virtual std::string description() const;

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -105,7 +105,7 @@ close_loops_keyframe
 
 /// Destructor
 close_loops_keyframe
-::~close_loops_keyframe() VITAL_NOTHROW
+::~close_loops_keyframe() noexcept
 {
 }
 

--- a/arrows/core/close_loops_keyframe.h
+++ b/arrows/core/close_loops_keyframe.h
@@ -60,7 +60,7 @@ public:
   close_loops_keyframe();
 
   /// Destructor
-  virtual ~close_loops_keyframe() VITAL_NOTHROW;
+  virtual ~close_loops_keyframe() noexcept;
 
   /// Returns implementation description
   virtual std::string description() const;

--- a/arrows/core/hierarchical_bundle_adjust.cxx
+++ b/arrows/core/hierarchical_bundle_adjust.cxx
@@ -141,7 +141,7 @@ hierarchical_bundle_adjust
 
 /// Destructor
 hierarchical_bundle_adjust
-::~hierarchical_bundle_adjust() VITAL_NOTHROW
+::~hierarchical_bundle_adjust() noexcept
 {
 }
 

--- a/arrows/core/hierarchical_bundle_adjust.h
+++ b/arrows/core/hierarchical_bundle_adjust.h
@@ -59,7 +59,7 @@ public:
   /// Constructor
   hierarchical_bundle_adjust();
   /// Destructor
-  virtual ~hierarchical_bundle_adjust() VITAL_NOTHROW;
+  virtual ~hierarchical_bundle_adjust() noexcept;
 
   /// Get this algorithm's \link kwiver::vital::config_block configuration block \endlink
   virtual vital::config_block_sptr get_configuration() const;

--- a/arrows/core/track_features_core.cxx
+++ b/arrows/core/track_features_core.cxx
@@ -106,7 +106,7 @@ track_features_core
 
 /// Destructor
 track_features_core
-::~track_features_core() VITAL_NOTHROW
+::~track_features_core() noexcept
 {
 }
 

--- a/arrows/core/track_features_core.h
+++ b/arrows/core/track_features_core.h
@@ -61,7 +61,7 @@ public:
   track_features_core();
 
   /// Destructor
-  virtual ~track_features_core() VITAL_NOTHROW;
+  virtual ~track_features_core() noexcept;
 
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**

--- a/arrows/matlab/matlab_exception.cxx
+++ b/arrows/matlab/matlab_exception.cxx
@@ -41,7 +41,7 @@ namespace matlab {
 
 
 matlab_exception::
-matlab_exception(const std::string& msg) VITAL_NOTHROW
+matlab_exception(const std::string& msg) noexcept
   : vital_core_base_exception()
 {
     m_what = msg;
@@ -49,7 +49,7 @@ matlab_exception(const std::string& msg) VITAL_NOTHROW
 
 
 matlab_exception::
-~matlab_exception() VITAL_NOTHROW
+~matlab_exception() noexcept
 { }
 
 

--- a/arrows/matlab/matlab_exception.h
+++ b/arrows/matlab/matlab_exception.h
@@ -54,9 +54,9 @@ class KWIVER_ALGO_MATLAB_EXPORT matlab_exception
 {
 public:
   // -- CONSTRUCTORS --
-  matlab_exception( const std::string& msg ) VITAL_NOTHROW;
+  matlab_exception( const std::string& msg ) noexcept;
 
-  virtual ~matlab_exception() VITAL_NOTHROW;
+  virtual ~matlab_exception() noexcept;
 
 }; // end class matlab_exception
 

--- a/sprokit/src/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/sprokit/pipeline/datum.cxx
@@ -179,14 +179,14 @@ datum
 
 // ------------------------------------------------------------------
 datum_exception
-::datum_exception() VITAL_NOTHROW
+::datum_exception() noexcept
   : pipeline_exception()
 {
 }
 
 
 datum_exception
-::~datum_exception() VITAL_NOTHROW
+::~datum_exception() noexcept
 {
 }
 
@@ -200,7 +200,7 @@ bad_datum_cast_exception
                            std::string const& typeid_,
                            datum::type_t const& type,
                            datum::error_t const& error,
-                           char const* reason) VITAL_NOTHROW
+                           char const* reason) noexcept
   : datum_exception()
   , m_requested_typeid(requested_typeid)
   , m_typeid(typeid_)
@@ -238,7 +238,7 @@ bad_datum_cast_exception
 
 // ------------------------------------------------------------------
 bad_datum_cast_exception
-::~bad_datum_cast_exception() VITAL_NOTHROW
+::~bad_datum_cast_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/datum.h
+++ b/sprokit/src/sprokit/pipeline/datum.h
@@ -199,11 +199,11 @@ class SPROKIT_PIPELINE_EXPORT datum_exception
     /**
      * \brief Constructor.
      */
-    datum_exception() VITAL_NOTHROW;
+    datum_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~datum_exception() VITAL_NOTHROW;
+    virtual ~datum_exception() noexcept;
 };
 
 /**
@@ -226,11 +226,11 @@ class SPROKIT_PIPELINE_EXPORT bad_datum_cast_exception
      * \param error The type that was requested.
      * \param reason The reason for the bad cast.
      */
-    bad_datum_cast_exception(std::string const& requested_typeid, std::string const& typeid_, datum::type_t const& type, datum::error_t const& error, char const* reason) VITAL_NOTHROW;
+    bad_datum_cast_exception(std::string const& requested_typeid, std::string const& typeid_, datum::type_t const& type, datum::error_t const& error, char const* reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~bad_datum_cast_exception() VITAL_NOTHROW;
+    ~bad_datum_cast_exception() noexcept;
 
     /// The requested datum type.
     std::string const m_requested_typeid;

--- a/sprokit/src/sprokit/pipeline/edge_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/edge_exception.cxx
@@ -42,18 +42,18 @@ namespace sprokit
 {
 
 edge_exception
-::edge_exception() VITAL_NOTHROW
+::edge_exception() noexcept
   : pipeline_exception()
 {
 }
 
 edge_exception
-::~edge_exception() VITAL_NOTHROW
+::~edge_exception() noexcept
 {
 }
 
 null_edge_config_exception
-::null_edge_config_exception() VITAL_NOTHROW
+::null_edge_config_exception() noexcept
   : edge_exception()
 {
   std::ostringstream sstr;
@@ -64,12 +64,12 @@ null_edge_config_exception
 }
 
 null_edge_config_exception
-::~null_edge_config_exception() VITAL_NOTHROW
+::~null_edge_config_exception() noexcept
 {
 }
 
 datum_requested_after_complete
-::datum_requested_after_complete() VITAL_NOTHROW
+::datum_requested_after_complete() noexcept
   : edge_exception()
 {
   std::ostringstream sstr;
@@ -81,23 +81,23 @@ datum_requested_after_complete
 }
 
 datum_requested_after_complete
-::~datum_requested_after_complete() VITAL_NOTHROW
+::~datum_requested_after_complete() noexcept
 {
 }
 
 edge_connection_exception
-::edge_connection_exception() VITAL_NOTHROW
+::edge_connection_exception() noexcept
   : edge_exception()
 {
 }
 
 edge_connection_exception
-::~edge_connection_exception() VITAL_NOTHROW
+::~edge_connection_exception() noexcept
 {
 }
 
 null_process_connection_exception
-::null_process_connection_exception() VITAL_NOTHROW
+::null_process_connection_exception() noexcept
   : edge_connection_exception()
 {
   std::ostringstream sstr;
@@ -108,12 +108,12 @@ null_process_connection_exception
 }
 
 null_process_connection_exception
-::~null_process_connection_exception() VITAL_NOTHROW
+::~null_process_connection_exception() noexcept
 {
 }
 
 duplicate_edge_connection_exception
-::duplicate_edge_connection_exception(process::name_t const& name, process::name_t const& new_name, std::string const& type) VITAL_NOTHROW
+::duplicate_edge_connection_exception(process::name_t const& name, process::name_t const& new_name, std::string const& type) noexcept
   : edge_connection_exception()
   , m_name(name)
   , m_new_name(new_name)
@@ -129,29 +129,29 @@ duplicate_edge_connection_exception
 }
 
 duplicate_edge_connection_exception
-::~duplicate_edge_connection_exception() VITAL_NOTHROW
+::~duplicate_edge_connection_exception() noexcept
 {
 }
 
 input_already_connected_exception
-::input_already_connected_exception(process::name_t const& name, process::name_t const& new_name) VITAL_NOTHROW
+::input_already_connected_exception(process::name_t const& name, process::name_t const& new_name) noexcept
   : duplicate_edge_connection_exception(name, new_name, "input")
 {
 }
 
 input_already_connected_exception
-::~input_already_connected_exception() VITAL_NOTHROW
+::~input_already_connected_exception() noexcept
 {
 }
 
 output_already_connected_exception
-::output_already_connected_exception(process::name_t const& name, process::name_t const& new_name) VITAL_NOTHROW
+::output_already_connected_exception(process::name_t const& name, process::name_t const& new_name) noexcept
   : duplicate_edge_connection_exception(name, new_name, "output")
 {
 }
 
 output_already_connected_exception
-::~output_already_connected_exception() VITAL_NOTHROW
+::~output_already_connected_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/edge_exception.h
+++ b/sprokit/src/sprokit/pipeline/edge_exception.h
@@ -61,11 +61,11 @@ class SPROKIT_PIPELINE_EXPORT edge_exception
     /**
      * \brief Constructor.
      */
-    edge_exception() VITAL_NOTHROW;
+    edge_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~edge_exception() VITAL_NOTHROW;
+    virtual ~edge_exception() noexcept;
 };
 
 /**
@@ -82,11 +82,11 @@ class SPROKIT_PIPELINE_EXPORT null_edge_config_exception
     /**
      * \brief Constructor.
      */
-    null_edge_config_exception() VITAL_NOTHROW;
+    null_edge_config_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_edge_config_exception() VITAL_NOTHROW;
+    ~null_edge_config_exception() noexcept;
 };
 
 /**
@@ -103,11 +103,11 @@ class SPROKIT_PIPELINE_EXPORT datum_requested_after_complete
     /**
      * \brief Constructor.
      */
-    datum_requested_after_complete() VITAL_NOTHROW;
+    datum_requested_after_complete() noexcept;
     /**
      * \brief Destructor.
      */
-    ~datum_requested_after_complete() VITAL_NOTHROW;
+    ~datum_requested_after_complete() noexcept;
 };
 
 /**
@@ -124,11 +124,11 @@ class SPROKIT_PIPELINE_EXPORT edge_connection_exception
     /**
      * \brief Constructor.
      */
-    edge_connection_exception() VITAL_NOTHROW;
+    edge_connection_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~edge_connection_exception() VITAL_NOTHROW;
+    virtual ~edge_connection_exception() noexcept;
 };
 
 /**
@@ -145,11 +145,11 @@ class SPROKIT_PIPELINE_EXPORT null_process_connection_exception
     /**
      * \brief Constructor.
      */
-    null_process_connection_exception() VITAL_NOTHROW;
+    null_process_connection_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_process_connection_exception() VITAL_NOTHROW;
+    ~null_process_connection_exception() noexcept;
 };
 
 /**
@@ -170,11 +170,11 @@ class SPROKIT_PIPELINE_EXPORT duplicate_edge_connection_exception
      * \param new_name The name of the process which was attemted to be connected.
      * \param type The type of connection.
      */
-    duplicate_edge_connection_exception(process::name_t const& name, process::name_t const& new_name, std::string const& type) VITAL_NOTHROW;
+    duplicate_edge_connection_exception(process::name_t const& name, process::name_t const& new_name, std::string const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~duplicate_edge_connection_exception() VITAL_NOTHROW;
+    virtual ~duplicate_edge_connection_exception() noexcept;
 
     /// The name of the process which was already connected.
     process::name_t const m_name;
@@ -199,11 +199,11 @@ class SPROKIT_PIPELINE_EXPORT input_already_connected_exception
      * \param name The name of the process that was already connected.
      * \param new_name The name of the process which was attemted to be connected.
      */
-    input_already_connected_exception(process::name_t const& name, process::name_t const& new_name) VITAL_NOTHROW;
+    input_already_connected_exception(process::name_t const& name, process::name_t const& new_name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~input_already_connected_exception() VITAL_NOTHROW;
+    ~input_already_connected_exception() noexcept;
 };
 
 /**
@@ -223,11 +223,11 @@ class SPROKIT_PIPELINE_EXPORT output_already_connected_exception
      * \param name The name of the process that was already connected.
      * \param new_name The name of the process which was attemted to be connected.
      */
-    output_already_connected_exception(process::name_t const& name, process::name_t const& new_name) VITAL_NOTHROW;
+    output_already_connected_exception(process::name_t const& name, process::name_t const& new_name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~output_already_connected_exception() VITAL_NOTHROW;
+    ~output_already_connected_exception() noexcept;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -178,8 +178,8 @@ class pipeline::priv
                               process::name_t const& downstream_name,
                               process::port_t const& downstream_port,
                               process::port_type_t const& type,
-                              bool push_upstream) VITAL_NOTHROW;
-        ~propagation_exception() VITAL_NOTHROW;
+                              bool push_upstream) noexcept;
+        ~propagation_exception() noexcept;
 
         process::name_t const m_upstream_name;
         process::port_t const m_upstream_port;
@@ -2281,7 +2281,7 @@ pipeline::priv::propagation_exception
                         process::name_t const& downstream_name,
                         process::port_t const& downstream_port,
                         process::port_type_t const& type,
-                        bool push_upstream) VITAL_NOTHROW
+                        bool push_upstream) noexcept
   : m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
   , m_downstream_name(downstream_name)
@@ -2295,7 +2295,7 @@ pipeline::priv::propagation_exception
 
 // ------------------------------------------------------------------
 pipeline::priv::propagation_exception
-::~propagation_exception() VITAL_NOTHROW
+::~propagation_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/pipeline_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline_exception.cxx
@@ -43,18 +43,18 @@ namespace sprokit
 {
 
 pipeline_addition_exception
-::pipeline_addition_exception() VITAL_NOTHROW
+::pipeline_addition_exception() noexcept
   : pipeline_exception()
 {
 }
 
 pipeline_addition_exception
-::~pipeline_addition_exception() VITAL_NOTHROW
+::~pipeline_addition_exception() noexcept
 {
 }
 
 null_pipeline_config_exception
-::null_pipeline_config_exception() VITAL_NOTHROW
+::null_pipeline_config_exception() noexcept
   : pipeline_exception()
 {
   std::ostringstream sstr;
@@ -65,12 +65,12 @@ null_pipeline_config_exception
 }
 
 null_pipeline_config_exception
-::~null_pipeline_config_exception() VITAL_NOTHROW
+::~null_pipeline_config_exception() noexcept
 {
 }
 
 add_after_setup_exception
-::add_after_setup_exception(process::name_t const& name) VITAL_NOTHROW
+::add_after_setup_exception(process::name_t const& name) noexcept
   : pipeline_addition_exception()
   , m_name(name)
 {
@@ -83,12 +83,12 @@ add_after_setup_exception
 }
 
 add_after_setup_exception
-::~add_after_setup_exception() VITAL_NOTHROW
+::~add_after_setup_exception() noexcept
 {
 }
 
 null_process_addition_exception
-::null_process_addition_exception() VITAL_NOTHROW
+::null_process_addition_exception() noexcept
   : pipeline_addition_exception()
 {
   std::ostringstream sstr;
@@ -100,23 +100,23 @@ null_process_addition_exception
 }
 
 null_process_addition_exception
-::~null_process_addition_exception() VITAL_NOTHROW
+::~null_process_addition_exception() noexcept
 {
 }
 
 pipeline_setup_exception
-::pipeline_setup_exception() VITAL_NOTHROW
+::pipeline_setup_exception() noexcept
   : pipeline_exception()
 {
 }
 
 pipeline_setup_exception
-::~pipeline_setup_exception() VITAL_NOTHROW
+::~pipeline_setup_exception() noexcept
 {
 }
 
 duplicate_process_name_exception
-::duplicate_process_name_exception(process::name_t const& name) VITAL_NOTHROW
+::duplicate_process_name_exception(process::name_t const& name) noexcept
   : pipeline_addition_exception()
   , m_name(name)
 {
@@ -130,23 +130,23 @@ duplicate_process_name_exception
 }
 
 duplicate_process_name_exception
-::~duplicate_process_name_exception() VITAL_NOTHROW
+::~duplicate_process_name_exception() noexcept
 {
 }
 
 pipeline_removal_exception
-::pipeline_removal_exception() VITAL_NOTHROW
+::pipeline_removal_exception() noexcept
   : pipeline_exception()
 {
 }
 
 pipeline_removal_exception
-::~pipeline_removal_exception() VITAL_NOTHROW
+::~pipeline_removal_exception() noexcept
 {
 }
 
 remove_after_setup_exception
-::remove_after_setup_exception(process::name_t const& name) VITAL_NOTHROW
+::remove_after_setup_exception(process::name_t const& name) noexcept
   : pipeline_removal_exception()
   , m_name(name)
 {
@@ -159,12 +159,12 @@ remove_after_setup_exception
 }
 
 remove_after_setup_exception
-::~remove_after_setup_exception() VITAL_NOTHROW
+::~remove_after_setup_exception() noexcept
 {
 }
 
 reconfigure_before_setup_exception
-::reconfigure_before_setup_exception() VITAL_NOTHROW
+::reconfigure_before_setup_exception() noexcept
   : pipeline_exception()
 {
   std::ostringstream sstr;
@@ -175,18 +175,18 @@ reconfigure_before_setup_exception
 }
 
 reconfigure_before_setup_exception
-::~reconfigure_before_setup_exception() VITAL_NOTHROW
+::~reconfigure_before_setup_exception() noexcept
 {
 }
 
 pipeline_connection_exception
-::pipeline_connection_exception() VITAL_NOTHROW
+::pipeline_connection_exception() noexcept
   : pipeline_exception()
 {
 }
 
 pipeline_connection_exception
-::~pipeline_connection_exception() VITAL_NOTHROW
+::~pipeline_connection_exception() noexcept
 {
 }
 
@@ -194,7 +194,7 @@ connection_after_setup_exception
 ::connection_after_setup_exception(process::name_t const& upstream_name,
                                    process::port_t const& upstream_port,
                                    process::name_t const& downstream_name,
-                                   process::port_t const& downstream_port) VITAL_NOTHROW
+                                   process::port_t const& downstream_port) noexcept
   : pipeline_connection_exception()
   , m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
@@ -212,7 +212,7 @@ connection_after_setup_exception
 }
 
 connection_after_setup_exception
-::~connection_after_setup_exception() VITAL_NOTHROW
+::~connection_after_setup_exception() noexcept
 {
 }
 
@@ -220,7 +220,7 @@ disconnection_after_setup_exception
 ::disconnection_after_setup_exception(process::name_t const& upstream_name,
                                       process::port_t const& upstream_port,
                                       process::name_t const& downstream_name,
-                                      process::port_t const& downstream_port) VITAL_NOTHROW
+                                      process::port_t const& downstream_port) noexcept
   : pipeline_connection_exception()
   , m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
@@ -238,12 +238,12 @@ disconnection_after_setup_exception
 }
 
 disconnection_after_setup_exception
-::~disconnection_after_setup_exception() VITAL_NOTHROW
+::~disconnection_after_setup_exception() noexcept
 {
 }
 
 no_such_process_exception
-::no_such_process_exception(process::name_t const& name) VITAL_NOTHROW
+::no_such_process_exception(process::name_t const& name) noexcept
   : pipeline_connection_exception()
   , m_name(name)
 {
@@ -257,7 +257,7 @@ no_such_process_exception
 }
 
 no_such_process_exception
-::~no_such_process_exception() VITAL_NOTHROW
+::~no_such_process_exception() noexcept
 {
 }
 
@@ -267,7 +267,7 @@ connection_dependent_type_exception
                                       process::name_t const& downstream_name,
                                       process::port_t const& downstream_port,
                                       process::port_type_t const& type,
-                                      bool push_upstream) VITAL_NOTHROW
+                                      bool push_upstream) noexcept
   : pipeline_connection_exception()
   , m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
@@ -290,7 +290,7 @@ connection_dependent_type_exception
 }
 
 connection_dependent_type_exception
-::~connection_dependent_type_exception() VITAL_NOTHROW
+::~connection_dependent_type_exception() noexcept
 {
 }
 
@@ -303,7 +303,7 @@ connection_dependent_type_cascade_exception
                                               process::name_t const& downstream_name,
                                               process::port_t const& downstream_port,
                                               process::port_type_t const& cascade_type,
-                                              bool push_upstream) VITAL_NOTHROW
+                                              bool push_upstream) noexcept
   : pipeline_connection_exception()
   , m_name(name)
   , m_port(port)
@@ -331,7 +331,7 @@ connection_dependent_type_cascade_exception
 }
 
 connection_dependent_type_cascade_exception
-::~connection_dependent_type_cascade_exception() VITAL_NOTHROW
+::~connection_dependent_type_cascade_exception() noexcept
 {
 }
 
@@ -341,7 +341,7 @@ connection_type_mismatch_exception
                                      process::port_type_t const& upstream_type,
                                      process::name_t const& downstream_name,
                                      process::port_t const& downstream_port,
-                                     process::port_type_t const& downstream_type) VITAL_NOTHROW
+                                     process::port_type_t const& downstream_type) noexcept
   : pipeline_connection_exception()
   , m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
@@ -363,7 +363,7 @@ connection_type_mismatch_exception
 }
 
 connection_type_mismatch_exception
-::~connection_type_mismatch_exception() VITAL_NOTHROW
+::~connection_type_mismatch_exception() noexcept
 {
 }
 
@@ -371,7 +371,7 @@ connection_flag_mismatch_exception
 ::connection_flag_mismatch_exception(process::name_t const& upstream_name,
                                      process::port_t const& upstream_port,
                                      process::name_t const& downstream_name,
-                                     process::port_t const& downstream_port) VITAL_NOTHROW
+                                     process::port_t const& downstream_port) noexcept
   : pipeline_connection_exception()
   , m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
@@ -390,12 +390,12 @@ connection_flag_mismatch_exception
 }
 
 connection_flag_mismatch_exception
-::~connection_flag_mismatch_exception() VITAL_NOTHROW
+::~connection_flag_mismatch_exception() noexcept
 {
 }
 
 pipeline_duplicate_setup_exception
-::pipeline_duplicate_setup_exception() VITAL_NOTHROW
+::pipeline_duplicate_setup_exception() noexcept
   : pipeline_setup_exception()
 {
   std::ostringstream sstr;
@@ -406,12 +406,12 @@ pipeline_duplicate_setup_exception
 }
 
 pipeline_duplicate_setup_exception
-::~pipeline_duplicate_setup_exception() VITAL_NOTHROW
+::~pipeline_duplicate_setup_exception() noexcept
 {
 }
 
 no_processes_exception
-::no_processes_exception() VITAL_NOTHROW
+::no_processes_exception() noexcept
   : pipeline_setup_exception()
 {
   std::ostringstream sstr;
@@ -422,12 +422,12 @@ no_processes_exception
 }
 
 no_processes_exception
-::~no_processes_exception() VITAL_NOTHROW
+::~no_processes_exception() noexcept
 {
 }
 
 orphaned_processes_exception
-::orphaned_processes_exception() VITAL_NOTHROW
+::orphaned_processes_exception() noexcept
   : pipeline_setup_exception()
 {
   std::ostringstream sstr;
@@ -438,12 +438,12 @@ orphaned_processes_exception
 }
 
 orphaned_processes_exception
-::~orphaned_processes_exception() VITAL_NOTHROW
+::~orphaned_processes_exception() noexcept
 {
 }
 
 not_a_dag_exception
-::not_a_dag_exception() VITAL_NOTHROW
+::not_a_dag_exception() noexcept
   : pipeline_setup_exception()
 {
   std::ostringstream sstr;
@@ -456,12 +456,12 @@ not_a_dag_exception
 }
 
 not_a_dag_exception
-::~not_a_dag_exception() VITAL_NOTHROW
+::~not_a_dag_exception() noexcept
 {
 }
 
 untyped_data_dependent_exception
-::untyped_data_dependent_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::untyped_data_dependent_exception(process::name_t const& name, process::port_t const& port) noexcept
   : pipeline_setup_exception()
   , m_name(name)
   , m_port(port)
@@ -476,12 +476,12 @@ untyped_data_dependent_exception
 }
 
 untyped_data_dependent_exception
-::~untyped_data_dependent_exception() VITAL_NOTHROW
+::~untyped_data_dependent_exception() noexcept
 {
 }
 
 untyped_connection_exception
-::untyped_connection_exception() VITAL_NOTHROW
+::untyped_connection_exception() noexcept
   : pipeline_setup_exception()
 {
   std::ostringstream sstr;
@@ -493,7 +493,7 @@ untyped_connection_exception
 }
 
 untyped_connection_exception
-::~untyped_connection_exception() VITAL_NOTHROW
+::~untyped_connection_exception() noexcept
 {
 }
 
@@ -505,7 +505,7 @@ frequency_mismatch_exception
                                process::name_t const& downstream_name,
                                process::port_t const& downstream_port,
                                process::port_frequency_t const& downstream_frequency,
-                               process::port_frequency_t const& downstream_port_frequency) VITAL_NOTHROW
+                               process::port_frequency_t const& downstream_port_frequency) noexcept
   : m_upstream_name(upstream_name)
   , m_upstream_port(upstream_port)
   , m_upstream_frequency(upstream_frequency)
@@ -530,12 +530,12 @@ frequency_mismatch_exception
 }
 
 frequency_mismatch_exception
-::~frequency_mismatch_exception() VITAL_NOTHROW
+::~frequency_mismatch_exception() noexcept
 {
 }
 
 reset_running_pipeline_exception
-::reset_running_pipeline_exception() VITAL_NOTHROW
+::reset_running_pipeline_exception() noexcept
 {
   std::ostringstream sstr;
 
@@ -545,12 +545,12 @@ reset_running_pipeline_exception
 }
 
 reset_running_pipeline_exception
-::~reset_running_pipeline_exception() VITAL_NOTHROW
+::~reset_running_pipeline_exception() noexcept
 {
 }
 
 pipeline_not_setup_exception
-::pipeline_not_setup_exception() VITAL_NOTHROW
+::pipeline_not_setup_exception() noexcept
   : pipeline_exception()
 {
   std::ostringstream sstr;
@@ -561,12 +561,12 @@ pipeline_not_setup_exception
 }
 
 pipeline_not_setup_exception
-::~pipeline_not_setup_exception() VITAL_NOTHROW
+::~pipeline_not_setup_exception() noexcept
 {
 }
 
 pipeline_not_ready_exception
-::pipeline_not_ready_exception() VITAL_NOTHROW
+::pipeline_not_ready_exception() noexcept
   : pipeline_exception()
 {
   std::ostringstream sstr;
@@ -577,7 +577,7 @@ pipeline_not_ready_exception
 }
 
 pipeline_not_ready_exception
-::~pipeline_not_ready_exception() VITAL_NOTHROW
+::~pipeline_not_ready_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/pipeline_exception.h
+++ b/sprokit/src/sprokit/pipeline/pipeline_exception.h
@@ -60,11 +60,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_addition_exception
     /**
      * \brief Constructor.
      */
-    pipeline_addition_exception() VITAL_NOTHROW;
+    pipeline_addition_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipeline_addition_exception() VITAL_NOTHROW;
+    virtual ~pipeline_addition_exception() noexcept;
 };
 
 /**
@@ -81,11 +81,11 @@ class SPROKIT_PIPELINE_EXPORT null_pipeline_config_exception
     /**
      * \brief Constructor.
      */
-    null_pipeline_config_exception() VITAL_NOTHROW;
+    null_pipeline_config_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_pipeline_config_exception() VITAL_NOTHROW;
+    ~null_pipeline_config_exception() noexcept;
 };
 
 /**
@@ -104,11 +104,11 @@ class SPROKIT_PIPELINE_EXPORT add_after_setup_exception
      *
      * \param name The name of the process.
      */
-    add_after_setup_exception(process::name_t const& name) VITAL_NOTHROW;
+    add_after_setup_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~add_after_setup_exception() VITAL_NOTHROW;
+    ~add_after_setup_exception() noexcept;
 
     /// The name of the process.
     process::name_t const m_name;
@@ -128,11 +128,11 @@ class SPROKIT_PIPELINE_EXPORT null_process_addition_exception
     /**
      * \brief Constructor.
      */
-    null_process_addition_exception() VITAL_NOTHROW;
+    null_process_addition_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_process_addition_exception() VITAL_NOTHROW;
+    ~null_process_addition_exception() noexcept;
 };
 
 /**
@@ -151,11 +151,11 @@ class SPROKIT_PIPELINE_EXPORT duplicate_process_name_exception
      *
      * \param name The name requested.
      */
-    duplicate_process_name_exception(process::name_t const& name) VITAL_NOTHROW;
+    duplicate_process_name_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~duplicate_process_name_exception() VITAL_NOTHROW;
+    ~duplicate_process_name_exception() noexcept;
 
     /// The name of the process.
     process::name_t const m_name;
@@ -175,11 +175,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_removal_exception
     /**
      * \brief Constructor.
      */
-    pipeline_removal_exception() VITAL_NOTHROW;
+    pipeline_removal_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipeline_removal_exception() VITAL_NOTHROW;
+    virtual ~pipeline_removal_exception() noexcept;
 };
 
 /**
@@ -198,11 +198,11 @@ class SPROKIT_PIPELINE_EXPORT remove_after_setup_exception
      *
      * \param name The name of the process.
      */
-    remove_after_setup_exception(process::name_t const& name) VITAL_NOTHROW;
+    remove_after_setup_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~remove_after_setup_exception() VITAL_NOTHROW;
+    ~remove_after_setup_exception() noexcept;
 
     /// The name of the process.
     process::name_t const m_name;
@@ -222,11 +222,11 @@ class SPROKIT_PIPELINE_EXPORT reconfigure_before_setup_exception
     /**
      * \brief Constructor.
      */
-    reconfigure_before_setup_exception() VITAL_NOTHROW;
+    reconfigure_before_setup_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~reconfigure_before_setup_exception() VITAL_NOTHROW;
+    virtual ~reconfigure_before_setup_exception() noexcept;
 };
 
 /**
@@ -243,11 +243,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_connection_exception
     /**
      * \brief Constructor.
      */
-    pipeline_connection_exception() VITAL_NOTHROW;
+    pipeline_connection_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipeline_connection_exception() VITAL_NOTHROW;
+    virtual ~pipeline_connection_exception() noexcept;
 };
 
 /**
@@ -272,11 +272,11 @@ class SPROKIT_PIPELINE_EXPORT connection_after_setup_exception
     connection_after_setup_exception(process::name_t const& upstream_name,
                                      process::port_t const& upstream_port,
                                      process::name_t const& downstream_name,
-                                     process::port_t const& downstream_port) VITAL_NOTHROW;
+                                     process::port_t const& downstream_port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connection_after_setup_exception() VITAL_NOTHROW;
+    ~connection_after_setup_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -310,11 +310,11 @@ class SPROKIT_PIPELINE_EXPORT disconnection_after_setup_exception
     disconnection_after_setup_exception(process::name_t const& upstream_name,
                                         process::port_t const& upstream_port,
                                         process::name_t const& downstream_name,
-                                        process::port_t const& downstream_port) VITAL_NOTHROW;
+                                        process::port_t const& downstream_port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~disconnection_after_setup_exception() VITAL_NOTHROW;
+    ~disconnection_after_setup_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -342,11 +342,11 @@ class SPROKIT_PIPELINE_EXPORT no_such_process_exception
      *
      * \param name The name requested.
      */
-    no_such_process_exception(process::name_t const& name) VITAL_NOTHROW;
+    no_such_process_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~no_such_process_exception() VITAL_NOTHROW;
+    ~no_such_process_exception() noexcept;
 
     /// The name of the process requested.
     process::name_t const m_name;
@@ -378,11 +378,11 @@ class SPROKIT_PIPELINE_EXPORT connection_dependent_type_exception
                                         process::name_t const& downstream_name,
                                         process::port_t const& downstream_port,
                                         process::port_type_t const& type,
-                                        bool push_upstream) VITAL_NOTHROW;
+                                        bool push_upstream) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connection_dependent_type_exception() VITAL_NOTHROW;
+    ~connection_dependent_type_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -430,11 +430,11 @@ class SPROKIT_PIPELINE_EXPORT connection_dependent_type_cascade_exception
                                                 process::name_t const& downstream_name,
                                                 process::port_t const& downstream_port,
                                                 process::port_type_t const& cascade_type,
-                                                bool push_upstream) VITAL_NOTHROW;
+                                                bool push_upstream) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connection_dependent_type_cascade_exception() VITAL_NOTHROW;
+    ~connection_dependent_type_cascade_exception() noexcept;
 
     /// The name of the process which had a type set.
     process::name_t const m_name;
@@ -482,11 +482,11 @@ class SPROKIT_PIPELINE_EXPORT connection_type_mismatch_exception
                                        process::port_type_t const& upstream_type,
                                        process::name_t const& downstream_name,
                                        process::port_t const& downstream_port,
-                                       process::port_type_t const& downstream_type) VITAL_NOTHROW;
+                                       process::port_type_t const& downstream_type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connection_type_mismatch_exception() VITAL_NOTHROW;
+    ~connection_type_mismatch_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -524,11 +524,11 @@ class SPROKIT_PIPELINE_EXPORT connection_flag_mismatch_exception
     connection_flag_mismatch_exception(process::name_t const& upstream_name,
                                        process::port_t const& upstream_port,
                                        process::name_t const& downstream_name,
-                                       process::port_t const& downstream_port) VITAL_NOTHROW;
+                                       process::port_t const& downstream_port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connection_flag_mismatch_exception() VITAL_NOTHROW;
+    ~connection_flag_mismatch_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -554,11 +554,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_setup_exception
     /**
      * \brief Constructor.
      */
-    pipeline_setup_exception() VITAL_NOTHROW;
+    pipeline_setup_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipeline_setup_exception() VITAL_NOTHROW;
+    virtual ~pipeline_setup_exception() noexcept;
 };
 
 /**
@@ -575,11 +575,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_duplicate_setup_exception
     /**
      * \brief Constructor.
      */
-    pipeline_duplicate_setup_exception() VITAL_NOTHROW;
+    pipeline_duplicate_setup_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~pipeline_duplicate_setup_exception() VITAL_NOTHROW;
+    ~pipeline_duplicate_setup_exception() noexcept;
 };
 
 /**
@@ -596,11 +596,11 @@ class SPROKIT_PIPELINE_EXPORT no_processes_exception
     /**
      * \brief Constructor.
      */
-    no_processes_exception() VITAL_NOTHROW;
+    no_processes_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~no_processes_exception() VITAL_NOTHROW;
+    ~no_processes_exception() noexcept;
 };
 
 /**
@@ -617,11 +617,11 @@ class SPROKIT_PIPELINE_EXPORT orphaned_processes_exception
     /**
      * \brief Constructor.
      */
-    orphaned_processes_exception() VITAL_NOTHROW;
+    orphaned_processes_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~orphaned_processes_exception() VITAL_NOTHROW;
+    ~orphaned_processes_exception() noexcept;
 };
 
 /**
@@ -638,11 +638,11 @@ class SPROKIT_PIPELINE_EXPORT not_a_dag_exception
     /**
      * \brief Constructor.
      */
-    not_a_dag_exception() VITAL_NOTHROW;
+    not_a_dag_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~not_a_dag_exception() VITAL_NOTHROW;
+    ~not_a_dag_exception() noexcept;
 };
 
 /**
@@ -662,11 +662,11 @@ class SPROKIT_PIPELINE_EXPORT untyped_data_dependent_exception
      * \param name The name of the process.
      * \param port The name of the untyped port on the process.
      */
-    untyped_data_dependent_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    untyped_data_dependent_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~untyped_data_dependent_exception() VITAL_NOTHROW;
+    ~untyped_data_dependent_exception() noexcept;
 
     /// The name of the process.
     process::name_t const m_name;
@@ -688,11 +688,11 @@ class SPROKIT_PIPELINE_EXPORT untyped_connection_exception
     /**
      * \brief Constructor.
      */
-    untyped_connection_exception() VITAL_NOTHROW;
+    untyped_connection_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~untyped_connection_exception() VITAL_NOTHROW;
+    ~untyped_connection_exception() noexcept;
 };
 
 /**
@@ -725,11 +725,11 @@ class SPROKIT_PIPELINE_EXPORT frequency_mismatch_exception
                                  process::name_t const& downstream_name,
                                  process::port_t const& downstream_port,
                                  process::port_frequency_t const& downstream_frequency,
-                                 process::port_frequency_t const& downstream_port_frequency) VITAL_NOTHROW;
+                                 process::port_frequency_t const& downstream_port_frequency) noexcept;
     /**
      * \brief Destructor.
      */
-    ~frequency_mismatch_exception() VITAL_NOTHROW;
+    ~frequency_mismatch_exception() noexcept;
 
     /// The name of the upstream process requested.
     process::name_t const m_upstream_name;
@@ -763,11 +763,11 @@ class SPROKIT_PIPELINE_EXPORT reset_running_pipeline_exception
     /**
      * \brief Constructor.
      */
-    reset_running_pipeline_exception() VITAL_NOTHROW;
+    reset_running_pipeline_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~reset_running_pipeline_exception() VITAL_NOTHROW;
+    ~reset_running_pipeline_exception() noexcept;
 };
 
 /**
@@ -784,11 +784,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_not_setup_exception
     /**
      * \brief Constructor.
      */
-    pipeline_not_setup_exception() VITAL_NOTHROW;
+    pipeline_not_setup_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~pipeline_not_setup_exception() VITAL_NOTHROW;
+    ~pipeline_not_setup_exception() noexcept;
 };
 
 /**
@@ -805,11 +805,11 @@ class SPROKIT_PIPELINE_EXPORT pipeline_not_ready_exception
     /**
      * \brief Constructor.
      */
-    pipeline_not_ready_exception() VITAL_NOTHROW;
+    pipeline_not_ready_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~pipeline_not_ready_exception() VITAL_NOTHROW;
+    ~pipeline_not_ready_exception() noexcept;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/process_cluster_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/process_cluster_exception.cxx
@@ -42,13 +42,13 @@ namespace sprokit
 {
 
 process_cluster_exception
-::process_cluster_exception() VITAL_NOTHROW
+::process_cluster_exception() noexcept
   : process_exception()
 {
 }
 
 process_cluster_exception
-::~process_cluster_exception() VITAL_NOTHROW
+::~process_cluster_exception() noexcept
 {
 }
 
@@ -56,7 +56,7 @@ mapping_after_process_exception
 ::mapping_after_process_exception(process::name_t const& name,
                                   kwiver::vital::config_block_key_t const& key,
                                   process::name_t const& mapped_name,
-                                  kwiver::vital::config_block_key_t const& mapped_key) VITAL_NOTHROW
+                                  kwiver::vital::config_block_key_t const& mapped_key) noexcept
   : process_cluster_exception()
   , m_name(name)
   , m_key(key)
@@ -75,7 +75,7 @@ mapping_after_process_exception
 }
 
 mapping_after_process_exception
-::~mapping_after_process_exception() VITAL_NOTHROW
+::~mapping_after_process_exception() noexcept
 {
 }
 
@@ -85,7 +85,7 @@ mapping_to_read_only_value_exception
                                        kwiver::vital::config_block_value_t const& value,
                                        process::name_t const& mapped_name,
                                        kwiver::vital::config_block_key_t const& mapped_key,
-                                       kwiver::vital::config_block_value_t const& ro_value) VITAL_NOTHROW
+                                       kwiver::vital::config_block_value_t const& ro_value) noexcept
   : process_cluster_exception()
   , m_name(name)
   , m_key(key)
@@ -108,7 +108,7 @@ mapping_to_read_only_value_exception
 }
 
 mapping_to_read_only_value_exception
-::~mapping_to_read_only_value_exception() VITAL_NOTHROW
+::~mapping_to_read_only_value_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/process_cluster_exception.h
+++ b/sprokit/src/sprokit/pipeline/process_cluster_exception.h
@@ -61,11 +61,11 @@ class SPROKIT_PIPELINE_EXPORT process_cluster_exception
     /**
      * \brief Constructor.
      */
-    process_cluster_exception() VITAL_NOTHROW;
+    process_cluster_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~process_cluster_exception() VITAL_NOTHROW;
+    virtual ~process_cluster_exception() noexcept;
 };
 
 /**
@@ -90,11 +90,11 @@ class SPROKIT_PIPELINE_EXPORT mapping_after_process_exception
     mapping_after_process_exception(process::name_t const& name,
                                     kwiver::vital::config_block_key_t const& key,
                                     process::name_t const& mapped_name,
-                                    kwiver::vital::config_block_key_t const& mapped_key) VITAL_NOTHROW;
+                                    kwiver::vital::config_block_key_t const& mapped_key) noexcept;
     /**
      * \brief Destructor.
      */
-    ~mapping_after_process_exception() VITAL_NOTHROW;
+    ~mapping_after_process_exception() noexcept;
 
     /// The name of the \ref process_cluster the mapping occurred in.
     process::name_t const m_name;
@@ -130,11 +130,11 @@ class SPROKIT_PIPELINE_EXPORT mapping_to_read_only_value_exception
                                          kwiver::vital::config_block_value_t const& value,
                                          process::name_t const& mapped_name,
                                          kwiver::vital::config_block_key_t const& mapped_key,
-                                         kwiver::vital::config_block_value_t const& ro_value) VITAL_NOTHROW;
+                                         kwiver::vital::config_block_value_t const& ro_value) noexcept;
     /**
      * \brief Destructor.
      */
-    ~mapping_to_read_only_value_exception() VITAL_NOTHROW;
+    ~mapping_to_read_only_value_exception() noexcept;
 
     /// The name of the \ref process_cluster the mapping occurred in.
     process::name_t const m_name;

--- a/sprokit/src/sprokit/pipeline/process_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/process_exception.cxx
@@ -42,18 +42,18 @@ namespace sprokit
 {
 
 process_exception
-::process_exception() VITAL_NOTHROW
+::process_exception() noexcept
   : pipeline_exception()
 {
 }
 
 process_exception
-::~process_exception() VITAL_NOTHROW
+::~process_exception() noexcept
 {
 }
 
 null_process_config_exception
-::null_process_config_exception() VITAL_NOTHROW
+::null_process_config_exception() noexcept
   : process_exception()
 {
   std::ostringstream sstr;
@@ -64,12 +64,12 @@ null_process_config_exception
 }
 
 null_process_config_exception
-::~null_process_config_exception() VITAL_NOTHROW
+::~null_process_config_exception() noexcept
 {
 }
 
 already_initialized_exception
-::already_initialized_exception(process::name_t const& name) VITAL_NOTHROW
+::already_initialized_exception(process::name_t const& name) noexcept
   : process_exception()
   , m_name(name)
 {
@@ -82,12 +82,12 @@ already_initialized_exception
 }
 
 already_initialized_exception
-::~already_initialized_exception() VITAL_NOTHROW
+::~already_initialized_exception() noexcept
 {
 }
 
 unconfigured_exception
-::unconfigured_exception(process::name_t const& name) VITAL_NOTHROW
+::unconfigured_exception(process::name_t const& name) noexcept
   : process_exception()
   , m_name(name)
 {
@@ -100,12 +100,12 @@ unconfigured_exception
 }
 
 unconfigured_exception
-::~unconfigured_exception() VITAL_NOTHROW
+::~unconfigured_exception() noexcept
 {
 }
 
 reconfigured_exception
-::reconfigured_exception(process::name_t const& name) VITAL_NOTHROW
+::reconfigured_exception(process::name_t const& name) noexcept
   : process_exception()
   , m_name(name)
 {
@@ -118,12 +118,12 @@ reconfigured_exception
 }
 
 reconfigured_exception
-::~reconfigured_exception() VITAL_NOTHROW
+::~reconfigured_exception() noexcept
 {
 }
 
 reinitialization_exception
-::reinitialization_exception(process::name_t const& name) VITAL_NOTHROW
+::reinitialization_exception(process::name_t const& name) noexcept
   : process_exception()
   , m_name(name)
 {
@@ -136,12 +136,12 @@ reinitialization_exception
 }
 
 reinitialization_exception
-::~reinitialization_exception() VITAL_NOTHROW
+::~reinitialization_exception() noexcept
 {
 }
 
 null_conf_info_exception
-::null_conf_info_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) VITAL_NOTHROW
+::null_conf_info_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) noexcept
   : process_exception()
   , m_name(name)
   , m_key(key)
@@ -156,12 +156,12 @@ null_conf_info_exception
 }
 
 null_conf_info_exception
-::~null_conf_info_exception() VITAL_NOTHROW
+::~null_conf_info_exception() noexcept
 {
 }
 
 null_port_info_exception
-::null_port_info_exception(process::name_t const& name, process::port_t const& port, std::string const& type) VITAL_NOTHROW
+::null_port_info_exception(process::name_t const& name, process::port_t const& port, std::string const& type) noexcept
   : process_exception()
   , m_name(name)
   , m_port(port)
@@ -177,34 +177,34 @@ null_port_info_exception
 }
 
 null_port_info_exception
-::~null_port_info_exception() VITAL_NOTHROW
+::~null_port_info_exception() noexcept
 {
 }
 
 null_input_port_info_exception
-::null_input_port_info_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::null_input_port_info_exception(process::name_t const& name, process::port_t const& port) noexcept
   : null_port_info_exception(name, port, "input")
 {
 }
 
 null_input_port_info_exception
-::~null_input_port_info_exception() VITAL_NOTHROW
+::~null_input_port_info_exception() noexcept
 {
 }
 
 null_output_port_info_exception
-::null_output_port_info_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::null_output_port_info_exception(process::name_t const& name, process::port_t const& port) noexcept
   : null_port_info_exception(name, port, "output")
 {
 }
 
 null_output_port_info_exception
-::~null_output_port_info_exception() VITAL_NOTHROW
+::~null_output_port_info_exception() noexcept
 {
 }
 
 flag_mismatch_exception
-::flag_mismatch_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) VITAL_NOTHROW
+::flag_mismatch_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) noexcept
   : process_exception()
   , m_name(name)
   , m_port(port)
@@ -221,12 +221,12 @@ flag_mismatch_exception
 }
 
 flag_mismatch_exception
-::~flag_mismatch_exception() VITAL_NOTHROW
+::~flag_mismatch_exception() noexcept
 {
 }
 
 set_type_on_initialized_process_exception
-::set_type_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& type) VITAL_NOTHROW
+::set_type_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& type) noexcept
   : process_exception()
   , m_name(name)
   , m_port(port)
@@ -242,12 +242,12 @@ set_type_on_initialized_process_exception
 }
 
 set_type_on_initialized_process_exception
-::~set_type_on_initialized_process_exception() VITAL_NOTHROW
+::~set_type_on_initialized_process_exception() noexcept
 {
 }
 
 set_frequency_on_initialized_process_exception
-::set_frequency_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_frequency_t const& frequency) VITAL_NOTHROW
+::set_frequency_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_frequency_t const& frequency) noexcept
   : process_exception()
   , m_name(name)
   , m_port(port)
@@ -263,12 +263,12 @@ set_frequency_on_initialized_process_exception
 }
 
 set_frequency_on_initialized_process_exception
-::~set_frequency_on_initialized_process_exception() VITAL_NOTHROW
+::~set_frequency_on_initialized_process_exception() noexcept
 {
 }
 
 uninitialized_exception
-::uninitialized_exception(process::name_t const& name) VITAL_NOTHROW
+::uninitialized_exception(process::name_t const& name) noexcept
   : process_exception()
   , m_name(name)
 {
@@ -281,12 +281,12 @@ uninitialized_exception
 }
 
 uninitialized_exception
-::~uninitialized_exception() VITAL_NOTHROW
+::~uninitialized_exception() noexcept
 {
 }
 
 port_connection_exception
-::port_connection_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::port_connection_exception(process::name_t const& name, process::port_t const& port) noexcept
   : process_exception()
   , m_name(name)
   , m_port(port)
@@ -294,12 +294,12 @@ port_connection_exception
 }
 
 port_connection_exception
-::~port_connection_exception() VITAL_NOTHROW
+::~port_connection_exception() noexcept
 {
 }
 
 connect_to_initialized_process_exception
-::connect_to_initialized_process_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::connect_to_initialized_process_exception(process::name_t const& name, process::port_t const& port) noexcept
   : port_connection_exception(name, port)
 {
   std::ostringstream sstr;
@@ -313,12 +313,12 @@ connect_to_initialized_process_exception
 }
 
 connect_to_initialized_process_exception
-::~connect_to_initialized_process_exception() VITAL_NOTHROW
+::~connect_to_initialized_process_exception() noexcept
 {
 }
 
 no_such_port_exception
-::no_such_port_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::no_such_port_exception(process::name_t const& name, process::port_t const& port) noexcept
   : port_connection_exception(name, port)
 {
   std::ostringstream sstr;
@@ -331,12 +331,12 @@ no_such_port_exception
 }
 
 no_such_port_exception
-::~no_such_port_exception() VITAL_NOTHROW
+::~no_such_port_exception() noexcept
 {
 }
 
 null_edge_port_connection_exception
-::null_edge_port_connection_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::null_edge_port_connection_exception(process::name_t const& name, process::port_t const& port) noexcept
   : port_connection_exception(name, port)
 {
   std::ostringstream sstr;
@@ -349,12 +349,12 @@ null_edge_port_connection_exception
 }
 
 null_edge_port_connection_exception
-::~null_edge_port_connection_exception() VITAL_NOTHROW
+::~null_edge_port_connection_exception() noexcept
 {
 }
 
 static_type_reset_exception
-::static_type_reset_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& orig_type, process::port_type_t const& new_type) VITAL_NOTHROW
+::static_type_reset_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& orig_type, process::port_type_t const& new_type) noexcept
   : port_connection_exception(name, port)
   , m_orig_type(orig_type)
   , m_new_type(new_type)
@@ -371,12 +371,12 @@ static_type_reset_exception
 }
 
 static_type_reset_exception
-::~static_type_reset_exception() VITAL_NOTHROW
+::~static_type_reset_exception() noexcept
 {
 }
 
 port_reconnect_exception
-::port_reconnect_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW
+::port_reconnect_exception(process::name_t const& name, process::port_t const& port) noexcept
   : port_connection_exception(name, port)
 {
   std::ostringstream sstr;
@@ -389,12 +389,12 @@ port_reconnect_exception
 }
 
 port_reconnect_exception
-::~port_reconnect_exception() VITAL_NOTHROW
+::~port_reconnect_exception() noexcept
 {
 }
 
 missing_connection_exception
-::missing_connection_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) VITAL_NOTHROW
+::missing_connection_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) noexcept
   : port_connection_exception(name, port)
   , m_reason(reason)
 {
@@ -408,23 +408,23 @@ missing_connection_exception
 }
 
 missing_connection_exception
-::~missing_connection_exception() VITAL_NOTHROW
+::~missing_connection_exception() noexcept
 {
 }
 
 process_configuration_exception
-::process_configuration_exception() VITAL_NOTHROW
+::process_configuration_exception() noexcept
   : process_exception()
 {
 }
 
 process_configuration_exception
-::~process_configuration_exception() VITAL_NOTHROW
+::~process_configuration_exception() noexcept
 {
 }
 
 unknown_configuration_value_exception
-::unknown_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) VITAL_NOTHROW
+::unknown_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) noexcept
   : process_configuration_exception()
   , m_name(name)
   , m_key(key)
@@ -439,7 +439,7 @@ unknown_configuration_value_exception
 }
 
 unknown_configuration_value_exception
-::~unknown_configuration_value_exception() VITAL_NOTHROW
+::~unknown_configuration_value_exception() noexcept
 {
 }
 
@@ -447,7 +447,7 @@ invalid_configuration_value_exception
 ::invalid_configuration_value_exception(process::name_t const& name,
                                         kwiver::vital::config_block_key_t const& key,
                                         kwiver::vital::config_block_value_t const& value,
-                                        kwiver::vital::config_block_description_t const& desc) VITAL_NOTHROW
+                                        kwiver::vital::config_block_description_t const& desc) noexcept
   : process_configuration_exception()
   , m_name(name)
   , m_key(key)
@@ -465,12 +465,12 @@ invalid_configuration_value_exception
 }
 
 invalid_configuration_value_exception
-::~invalid_configuration_value_exception() VITAL_NOTHROW
+::~invalid_configuration_value_exception() noexcept
 {
 }
 
 invalid_configuration_exception
-::invalid_configuration_exception(process::name_t const& name, std::string const& reason) VITAL_NOTHROW
+::invalid_configuration_exception(process::name_t const& name, std::string const& reason) noexcept
   : process_configuration_exception()
   , m_name(name)
   , m_reason(reason)
@@ -484,7 +484,7 @@ invalid_configuration_exception
 }
 
 invalid_configuration_exception
-::~invalid_configuration_exception() VITAL_NOTHROW
+::~invalid_configuration_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/process_exception.h
+++ b/sprokit/src/sprokit/pipeline/process_exception.h
@@ -62,11 +62,11 @@ class SPROKIT_PIPELINE_EXPORT process_exception
     /**
      * \brief Constructor.
      */
-    process_exception() VITAL_NOTHROW;
+    process_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~process_exception() VITAL_NOTHROW;
+    virtual ~process_exception() noexcept;
 };
 
 /**
@@ -83,11 +83,11 @@ class SPROKIT_PIPELINE_EXPORT null_process_config_exception
     /**
      * \brief Constructor.
      */
-    null_process_config_exception() VITAL_NOTHROW;
+    null_process_config_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_process_config_exception() VITAL_NOTHROW;
+    ~null_process_config_exception() noexcept;
 };
 
 /**
@@ -106,11 +106,11 @@ class SPROKIT_PIPELINE_EXPORT already_initialized_exception
      *
      * \param name The name of the process.
      */
-    already_initialized_exception(process::name_t const& name) VITAL_NOTHROW;
+    already_initialized_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~already_initialized_exception() VITAL_NOTHROW;
+    ~already_initialized_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -132,11 +132,11 @@ class SPROKIT_PIPELINE_EXPORT unconfigured_exception
      *
      * \param name The name of the process.
      */
-    unconfigured_exception(process::name_t const& name) VITAL_NOTHROW;
+    unconfigured_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~unconfigured_exception() VITAL_NOTHROW;
+    ~unconfigured_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -158,11 +158,11 @@ class SPROKIT_PIPELINE_EXPORT reconfigured_exception
      *
      * \param name The name of the process.
      */
-    reconfigured_exception(process::name_t const& name) VITAL_NOTHROW;
+    reconfigured_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~reconfigured_exception() VITAL_NOTHROW;
+    ~reconfigured_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -184,11 +184,11 @@ class SPROKIT_PIPELINE_EXPORT reinitialization_exception
      *
      * \param name The name of the process.
      */
-    reinitialization_exception(process::name_t const& name) VITAL_NOTHROW;
+    reinitialization_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~reinitialization_exception() VITAL_NOTHROW;
+    ~reinitialization_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -211,11 +211,11 @@ class SPROKIT_PIPELINE_EXPORT null_conf_info_exception
      * \param name The name of the process.
      * \param key The configuration key with \c NULL information.
      */
-    null_conf_info_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) VITAL_NOTHROW;
+    null_conf_info_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_conf_info_exception() VITAL_NOTHROW;
+    ~null_conf_info_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -241,11 +241,11 @@ class SPROKIT_PIPELINE_EXPORT null_port_info_exception
      * \param port The port with \c NULL information.
      * \param type The type of port.
      */
-    null_port_info_exception(process::name_t const& name, process::port_t const& port, std::string const& type) VITAL_NOTHROW;
+    null_port_info_exception(process::name_t const& name, process::port_t const& port, std::string const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_port_info_exception() VITAL_NOTHROW;
+    ~null_port_info_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -270,11 +270,11 @@ class SPROKIT_PIPELINE_EXPORT null_input_port_info_exception
      * \param name The name of the \ref process.
      * \param port The port with \c NULL information.
      */
-    null_input_port_info_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    null_input_port_info_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_input_port_info_exception() VITAL_NOTHROW;
+    ~null_input_port_info_exception() noexcept;
 };
 
 /**
@@ -294,11 +294,11 @@ class SPROKIT_PIPELINE_EXPORT null_output_port_info_exception
      * \param name The name of the \ref process.
      * \param port The port with \c NULL information.
      */
-    null_output_port_info_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    null_output_port_info_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_output_port_info_exception() VITAL_NOTHROW;
+    ~null_output_port_info_exception() noexcept;
 };
 
 /**
@@ -319,11 +319,11 @@ class SPROKIT_PIPELINE_EXPORT flag_mismatch_exception
      * \param port The port with \c NULL information.
      * \param reason The reason why the flags are incompatible.
      */
-    flag_mismatch_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) VITAL_NOTHROW;
+    flag_mismatch_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~flag_mismatch_exception() VITAL_NOTHROW;
+    ~flag_mismatch_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -351,11 +351,11 @@ class SPROKIT_PIPELINE_EXPORT set_type_on_initialized_process_exception
      * \param port The name of the port on the \ref process.
      * \param type The type that was attempted to be set.
      */
-    set_type_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& type) VITAL_NOTHROW;
+    set_type_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~set_type_on_initialized_process_exception() VITAL_NOTHROW;
+    ~set_type_on_initialized_process_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -383,11 +383,11 @@ class SPROKIT_PIPELINE_EXPORT set_frequency_on_initialized_process_exception
      * \param port The name of the port on the \ref process.
      * \param frequency The frequency that was attempted to be set.
      */
-    set_frequency_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_frequency_t const& frequency) VITAL_NOTHROW;
+    set_frequency_on_initialized_process_exception(process::name_t const& name, process::port_t const& port, process::port_frequency_t const& frequency) noexcept;
     /**
      * \brief Destructor.
      */
-    ~set_frequency_on_initialized_process_exception() VITAL_NOTHROW;
+    ~set_frequency_on_initialized_process_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -413,11 +413,11 @@ class SPROKIT_PIPELINE_EXPORT uninitialized_exception
      *
      * \param name The name of the process.
      */
-    uninitialized_exception(process::name_t const& name) VITAL_NOTHROW;
+    uninitialized_exception(process::name_t const& name) noexcept;
     /**
      * \brief Destructor.
      */
-    ~uninitialized_exception() VITAL_NOTHROW;
+    ~uninitialized_exception() noexcept;
 
     /// The name of the \ref process.
     process::name_t const m_name;
@@ -440,11 +440,11 @@ class SPROKIT_PIPELINE_EXPORT port_connection_exception
      * \param name The name of the process.
      * \param port The name of the port.
      */
-    port_connection_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    port_connection_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~port_connection_exception() VITAL_NOTHROW;
+    virtual ~port_connection_exception() noexcept;
 
     /// The name of the \ref process which was connected to.
     process::name_t const m_name;
@@ -469,11 +469,11 @@ class SPROKIT_PIPELINE_EXPORT connect_to_initialized_process_exception
      * \param name The name of the process.
      * \param port The name of the port.
      */
-    connect_to_initialized_process_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    connect_to_initialized_process_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~connect_to_initialized_process_exception() VITAL_NOTHROW;
+    ~connect_to_initialized_process_exception() noexcept;
 };
 
 /**
@@ -493,11 +493,11 @@ class SPROKIT_PIPELINE_EXPORT no_such_port_exception
      * \param name The name of the process.
      * \param port The name of the port.
      */
-    no_such_port_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    no_such_port_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~no_such_port_exception() VITAL_NOTHROW;
+    ~no_such_port_exception() noexcept;
 };
 
 /**
@@ -517,11 +517,11 @@ class SPROKIT_PIPELINE_EXPORT null_edge_port_connection_exception
      * \param name The name of the process.
      * \param port The name of the port.
      */
-    null_edge_port_connection_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    null_edge_port_connection_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_edge_port_connection_exception() VITAL_NOTHROW;
+    ~null_edge_port_connection_exception() noexcept;
 };
 
 /**
@@ -543,11 +543,11 @@ class SPROKIT_PIPELINE_EXPORT static_type_reset_exception
      * \param orig_type The original type of the port.
      * \param new_type The type that was attempted to be set on the port.
      */
-    static_type_reset_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& orig_type, process::port_type_t const& new_type) VITAL_NOTHROW;
+    static_type_reset_exception(process::name_t const& name, process::port_t const& port, process::port_type_t const& orig_type, process::port_type_t const& new_type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~static_type_reset_exception() VITAL_NOTHROW;
+    ~static_type_reset_exception() noexcept;
 
     /// The original type on the port.
     process::port_type_t const m_orig_type;
@@ -572,11 +572,11 @@ class SPROKIT_PIPELINE_EXPORT port_reconnect_exception
      * \param name The name of the process.
      * \param port The name of the port.
      */
-    port_reconnect_exception(process::name_t const& name, process::port_t const& port) VITAL_NOTHROW;
+    port_reconnect_exception(process::name_t const& name, process::port_t const& port) noexcept;
     /**
      * \brief Destructor.
      */
-    ~port_reconnect_exception() VITAL_NOTHROW;
+    ~port_reconnect_exception() noexcept;
 };
 
 /**
@@ -597,11 +597,11 @@ class SPROKIT_PIPELINE_EXPORT missing_connection_exception
      * \param port The name of the port.
      * \param reason The reason why the connection is necessary.
      */
-    missing_connection_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) VITAL_NOTHROW;
+    missing_connection_exception(process::name_t const& name, process::port_t const& port, std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~missing_connection_exception() VITAL_NOTHROW;
+    ~missing_connection_exception() noexcept;
 
     /// A reason for the missing connection.
     std::string const m_reason;
@@ -621,11 +621,11 @@ class SPROKIT_PIPELINE_EXPORT process_configuration_exception
     /**
      * \brief Constructor.
      */
-    process_configuration_exception() VITAL_NOTHROW;
+    process_configuration_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~process_configuration_exception() VITAL_NOTHROW;
+    virtual ~process_configuration_exception() noexcept;
 };
 
 /**
@@ -645,11 +645,11 @@ class SPROKIT_PIPELINE_EXPORT unknown_configuration_value_exception
      * \param name The name of the process.
      * \param key The key requested.
      */
-    unknown_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) VITAL_NOTHROW;
+    unknown_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key) noexcept;
     /**
      * \brief Destructor.
      */
-    ~unknown_configuration_value_exception() VITAL_NOTHROW;
+    ~unknown_configuration_value_exception() noexcept;
 
     /// The name of the \ref process which was connected to.
     process::name_t const m_name;
@@ -676,11 +676,11 @@ class SPROKIT_PIPELINE_EXPORT invalid_configuration_value_exception
      * \param value The value given.
      * \param desc A description of the configuration value.
      */
-    invalid_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key, kwiver::vital::config_block_value_t const& value, kwiver::vital::config_block_description_t const& desc) VITAL_NOTHROW;
+    invalid_configuration_value_exception(process::name_t const& name, kwiver::vital::config_block_key_t const& key, kwiver::vital::config_block_value_t const& value, kwiver::vital::config_block_description_t const& desc) noexcept;
     /**
      * \brief Destructor.
      */
-    ~invalid_configuration_value_exception() VITAL_NOTHROW;
+    ~invalid_configuration_value_exception() noexcept;
 
     /// The name of the \ref process which was connected to.
     process::name_t const m_name;
@@ -709,11 +709,11 @@ class SPROKIT_PIPELINE_EXPORT invalid_configuration_exception
      * \param name The name of the process.
      * \param reason The reason why the configuration is invalid.
      */
-    invalid_configuration_exception(process::name_t const& name, std::string const& reason) VITAL_NOTHROW;
+    invalid_configuration_exception(process::name_t const& name, std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~invalid_configuration_exception() VITAL_NOTHROW;
+    ~invalid_configuration_exception() noexcept;
 
     /// The name of the \ref process which was connected to.
     process::name_t const m_name;

--- a/sprokit/src/sprokit/pipeline/process_registry_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/process_registry_exception.cxx
@@ -42,18 +42,18 @@ namespace sprokit
 {
 
 process_registry_exception
-::process_registry_exception() VITAL_NOTHROW
+::process_registry_exception() noexcept
   : pipeline_exception()
 {
 }
 
 process_registry_exception
-::~process_registry_exception() VITAL_NOTHROW
+::~process_registry_exception() noexcept
 {
 }
 
 null_process_ctor_exception
-::null_process_ctor_exception(process::type_t const& type) VITAL_NOTHROW
+::null_process_ctor_exception(process::type_t const& type) noexcept
   : process_registry_exception()
   , m_type(type)
 {
@@ -66,12 +66,12 @@ null_process_ctor_exception
 }
 
 null_process_ctor_exception
-::~null_process_ctor_exception() VITAL_NOTHROW
+::~null_process_ctor_exception() noexcept
 {
 }
 
 null_process_registry_config_exception
-::null_process_registry_config_exception() VITAL_NOTHROW
+::null_process_registry_config_exception() noexcept
   : process_registry_exception()
 {
   std::ostringstream sstr;
@@ -82,12 +82,12 @@ null_process_registry_config_exception
 }
 
 null_process_registry_config_exception
-::~null_process_registry_config_exception() VITAL_NOTHROW
+::~null_process_registry_config_exception() noexcept
 {
 }
 
 no_such_process_type_exception
-::no_such_process_type_exception(process::type_t const& type) VITAL_NOTHROW
+::no_such_process_type_exception(process::type_t const& type) noexcept
   : process_registry_exception()
   , m_type(type)
 {
@@ -100,12 +100,12 @@ no_such_process_type_exception
 }
 
 no_such_process_type_exception
-::~no_such_process_type_exception() VITAL_NOTHROW
+::~no_such_process_type_exception() noexcept
 {
 }
 
 process_type_already_exists_exception
-::process_type_already_exists_exception(process::type_t const& type) VITAL_NOTHROW
+::process_type_already_exists_exception(process::type_t const& type) noexcept
   : process_registry_exception()
   , m_type(type)
 {
@@ -118,7 +118,7 @@ process_type_already_exists_exception
 }
 
 process_type_already_exists_exception
-::~process_type_already_exists_exception() VITAL_NOTHROW
+::~process_type_already_exists_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/process_registry_exception.h
+++ b/sprokit/src/sprokit/pipeline/process_registry_exception.h
@@ -59,11 +59,11 @@ class SPROKIT_PIPELINE_EXPORT process_registry_exception
     /**
      * \brief Constructor.
      */
-    process_registry_exception() VITAL_NOTHROW;
+    process_registry_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~process_registry_exception() VITAL_NOTHROW;
+    virtual ~process_registry_exception() noexcept;
 };
 
 /**
@@ -82,11 +82,11 @@ class SPROKIT_PIPELINE_EXPORT null_process_ctor_exception
      *
      * \param type The type the ctor is for.
      */
-    null_process_ctor_exception(process::type_t const& type) VITAL_NOTHROW;
+    null_process_ctor_exception(process::type_t const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_process_ctor_exception() VITAL_NOTHROW;
+    ~null_process_ctor_exception() noexcept;
 
     /// The type that was passed a \c NULL constructor.
     process::type_t const m_type;
@@ -106,11 +106,11 @@ class SPROKIT_PIPELINE_EXPORT null_process_registry_config_exception
     /**
      * \brief Constructor.
      */
-    null_process_registry_config_exception() VITAL_NOTHROW;
+    null_process_registry_config_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_process_registry_config_exception() VITAL_NOTHROW;
+    ~null_process_registry_config_exception() noexcept;
 };
 
 /**
@@ -129,11 +129,11 @@ class SPROKIT_PIPELINE_EXPORT no_such_process_type_exception
      *
      * \param type The type requested.
      */
-    no_such_process_type_exception(process::type_t const& type) VITAL_NOTHROW;
+    no_such_process_type_exception(process::type_t const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~no_such_process_type_exception() VITAL_NOTHROW;
+    ~no_such_process_type_exception() noexcept;
 
     /// The type that was requested from the \link process_registry process registry\endlink.
     process::type_t const m_type;
@@ -155,11 +155,11 @@ class SPROKIT_PIPELINE_EXPORT process_type_already_exists_exception
      *
      * \param type The type requested.
      */
-    process_type_already_exists_exception(process::type_t const& type) VITAL_NOTHROW;
+    process_type_already_exists_exception(process::type_t const& type) noexcept;
     /**
      * \brief Destructor.
      */
-    ~process_type_already_exists_exception() VITAL_NOTHROW;
+    ~process_type_already_exists_exception() noexcept;
 
     /// The type that was requested from the \link process_registry process registry\endlink.
     process::type_t const m_type;

--- a/sprokit/src/sprokit/pipeline/scheduler_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_exception.cxx
@@ -42,18 +42,18 @@ namespace sprokit
 {
 
 scheduler_exception
-::scheduler_exception() VITAL_NOTHROW
+::scheduler_exception() noexcept
   : pipeline_exception()
 {
 }
 
 scheduler_exception
-::~scheduler_exception() VITAL_NOTHROW
+::~scheduler_exception() noexcept
 {
 }
 
 incompatible_pipeline_exception
-::incompatible_pipeline_exception(std::string const& reason) VITAL_NOTHROW
+::incompatible_pipeline_exception(std::string const& reason) noexcept
   : scheduler_exception()
   , m_reason(reason)
 {
@@ -65,12 +65,12 @@ incompatible_pipeline_exception
 }
 
 incompatible_pipeline_exception
-::~incompatible_pipeline_exception() VITAL_NOTHROW
+::~incompatible_pipeline_exception() noexcept
 {
 }
 
 null_scheduler_config_exception
-::null_scheduler_config_exception() VITAL_NOTHROW
+::null_scheduler_config_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -81,12 +81,12 @@ null_scheduler_config_exception
 }
 
 null_scheduler_config_exception
-::~null_scheduler_config_exception() VITAL_NOTHROW
+::~null_scheduler_config_exception() noexcept
 {
 }
 
 null_scheduler_pipeline_exception
-::null_scheduler_pipeline_exception() VITAL_NOTHROW
+::null_scheduler_pipeline_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -97,12 +97,12 @@ null_scheduler_pipeline_exception
 }
 
 null_scheduler_pipeline_exception
-::~null_scheduler_pipeline_exception() VITAL_NOTHROW
+::~null_scheduler_pipeline_exception() noexcept
 {
 }
 
 restart_scheduler_exception
-::restart_scheduler_exception() VITAL_NOTHROW
+::restart_scheduler_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -113,12 +113,12 @@ restart_scheduler_exception
 }
 
 restart_scheduler_exception
-::~restart_scheduler_exception() VITAL_NOTHROW
+::~restart_scheduler_exception() noexcept
 {
 }
 
 wait_before_start_exception
-::wait_before_start_exception() VITAL_NOTHROW
+::wait_before_start_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -129,12 +129,12 @@ wait_before_start_exception
 }
 
 wait_before_start_exception
-::~wait_before_start_exception() VITAL_NOTHROW
+::~wait_before_start_exception() noexcept
 {
 }
 
 pause_before_start_exception
-::pause_before_start_exception() VITAL_NOTHROW
+::pause_before_start_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -145,12 +145,12 @@ pause_before_start_exception
 }
 
 pause_before_start_exception
-::~pause_before_start_exception() VITAL_NOTHROW
+::~pause_before_start_exception() noexcept
 {
 }
 
 repause_scheduler_exception
-::repause_scheduler_exception() VITAL_NOTHROW
+::repause_scheduler_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -161,12 +161,12 @@ repause_scheduler_exception
 }
 
 repause_scheduler_exception
-::~repause_scheduler_exception() VITAL_NOTHROW
+::~repause_scheduler_exception() noexcept
 {
 }
 
 resume_before_start_exception
-::resume_before_start_exception() VITAL_NOTHROW
+::resume_before_start_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -177,12 +177,12 @@ resume_before_start_exception
 }
 
 resume_before_start_exception
-::~resume_before_start_exception() VITAL_NOTHROW
+::~resume_before_start_exception() noexcept
 {
 }
 
 resume_unpaused_scheduler_exception
-::resume_unpaused_scheduler_exception() VITAL_NOTHROW
+::resume_unpaused_scheduler_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -193,12 +193,12 @@ resume_unpaused_scheduler_exception
 }
 
 resume_unpaused_scheduler_exception
-::~resume_unpaused_scheduler_exception() VITAL_NOTHROW
+::~resume_unpaused_scheduler_exception() noexcept
 {
 }
 
 stop_before_start_exception
-::stop_before_start_exception() VITAL_NOTHROW
+::stop_before_start_exception() noexcept
   : scheduler_exception()
 {
   std::ostringstream sstr;
@@ -209,7 +209,7 @@ stop_before_start_exception
 }
 
 stop_before_start_exception
-::~stop_before_start_exception() VITAL_NOTHROW
+::~stop_before_start_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/scheduler_exception.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_exception.h
@@ -60,11 +60,11 @@ class SPROKIT_PIPELINE_EXPORT scheduler_exception
     /**
      * \brief Constructor.
      */
-    scheduler_exception() VITAL_NOTHROW;
+    scheduler_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~scheduler_exception() VITAL_NOTHROW;
+    virtual ~scheduler_exception() noexcept;
 };
 
 /**
@@ -81,11 +81,11 @@ class SPROKIT_PIPELINE_EXPORT incompatible_pipeline_exception
     /**
      * \brief Constructor.
      */
-    incompatible_pipeline_exception(std::string const& reason) VITAL_NOTHROW;
+    incompatible_pipeline_exception(std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~incompatible_pipeline_exception() VITAL_NOTHROW;
+    ~incompatible_pipeline_exception() noexcept;
 
     /// The reason why the scheduler cannot run the given pipeline.
     std::string const m_reason;
@@ -105,11 +105,11 @@ class SPROKIT_PIPELINE_EXPORT null_scheduler_config_exception
     /**
      * \brief Constructor.
      */
-    null_scheduler_config_exception() VITAL_NOTHROW;
+    null_scheduler_config_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_scheduler_config_exception() VITAL_NOTHROW;
+    ~null_scheduler_config_exception() noexcept;
 };
 
 /**
@@ -126,11 +126,11 @@ class SPROKIT_PIPELINE_EXPORT null_scheduler_pipeline_exception
     /**
      * \brief Constructor.
      */
-    null_scheduler_pipeline_exception() VITAL_NOTHROW;
+    null_scheduler_pipeline_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_scheduler_pipeline_exception() VITAL_NOTHROW;
+    ~null_scheduler_pipeline_exception() noexcept;
 };
 
 /**
@@ -147,11 +147,11 @@ class SPROKIT_PIPELINE_EXPORT restart_scheduler_exception
     /**
      * \brief Constructor.
      */
-    restart_scheduler_exception() VITAL_NOTHROW;
+    restart_scheduler_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~restart_scheduler_exception() VITAL_NOTHROW;
+    ~restart_scheduler_exception() noexcept;
 };
 
 /**
@@ -168,11 +168,11 @@ class SPROKIT_PIPELINE_EXPORT wait_before_start_exception
     /**
      * \brief Constructor.
      */
-    wait_before_start_exception() VITAL_NOTHROW;
+    wait_before_start_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~wait_before_start_exception() VITAL_NOTHROW;
+    ~wait_before_start_exception() noexcept;
 };
 
 /**
@@ -189,11 +189,11 @@ class SPROKIT_PIPELINE_EXPORT pause_before_start_exception
     /**
      * \brief Constructor.
      */
-    pause_before_start_exception() VITAL_NOTHROW;
+    pause_before_start_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~pause_before_start_exception() VITAL_NOTHROW;
+    ~pause_before_start_exception() noexcept;
 };
 
 /**
@@ -210,11 +210,11 @@ class SPROKIT_PIPELINE_EXPORT repause_scheduler_exception
     /**
      * \brief Constructor.
      */
-    repause_scheduler_exception() VITAL_NOTHROW;
+    repause_scheduler_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~repause_scheduler_exception() VITAL_NOTHROW;
+    ~repause_scheduler_exception() noexcept;
 };
 
 /**
@@ -231,11 +231,11 @@ class SPROKIT_PIPELINE_EXPORT resume_before_start_exception
     /**
      * \brief Constructor.
      */
-    resume_before_start_exception() VITAL_NOTHROW;
+    resume_before_start_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~resume_before_start_exception() VITAL_NOTHROW;
+    ~resume_before_start_exception() noexcept;
 };
 
 /**
@@ -252,11 +252,11 @@ class SPROKIT_PIPELINE_EXPORT resume_unpaused_scheduler_exception
     /**
      * \brief Constructor.
      */
-    resume_unpaused_scheduler_exception() VITAL_NOTHROW;
+    resume_unpaused_scheduler_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~resume_unpaused_scheduler_exception() VITAL_NOTHROW;
+    ~resume_unpaused_scheduler_exception() noexcept;
 };
 
 /**
@@ -273,11 +273,11 @@ class SPROKIT_PIPELINE_EXPORT stop_before_start_exception
     /**
      * \brief Constructor.
      */
-    stop_before_start_exception() VITAL_NOTHROW;
+    stop_before_start_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~stop_before_start_exception() VITAL_NOTHROW;
+    ~stop_before_start_exception() noexcept;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/scheduler_registry_exception.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_registry_exception.cxx
@@ -42,7 +42,7 @@ namespace sprokit{
 
 // ------------------------------------------------------------------
 scheduler_registry_exception
-::scheduler_registry_exception() VITAL_NOTHROW
+::scheduler_registry_exception() noexcept
   : pipeline_exception()
 {
 }
@@ -50,14 +50,14 @@ scheduler_registry_exception
 
 // ------------------------------------------------------------------
 scheduler_registry_exception
-::~scheduler_registry_exception() VITAL_NOTHROW
+::~scheduler_registry_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 null_scheduler_ctor_exception
-::null_scheduler_ctor_exception(sprokit::scheduler::type_t const& type) VITAL_NOTHROW
+::null_scheduler_ctor_exception(sprokit::scheduler::type_t const& type) noexcept
   : scheduler_registry_exception()
   , m_type(type)
 {
@@ -72,14 +72,14 @@ null_scheduler_ctor_exception
 
 // ------------------------------------------------------------------
 null_scheduler_ctor_exception
-::~null_scheduler_ctor_exception() VITAL_NOTHROW
+::~null_scheduler_ctor_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 null_scheduler_registry_config_exception
-::null_scheduler_registry_config_exception() VITAL_NOTHROW
+::null_scheduler_registry_config_exception() noexcept
   : scheduler_registry_exception()
 {
   std::ostringstream sstr;
@@ -92,14 +92,14 @@ null_scheduler_registry_config_exception
 
 // ------------------------------------------------------------------
 null_scheduler_registry_config_exception
-::~null_scheduler_registry_config_exception() VITAL_NOTHROW
+::~null_scheduler_registry_config_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 null_scheduler_registry_pipeline_exception
-::null_scheduler_registry_pipeline_exception() VITAL_NOTHROW
+::null_scheduler_registry_pipeline_exception() noexcept
   : scheduler_registry_exception()
 {
   std::ostringstream sstr;
@@ -112,14 +112,14 @@ null_scheduler_registry_pipeline_exception
 
 // ------------------------------------------------------------------
 null_scheduler_registry_pipeline_exception
-::~null_scheduler_registry_pipeline_exception() VITAL_NOTHROW
+::~null_scheduler_registry_pipeline_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 no_such_scheduler_type_exception
-::no_such_scheduler_type_exception(sprokit::scheduler::type_t const& type) VITAL_NOTHROW
+::no_such_scheduler_type_exception(sprokit::scheduler::type_t const& type) noexcept
   : scheduler_registry_exception()
   , m_type(type)
 {
@@ -134,14 +134,14 @@ no_such_scheduler_type_exception
 
 // ------------------------------------------------------------------
 no_such_scheduler_type_exception
-::~no_such_scheduler_type_exception() VITAL_NOTHROW
+::~no_such_scheduler_type_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 scheduler_type_already_exists_exception
-::scheduler_type_already_exists_exception(sprokit::scheduler::type_t const& type) VITAL_NOTHROW
+::scheduler_type_already_exists_exception(sprokit::scheduler::type_t const& type) noexcept
   : scheduler_registry_exception()
   , m_type(type)
 {
@@ -156,7 +156,7 @@ scheduler_type_already_exists_exception
 
 // ------------------------------------------------------------------
 scheduler_type_already_exists_exception
-::~scheduler_type_already_exists_exception() VITAL_NOTHROW
+::~scheduler_type_already_exists_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/types.cxx
+++ b/sprokit/src/sprokit/pipeline/types.cxx
@@ -40,20 +40,20 @@ namespace sprokit
 {
 
 pipeline_exception
-::pipeline_exception() VITAL_NOTHROW
+::pipeline_exception() noexcept
   : std::exception()
   , m_what()
 {
 }
 
 pipeline_exception
-::~pipeline_exception() VITAL_NOTHROW
+::~pipeline_exception() noexcept
 {
 }
 
 char const*
 pipeline_exception
-::what() const VITAL_NOTHROW
+::what() const noexcept
 {
   return m_what.c_str();
 }

--- a/sprokit/src/sprokit/pipeline/types.h
+++ b/sprokit/src/sprokit/pipeline/types.h
@@ -101,18 +101,18 @@ class SPROKIT_PIPELINE_EXPORT pipeline_exception
     /**
      * \brief Constructor.
      */
-    pipeline_exception() VITAL_NOTHROW;
+    pipeline_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipeline_exception() VITAL_NOTHROW;
+    virtual ~pipeline_exception() noexcept;
 
     /**
      * \brief A description of the exception.
      *
      * \returns A string describing what went wrong.
      */
-    char const* what() const VITAL_NOTHROW;
+    char const* what() const noexcept;
 
 protected:
     /// The text of the exception.

--- a/sprokit/src/sprokit/pipeline_util/export_dot_exception.cxx
+++ b/sprokit/src/sprokit/pipeline_util/export_dot_exception.cxx
@@ -42,18 +42,18 @@ namespace sprokit
 {
 
 export_dot_exception
-::export_dot_exception() VITAL_NOTHROW
+::export_dot_exception() noexcept
   : pipeline_exception()
 {
 }
 
 export_dot_exception
-::~export_dot_exception() VITAL_NOTHROW
+::~export_dot_exception() noexcept
 {
 }
 
 null_pipeline_export_dot_exception
-::null_pipeline_export_dot_exception() VITAL_NOTHROW
+::null_pipeline_export_dot_exception() noexcept
   : export_dot_exception()
 {
   std::stringstream sstr;
@@ -64,12 +64,12 @@ null_pipeline_export_dot_exception
 }
 
 null_pipeline_export_dot_exception
-::~null_pipeline_export_dot_exception() VITAL_NOTHROW
+::~null_pipeline_export_dot_exception() noexcept
 {
 }
 
 null_cluster_export_dot_exception
-::null_cluster_export_dot_exception() VITAL_NOTHROW
+::null_cluster_export_dot_exception() noexcept
   : export_dot_exception()
 {
   std::stringstream sstr;
@@ -80,12 +80,12 @@ null_cluster_export_dot_exception
 }
 
 null_cluster_export_dot_exception
-::~null_cluster_export_dot_exception() VITAL_NOTHROW
+::~null_cluster_export_dot_exception() noexcept
 {
 }
 
 empty_name_export_dot_exception
-::empty_name_export_dot_exception() VITAL_NOTHROW
+::empty_name_export_dot_exception() noexcept
   : export_dot_exception()
 {
   std::stringstream sstr;
@@ -97,7 +97,7 @@ empty_name_export_dot_exception
 }
 
 empty_name_export_dot_exception
-::~empty_name_export_dot_exception() VITAL_NOTHROW
+::~empty_name_export_dot_exception() noexcept
 {
 }
 

--- a/sprokit/src/sprokit/pipeline_util/export_dot_exception.h
+++ b/sprokit/src/sprokit/pipeline_util/export_dot_exception.h
@@ -58,11 +58,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT export_dot_exception
     /**
      * \brief Constructor.
      */
-    export_dot_exception() VITAL_NOTHROW;
+    export_dot_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~export_dot_exception() VITAL_NOTHROW;
+    virtual ~export_dot_exception() noexcept;
 };
 
 /**
@@ -79,11 +79,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT null_pipeline_export_dot_exception
     /**
      * \brief Constructor.
      */
-    null_pipeline_export_dot_exception() VITAL_NOTHROW;
+    null_pipeline_export_dot_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_pipeline_export_dot_exception() VITAL_NOTHROW;
+    ~null_pipeline_export_dot_exception() noexcept;
 };
 
 /**
@@ -100,11 +100,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT null_cluster_export_dot_exception
     /**
      * \brief Constructor.
      */
-    null_cluster_export_dot_exception() VITAL_NOTHROW;
+    null_cluster_export_dot_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~null_cluster_export_dot_exception() VITAL_NOTHROW;
+    ~null_cluster_export_dot_exception() noexcept;
 };
 
 /**
@@ -121,11 +121,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT empty_name_export_dot_exception
     /**
      * \brief Constructor.
      */
-    empty_name_export_dot_exception() VITAL_NOTHROW;
+    empty_name_export_dot_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~empty_name_export_dot_exception() VITAL_NOTHROW;
+    ~empty_name_export_dot_exception() noexcept;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline_util/load_pipe_exception.cxx
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe_exception.cxx
@@ -42,20 +42,20 @@ namespace sprokit
 {
 
 load_pipe_exception
-::load_pipe_exception() VITAL_NOTHROW
+::load_pipe_exception() noexcept
   : pipeline_exception()
 {
 }
 
 load_pipe_exception
-::~load_pipe_exception() VITAL_NOTHROW
+::~load_pipe_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 file_no_exist_exception
-::file_no_exist_exception( kwiver::vital::path_t const& fname) VITAL_NOTHROW
+::file_no_exist_exception( kwiver::vital::path_t const& fname) noexcept
   : load_pipe_exception()
   , m_fname(fname)
 {
@@ -66,14 +66,14 @@ file_no_exist_exception
 }
 
 file_no_exist_exception
-::~file_no_exist_exception() VITAL_NOTHROW
+::~file_no_exist_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 parsing_exception::
-parsing_exception( const std::string& msg ) VITAL_NOTHROW
+parsing_exception( const std::string& msg ) noexcept
 : load_pipe_exception()
 {
   m_what = msg;
@@ -81,7 +81,7 @@ parsing_exception( const std::string& msg ) VITAL_NOTHROW
 
 
 parsing_exception::
-~parsing_exception() VITAL_NOTHROW
+~parsing_exception() noexcept
 { }
 
 }

--- a/sprokit/src/sprokit/pipeline_util/load_pipe_exception.h
+++ b/sprokit/src/sprokit/pipeline_util/load_pipe_exception.h
@@ -62,12 +62,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT load_pipe_exception
     /**
      * \brief Constructor.
      */
-    load_pipe_exception() VITAL_NOTHROW;
+    load_pipe_exception() noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~load_pipe_exception() VITAL_NOTHROW;
+    virtual ~load_pipe_exception() noexcept;
 };
 
 /**
@@ -86,11 +86,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT file_no_exist_exception
      *
      * \param fname The path that does not exist.
      */
-  file_no_exist_exception(kwiver::vital::path_t const& fname) VITAL_NOTHROW;
+  file_no_exist_exception(kwiver::vital::path_t const& fname) noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~file_no_exist_exception() VITAL_NOTHROW;
+    virtual ~file_no_exist_exception() noexcept;
 
     /// The path that does not exist.
     kwiver::vital::path_t const m_fname;
@@ -105,12 +105,12 @@ public:
   /**
    * \brief Constructor.
    */
-  parsing_exception( const std::string& msg) VITAL_NOTHROW;
+  parsing_exception( const std::string& msg) noexcept;
 
   /**
    * \brief Destructor.
    */
-  virtual ~parsing_exception() VITAL_NOTHROW;
+  virtual ~parsing_exception() noexcept;
 
 };
 

--- a/sprokit/src/sprokit/pipeline_util/pipe_bakery_exception.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipe_bakery_exception.cxx
@@ -44,21 +44,21 @@ namespace sprokit {
 
 // ------------------------------------------------------------------
 pipe_bakery_exception
-::pipe_bakery_exception() VITAL_NOTHROW
+::pipe_bakery_exception() noexcept
   : pipeline_exception()
 {
 }
 
 
 pipe_bakery_exception
-::~pipe_bakery_exception() VITAL_NOTHROW
+::~pipe_bakery_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 missing_cluster_block_exception
-::missing_cluster_block_exception() VITAL_NOTHROW
+::missing_cluster_block_exception() noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -69,14 +69,14 @@ missing_cluster_block_exception
 
 
 missing_cluster_block_exception
-::~missing_cluster_block_exception() VITAL_NOTHROW
+::~missing_cluster_block_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 multiple_cluster_blocks_exception
-::multiple_cluster_blocks_exception() VITAL_NOTHROW
+::multiple_cluster_blocks_exception() noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -87,14 +87,14 @@ multiple_cluster_blocks_exception
 
 
 multiple_cluster_blocks_exception
-::~multiple_cluster_blocks_exception() VITAL_NOTHROW
+::~multiple_cluster_blocks_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 cluster_without_processes_exception
-::cluster_without_processes_exception() VITAL_NOTHROW
+::cluster_without_processes_exception() noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -105,14 +105,14 @@ cluster_without_processes_exception
 
 
 cluster_without_processes_exception
-::~cluster_without_processes_exception() VITAL_NOTHROW
+::~cluster_without_processes_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 cluster_without_ports_exception
-::cluster_without_ports_exception() VITAL_NOTHROW
+::cluster_without_ports_exception() noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -123,7 +123,7 @@ cluster_without_ports_exception
 
 
 cluster_without_ports_exception
-::~cluster_without_ports_exception() VITAL_NOTHROW
+::~cluster_without_ports_exception() noexcept
 {
 }
 
@@ -131,7 +131,7 @@ cluster_without_ports_exception
 // ------------------------------------------------------------------
 duplicate_cluster_port_exception
 ::duplicate_cluster_port_exception( process::port_t const& port,
-                                    char const* const      side ) VITAL_NOTHROW
+                                    char const* const      side ) noexcept
   : pipe_bakery_exception(),
   m_port( port )
 {
@@ -146,42 +146,42 @@ duplicate_cluster_port_exception
 
 
 duplicate_cluster_port_exception
-::~duplicate_cluster_port_exception() VITAL_NOTHROW
+::~duplicate_cluster_port_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 duplicate_cluster_input_port_exception
-::duplicate_cluster_input_port_exception( process::port_t const& port ) VITAL_NOTHROW
+::duplicate_cluster_input_port_exception( process::port_t const& port ) noexcept
   : duplicate_cluster_port_exception( port, "input" )
 {
 }
 
 
 duplicate_cluster_input_port_exception
-::~duplicate_cluster_input_port_exception() VITAL_NOTHROW
+::~duplicate_cluster_input_port_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 duplicate_cluster_output_port_exception
-::duplicate_cluster_output_port_exception( process::port_t const& port ) VITAL_NOTHROW
+::duplicate_cluster_output_port_exception( process::port_t const& port ) noexcept
   : duplicate_cluster_port_exception( port, "output" )
 {
 }
 
 
 duplicate_cluster_output_port_exception
-::~duplicate_cluster_output_port_exception() VITAL_NOTHROW
+::~duplicate_cluster_output_port_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 unrecognized_config_flag_exception
-::unrecognized_config_flag_exception( kwiver::vital::config_block_key_t const& key, config_flag_t const& flag ) VITAL_NOTHROW
+::unrecognized_config_flag_exception( kwiver::vital::config_block_key_t const& key, config_flag_t const& flag ) noexcept
   : pipe_bakery_exception(),
   m_key( key ),
   m_flag( flag )
@@ -197,7 +197,7 @@ unrecognized_config_flag_exception
 
 
 unrecognized_config_flag_exception
-::~unrecognized_config_flag_exception() VITAL_NOTHROW
+::~unrecognized_config_flag_exception() noexcept
 {
 }
 
@@ -205,7 +205,7 @@ unrecognized_config_flag_exception
 // ------------------------------------------------------------------
 config_flag_mismatch_exception
 ::config_flag_mismatch_exception( kwiver::vital::config_block_key_t const& key,
-                                  std::string const&                       reason ) VITAL_NOTHROW
+                                  std::string const&                       reason ) noexcept
   : pipe_bakery_exception()
   , m_key( key )
   , m_reason( reason )
@@ -221,7 +221,7 @@ config_flag_mismatch_exception
 
 
 config_flag_mismatch_exception
-::~config_flag_mismatch_exception() VITAL_NOTHROW
+::~config_flag_mismatch_exception() noexcept
 {
 }
 
@@ -229,7 +229,7 @@ config_flag_mismatch_exception
 // ------------------------------------------------------------------
 relativepath_exception
 ::relativepath_exception( const std::string&                    msg,
-                          const kwiver::vital::source_location& loc ) VITAL_NOTHROW
+                          const kwiver::vital::source_location& loc ) noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -240,14 +240,14 @@ relativepath_exception
 
 
 relativepath_exception::
-  ~relativepath_exception() VITAL_NOTHROW
+  ~relativepath_exception() noexcept
 { }
 
 
 // ------------------------------------------------------------------
 provider_error_exception::
 provider_error_exception( const std::string&                    msg,
-                          const kwiver::vital::source_location& loc ) VITAL_NOTHROW
+                          const kwiver::vital::source_location& loc ) noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -258,7 +258,7 @@ provider_error_exception( const std::string&                    msg,
 
 
   provider_error_exception::
-  provider_error_exception( const std::string& msg ) VITAL_NOTHROW
+  provider_error_exception( const std::string& msg ) noexcept
   : pipe_bakery_exception()
 {
   std::stringstream sstr;
@@ -269,7 +269,7 @@ provider_error_exception( const std::string&                    msg,
 
 
 provider_error_exception::
-  ~provider_error_exception() VITAL_NOTHROW
+  ~provider_error_exception() noexcept
 { }
 
 } // end namespace

--- a/sprokit/src/sprokit/pipeline_util/pipe_bakery_exception.h
+++ b/sprokit/src/sprokit/pipeline_util/pipe_bakery_exception.h
@@ -72,11 +72,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT pipe_bakery_exception
     /**
      * \brief Constructor.
      */
-    pipe_bakery_exception() VITAL_NOTHROW;
+    pipe_bakery_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~pipe_bakery_exception() VITAL_NOTHROW;
+    virtual ~pipe_bakery_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -94,11 +94,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT missing_cluster_block_exception
     /**
      * \brief Constructor.
      */
-    missing_cluster_block_exception() VITAL_NOTHROW;
+    missing_cluster_block_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~missing_cluster_block_exception() VITAL_NOTHROW;
+    ~missing_cluster_block_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -116,11 +116,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT multiple_cluster_blocks_exception
     /**
      * \brief Constructor.
      */
-    multiple_cluster_blocks_exception() VITAL_NOTHROW;
+    multiple_cluster_blocks_exception() noexcept;
     /**
      * \brief Destructor.
      */
-    ~multiple_cluster_blocks_exception() VITAL_NOTHROW;
+    ~multiple_cluster_blocks_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -138,12 +138,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT cluster_without_processes_exception
     /**
      * \brief Constructor.
      */
-    cluster_without_processes_exception() VITAL_NOTHROW;
+    cluster_without_processes_exception() noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~cluster_without_processes_exception() VITAL_NOTHROW;
+    virtual ~cluster_without_processes_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -161,12 +161,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT cluster_without_ports_exception
     /**
      * \brief Constructor.
      */
-    cluster_without_ports_exception() VITAL_NOTHROW;
+    cluster_without_ports_exception() noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~cluster_without_ports_exception() VITAL_NOTHROW;
+    virtual ~cluster_without_ports_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -184,12 +184,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT duplicate_cluster_port_exception
     /**
      * \brief Constructor.
      */
-    duplicate_cluster_port_exception(process::port_t const& port, char const* const side) VITAL_NOTHROW;
+    duplicate_cluster_port_exception(process::port_t const& port, char const* const side) noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~duplicate_cluster_port_exception() VITAL_NOTHROW;
+    virtual ~duplicate_cluster_port_exception() noexcept;
 
     /// The name of the duplicate port.
     process::port_t const m_port;
@@ -210,12 +210,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT duplicate_cluster_input_port_exception
     /**
      * \brief Constructor.
      */
-    duplicate_cluster_input_port_exception(process::port_t const& port) VITAL_NOTHROW;
+    duplicate_cluster_input_port_exception(process::port_t const& port) noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~duplicate_cluster_input_port_exception() VITAL_NOTHROW;
+    virtual ~duplicate_cluster_input_port_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -233,12 +233,12 @@ class SPROKIT_PIPELINE_UTIL_EXPORT duplicate_cluster_output_port_exception
     /**
      * \brief Constructor.
      */
-    duplicate_cluster_output_port_exception(process::port_t const& port) VITAL_NOTHROW;
+    duplicate_cluster_output_port_exception(process::port_t const& port) noexcept;
 
     /**
      * \brief Destructor.
      */
-    virtual ~duplicate_cluster_output_port_exception() VITAL_NOTHROW;
+    virtual ~duplicate_cluster_output_port_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -259,11 +259,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT unrecognized_config_flag_exception
      * \param key The key the flag was on.
      * \param flag The unrecognized flag.
      */
-    unrecognized_config_flag_exception(kwiver::vital::config_block_key_t const& key, config_flag_t const& flag) VITAL_NOTHROW;
+    unrecognized_config_flag_exception(kwiver::vital::config_block_key_t const& key, config_flag_t const& flag) noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~unrecognized_config_flag_exception() VITAL_NOTHROW;
+    virtual ~unrecognized_config_flag_exception() noexcept;
 
     /// The key the flag was on.
     kwiver::vital::config_block_key_t const m_key;
@@ -290,11 +290,11 @@ class SPROKIT_PIPELINE_UTIL_EXPORT config_flag_mismatch_exception
      * \param key The key the flag was on.
      * \param reason The reason for the mismatch.
      */
-    config_flag_mismatch_exception(kwiver::vital::config_block_key_t const& key, std::string const& reason) VITAL_NOTHROW;
+    config_flag_mismatch_exception(kwiver::vital::config_block_key_t const& key, std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    virtual ~config_flag_mismatch_exception() VITAL_NOTHROW;
+    virtual ~config_flag_mismatch_exception() noexcept;
 
     /// The key the flag was on.
     kwiver::vital::config_block_key_t const m_key;
@@ -312,12 +312,12 @@ public:
    * \brief Constructor.
    */
   relativepath_exception( const std::string& msg,
-                          const kwiver::vital::source_location& loc) VITAL_NOTHROW;
+                          const kwiver::vital::source_location& loc) noexcept;
 
   /**
    * \brief Destructor.
    */
-  virtual ~relativepath_exception() VITAL_NOTHROW;
+  virtual ~relativepath_exception() noexcept;
 
 };
 
@@ -331,14 +331,14 @@ public:
    * \brief Constructor.
    */
   provider_error_exception( const std::string& msg,
-                            const kwiver::vital::source_location& loc) VITAL_NOTHROW;
+                            const kwiver::vital::source_location& loc) noexcept;
 
-  provider_error_exception( const std::string& msg ) VITAL_NOTHROW;
+  provider_error_exception( const std::string& msg ) noexcept;
 
   /**
    * \brief Destructor.
    */
-  virtual ~provider_error_exception() VITAL_NOTHROW;
+  virtual ~provider_error_exception() noexcept;
 
 };
 

--- a/vital/any.h
+++ b/vital/any.h
@@ -54,7 +54,7 @@ public:
    * @brief Create empty object.
    *
    */
-  any() VITAL_NOTHROW
+  any() noexcept
     : m_content( 0 )
   { }
 
@@ -83,7 +83,7 @@ public:
     : m_content( other.m_content ? other.m_content->clone() : 0 )
   { }
 
-  ~any() VITAL_NOTHROW
+  ~any() noexcept
   {
     delete m_content;
   }
@@ -99,7 +99,7 @@ public:
    *
    * @return Modified current (this) object.
    */
-  any& swap(any& rhs) VITAL_NOTHROW
+  any& swap(any& rhs) noexcept
   {
     std::swap(m_content, rhs.m_content);
     return *this;
@@ -148,7 +148,7 @@ public:
    * @return \b true if no value in object, \b false if there is a
    * value.
    */
-  bool empty() const VITAL_NOTHROW
+  bool empty() const noexcept
   {
     return ! m_content;
   }
@@ -161,7 +161,7 @@ public:
    * object. The empty() method will return /b true after this call.
    *
    */
-  void clear() VITAL_NOTHROW
+  void clear() noexcept
   {
     any().swap( *this );
   }
@@ -184,7 +184,7 @@ public:
    *
    * @return The type info for the datum in this object is returned.
    */
-  std::type_info const& type() const VITAL_NOTHROW
+  std::type_info const& type() const noexcept
   {
     return m_content ? m_content->type() : typeid(void);
   }
@@ -197,7 +197,7 @@ public:
    *
    * @return Demangled type name string.
    */
-  std::string type_name() const VITAL_NOTHROW
+  std::string type_name() const noexcept
   {
     return demangle( this->type().name() );
   }
@@ -209,7 +209,7 @@ private:
   {
   public:
     virtual ~internal() { }
-    virtual std::type_info const& type() const VITAL_NOTHROW = 0;
+    virtual std::type_info const& type() const noexcept = 0;
     virtual internal* clone() const = 0;
   };
 
@@ -219,7 +219,7 @@ private:
   {
   public:
     internal_typed( T const& value ) : m_any_data( value ) { }
-    virtual std::type_info const& type() const VITAL_NOTHROW
+    virtual std::type_info const& type() const noexcept
     {
       return typeid(T);
     }
@@ -238,7 +238,7 @@ private:
 
 private:
   template < typename T >
-  friend T* any_cast( any * aval ) VITAL_NOTHROW;
+  friend T* any_cast( any * aval ) noexcept;
 
   template < typename T >
   friend T any_cast(any const& aval);
@@ -269,8 +269,8 @@ public:
       + demangle( from_type ) + "\" to type \"" + demangle( to_type ) + "\"";
   }
 
-  virtual ~bad_any_cast() VITAL_NOTHROW {}
-  virtual const char * what() const VITAL_NOTHROW
+  virtual ~bad_any_cast() noexcept {}
+  virtual const char * what() const noexcept
   {
     return m_message.c_str();
   }
@@ -294,7 +294,7 @@ private:
  */
 template < typename T >
 inline T*
-any_cast( any* operand ) VITAL_NOTHROW
+any_cast( any* operand ) noexcept
 {
   if ( operand && ( operand->type() == typeid( T ) ) )
   {
@@ -317,7 +317,7 @@ any_cast( any* operand ) VITAL_NOTHROW
  */
 template < typename T >
 inline const T*
-any_cast( any const* operand ) VITAL_NOTHROW
+any_cast( any const* operand ) noexcept
 {
   return any_cast< T > ( const_cast< any* > ( operand ) );
 }

--- a/vital/attribute_set.cxx
+++ b/vital/attribute_set.cxx
@@ -50,7 +50,7 @@ attribute_set_exception( std::string const& str )
 
 
 attribute_set_exception::
-~attribute_set_exception() VITAL_NOTHROW
+~attribute_set_exception() noexcept
 { }
 
 

--- a/vital/attribute_set.h
+++ b/vital/attribute_set.h
@@ -57,7 +57,7 @@ class VITAL_EXPORT attribute_set_exception
 public:
   attribute_set_exception( std::string const& str );
 
-  virtual ~attribute_set_exception() VITAL_NOTHROW;
+  virtual ~attribute_set_exception() noexcept;
 };
 
 class attribute_set;

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -176,7 +176,7 @@ public:
    * \returns The value stored within the configuration, or \p def if something goes wrong.
    */
   template < typename T >
-  T get_value( config_block_key_t const& key, T const& def ) const VITAL_NOTHROW;
+  T get_value( config_block_key_t const& key, T const& def ) const noexcept;
 
 
   /**
@@ -693,7 +693,7 @@ config_block
 template < typename T >
 T
 config_block
-::get_value( config_block_key_t const& key, T const& def ) const VITAL_NOTHROW
+::get_value( config_block_key_t const& key, T const& def ) const noexcept
 {
   try
   {

--- a/vital/config/config_block_exception.cxx
+++ b/vital/config/config_block_exception.cxx
@@ -42,21 +42,21 @@ namespace vital {
 
 // ------------------------------------------------------------------
 config_block_exception
-::config_block_exception() VITAL_NOTHROW
+::config_block_exception() noexcept
   : std::exception()
 {
 }
 
 
 config_block_exception
-::~config_block_exception() VITAL_NOTHROW
+::~config_block_exception() noexcept
 {
 }
 
 
 char const*
 config_block_exception
-::what() const VITAL_NOTHROW
+::what() const noexcept
 {
   return this->m_what.c_str();
 }
@@ -64,7 +64,7 @@ config_block_exception
 
 // ------------------------------------------------------------------
 bad_config_block_cast
-::bad_config_block_cast( std::string const& reason ) VITAL_NOTHROW
+::bad_config_block_cast( std::string const& reason ) noexcept
   : config_block_exception()
 {
   this->m_what = reason;
@@ -72,7 +72,7 @@ bad_config_block_cast
 
 
 bad_config_block_cast
-::~bad_config_block_cast() VITAL_NOTHROW
+::~bad_config_block_cast() noexcept
 {
 }
 
@@ -82,7 +82,7 @@ bad_config_block_cast_exception
 ::bad_config_block_cast_exception( config_block_key_t const&    key,
                                    config_block_value_t const&  value,
                                    std::string const&           type,
-                                   std::string const&           reason ) VITAL_NOTHROW
+                                   std::string const&           reason ) noexcept
 : config_block_exception(),
   m_key( key ),
   m_value( value ),
@@ -98,14 +98,14 @@ bad_config_block_cast_exception
 
 
 bad_config_block_cast_exception
-::~bad_config_block_cast_exception() VITAL_NOTHROW
+::~bad_config_block_cast_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 no_such_configuration_value_exception
-::no_such_configuration_value_exception( config_block_key_t const& key ) VITAL_NOTHROW
+::no_such_configuration_value_exception( config_block_key_t const& key ) noexcept
   : config_block_exception(),
   m_key( key )
 {
@@ -118,7 +118,7 @@ no_such_configuration_value_exception
 
 
 no_such_configuration_value_exception
-::~no_such_configuration_value_exception() VITAL_NOTHROW
+::~no_such_configuration_value_exception() noexcept
 {
 }
 
@@ -127,7 +127,7 @@ no_such_configuration_value_exception
 set_on_read_only_value_exception
 ::set_on_read_only_value_exception( config_block_key_t const&   key,
                                       config_block_value_t const& value,
-                                      config_block_value_t const& new_value ) VITAL_NOTHROW
+                                      config_block_value_t const& new_value ) noexcept
   : config_block_exception(),
   m_key( key ),
   m_value( value ),
@@ -144,7 +144,7 @@ set_on_read_only_value_exception
 
 
 set_on_read_only_value_exception
-::~set_on_read_only_value_exception() VITAL_NOTHROW
+::~set_on_read_only_value_exception() noexcept
 {
 }
 
@@ -152,7 +152,7 @@ set_on_read_only_value_exception
 // ------------------------------------------------------------------
 unset_on_read_only_value_exception
 ::unset_on_read_only_value_exception( config_block_key_t const&   key,
-                                        config_block_value_t const& value ) VITAL_NOTHROW
+                                        config_block_value_t const& value ) noexcept
   : config_block_exception(),
   m_key( key ),
   m_value( value )
@@ -168,7 +168,7 @@ unset_on_read_only_value_exception
 
 
 unset_on_read_only_value_exception
-::~unset_on_read_only_value_exception() VITAL_NOTHROW
+::~unset_on_read_only_value_exception() noexcept
 {
 }
 
@@ -176,7 +176,7 @@ unset_on_read_only_value_exception
 // ------------------------------------------------------------------
 config_block_io_exception
 ::config_block_io_exception( config_path_t const& file_path,
-                             std::string const& reason ) VITAL_NOTHROW
+                             std::string const& reason ) noexcept
   : config_block_exception(),
   m_file_path( file_path ),
   m_reason( reason )
@@ -185,21 +185,21 @@ config_block_io_exception
 
 
 config_block_io_exception
-::~config_block_io_exception() VITAL_NOTHROW
+::~config_block_io_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 bad_configuration_cast
-::bad_configuration_cast(std::string const& reason) VITAL_NOTHROW
+::bad_configuration_cast(std::string const& reason) noexcept
   : config_block_exception()
 {
   m_what = reason;
 }
 
 bad_configuration_cast
-::~bad_configuration_cast() VITAL_NOTHROW
+::~bad_configuration_cast() noexcept
 {
 }
 
@@ -209,7 +209,7 @@ bad_configuration_cast_exception
 ::bad_configuration_cast_exception(kwiver::vital::config_block_key_t const& key,
                                    kwiver::vital::config_block_value_t const& value,
                                    char const* type,
-                                   char const* reason) VITAL_NOTHROW
+                                   char const* reason) noexcept
   : config_block_exception()
   , m_key(key)
   , m_value(value)
@@ -226,14 +226,14 @@ bad_configuration_cast_exception
 }
 
 bad_configuration_cast_exception
-::~bad_configuration_cast_exception() VITAL_NOTHROW
+::~bad_configuration_cast_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 config_file_not_found_exception
-::config_file_not_found_exception( config_path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::config_file_not_found_exception( config_path_t const& file_path, std::string const& reason ) noexcept
   : config_block_io_exception( file_path, reason )
 {
   std::ostringstream sstr;
@@ -245,14 +245,14 @@ config_file_not_found_exception
 
 
 config_file_not_found_exception
-::~config_file_not_found_exception() VITAL_NOTHROW
+::~config_file_not_found_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 config_file_not_read_exception
-::config_file_not_read_exception( config_path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::config_file_not_read_exception( config_path_t const& file_path, std::string const& reason ) noexcept
   : config_block_io_exception( file_path, reason )
 {
   std::ostringstream sstr;
@@ -264,14 +264,14 @@ config_file_not_read_exception
 
 
 config_file_not_read_exception
-::~config_file_not_read_exception() VITAL_NOTHROW
+::~config_file_not_read_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 config_file_not_parsed_exception
-::config_file_not_parsed_exception( config_path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::config_file_not_parsed_exception( config_path_t const& file_path, std::string const& reason ) noexcept
   : config_block_io_exception( file_path, reason )
 {
   std::ostringstream sstr;
@@ -283,14 +283,14 @@ config_file_not_parsed_exception
 
 
 config_file_not_parsed_exception
-::~config_file_not_parsed_exception() VITAL_NOTHROW
+::~config_file_not_parsed_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 config_file_write_exception
-::config_file_write_exception( config_path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::config_file_write_exception( config_path_t const& file_path, std::string const& reason ) noexcept
   : config_block_io_exception( file_path, reason )
 {
   std::ostringstream sstr;
@@ -302,7 +302,7 @@ config_file_write_exception
 
 
 config_file_write_exception
-::~config_file_write_exception() VITAL_NOTHROW
+::~config_file_write_exception() noexcept
 {
 }
 

--- a/vital/config/config_block_exception.h
+++ b/vital/config/config_block_exception.h
@@ -57,15 +57,15 @@ class VITAL_CONFIG_EXPORT config_block_exception
 {
 public:
   /// Constructor.
-  config_block_exception() VITAL_NOTHROW;
+  config_block_exception() noexcept;
   /// Destructor.
-  virtual ~config_block_exception() VITAL_NOTHROW;
+  virtual ~config_block_exception() noexcept;
 
   /// Description of the exception
   /**
    * \returns A string describing what went wrong.
    */
-  char const* what() const VITAL_NOTHROW;
+  char const* what() const noexcept;
 
 
 protected:
@@ -87,9 +87,9 @@ public:
    * \brief Constructor.
    * \param reason The reason for the bad cast.
    */
-  bad_config_block_cast( std::string const& reason ) VITAL_NOTHROW;
+  bad_config_block_cast( std::string const& reason ) noexcept;
   /// Destructor.
-  virtual ~bad_config_block_cast() VITAL_NOTHROW;
+  virtual ~bad_config_block_cast() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -112,9 +112,9 @@ public:
   bad_config_block_cast_exception( config_block_key_t const&    key,
                                    config_block_value_t const&  value,
                                    std::string const&           type,
-                                   std::string const&           reason ) VITAL_NOTHROW;
+                                   std::string const&           reason ) noexcept;
   /// Destructor.
-  virtual ~bad_config_block_cast_exception() VITAL_NOTHROW;
+  virtual ~bad_config_block_cast_exception() noexcept;
 
   /// The requested key name.
   config_block_key_t const m_key;
@@ -139,9 +139,9 @@ public:
    * \brief Constructor.
    * \param key The key that was requested from the configuration.
    */
-  no_such_configuration_value_exception( config_block_key_t const& key ) VITAL_NOTHROW;
+  no_such_configuration_value_exception( config_block_key_t const& key ) noexcept;
   /// Destructor.
-  virtual ~no_such_configuration_value_exception() VITAL_NOTHROW;
+  virtual ~no_such_configuration_value_exception() noexcept;
 
   /// The requested key name.
   config_block_key_t const m_key;
@@ -165,11 +165,11 @@ public:
    */
   set_on_read_only_value_exception( config_block_key_t const&   key,
                                     config_block_value_t const& value,
-                                    config_block_value_t const& new_value ) VITAL_NOTHROW;
+                                    config_block_value_t const& new_value ) noexcept;
   /**
    * \brief Destructor.
    */
-  virtual ~set_on_read_only_value_exception() VITAL_NOTHROW;
+  virtual ~set_on_read_only_value_exception() noexcept;
 
   /// The requested key name.
   config_block_key_t const m_key;
@@ -195,11 +195,11 @@ public:
    * \param value The current value for \p key.
    */
   unset_on_read_only_value_exception( config_block_key_t const&   key,
-                                      config_block_value_t const& value ) VITAL_NOTHROW;
+                                      config_block_value_t const& value ) noexcept;
   /**
    * \brief Destructor.
    */
-  virtual ~unset_on_read_only_value_exception() VITAL_NOTHROW;
+  virtual ~unset_on_read_only_value_exception() noexcept;
 
   /// The requested key name.
   config_block_key_t const m_key;
@@ -223,11 +223,11 @@ class VITAL_CONFIG_EXPORT bad_configuration_cast
      *
      * \param reason The reason for the bad cast.
      */
-  bad_configuration_cast(std::string const& reason) VITAL_NOTHROW;
+  bad_configuration_cast(std::string const& reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~bad_configuration_cast() VITAL_NOTHROW;
+    ~bad_configuration_cast() noexcept;
 };
 
 
@@ -252,11 +252,11 @@ class VITAL_CONFIG_EXPORT bad_configuration_cast_exception
     bad_configuration_cast_exception(kwiver::vital::config_block_key_t const& key,
                                      kwiver::vital::config_block_value_t const& value,
                                      char const* type,
-                                     char const* reason) VITAL_NOTHROW;
+                                     char const* reason) noexcept;
     /**
      * \brief Destructor.
      */
-    ~bad_configuration_cast_exception() VITAL_NOTHROW;
+    ~bad_configuration_cast_exception() noexcept;
 
     /// The requested key name.
     kwiver::vital::config_block_key_t const m_key;
@@ -281,9 +281,9 @@ public:
    * \param reason    Reason for the exception.
    */
   config_block_io_exception( config_path_t const& file_path,
-                             std::string const&   reason ) VITAL_NOTHROW;
+                             std::string const&   reason ) noexcept;
   /// Deconstructor
-  virtual ~config_block_io_exception() VITAL_NOTHROW;
+  virtual ~config_block_io_exception() noexcept;
 
   /// Path to file this exception revolves around.
   config_path_t m_file_path;
@@ -304,9 +304,9 @@ public:
    * \param reason    The reason the file wasn't found.
    */
   config_file_not_found_exception( config_path_t const&  file_path,
-                                   std::string const&    reason ) VITAL_NOTHROW;
+                                   std::string const&    reason ) noexcept;
   /// Deconstructor
-  virtual ~config_file_not_found_exception() VITAL_NOTHROW;
+  virtual ~config_file_not_found_exception() noexcept;
 };
 
 
@@ -322,9 +322,9 @@ public:
    * \param reason    The reason for the read exception.
    */
   config_file_not_read_exception( config_path_t const& file_path,
-                                  std::string const&   reason ) VITAL_NOTHROW;
+                                  std::string const&   reason ) noexcept;
   /// Deconstructor
-  virtual ~config_file_not_read_exception() VITAL_NOTHROW;
+  virtual ~config_file_not_read_exception() noexcept;
 };
 
 
@@ -340,9 +340,9 @@ public:
    * \param reason    The reason for the parsing exception.
    */
   config_file_not_parsed_exception( config_path_t const& file_path,
-                                    std::string const&   reason ) VITAL_NOTHROW;
+                                    std::string const&   reason ) noexcept;
   /// Deconstructor
-  virtual ~config_file_not_parsed_exception() VITAL_NOTHROW;
+  virtual ~config_file_not_parsed_exception() noexcept;
 };
 
 
@@ -358,9 +358,9 @@ public:
    * \param reason    The reason for the write exception
    */
   config_file_write_exception( config_path_t const&  file_path,
-                               std::string const&    reason ) VITAL_NOTHROW;
+                               std::string const&    reason ) noexcept;
   /// Deconstructor
-  virtual ~config_file_write_exception() VITAL_NOTHROW;
+  virtual ~config_file_write_exception() noexcept;
 };
 
 

--- a/vital/exceptions/algorithm.cxx
+++ b/vital/exceptions/algorithm.cxx
@@ -42,7 +42,7 @@ namespace vital {
 algorithm_exception
 ::algorithm_exception(std::string type,
                       std::string impl,
-                      std::string reason) VITAL_NOTHROW
+                      std::string reason) noexcept
   : m_algo_type(type)
   , m_algo_impl(impl)
   , m_reason(reason)
@@ -55,14 +55,14 @@ algorithm_exception
 }
 
 algorithm_exception
-::~algorithm_exception() VITAL_NOTHROW
+::~algorithm_exception() noexcept
 {
 }
 
 algorithm_configuration_exception
 ::algorithm_configuration_exception(std::string type,
                                     std::string impl,
-                                    std::string reason) VITAL_NOTHROW
+                                    std::string reason) noexcept
   : algorithm_exception(type, impl, reason)
 {
   std::ostringstream sstr;
@@ -73,13 +73,13 @@ algorithm_configuration_exception
 }
 
 algorithm_configuration_exception
-::~algorithm_configuration_exception() VITAL_NOTHROW
+::~algorithm_configuration_exception() noexcept
 {
 }
 
 invalid_name_exception
 ::invalid_name_exception(std::string type,
-                         std::string impl) VITAL_NOTHROW
+                         std::string impl) noexcept
   : algorithm_exception(type, impl, "")
 {
   std::ostringstream sstr;
@@ -89,7 +89,7 @@ invalid_name_exception
 }
 
 invalid_name_exception
-::~invalid_name_exception() VITAL_NOTHROW
+::~invalid_name_exception() noexcept
 {
 }
 

--- a/vital/exceptions/algorithm.h
+++ b/vital/exceptions/algorithm.h
@@ -51,9 +51,9 @@ class VITAL_EXPORT algorithm_exception
     /// Constructor
     algorithm_exception(std::string type,
                         std::string impl,
-                        std::string reason) VITAL_NOTHROW;
+                        std::string reason) noexcept;
     /// Deconstructor
-    virtual ~algorithm_exception() VITAL_NOTHROW;
+    virtual ~algorithm_exception() noexcept;
 
     /// The name of the algorithm type
     std::string m_algo_type;
@@ -75,9 +75,9 @@ class VITAL_EXPORT algorithm_configuration_exception
     /// Constructor
     algorithm_configuration_exception(std::string type,
                                       std::string impl,
-                                      std::string reason) VITAL_NOTHROW;
+                                      std::string reason) noexcept;
     /// Destructor
-    virtual ~algorithm_configuration_exception() VITAL_NOTHROW;
+    virtual ~algorithm_configuration_exception() noexcept;
 };
 
 
@@ -89,10 +89,10 @@ class VITAL_EXPORT invalid_name_exception
   public:
     /// Constructor
     invalid_name_exception(std::string type,
-                           std::string impl) VITAL_NOTHROW;
+                           std::string impl) noexcept;
 
     /// Destructor
-    virtual ~invalid_name_exception() VITAL_NOTHROW;
+    virtual ~invalid_name_exception() noexcept;
 };
 
 } } // end namespace vital

--- a/vital/exceptions/base.cxx
+++ b/vital/exceptions/base.cxx
@@ -39,7 +39,7 @@ namespace kwiver {
 namespace vital {
 
 vital_core_base_exception
-::vital_core_base_exception() VITAL_NOTHROW
+::vital_core_base_exception() noexcept
   : std::exception()
   , m_line_number(0)
 {
@@ -47,7 +47,7 @@ vital_core_base_exception
 
 
 vital_core_base_exception
-::~vital_core_base_exception() VITAL_NOTHROW
+::~vital_core_base_exception() noexcept
 {
 }
 
@@ -65,7 +65,7 @@ vital_core_base_exception
 // ------------------------------------------------------------------
 char const*
 vital_core_base_exception
-::what() const VITAL_NOTHROW
+::what() const noexcept
 {
   return this->m_what.c_str();
 }
@@ -73,14 +73,14 @@ vital_core_base_exception
 
 // ------------------------------------------------------------------
 invalid_value
-::invalid_value(std::string reason) VITAL_NOTHROW
+::invalid_value(std::string reason) noexcept
   : m_reason(reason)
 {
   m_what = "Invalid value(s): " + reason;
 }
 
 invalid_value
-::~invalid_value() VITAL_NOTHROW
+::~invalid_value() noexcept
 {
 }
 

--- a/vital/exceptions/base.h
+++ b/vital/exceptions/base.h
@@ -55,16 +55,16 @@ class VITAL_EXPORT vital_core_base_exception
 {
 public:
   /// Constructor
-  vital_core_base_exception() VITAL_NOTHROW;
+  vital_core_base_exception() noexcept;
 
   /// Destructor
-  virtual ~vital_core_base_exception() VITAL_NOTHROW;
+  virtual ~vital_core_base_exception() noexcept;
 
   /**
    * \brief Description of the exception
    * \returns A string describing what went wrong.
    */
-  char const* what() const VITAL_NOTHROW;
+  char const* what() const noexcept;
 
   /**
    * \brief Set optional location of exception.
@@ -95,9 +95,9 @@ class VITAL_EXPORT invalid_value
 {
 public:
   /// Constructor
-  invalid_value(std::string reason) VITAL_NOTHROW;
+  invalid_value(std::string reason) noexcept;
   /// Destructor
-  virtual ~invalid_value() VITAL_NOTHROW;
+  virtual ~invalid_value() noexcept;
 protected:
   /// Reason for invalidity
   std::string m_reason;

--- a/vital/exceptions/image.cxx
+++ b/vital/exceptions/image.cxx
@@ -42,27 +42,27 @@ namespace vital {
 
 
 image_exception
-::image_exception() VITAL_NOTHROW
+::image_exception() noexcept
 {
   m_what = "An image exception";
 }
 
 image_exception
-::~image_exception() VITAL_NOTHROW
+::~image_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 image_type_mismatch_exception
-::image_type_mismatch_exception(std::string message) VITAL_NOTHROW
+::image_type_mismatch_exception(std::string message) noexcept
   : m_message(message)
 {
   m_what = message;
 }
 
 image_type_mismatch_exception
-::~image_type_mismatch_exception() VITAL_NOTHROW
+::~image_type_mismatch_exception() noexcept
 {
 }
 
@@ -71,7 +71,7 @@ image_type_mismatch_exception
 image_size_mismatch_exception
 ::image_size_mismatch_exception(std::string message,
                                 size_t correct_w, size_t correct_h,
-                                size_t given_w, size_t given_h) VITAL_NOTHROW
+                                size_t given_w, size_t given_h) noexcept
   : m_message(message),
     m_correct_w(correct_w),
     m_correct_h(correct_h),
@@ -86,7 +86,7 @@ image_size_mismatch_exception
 }
 
 image_size_mismatch_exception
-::~image_size_mismatch_exception() VITAL_NOTHROW
+::~image_size_mismatch_exception() noexcept
 {
 }
 

--- a/vital/exceptions/image.h
+++ b/vital/exceptions/image.h
@@ -50,9 +50,9 @@ class VITAL_EXPORT image_exception
 {
 public:
   /// Constructor
-  image_exception() VITAL_NOTHROW;
+  image_exception() noexcept;
   /// Destructor
-  virtual ~image_exception() VITAL_NOTHROW;
+  virtual ~image_exception() noexcept;
 };
 
 
@@ -69,9 +69,9 @@ public:
   /**
    * \param message     Description of circumstances surrounding error.
    */
-  image_type_mismatch_exception(std::string message) VITAL_NOTHROW;
+  image_type_mismatch_exception(std::string message) noexcept;
   /// Destructor
-  virtual ~image_type_mismatch_exception() VITAL_NOTHROW;
+  virtual ~image_type_mismatch_exception() noexcept;
 
   /// Given error message string
   std::string m_message;
@@ -97,9 +97,9 @@ public:
    */
   image_size_mismatch_exception(std::string message,
                                 size_t correct_w, size_t correct_h,
-                                size_t given_w, size_t given_h) VITAL_NOTHROW;
+                                size_t given_w, size_t given_h) noexcept;
   /// Destructor
-  virtual ~image_size_mismatch_exception() VITAL_NOTHROW;
+  virtual ~image_size_mismatch_exception() noexcept;
 
   /// Given error message string
   std::string m_message;

--- a/vital/exceptions/io.cxx
+++ b/vital/exceptions/io.cxx
@@ -41,21 +41,21 @@ namespace vital {
 
 // ------------------------------------------------------------------
 io_exception
-::io_exception() VITAL_NOTHROW
+::io_exception() noexcept
 {
   m_what = "An IO exception occurred.";
 }
 
 
 io_exception
-::~io_exception() VITAL_NOTHROW
+::~io_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 path_not_exists
-::path_not_exists( path_t const& path ) VITAL_NOTHROW
+::path_not_exists( path_t const& path ) noexcept
 {
   std::ostringstream sstr;
 
@@ -65,42 +65,42 @@ path_not_exists
 
 
 path_not_exists
-::~path_not_exists() VITAL_NOTHROW
+::~path_not_exists() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 path_not_a_file
-::path_not_a_file( path_t const& path ) VITAL_NOTHROW
+::path_not_a_file( path_t const& path ) noexcept
 {
   m_what = "Path does not point to a file: " + path;
 }
 
 
 path_not_a_file
-::~path_not_a_file() VITAL_NOTHROW
+::~path_not_a_file() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 path_not_a_directory
-::path_not_a_directory( path_t const& path ) VITAL_NOTHROW
+::path_not_a_directory( path_t const& path ) noexcept
 {
   m_what = "Path does not point to a directory: " + path;
 }
 
 
 path_not_a_directory
-::~path_not_a_directory() VITAL_NOTHROW
+::~path_not_a_directory() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 invalid_file
-::invalid_file( path_t const& path, std::string const& reason ) VITAL_NOTHROW
+::invalid_file( path_t const& path, std::string const& reason ) noexcept
 {
   std::ostringstream ss;
 
@@ -110,28 +110,28 @@ invalid_file
 
 
 invalid_file
-::~invalid_file() VITAL_NOTHROW
+::~invalid_file() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 invalid_data
-::invalid_data( std::string const& reason ) VITAL_NOTHROW
+::invalid_data( std::string const& reason ) noexcept
 {
   m_what = "Invalid data: " + reason;
 }
 
 
 invalid_data
-::~invalid_data() VITAL_NOTHROW
+::~invalid_data() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 file_not_found_exception
-::file_not_found_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::file_not_found_exception( path_t const& file_path, std::string const& reason ) noexcept
 {
   std::ostringstream sstr;
 
@@ -142,14 +142,14 @@ file_not_found_exception
 
 
 file_not_found_exception
-::~file_not_found_exception() VITAL_NOTHROW
+::~file_not_found_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 file_not_read_exception
-::file_not_read_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::file_not_read_exception( path_t const& file_path, std::string const& reason ) noexcept
 {
   std::ostringstream sstr;
 
@@ -160,14 +160,14 @@ file_not_read_exception
 
 
 file_not_read_exception
-::~file_not_read_exception() VITAL_NOTHROW
+::~file_not_read_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 file_write_exception
-::file_write_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW
+::file_write_exception( path_t const& file_path, std::string const& reason ) noexcept
 {
   std::ostringstream sstr;
 
@@ -178,7 +178,7 @@ file_write_exception
 
 
 file_write_exception
-::~file_write_exception() VITAL_NOTHROW
+::~file_write_exception() noexcept
 {
 }
 

--- a/vital/exceptions/io.h
+++ b/vital/exceptions/io.h
@@ -50,9 +50,9 @@ class VITAL_EXPORT io_exception
 {
 public:
   /// Constructor
-  io_exception() VITAL_NOTHROW;
+  io_exception() noexcept;
   /// Destructor
-  virtual ~io_exception() VITAL_NOTHROW;
+  virtual ~io_exception() noexcept;
 };
 
 
@@ -66,9 +66,9 @@ public:
   /**
    * \param path The path that doesn't point to an existing file or directory
    */
-  path_not_exists(path_t const& path) VITAL_NOTHROW;
+  path_not_exists(path_t const& path) noexcept;
   /// Destructor
-  virtual ~path_not_exists() VITAL_NOTHROW;
+  virtual ~path_not_exists() noexcept;
 };
 
 
@@ -82,9 +82,9 @@ public:
   /**
    * \param path The path that doesn't point to a file.
    */
-  path_not_a_file(path_t const& path) VITAL_NOTHROW;
+  path_not_a_file(path_t const& path) noexcept;
   /// Destructor
-  virtual ~path_not_a_file() VITAL_NOTHROW;
+  virtual ~path_not_a_file() noexcept;
 };
 
 
@@ -98,9 +98,9 @@ public:
   /**
    * \param path The path that doesn't point to a directory.
    */
-  path_not_a_directory(path_t const& path) VITAL_NOTHROW;
+  path_not_a_directory(path_t const& path) noexcept;
   /// Destructor
-  virtual ~path_not_a_directory() VITAL_NOTHROW;
+  virtual ~path_not_a_directory() noexcept;
 };
 
 
@@ -115,9 +115,9 @@ public:
    * \param file    The file that has been deemed invalid
    * \param reason  The reason for invalidity.
    */
-  invalid_file(path_t const& file, std::string const& reason) VITAL_NOTHROW;
+  invalid_file(path_t const& file, std::string const& reason) noexcept;
   /// Destructor
-  virtual ~invalid_file() VITAL_NOTHROW;
+  virtual ~invalid_file() noexcept;
 };
 
 
@@ -128,9 +128,9 @@ class VITAL_EXPORT invalid_data
 {
 public:
   /// Constructor
-  invalid_data(std::string const& reason) VITAL_NOTHROW;
+  invalid_data(std::string const& reason) noexcept;
   /// Destructor
-  virtual ~invalid_data() VITAL_NOTHROW;
+  virtual ~invalid_data() noexcept;
 };
 
 
@@ -145,9 +145,9 @@ public:
    * \param file_path The file path that was looked for.
    * \param reason    The reason the file wasn't found.
    */
-  file_not_found_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW;
+  file_not_found_exception( path_t const& file_path, std::string const& reason ) noexcept;
   /// Deconstructor
-  virtual ~file_not_found_exception() VITAL_NOTHROW;
+  virtual ~file_not_found_exception() noexcept;
 };
 
 
@@ -162,9 +162,9 @@ public:
    * \param file_path The file path on which the read was attempted.
    * \param reason    The reason for the read exception.
    */
-  file_not_read_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW;
+  file_not_read_exception( path_t const& file_path, std::string const& reason ) noexcept;
   /// Deconstructor
-  virtual ~file_not_read_exception() VITAL_NOTHROW;
+  virtual ~file_not_read_exception() noexcept;
 };
 
 
@@ -179,9 +179,9 @@ public:
    * \param file_path The file path to which the write was attempted.
    * \param reason    The reason for the exception
    */
-  file_write_exception( path_t const& file_path, std::string const& reason ) VITAL_NOTHROW;
+  file_write_exception( path_t const& file_path, std::string const& reason ) noexcept;
   /// Deconstructor
-  virtual ~file_write_exception() VITAL_NOTHROW;
+  virtual ~file_write_exception() noexcept;
 };
 
 

--- a/vital/exceptions/klv.cxx
+++ b/vital/exceptions/klv.cxx
@@ -41,7 +41,7 @@ klv_exception
 
 
 klv_exception
-::~klv_exception() VITAL_NOTHROW
+::~klv_exception() noexcept
 { }
 
 

--- a/vital/exceptions/klv.h
+++ b/vital/exceptions/klv.h
@@ -50,7 +50,7 @@ class VITAL_EXPORT klv_exception
 public:
   klv_exception( std::string const& str );
 
-  virtual ~klv_exception() VITAL_NOTHROW;
+  virtual ~klv_exception() noexcept;
 };
 
 } } // end namespace

--- a/vital/exceptions/math.cxx
+++ b/vital/exceptions/math.cxx
@@ -40,49 +40,49 @@ namespace vital {
 
 
 math_exception
-::math_exception() VITAL_NOTHROW
+::math_exception() noexcept
 {
   m_what = "A math exception occurred.";
 }
 
 math_exception
-::~math_exception() VITAL_NOTHROW
+::~math_exception() noexcept
 {
 }
 
 
 non_invertible_matrix
-::non_invertible_matrix() VITAL_NOTHROW
+::non_invertible_matrix() noexcept
 {
   m_what = "A matrix was found to be non-invertible";
 }
 
 non_invertible_matrix
-::~non_invertible_matrix() VITAL_NOTHROW
+::~non_invertible_matrix() noexcept
 {
 }
 
 
 point_maps_to_infinity
-::point_maps_to_infinity() VITAL_NOTHROW
+::point_maps_to_infinity() noexcept
 {
   m_what = "A point mapped to infinity";
 }
 
 point_maps_to_infinity
-::~point_maps_to_infinity() VITAL_NOTHROW
+::~point_maps_to_infinity() noexcept
 {
 }
 
 
 invalid_matrix_operation
-::invalid_matrix_operation(std::string reason) VITAL_NOTHROW
+::invalid_matrix_operation(std::string reason) noexcept
 {
   m_what = "Invalid operation: " + reason;
 }
 
 invalid_matrix_operation
-::~invalid_matrix_operation() VITAL_NOTHROW
+::~invalid_matrix_operation() noexcept
 {
 }
 

--- a/vital/exceptions/math.h
+++ b/vital/exceptions/math.h
@@ -50,9 +50,9 @@ class VITAL_EXPORT math_exception
 {
 public:
   /// Constructor
-  math_exception() VITAL_NOTHROW;
+  math_exception() noexcept;
   /// Destructor
-  virtual ~math_exception() VITAL_NOTHROW;
+  virtual ~math_exception() noexcept;
 };
 
 
@@ -62,9 +62,9 @@ class VITAL_EXPORT non_invertible_matrix
 {
 public:
   /// Constructor
-  non_invertible_matrix() VITAL_NOTHROW;
+  non_invertible_matrix() noexcept;
   /// Destructor
-  virtual ~non_invertible_matrix() VITAL_NOTHROW;
+  virtual ~non_invertible_matrix() noexcept;
 };
 
 
@@ -74,9 +74,9 @@ class VITAL_EXPORT point_maps_to_infinity
 {
 public:
   /// Constructor
-  point_maps_to_infinity() VITAL_NOTHROW;
+  point_maps_to_infinity() noexcept;
   /// Destructor
-  virtual ~point_maps_to_infinity() VITAL_NOTHROW;
+  virtual ~point_maps_to_infinity() noexcept;
 };
 
 
@@ -89,9 +89,9 @@ public:
   /*
    * \param reason  The reason for invalidity.
    */
-  invalid_matrix_operation(std::string reason) VITAL_NOTHROW;
+  invalid_matrix_operation(std::string reason) noexcept;
   /// Destructor
-  virtual ~invalid_matrix_operation() VITAL_NOTHROW;
+  virtual ~invalid_matrix_operation() noexcept;
 
   /// Reason the operation is invalid
   std::string m_reason;

--- a/vital/exceptions/plugin.cxx
+++ b/vital/exceptions/plugin.cxx
@@ -41,51 +41,51 @@ namespace vital {
 
 // ------------------------------------------------------------------
 plugin_exception
-::plugin_exception() VITAL_NOTHROW
+::plugin_exception() noexcept
 {
 }
 
 plugin_exception
-::~plugin_exception() VITAL_NOTHROW
+::~plugin_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 plugin_factory_not_found
-::plugin_factory_not_found( std::string const& msg) VITAL_NOTHROW
+::plugin_factory_not_found( std::string const& msg) noexcept
 {
   m_what = msg;
 }
 
 plugin_factory_not_found
-::~plugin_factory_not_found() VITAL_NOTHROW
+::~plugin_factory_not_found() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 plugin_factory_type_creation_error
-::plugin_factory_type_creation_error( std::string const& msg) VITAL_NOTHROW
+::plugin_factory_type_creation_error( std::string const& msg) noexcept
 {
   m_what = msg;
 }
 
 plugin_factory_type_creation_error
-::~plugin_factory_type_creation_error() VITAL_NOTHROW
+::~plugin_factory_type_creation_error() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 plugin_already_exists
-::plugin_already_exists( std::string const& msg) VITAL_NOTHROW
+::plugin_already_exists( std::string const& msg) noexcept
 {
   m_what = msg;
 }
 
 plugin_already_exists
-::~plugin_already_exists() VITAL_NOTHROW
+::~plugin_already_exists() noexcept
 {
 }
 

--- a/vital/exceptions/plugin.h
+++ b/vital/exceptions/plugin.h
@@ -48,10 +48,10 @@ class VITAL_EXPORT plugin_exception
 {
 public:
   /// Constructor
-  plugin_exception() VITAL_NOTHROW;
+  plugin_exception() noexcept;
 
   /// Destructor
-  virtual ~plugin_exception() VITAL_NOTHROW;
+  virtual ~plugin_exception() noexcept;
 };
 
 
@@ -62,10 +62,10 @@ class VITAL_EXPORT plugin_factory_not_found
 {
 public:
   /// Constructor
-  plugin_factory_not_found( std::string const& msg) VITAL_NOTHROW;
+  plugin_factory_not_found( std::string const& msg) noexcept;
 
   /// Destructor
-  virtual ~plugin_factory_not_found() VITAL_NOTHROW;
+  virtual ~plugin_factory_not_found() noexcept;
 };
 
 
@@ -76,10 +76,10 @@ class VITAL_EXPORT plugin_factory_type_creation_error
 {
 public:
   /// Constructor
-  plugin_factory_type_creation_error( std::string const& msg) VITAL_NOTHROW;
+  plugin_factory_type_creation_error( std::string const& msg) noexcept;
 
   /// Destructor
-  virtual ~plugin_factory_type_creation_error() VITAL_NOTHROW;
+  virtual ~plugin_factory_type_creation_error() noexcept;
 };
 
 
@@ -90,10 +90,10 @@ class VITAL_EXPORT plugin_already_exists
 {
 public:
   /// Constructor
-  plugin_already_exists( std::string const& msg) VITAL_NOTHROW;
+  plugin_already_exists( std::string const& msg) noexcept;
 
   /// Destructor
-  virtual ~plugin_already_exists() VITAL_NOTHROW;
+  virtual ~plugin_already_exists() noexcept;
 };
 
 } } // end namespace

--- a/vital/exceptions/video.cxx
+++ b/vital/exceptions/video.cxx
@@ -41,68 +41,68 @@ namespace vital {
 
 // ------------------------------------------------------------------
 video_exception
-::video_exception() VITAL_NOTHROW
+::video_exception() noexcept
 {
   m_what = "Yo, Yo, we have a Vide-o exception";
 }
 
 video_exception
-::~video_exception() VITAL_NOTHROW
+::~video_exception() noexcept
 {
 }
 
 // ------------------------------------------------------------------
 video_input_timeout_exception
-::video_input_timeout_exception() VITAL_NOTHROW
+::video_input_timeout_exception() noexcept
 {
   m_what = "End of video exception";
 }
 
 
 video_input_timeout_exception
-::~video_input_timeout_exception() VITAL_NOTHROW
+::~video_input_timeout_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 video_stream_exception
-::video_stream_exception( std::string const& msg) VITAL_NOTHROW
+::video_stream_exception( std::string const& msg) noexcept
 {
   m_what = "Video stream exception:" + msg;
 }
 
 
 video_stream_exception
-::~video_stream_exception() VITAL_NOTHROW
+::~video_stream_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 video_config_exception
-::video_config_exception( std::string const& msg) VITAL_NOTHROW
+::video_config_exception( std::string const& msg) noexcept
 {
   m_what = "Video config exception:" + msg;
 }
 
 
 video_config_exception
-::~video_config_exception() VITAL_NOTHROW
+::~video_config_exception() noexcept
 {
 }
 
 
 // ------------------------------------------------------------------
 video_runtime_exception
-::video_runtime_exception( std::string const& msg) VITAL_NOTHROW
+::video_runtime_exception( std::string const& msg) noexcept
 {
   m_what = "Video runtime exception: " + msg;
 }
 
 
 video_runtime_exception
-::~video_runtime_exception() VITAL_NOTHROW
+::~video_runtime_exception() noexcept
 {
 }
 

--- a/vital/exceptions/video.h
+++ b/vital/exceptions/video.h
@@ -50,10 +50,10 @@ class VITAL_EXPORT video_exception
 {
 public:
   /// Constructor
-  video_exception() VITAL_NOTHROW;
+  video_exception() noexcept;
 
   /// Destructor
-  virtual ~video_exception() VITAL_NOTHROW;
+  virtual ~video_exception() noexcept;
 };
 
 
@@ -68,10 +68,10 @@ class VITAL_EXPORT video_input_timeout_exception
 {
 public:
   /// Constructor
-  video_input_timeout_exception() VITAL_NOTHROW;
+  video_input_timeout_exception() noexcept;
 
   /// Destructor
-  virtual ~video_input_timeout_exception() VITAL_NOTHROW;
+  virtual ~video_input_timeout_exception() noexcept;
 };
 
 
@@ -86,10 +86,10 @@ class VITAL_EXPORT video_stream_exception
 {
 public:
   /// Constructor
-  video_stream_exception( std::string const& msg ) VITAL_NOTHROW;
+  video_stream_exception( std::string const& msg ) noexcept;
 
   /// Destructor
-  virtual ~video_stream_exception() VITAL_NOTHROW;
+  virtual ~video_stream_exception() noexcept;
 };
 
 
@@ -104,10 +104,10 @@ class VITAL_EXPORT video_config_exception
 {
 public:
   /// Constructor
-  video_config_exception( std::string const& msg ) VITAL_NOTHROW;
+  video_config_exception( std::string const& msg ) noexcept;
 
   /// Destructor
-  virtual ~video_config_exception() VITAL_NOTHROW;
+  virtual ~video_config_exception() noexcept;
 };
 
 // ------------------------------------------------------------------
@@ -121,10 +121,10 @@ class VITAL_EXPORT video_runtime_exception
 {
 public:
   /// Constructor
-  video_runtime_exception( std::string const& msg ) VITAL_NOTHROW;
+  video_runtime_exception( std::string const& msg ) noexcept;
 
   /// Destructor
-  virtual ~video_runtime_exception() VITAL_NOTHROW;
+  virtual ~video_runtime_exception() noexcept;
 };
 
 } } // end namespace

--- a/vital/video_metadata/video_metadata.cxx
+++ b/vital/video_metadata/video_metadata.cxx
@@ -55,7 +55,7 @@ video_metadata_exception
 
 
 video_metadata_exception
-::~video_metadata_exception() VITAL_NOTHROW
+::~video_metadata_exception() noexcept
 { }
 
 

--- a/vital/video_metadata/video_metadata.h
+++ b/vital/video_metadata/video_metadata.h
@@ -64,7 +64,7 @@ class VITAL_VIDEO_METADATA_EXPORT video_metadata_exception
 public:
   video_metadata_exception( std::string const& str );
 
-  virtual ~video_metadata_exception() VITAL_NOTHROW;
+  virtual ~video_metadata_exception() noexcept;
 };
 
 


### PR DESCRIPTION
Replace uses of `VITAL_NOTHROW` with `noexcept`. This is a no-op change, since `VITAL_NOTHROW` is defined to `noexcept` anyway, but it is part of an effort to modernize the code by by removing use of C++11 feature shims which existed for compatibility with older compilers (which we no longer support).