### PR TITLE
moved python setup before utils are included

### DIFF
--- a/CMake/kwiver-utils.cmake
+++ b/CMake/kwiver-utils.cmake
@@ -6,6 +6,10 @@
 
 set( KWIVER_CMAKE_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
+if (KWIVER_ENABLE_PYTHON)
+  include( kwiver-setup-python )
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/utils/kwiver-utils-configuration.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/utils/kwiver-utils-targets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/utils/kwiver-utils-flags.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,6 @@ if (KWIVER_ENABLE_PYTHON)
   if ( NOT KWIVER_ENABLE_C_BINDINGS )
     message( SEND_ERROR  "Python can not be enabled unless KWIVER_ENABLE_C_BINDINGS is also enabled." )
   endif()
-  include( kwiver-setup-python )
 endif()
 
 set(BUILD_SHARED_LIBS ${KWIVER_BUILD_SHARED})


### PR DESCRIPTION
This fixes an issue in external projects (VIAME), where if `include(kwiver-utils)` was called, the functions in `kwiver-utils-python` would misbehave because `kwiver-setup-python` was never included. 

Instead of requiring the external projects to include `kwiver-setup-python`, it seems more reasonable to have the python setup happen in `kwiver-utils`. 