### PR TITLE
Remove Qt from "dependencies"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ addons:
     - libproj-dev
     - libgl1-mesa-dev
     - libxt-dev
-    - libqt4-dev
     - libatlas-base-dev
     - python2.7-dev
 

--- a/doc/manuals/install_guide.rst
+++ b/doc/manuals/install_guide.rst
@@ -19,7 +19,7 @@ should help to provide a starting point.
 .. code::
 
   sudo apt-get install git zlib1g-dev libcurl4-openssl-dev libexpat1-dev dh-autoreconf liblapack-dev libxt-dev
-  sudo apt-get build-dep libboost-all-dev qt5-default
+  sudo apt-get build-dep libboost-all-dev
 
 Install CMAKE
 =============


### PR DESCRIPTION
Remove references to Qt from the build instructions and Travis config. These probably  sneaked in from copying stuff from MapTk, but are not needed for KWIVER.