### PR TITLE
Fixed typo in PYTHON_VERSION varname

### DIFF
--- a/CMake/kwiver-setup-python.cmake
+++ b/CMake/kwiver-setup-python.cmake
@@ -153,8 +153,8 @@ import sys
 print(sys.version[0:3])
 ")
 # assert that the right python version was found
-if(NOT _python_version MATCHES "^${fletch_PYTHON_MAJOR_VERSION}.*")
-  message(FATAL_ERROR "Requested python \"${fletch_PYTHON_MAJOR_VERSION}\" but got \"${_python_version}\"")
+if(NOT PYTHON_VERSION MATCHES "^${KWIVER_PYTHON_MAJOR_VERSION}.*")
+  message(FATAL_ERROR "Requested python \"${KWIVER_PYTHON_MAJOR_VERSION}\" but got \"${PYTHON_VERSION}\"")
 endif()
 
 


### PR DESCRIPTION
The variable `_python_version` was not defined. I fixed the script to use `PYTHON_VERSION`. 

Looking at this again I was trying to figure out how it ever worked. Then I realized that the `fletch_MAJOR_PYTHON_VERSION` does not exist yet in fletch master. So it was working because both variables were undefined. What I should have been checking is the `PYTHON_VERSION` variable against the `KWIVER_MAJOR_PYTHON_VERSION` variable.  This patch fixes the code to do that. 