### PR TITLE
Remove use of VITAL_DEFAULT_[CD]TOR

### DIFF
--- a/arrows/core/class_probablity_filter.h
+++ b/arrows/core/class_probablity_filter.h
@@ -68,7 +68,7 @@ class KWIVER_ALGO_CORE_EXPORT class_probablity_filter
 public:
 
   class_probablity_filter();
-  virtual ~class_probablity_filter() VITAL_DEFAULT_DTOR
+  virtual ~class_probablity_filter() = default;
 
   virtual vital::config_block_sptr get_configuration() const;
 

--- a/arrows/core/close_loops_bad_frames_only.h
+++ b/arrows/core/close_loops_bad_frames_only.h
@@ -67,7 +67,7 @@ public:
   close_loops_bad_frames_only();
 
   /// Destructor
-  virtual ~close_loops_bad_frames_only() VITAL_DEFAULT_DTOR;
+  virtual ~close_loops_bad_frames_only() = default;
 
   /// Returns implementation description
   virtual std::string description() const;

--- a/arrows/core/close_loops_multi_method.h
+++ b/arrows/core/close_loops_multi_method.h
@@ -66,7 +66,7 @@ public:
   close_loops_multi_method();
 
   /// Destructor
-  virtual ~close_loops_multi_method() VITAL_DEFAULT_DTOR;
+  virtual ~close_loops_multi_method() = default;
 
   /// Returns implementation description string
   virtual std::string description() const;

--- a/arrows/core/track_set_impl.h
+++ b/arrows/core/track_set_impl.h
@@ -73,7 +73,7 @@ public:
   explicit frame_index_track_set_impl( const std::vector< vital::track_sptr >& tracks );
 
   /// Destructor
-  virtual ~frame_index_track_set_impl() VITAL_DEFAULT_DTOR
+  virtual ~frame_index_track_set_impl() = default;
 
   /// Return the number of tracks in the set
   virtual size_t size() const;

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -112,7 +112,7 @@ public:
       .add_attribute( PLUGIN_CATEGORY, "scheduler" );
   }
 
-  virtual ~scheduler_factory() VITAL_DEFAULT_DTOR
+  virtual ~scheduler_factory() = default;
 
   virtual sprokit::scheduler_t create_object( pipeline_t const& pipe,
                                               kwiver::vital::config_block_sptr const& config )

--- a/vital/algo/algorithm.h
+++ b/vital/algo/algorithm.h
@@ -64,7 +64,7 @@ typedef std::shared_ptr< algorithm > algorithm_sptr;
 class VITAL_ALGO_EXPORT algorithm
 {
 public:
-  virtual ~algorithm() VITAL_DEFAULT_DTOR;
+  virtual ~algorithm() = default;
 
   /// Return the name of the base algorithm
   virtual std::string type_name() const = 0;
@@ -234,7 +234,7 @@ public:
   /// Shared pointer type of the templated vital::algorithm_def class
   typedef std::shared_ptr<Self> base_sptr;
 
-  virtual ~algorithm_def() VITAL_DEFAULT_DTOR;
+  virtual ~algorithm_def() = default;
 
   /// Factory method to make an instance of this algorithm by impl_name
   static base_sptr create(std::string const& impl_name);
@@ -347,7 +347,7 @@ class algorithm_impl
 public:
   /// shared pointer type of this impl's base vital::algorithm_def class.
 
-  virtual ~algorithm_impl() VITAL_DEFAULT_DTOR;
+  virtual ~algorithm_impl() = default;
 };
 
 

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -68,7 +68,7 @@ public:
       .add_attribute( PLUGIN_CATEGORY, "algorithm" );
   }
 
-  virtual ~algorithm_factory() VITAL_DEFAULT_DTOR
+  virtual ~algorithm_factory() = default;
 
   algorithm_sptr create_object()
   {
@@ -98,7 +98,7 @@ public:
     this->add_attribute( CONCRETE_TYPE, typeid( IMPL ).name() );
   }
 
-  virtual ~algorithm_factory_0() VITAL_DEFAULT_DTOR
+  virtual ~algorithm_factory_0() = default;
 
 protected:
   virtual algorithm_sptr create_object_a()

--- a/vital/algo/feature_descriptor_io.h
+++ b/vital/algo/feature_descriptor_io.h
@@ -58,7 +58,7 @@ class VITAL_ALGO_EXPORT feature_descriptor_io
   : public kwiver::vital::algorithm_def<feature_descriptor_io>
 {
 public:
-  virtual ~feature_descriptor_io() VITAL_DEFAULT_DTOR;
+  virtual ~feature_descriptor_io() = default;
 
   /// Return the name of this algorithm
   static std::string static_type_name() { return "feature_descriptor_io"; }

--- a/vital/algo/image_io.h
+++ b/vital/algo/image_io.h
@@ -57,7 +57,7 @@ class VITAL_ALGO_EXPORT image_io
   : public kwiver::vital::algorithm_def<image_io>
 {
 public:
-  virtual ~image_io() VITAL_DEFAULT_DTOR;
+  virtual ~image_io() = default;
 
   /// Return the name of this algorithm
   static std::string static_type_name() { return "image_io"; }

--- a/vital/bindings/c/helpers/c_utils.h
+++ b/vital/bindings/c/helpers/c_utils.h
@@ -216,7 +216,7 @@ public:
 
   // ------------------------------------------------------------------
   /// Destructor
-  virtual ~SharedPointerCache() VITAL_DEFAULT_DTOR
+  virtual ~SharedPointerCache() = default;
 
   // ------------------------------------------------------------------
   /// Store a shared pointer

--- a/vital/logger/default_logger.cxx
+++ b/vital/logger/default_logger.cxx
@@ -111,7 +111,7 @@ public:
     }
   }
 
-  virtual ~default_logger() VITAL_DEFAULT_DTOR
+  virtual ~default_logger() = default;
 
   // Check to see if level is enabled
   virtual bool is_fatal_enabled() const { return m_logLevel <= kwiver_logger::LEVEL_FATAL;  }

--- a/vital/logger/default_logger.h
+++ b/vital/logger/default_logger.h
@@ -67,7 +67,7 @@ class logger_factory_default
 {
 public:
   logger_factory_default();
-  virtual ~logger_factory_default() VITAL_DEFAULT_DTOR
+  virtual ~logger_factory_default() = default;
 
   /**
    * @brief Get logger object for /c name.

--- a/vital/logger/kwiver_logger_manager.cxx
+++ b/vital/logger/kwiver_logger_manager.cxx
@@ -76,8 +76,8 @@ kwiver_logger_manager* kwiver_logger_manager::s_instance = 0;
 class kwiver_logger_manager::impl
 {
 public:
-  impl() VITAL_DEFAULT_CTOR
-  ~impl() VITAL_DEFAULT_DTOR
+  impl() = default;
+  ~impl() = default;
 
   std::unique_ptr< logger_ns::kwiver_logger_factory > m_logFactory;
 

--- a/vital/plugin_loader/plugin_factory.h
+++ b/vital/plugin_loader/plugin_factory.h
@@ -204,7 +204,7 @@ public:
     this->add_attribute( CONCRETE_TYPE, typeid( T ).name() );
   }
 
-  virtual ~plugin_factory_0() VITAL_DEFAULT_DTOR
+  virtual ~plugin_factory_0() = default;
 
 protected:
   virtual void* create_object_i()

--- a/vital/tests/test_estimate_similarity_transform.cxx
+++ b/vital/tests/test_estimate_similarity_transform.cxx
@@ -69,7 +69,7 @@ public:
     : expected_size(expected_size)
   {}
 
-  virtual ~dummy_est() VITAL_DEFAULT_DTOR
+  virtual ~dummy_est() = default;
 
   void set_configuration(kwiver::vital::config_block_sptr config) {}
   bool check_configuration(kwiver::vital::config_block_sptr config) const {return true;}

--- a/vital/tools/explorer_plugin.h
+++ b/vital/tools/explorer_plugin.h
@@ -146,8 +146,8 @@ class category_explorer
 {
 public:
   // -- CONSTRUCTORS --
-  category_explorer() VITAL_DEFAULT_CTOR
-  virtual ~category_explorer() VITAL_DEFAULT_DTOR
+  category_explorer() = default;
+  virtual ~category_explorer() = default;
 
   /**
    * @brief Initialize the plugin

--- a/vital/types/camera.h
+++ b/vital/types/camera.h
@@ -72,7 +72,7 @@ class VITAL_EXPORT camera
 {
 public:
   /// Destructor
-  virtual ~camera() VITAL_DEFAULT_DTOR
+  virtual ~camera() = default;
 
   /// Create a clone of this camera object
   virtual camera_sptr clone() const = 0;

--- a/vital/types/camera_map.h
+++ b/vital/types/camera_map.h
@@ -55,7 +55,7 @@ public:
   typedef std::map< frame_id_t, camera_sptr > map_camera_t;
 
   /// Destructor
-  virtual ~camera_map() VITAL_DEFAULT_DTOR
+  virtual ~camera_map() = default;
 
   /// Return the number of cameras in the map
   virtual size_t size() const = 0;

--- a/vital/types/descriptor.h
+++ b/vital/types/descriptor.h
@@ -56,7 +56,7 @@ class descriptor
 {
 public:
   /// Destructor
-  virtual ~descriptor() VITAL_DEFAULT_DTOR
+  virtual ~descriptor() = default;
 
   /// Access the type info of the underlying data (double or float)
   virtual std::type_info const& data_type() const = 0;

--- a/vital/types/descriptor_request.h
+++ b/vital/types/descriptor_request.h
@@ -60,7 +60,7 @@ class descriptor_request
 public:
 
   descriptor_request();
-  ~descriptor_request() VITAL_DEFAULT_DTOR
+  ~descriptor_request() = default;
 
   uid id() const;
 

--- a/vital/types/descriptor_set.h
+++ b/vital/types/descriptor_set.h
@@ -55,7 +55,7 @@ class descriptor_set
 {
 public:
   /// Destructor
-  virtual ~descriptor_set() VITAL_DEFAULT_DTOR
+  virtual ~descriptor_set() = default;
 
   /// Return the number of descriptors in the set
   virtual size_t size() const = 0;

--- a/vital/types/detected_object.h
+++ b/vital/types/detected_object.h
@@ -93,7 +93,7 @@ public:
                    double confidence = 1.0,
                    detected_object_type_sptr classifications = detected_object_type_sptr() );
 
-  virtual ~detected_object() VITAL_DEFAULT_DTOR
+  virtual ~detected_object() = default;
 
   /**
    * @brief Create a deep copy of this object.

--- a/vital/types/detected_object_set.h
+++ b/vital/types/detected_object_set.h
@@ -81,7 +81,7 @@ public:
    */
   detected_object_set();
 
-  ~detected_object_set() VITAL_DEFAULT_DTOR
+  ~detected_object_set() = default;
 
   /**
    * @brief Create new set of detected objects.

--- a/vital/types/essential_matrix.h
+++ b/vital/types/essential_matrix.h
@@ -68,7 +68,7 @@ class VITAL_EXPORT essential_matrix
 {
 public:
   /// Destructor
-  virtual ~essential_matrix() VITAL_DEFAULT_DTOR
+  virtual ~essential_matrix() = default;
 
   /// Create a clone of this essential_matrix object, returning as smart pointer
   /**

--- a/vital/types/feature.h
+++ b/vital/types/feature.h
@@ -61,7 +61,7 @@ class feature
 {
 public:
   /// Destructor
-  virtual ~feature() VITAL_DEFAULT_DTOR
+  virtual ~feature() = default;
 
   /// Access the type info of the underlying data (double or float)
   virtual std::type_info const& data_type() const = 0;

--- a/vital/types/feature_set.h
+++ b/vital/types/feature_set.h
@@ -56,7 +56,7 @@ class feature_set
 {
 public:
   /// Destructor
-  virtual ~feature_set() VITAL_DEFAULT_DTOR
+  virtual ~feature_set() = default;
 
   /// Return the number of features in the set
   virtual size_t size() const = 0;

--- a/vital/types/feature_track_set.h
+++ b/vital/types/feature_track_set.h
@@ -100,7 +100,7 @@ public:
   feature_track_set(std::vector< track_sptr > const& tracks);
 
   /// Destructor
-  virtual ~feature_track_set() VITAL_DEFAULT_DTOR
+  virtual ~feature_track_set() = default;
 
   /// Return the set of features in tracks on the last frame
   virtual feature_set_sptr last_frame_features() const;

--- a/vital/types/fundamental_matrix.h
+++ b/vital/types/fundamental_matrix.h
@@ -67,7 +67,7 @@ class VITAL_EXPORT fundamental_matrix
 {
 public:
   /// Destructor
-  virtual ~fundamental_matrix() VITAL_DEFAULT_DTOR
+  virtual ~fundamental_matrix() = default;
 
   /// Create a clone of this fundamental_matrix object, returning as smart pointer
   /**

--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -73,7 +73,7 @@ public:
   geo_point();
   geo_point( geo_raw_point_t const&, int crs );
 
-  virtual ~geo_point() VITAL_DEFAULT_DTOR
+  virtual ~geo_point() = default;
 
   /**
    * \brief Accessor for location in original CRS.

--- a/vital/types/geo_polygon.h
+++ b/vital/types/geo_polygon.h
@@ -63,7 +63,7 @@ public:
   geo_polygon();
   geo_polygon( geo_raw_polygon_t const&, int crs );
 
-  virtual ~geo_polygon() VITAL_DEFAULT_DTOR
+  virtual ~geo_polygon() = default;
 
   /**
    * \brief Accessor for polygon in original CRS.

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -80,7 +80,7 @@ public:
   virtual vector_2d operator()( vector_2d const& point, int from, int to ) = 0;
 
 protected:
-  virtual ~geo_conversion() VITAL_DEFAULT_DTOR
+  virtual ~geo_conversion() = default;
 };
 
 /// Get the functor used for performing geodetic conversions. \see geo_conv

--- a/vital/types/homography.h
+++ b/vital/types/homography.h
@@ -67,7 +67,7 @@ class VITAL_EXPORT homography
 {
 public:
   /// Destructor
-  virtual ~homography() VITAL_DEFAULT_DTOR
+  virtual ~homography() = default;
 
   /// Access the type info of the underlying data
   virtual std::type_info const& data_type() const = 0;

--- a/vital/types/homography_f2f.h
+++ b/vital/types/homography_f2f.h
@@ -85,7 +85,7 @@ public:
   f2f_homography( f2f_homography const& h );
 
   /// Destructor
-  virtual ~f2f_homography() VITAL_DEFAULT_DTOR
+  virtual ~f2f_homography() = default;
 
   /// Get the sptr of the contained homography transformation
   virtual homography_sptr homography() const;

--- a/vital/types/homography_f2w.h
+++ b/vital/types/homography_f2w.h
@@ -58,7 +58,7 @@ public:
   /// Copy Constructor
   f2w_homography( f2w_homography const &h );
 
-  virtual ~f2w_homography() VITAL_DEFAULT_DTOR
+  virtual ~f2w_homography() = default;
 
   /// Get the homography transformation
   virtual homography_sptr homography() const;

--- a/vital/types/image_container.h
+++ b/vital/types/image_container.h
@@ -59,7 +59,7 @@ class image_container
 public:
 
   /// Destructor
-  virtual ~image_container() VITAL_DEFAULT_DTOR
+  virtual ~image_container() = default;
 
   /// The size of the image data in bytes
   /**

--- a/vital/types/landmark.h
+++ b/vital/types/landmark.h
@@ -65,7 +65,7 @@ class landmark
 {
 public:
   /// Destructor
-  virtual ~landmark() VITAL_DEFAULT_DTOR
+  virtual ~landmark() = default;
 
   /// Create a clone of this landmark object
   virtual landmark_sptr clone() const = 0;

--- a/vital/types/landmark_map.h
+++ b/vital/types/landmark_map.h
@@ -55,7 +55,7 @@ public:
   typedef std::map< landmark_id_t, landmark_sptr > map_landmark_t;
 
   /// Destructor
-  virtual ~landmark_map() VITAL_DEFAULT_DTOR
+  virtual ~landmark_map() = default;
 
   /// Return the number of landmarks in the map
   virtual size_t size() const = 0;

--- a/vital/types/match_set.h
+++ b/vital/types/match_set.h
@@ -53,7 +53,7 @@ class match_set
 {
 public:
   /// Destructor
-  virtual ~match_set() VITAL_DEFAULT_DTOR
+  virtual ~match_set() = default;
 
   /// Return the number of matches in the set
   virtual size_t size() const = 0;

--- a/vital/types/object_track_set.h
+++ b/vital/types/object_track_set.h
@@ -104,7 +104,7 @@ public:
   object_track_set(std::vector< track_sptr > const& tracks);
 
   /// Destructor
-  virtual ~object_track_set() VITAL_DEFAULT_DTOR
+  virtual ~object_track_set() = default;
 };
 
 

--- a/vital/types/query_plan.h
+++ b/vital/types/query_plan.h
@@ -72,7 +72,7 @@ public:
   };
 
   query_plan();
-  ~query_plan() VITAL_DEFAULT_DTOR
+  ~query_plan() = default;
 
   /// Accessor for query plan unique identifier. \see set_id
   uid id() const;

--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -93,7 +93,7 @@ public:
   /// Access the track containing this state
   track_sptr track() const { return track_.lock(); }
 
-  virtual ~track_state() VITAL_DEFAULT_DTOR
+  virtual ~track_state() = default;
 
 private:
   /// The frame identifier for this state
@@ -108,7 +108,7 @@ private:
 class VITAL_EXPORT track_data
 {
 protected:
-  virtual ~track_data() VITAL_DEFAULT_DTOR
+  virtual ~track_data() = default;
 };
 
 typedef std::shared_ptr<track_data> track_data_sptr;
@@ -164,7 +164,7 @@ public:
   typedef std::vector< track_state_sptr >::const_iterator history_const_itr;
 
   /// Destructor
-  ~track() VITAL_DEFAULT_DTOR
+  ~track() = default;
 
   /// Factory function
   static track_sptr create( track_data_sptr data = nullptr );

--- a/vital/types/track_descriptor.h
+++ b/vital/types/track_descriptor.h
@@ -87,7 +87,7 @@ public:
     typedef bounding_box_d world_bbox_t;
 
     /// Constructors
-    ~history_entry() VITAL_DEFAULT_DTOR
+    ~history_entry() = default;
 
     /**
      * Create new object.

--- a/vital/types/track_set.h
+++ b/vital/types/track_set.h
@@ -62,7 +62,7 @@ class VITAL_EXPORT track_set_interface
 {
 public:
   /// Destructor
-  virtual ~track_set_interface() VITAL_DEFAULT_DTOR
+  virtual ~track_set_interface() = default;
 
   /// Return the number of tracks in the set
   virtual size_t size() const = 0;
@@ -252,7 +252,7 @@ class VITAL_EXPORT track_set_implementation
 {
 public:
   /// Destructor
-  virtual ~track_set_implementation() VITAL_DEFAULT_DTOR
+  virtual ~track_set_implementation() = default;
 
   /// Return the number of tracks in the set
   virtual size_t size() const;
@@ -317,7 +317,7 @@ class VITAL_EXPORT track_set
 {
 public:
   /// Destructor
-  virtual ~track_set() VITAL_DEFAULT_DTOR
+  virtual ~track_set() = default;
 
   /// Default Constructor
   /**

--- a/vital/util/any_converter.h
+++ b/vital/util/any_converter.h
@@ -54,8 +54,8 @@ namespace any_convert {
 template < typename DEST >
 struct convert_base
 {
-  convert_base() VITAL_DEFAULT_CTOR
-  virtual ~convert_base() VITAL_DEFAULT_DTOR
+  convert_base() = default;
+  virtual ~convert_base() = default;
 
   virtual bool can_convert( kwiver::vital::any const& data ) const = 0;
   virtual DEST convert( kwiver::vital::any const& data ) const = 0;
@@ -72,8 +72,8 @@ template < typename DEST, typename SRC >
 struct converter
   : public convert_base< DEST >
 {
-  converter() VITAL_DEFAULT_CTOR
-  virtual ~converter() VITAL_DEFAULT_DTOR
+  converter() = default;
+  virtual ~converter() = default;
 
   virtual bool can_convert( kwiver::vital::any const& data ) const
   {
@@ -183,7 +183,7 @@ struct converter< bool, std::string >
   }
 
 
-  virtual ~converter() VITAL_DEFAULT_DTOR
+  virtual ~converter() = default;
 
   virtual bool can_convert( kwiver::vital::any const & data ) const
   {
@@ -244,8 +244,8 @@ public:
   typedef std::shared_ptr< any_convert::convert_base< T > > converter_ptr;
 #endif
 
-  any_converter() VITAL_DEFAULT_CTOR
-  virtual ~any_converter() VITAL_DEFAULT_DTOR
+  any_converter() = default;
+  virtual ~any_converter() = default;
 
   /// Apply conversion to an kwiver::vital::any object.
   /**

--- a/vital/util/tests/test_any_convert.cxx
+++ b/vital/util/tests/test_any_convert.cxx
@@ -112,7 +112,7 @@ struct converter< bool, std::string >
   }
 
 
-  virtual ~converter() VITAL_DEFAULT_DTOR
+  virtual ~converter() = default;
 
   virtual bool can_convert( kwiver::vital::any const & data ) const
   {

--- a/vital/util/thread_pool.h
+++ b/vital/util/thread_pool.h
@@ -122,7 +122,7 @@ public:
     backend()  VITAL_DEFAULT_CTOR
 
     /// Destructor
-    virtual ~backend() VITAL_DEFAULT_DTOR
+    virtual ~backend() = default;
 
     /// Returns the number of worker threads
     virtual size_t num_threads() const = 0;
@@ -141,7 +141,7 @@ private:
   thread_pool();
 
   /// Destructor
-  ~thread_pool() VITAL_DEFAULT_DTOR
+  ~thread_pool() = default;
 
   /// Enqueue a void function in the thread pool
   void enqueue_task(std::function<void()> task);

--- a/vital/video_metadata/video_metadata_map.h
+++ b/vital/video_metadata/video_metadata_map.h
@@ -61,7 +61,7 @@ public:
   typedef std::map< frame_id_t, video_metadata_vector > map_video_metadata_t;
 
   /// Destructor
-  virtual ~video_metadata_map() VITAL_DEFAULT_DTOR
+  virtual ~video_metadata_map() = default;
 
   /// Return the number of frames in the map
   virtual size_t size() const = 0;


### PR DESCRIPTION
Replace uses of `VITAL_DEFAULT_CTOR` and `VITAL_DEFAULT_DTOR` with `= default`. This is a no-op change, since those macros expand to the same, but it is part of an effort to modernize the code by by removing use of C++11 feature shims which existed for compatibility with older compilers (which we no longer support).