### PR TITLE
Assorted C++11 cleanup

### DIFF
--- a/sprokit/src/sprokit/pipeline_util/lex_processor.h
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.h
@@ -60,7 +60,7 @@ namespace sprokit {
  * 5) Quit when EOF token is returned.
  *
  */
-class SPROKIT_PIPELINE_UTIL_EXPORT lex_processor VITAL_FINAL
+class SPROKIT_PIPELINE_UTIL_EXPORT lex_processor final
 {
 public:
   /**

--- a/sprokit/src/sprokit/pipeline_util/pipe_parser.h
+++ b/sprokit/src/sprokit/pipeline_util/pipe_parser.h
@@ -55,7 +55,7 @@ namespace sprokit {
  * @brief Pipe and cluster parser.
  *
  */
-class SPROKIT_PIPELINE_UTIL_EXPORT pipe_parser VITAL_FINAL
+class SPROKIT_PIPELINE_UTIL_EXPORT pipe_parser final
 {
 public:
   // -- CONSTRUCTORS --

--- a/sprokit/src/sprokit/tools/tool_usage.h
+++ b/sprokit/src/sprokit/tools/tool_usage.h
@@ -43,7 +43,7 @@
 namespace sprokit
 {
 
-VITAL_NO_RETURN SPROKIT_TOOLS_EXPORT void tool_usage(int ret, boost::program_options::options_description const& options);
+[[noreturn]] SPROKIT_TOOLS_EXPORT void tool_usage(int ret, boost::program_options::options_description const& options);
 SPROKIT_TOOLS_EXPORT void tool_version_message();
 
 SPROKIT_TOOLS_EXPORT boost::program_options::options_description tool_common_options();

--- a/vital/algo/algorithm.h
+++ b/vital/algo/algorithm.h
@@ -70,7 +70,7 @@ public:
   virtual std::string type_name() const = 0;
 
   /// Return the name of this implementation
-  virtual std::string impl_name() const VITAL_FINAL;
+  virtual std::string impl_name() const final;
 
   /// Get this algorithm's \link kwiver::vital::config_block configuration block \endlink
   /**

--- a/vital/any.h
+++ b/vital/any.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -232,7 +232,7 @@ private:
     T m_any_data;
 
     // -- NOT IMPLEMENTED --
-    internal_typed& operator=( const internal_typed& ) VITAL_DELETE_DECL;
+    internal_typed& operator=( const internal_typed& ) = delete;
   };
 
 

--- a/vital/vital_config.h.in
+++ b/vital/vital_config.h.in
@@ -45,6 +45,8 @@
 // Support macros.
 #if defined(_WIN32) || defined(_WIN64)
 
+// TODO use C++17 attributes if available
+
 # define VITAL_MUST_USE_RESULT  /* unsupported */
 # define VITAL_UNUSED           /* unsupported */
 # define VITAL_SYSTEM_WIN_API (1)
@@ -56,6 +58,8 @@
 # define VITAL_SYSTEM_WIN_API (0)
 
 #else
+
+// TODO use C++17 attributes if available
 
 # define VITAL_MUST_USE_RESULT  /* unsupported */
 # define VITAL_UNUSED           /* unsupported */


### PR DESCRIPTION
Add TODO to use C++17 attributes when available for some of our decorations that currently are using old-style, GCC-only attributes. Remove uses of `VITAL_FINAL`, `VITAL_NO_RETURN` and `VITAL_DELETE_DECL`, replacing them with direct use of C++11 features.