### PR TITLE
Added loggers to sprokit python modules

### DIFF
--- a/sprokit/src/bindings/python/CMakeLists.txt
+++ b/sprokit/src/bindings/python/CMakeLists.txt
@@ -53,7 +53,14 @@ add_subdirectory(processes)
 add_subdirectory(schedulers)
 add_subdirectory(test)
 
+
+sprokit_add_python_module("${CMAKE_CURRENT_SOURCE_DIR}/sprokit_logging.py"
+  sprokit sprokit_logging)
+
 set(python_noarch FALSE)
-sprokit_create_python_init(sprokit)
+sprokit_add_python_module("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py"
+  sprokit __init__)
 set(python_noarch TRUE)
-sprokit_create_python_init(sprokit)
+sprokit_add_python_module("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py"
+  sprokit __init__)
+

--- a/sprokit/src/bindings/python/__init__.py
+++ b/sprokit/src/bindings/python/__init__.py
@@ -23,4 +23,4 @@ from sprokit import sprokit_logging
 sprokit_logging._configure_logging()
 
 logger = sprokit_logging.getLogger(__name__)
-logger.debug('initializing the sprokit python module')
+# logger.debug('initializing the sprokit python module')

--- a/sprokit/src/bindings/python/__init__.py
+++ b/sprokit/src/bindings/python/__init__.py
@@ -2,18 +2,12 @@
 """
 The base SPROKIT package initialization
 """
+# flake8: noqa
 from __future__ import print_function, unicode_literals, absolute_import
 import sys
-from sprokit import sprokit_logging
-
-sprokit_logging._configure_logging()
-
-logger = sprokit_logging.SprokitLogger(__name__)
-logger.log('debug', 'initializing sprokit module')
 
 
 # Handle issues when called from pybind11 modules
-@sprokit_logging.exc_report
 def _pybind11_argv_workaround():
     """
     If this module is imported by pybind11, argv will not be populated.  This
@@ -21,5 +15,12 @@ def _pybind11_argv_workaround():
     """
     if not hasattr(sys, 'argv'):
         sys.argv = []
-
 _pybind11_argv_workaround()
+
+
+# Configure logging and initialize the root sprokit logger
+from sprokit import sprokit_logging
+sprokit_logging._configure_logging()
+
+logger = sprokit_logging.getLogger(__name__)
+logger.debug('initializing the sprokit python module')

--- a/sprokit/src/bindings/python/__init__.py
+++ b/sprokit/src/bindings/python/__init__.py
@@ -22,27 +22,4 @@ def _pybind11_argv_workaround():
     if not hasattr(sys, 'argv'):
         sys.argv = []
 
-
-@sprokit_logging.exc_report
-def _pybind11_excepthook_workaround():
-    """
-    Implement a custom excepthook to (try and) ensure python errors are
-    reported.
-
-    Currently, I'm unsure if this even does anything. Pybind11 might just not
-    care about excepthooks.
-    """
-    _sys_excepthook = getattr(sys, 'excepthook', None)
-
-    def sprokit_excepthook(*exc_info):
-        print('! SPROKIT EXCEPTHOOK WAS TRIGGERED !')
-        try:
-            sprokit_logging.print_exc(exc_info)
-        except Exception:
-            if _sys_excepthook is not None:
-                _sys_excepthook(*exc_info)
-
-    sys.excepthook = sprokit_excepthook
-
 _pybind11_argv_workaround()
-_pybind11_excepthook_workaround()

--- a/sprokit/src/bindings/python/__init__.py
+++ b/sprokit/src/bindings/python/__init__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+The base SPROKIT package initialization
+"""
+from __future__ import print_function, unicode_literals, absolute_import
+import sys
+from sprokit import sprokit_logging
+
+sprokit_logging._configure_logging()
+
+logger = sprokit_logging.SprokitLogger(__name__)
+logger.log('debug', 'initializing sprokit module')
+
+
+# Handle issues when called from pybind11 modules
+@sprokit_logging.exc_report
+def _pybind11_argv_workaround():
+    """
+    If this module is imported by pybind11, argv will not be populated.  This
+    can cause issues with other modules, so set it as an attribute here.
+    """
+    if not hasattr(sys, 'argv'):
+        sys.argv = []
+
+
+@sprokit_logging.exc_report
+def _pybind11_excepthook_workaround():
+    """
+    Implement a custom excepthook to (try and) ensure python errors are
+    reported.
+
+    Currently, I'm unsure if this even does anything. Pybind11 might just not
+    care about excepthooks.
+    """
+    _sys_excepthook = getattr(sys, 'excepthook', None)
+
+    def sprokit_excepthook(*exc_info):
+        print('! SPROKIT EXCEPTHOOK WAS TRIGGERED !')
+        try:
+            sprokit_logging.print_exc(exc_info)
+        except Exception:
+            if _sys_excepthook is not None:
+                _sys_excepthook(*exc_info)
+
+    sys.excepthook = sprokit_excepthook
+
+_pybind11_argv_workaround()
+_pybind11_excepthook_workaround()

--- a/sprokit/src/bindings/python/modules/loaders.py
+++ b/sprokit/src/bindings/python/modules/loaders.py
@@ -34,7 +34,7 @@ import sys
 import os
 from importlib import import_module
 from sprokit import sprokit_logging
-logger = sprokit_logging.SprokitLogger(__name__)
+logger = sprokit_logging.getLogger(__name__)
 
 
 class Loader(object):
@@ -143,7 +143,6 @@ class ModuleLoader(Loader):
                             break
 
     def _findPluginModules(self, namespace):
-        logger.debug('Find plugins in namespace = {!r}'.format(namespace))
         for filepath in self._findPluginFilePaths(namespace):
             path_segments = list(filepath.split(os.path.sep))
             path_segments = [p for p in path_segments if p]
@@ -155,8 +154,6 @@ class ModuleLoader(Loader):
             except ImportError as e:
                 logger.warn('Could not import: {}, Reason: {}'.format(module_name, e))
                 module = None
-            else:
-                logger.debug('imported {}'.format(module))
 
             if module is not None:
                 yield module

--- a/sprokit/src/bindings/python/modules/loaders.py
+++ b/sprokit/src/bindings/python/modules/loaders.py
@@ -29,12 +29,12 @@
 # Only ModuleLoader is here since we only care about it.
 
 """Facility to load plugins."""
-
 from __future__ import print_function
 import sys
 import os
-
 from importlib import import_module
+from sprokit import sprokit_logging
+logger = sprokit_logging.SprokitLogger(__name__)
 
 
 class Loader(object):
@@ -42,8 +42,8 @@ class Loader(object):
     def __init__(self, *args, **kwargs):
         self._cache = []
 
-    def load(self, *args, **kwargs):
-        self._fill_cache(*args, **kwargs)
+    def load(self, namespace):
+        self._fill_cache(namespace)
         self._post_fill()
         self._order()
         return self._cache
@@ -102,8 +102,8 @@ class ModuleLoader(Loader):
 
         for ext in py_exts:
             if namespace.endswith(ext):
-                print(('[WARNING] do not specify .py extension for '
-                       'the {} sprokit python module').format(namespace))
+                logger.warn(('do not specify .py extension for the {} '
+                             'sprokit python module').format(namespace))
                 namespace = namespace[:-len(ext)]
 
         namespace_rel_path = namespace.replace('.', os.path.sep)
@@ -139,22 +139,24 @@ class ModuleLoader(Loader):
                             already_seen.add(base)
                             mod_rel_path = namespace_rel_path + ext
                             yield mod_rel_path
-                            # Dont test remaining pyo / pyc extensions.
+                            # Dont test remaining pyc / pyo extensions.
                             break
 
     def _findPluginModules(self, namespace):
+        logger.debug('Find plugins in namespace = {!r}'.format(namespace))
         for filepath in self._findPluginFilePaths(namespace):
             path_segments = list(filepath.split(os.path.sep))
             path_segments = [p for p in path_segments if p]
             path_segments[-1] = os.path.splitext(path_segments[-1])[0]
-            import_path = '.'.join(path_segments)
+            module_name = '.'.join(path_segments)
 
             try:
-                module = import_module(import_path)
+                module = import_module(module_name)
             except ImportError as e:
-                print('[DEBUG] Could not import: {} Reason: {}'.format(
-                    import_path, e))
+                logger.warn('Could not import: {}, Reason: {}'.format(module_name, e))
                 module = None
+            else:
+                logger.debug('imported {}'.format(module))
 
             if module is not None:
                 yield module

--- a/sprokit/src/bindings/python/modules/modules.py
+++ b/sprokit/src/bindings/python/modules/modules.py
@@ -28,31 +28,33 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 try:
     from . import loaders
 except:
     from straight.plugin import loaders
+from sprokit import sprokit_logging
+
+logger = sprokit_logging.SprokitLogger(__name__)
 
 
-def _log(msg):
-    import sys
-    sys.stderr.write("%s\n" % msg)
-    sys.stderr.flush()
-
-
+@sprokit_logging.exc_report
 def _load_python_module(mod):
+    logger.debug('Loading python module: "{}"'.format(mod))
     if hasattr(mod, '__sprokit_register__'):
         import collections
 
         if isinstance(mod.__sprokit_register__, collections.Callable):
             mod.__sprokit_register__()
-
+        else:
+            logger.warn(('Python module "{}" defined __sprokit_register__ but '
+                         'it is not callable').format(mod))
     else:
-        print(('[WARN] Python module {} does not have '
-               '__sprokit_register__ method').format(mod))
+        logger.warn(('Python module "{}" does not have '
+                     '__sprokit_register__ method').format(mod))
 
 
+@sprokit_logging.exc_report
 def load_python_modules():
     """
     Loads Sprokit python plugins
@@ -64,6 +66,7 @@ def load_python_modules():
     """
     import os
 
+    # default plugins that are always loaded
     packages = ['sprokit.processes',
                 'sprokit.schedulers']
 
@@ -72,6 +75,9 @@ def load_python_modules():
     extra_modules = os.environ.get(envvar, '').split(os.pathsep)
     # ensure the empty string is not considered as a module
     packages.extend([p for p in extra_modules if p])
+    logger.debug(
+        'Preparing to load sprokit python plugin modules: '
+        '[\n    {}\n]'.format(',\n    '.join(list(map(repr, packages)))))
 
     loader = loaders.ModuleLoader()
     all_modules = []
@@ -81,11 +87,7 @@ def load_python_modules():
         all_modules += modules
 
     for module in all_modules:
-        print('[DEBUG] Loading python module: {}'.format(module))
-
         try:
             _load_python_module(module)
-        except BaseException:
-            import sys
-            e = sys.exc_info()[1]
-            _log("Failed to load '%s': %s" % (module, str(e)))
+        except BaseException as ex:
+            logger.warn('Failed to load "{}": {}'.format(module, ex))

--- a/sprokit/src/bindings/python/modules/modules.py
+++ b/sprokit/src/bindings/python/modules/modules.py
@@ -35,7 +35,7 @@ except:
     from straight.plugin import loaders
 from sprokit import sprokit_logging
 
-logger = sprokit_logging.SprokitLogger(__name__)
+logger = sprokit_logging.getLogger(__name__)
 
 
 @sprokit_logging.exc_report
@@ -65,6 +65,7 @@ def load_python_modules():
     them with the C++ backend.
     """
     import os
+    logger.info('Loading python modules')
 
     # default plugins that are always loaded
     packages = ['sprokit.processes',

--- a/sprokit/src/bindings/python/sprokit_logging.py
+++ b/sprokit/src/bindings/python/sprokit_logging.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+A thin wrapper around python logging.
+"""
+from __future__ import print_function, unicode_literals, absolute_import
+import sys
+import six
+import os
+import logging
+
+
+def _configure_logging():
+    """
+    Configures python logging to using KWIVER / SPROKIT environment variables
+    """
+    # Use the C++ logging level by default, but allow python to be different
+    cxx_level = os.environ.get('KWIVER_DEFAULT_LOG_LEVEL', 'DEBUG')
+    py_level = os.environ.get('KWIVER_PYTHON_DEFAULT_LOG_LEVEL', cxx_level)
+    level = getattr(logging, py_level.upper())
+    logfmt = '%(name)s:%(levelname)s: %(message)s'
+
+    USE_COLOR = False
+    try:
+        import coloredlogs
+    except ImportError:
+        USE_COLOR = False
+
+    if USE_COLOR:
+        coloredlogs.DEFAULT_FIELD_STYLES['name']['color'] = 'blue'
+        coloredlogs.DEFAULT_LEVEL_STYLES['debug']['color'] = 'cyan'
+        # coloredlogs.DEFAULT_LEVEL_STYLES['warn']['color'] = 'yellow'
+        coloredlogs.install(level=level, fmt=logfmt)
+    else:
+        logging.basicConfig(format=logfmt, level=level)
+
+
+def print_exc(exc_info=None):
+    """
+    Prints a highly visible exception.
+
+    Example:
+        >>> try:
+        >>>     raise Exception('foobar')
+        >>> except Exception as ex:
+        >>>     import sys
+        >>>     exc_info = sys.exc_info()
+        >>>     print_exc(exc_info)
+    """
+    import traceback
+    if exc_info is None:
+        exc_info = sys.exc_info()
+    tbtext = ''.join(traceback.format_exception(*exc_info))
+
+    lines = [
+        '',
+        '┌───────────',
+        '│ EXCEPTION:',
+        '',
+        tbtext,
+        '└───────────',
+        ''
+    ]
+    text = '\n'.join(lines)
+    print(text)
+
+
+def exc_report(func):
+    """
+    Prints a message if an exception occurs in the decorated function.
+
+    Modules called from C++ (e.g. pybind11) are not gaurenteed to print
+    exceptions if they occur (unless the C++ program does the work). This
+    decorator can be used as a workaround to ensure that there is some
+    indication of when Python code raises an exception.
+    """
+    def _exc_report_wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            print_exc()
+            raise
+    return _exc_report_wrapper
+
+
+class SprokitLogger(object):
+    """
+    Lighweight wrapper around python's logging.Logger class.
+    """
+    @exc_report
+    def __init__(self, name):
+        self._logger = logging.getLogger(name)
+        self.log('debug', 'created logger for ' + name)
+
+    @exc_report
+    def log(self, level, msg):
+        if isinstance(level, six.string_types):
+            level = getattr(logging, level.upper())
+        self._logger.log(level, msg)
+
+    def debug(self, msg):
+        return self.log(logging.DEBUG, msg)
+
+    def info(self, msg):
+        return self.log(logging.INFO, msg)
+
+    def warn(self, msg):
+        return self.log(logging.WARN, msg)
+
+    def error(self, msg):
+        return self.log(logging.ERROR, msg)
+
+    def critical(self, msg):
+        return self.log(logging.CRITICAL, msg)

--- a/sprokit/src/sprokit/python/util/python_exceptions.h
+++ b/sprokit/src/sprokit/python/util/python_exceptions.h
@@ -38,42 +38,48 @@ namespace python {
 
 /// \todo More useful output?
 
-#define SPROKIT_PYTHON_HANDLE_EXCEPTION(call)     \
-  try                                             \
-  {                                               \
-    call;                                         \
-  }                                               \
-  catch (pybind11::error_already_set const&) \
-  {                                               \
-    sprokit::python::python_print_exception();    \
-                                                  \
-    throw;                                        \
+#define SPROKIT_PYTHON_HANDLE_EXCEPTION(call)                     \
+  try                                                             \
+  {                                                               \
+    call;                                                         \
+  }                                                               \
+  catch (pybind11::error_already_set const& e)                    \
+  {                                                               \
+    auto logger = kwiver::vital::get_logger("python_exceptions"); \
+    LOG_WARN(logger, "Handle Python Exception:");                 \
+    LOG_WARN(logger, e.what());                                   \
+    sprokit::python::python_print_exception();                    \
+                                                                  \
+    throw;                                                        \
   }
 
-#define SPROKIT_PYTHON_IGNORE_EXCEPTION(call)      \
-  try                                              \
-  {                                                \
-    call;                                          \
-  }                                                \
-  catch (pybind11::error_already_set const&)  \
-  {                                                \
-    sprokit::python::python_print_exception();     \
+#define SPROKIT_PYTHON_IGNORE_EXCEPTION(call)                     \
+  try                                                             \
+  {                                                               \
+    call;                                                         \
+  }                                                               \
+  catch (pybind11::error_already_set const& e)                    \
+  {                                                               \
+    auto logger = kwiver::vital::get_logger("python_exceptions"); \
+    LOG_WARN(logger, "Ignore Python Exception:");                 \
+    LOG_WARN(logger, e.what());                                   \
+    sprokit::python::python_print_exception();                    \
   }
 
-#define SPROKIT_PYTHON_TRANSLATE_EXCEPTION(call)   \
-  try                                              \
-  {                                                \
-    call;                                          \
-  }                                                \
-  catch (std::exception const& e)                  \
-  {                                                \
-    sprokit::python::python_gil const gil;         \
-                                                   \
-    (void)gil;                                     \
-                                                   \
-    PyErr_SetString(PyExc_RuntimeError, e.what()); \
-                                                   \
-    throw;                                         \
+#define SPROKIT_PYTHON_TRANSLATE_EXCEPTION(call)                  \
+  try                                                             \
+  {                                                               \
+    call;                                                         \
+  }                                                               \
+  catch (std::exception const& e)                                 \
+  {                                                               \
+    sprokit::python::python_gil const gil;                        \
+                                                                  \
+    (void)gil;                                                    \
+                                                                  \
+    PyErr_SetString(PyExc_RuntimeError, e.what());                \
+                                                                  \
+    throw;                                                        \
   }
 
 SPROKIT_PYTHON_UTIL_EXPORT void python_print_exception();

--- a/sprokit/src/sprokit/python/util/python_exceptions.h
+++ b/sprokit/src/sprokit/python/util/python_exceptions.h
@@ -46,8 +46,7 @@ namespace python {
   catch (pybind11::error_already_set const& e)                    \
   {                                                               \
     auto logger = kwiver::vital::get_logger("python_exceptions"); \
-    LOG_WARN(logger, "Handle Python Exception:");                 \
-    LOG_WARN(logger, e.what());                                   \
+    LOG_WARN(logger, "Ignore Python Exception:\n" << e.what());   \
     sprokit::python::python_print_exception();                    \
                                                                   \
     throw;                                                        \
@@ -61,8 +60,7 @@ namespace python {
   catch (pybind11::error_already_set const& e)                    \
   {                                                               \
     auto logger = kwiver::vital::get_logger("python_exceptions"); \
-    LOG_WARN(logger, "Ignore Python Exception:");                 \
-    LOG_WARN(logger, e.what());                                   \
+    LOG_WARN(logger, "Ignore Python Exception:\n" << e.what());   \
     sprokit::python::python_print_exception();                    \
   }
 


### PR DESCRIPTION
This PR makes two changes.

1. Pure python modules in sprokit now use logging instead of print statements. 
2. Python exceptions are now printed when called from C++. 

First: 

The print statements used in python files have been converted to use the builtin python logging module. 
This logger will respect the `KWIVER_DEFAULT_LOG_LEVEL` environment variable unless the `KWIVER_PYTHON_DEFAULT_LOG_LEVEL` is set, in which case it will be overriden. 

Second: 

Previously, if Python raised an exception, when called from C++, it would fail silently. The `SPROKIT_PYTHON_IGNORE_EXCEPTION` and `SPROKIT_PYTHON_HANDLE_EXCEPTION` macros catch the exception and then call a function called `sprokit::python::python_print_exception`, but for some reason (that I don't understand), that call is not actually printing the exception. Therefore I've used the vital logger to log the error message as a warning. While this doesn't fix the underlying issue, it does indicate that something has happened.
