### PR TITLE
Removed duplicate paths in sprokit plugins

### DIFF
--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -34,6 +34,7 @@
 #include <vital/exceptions/plugin.h>
 #include <vital/logger/logger.h>
 #include <vital/util/demangle.h>
+#include <vital/util/string.h>
 
 #include <sstream>
 
@@ -220,6 +221,8 @@ plugin_loader
 ::add_search_path( path_list_t const& path)
 {
   m_impl->m_search_paths.insert(m_impl->m_search_paths.end(), path.begin(), path.end() );
+  // remove any duplicate paths that were added
+  erase_duplicates(m_impl->m_search_paths);
 }
 
 

--- a/vital/util/string.cxx
+++ b/vital/util/string.cxx
@@ -30,6 +30,7 @@
 
 #include "string.h"
 
+#include <unordered_set>
 #include <algorithm>
 #include <iterator>
 #include <memory>    // For std::unique_ptr
@@ -92,6 +93,33 @@ join( const std::vector<std::string>& elements, const std::string& str_separator
     return os.str();
   }
   } // end switch
+}
+
+
+//----------------------------------------------------------------------------
+/**
+ * Removes duplicate strings in a vector while preserving original order
+ */
+void
+erase_duplicates(std::vector<std::string>& items)
+{
+  // For each item: if it has been seen before, then remove it (inplace)
+  std::unordered_set<std::string> seen;
+  std::vector<std::string>::iterator itr = items.begin();
+  while (itr != items.end())
+  {
+    if (!seen.insert((*itr)).second)
+    {
+      // If the item has been seen before, remove it and move itr to the new
+      // location of the next item
+      itr = items.erase(itr);
+    }
+    else
+    {
+      // otherwise go to the next item
+      ++itr;
+    }
+  }
 }
 
 

--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -85,6 +85,19 @@ starts_with( const std::string& input, const std::string& pattern)
 VITAL_UTIL_EXPORT std::string
 join( const std::vector<std::string>& elements, const std::string& str_separator);
 
+
+/**
+ * @brief Removes duplicate strings while preserving original order.
+ *
+ * Modifies a vector of strings inplace by removing duplicates encountered in a
+ * forward iteration. The result is a unique vector of strings that preserves
+ * the forwards order.
+ *
+ * @param items Vector of strings to modify inplace
+ */
+VITAL_UTIL_EXPORT void
+erase_duplicates(std::vector<std::string>& items);
+
 } } // end namespace
 
 #endif /* KWIVER_VITAL_UTIL_STRING_FORMAT_H */


### PR DESCRIPTION
This fixes an issue where if a path is specified multiple times in `KWIVER_PLUGIN_PATH`, then it is loaded multiple times. This PR seeks to address this by removing exact duplicate paths after the environment variable has been split into a vector of strings. It does this using a new function called `UniqueOrdered` that I've added to SystemTools.cxx that does inplace removal of duplicate items. 

The alternative to using `UniqueOrdered` would be just to store all paths in a `std::set` (which is ordered). However, this would require changing many of the Sprokit API functions from using `vector<string>` to using `set<string>`. The interfaces existing in SystemTools also seem to assume vectors, so this seemed like the simplest change in terms of code clarity. 