### PR TITLE
[WIP] Dev/explorer add formatting types

### DIFF
--- a/doc/manuals/sprokit/getting-started.rst
+++ b/doc/manuals/sprokit/getting-started.rst
@@ -7,7 +7,7 @@ pipelining facilities to manage, integrate and run many of KWIVER's
 modules and capabilities.  To see what modules (called processes in
 sprockit) are available, run the following command::
 
-    $ plugin_explorer --process -b
+    $ plugin_explorer --proc all -b
 
 Here's a typical list of modules (note that as KWIVER expands, this
 list is likely to grow):

--- a/sprokit/processes/kwiver_type_traits.h
+++ b/sprokit/processes/kwiver_type_traits.h
@@ -78,7 +78,7 @@ namespace vital {
 create_type_trait( bounding_box, "kwiver:bounding_box",
                    kwiver::vital::bounding_box_d);
 create_type_trait( timestamp, "kwiver:timestamp", kwiver::vital::timestamp );
-create_type_trait( gsd, "kwiver:gsd", kwiver::vital::gsd_t );
+create_type_trait( gsd, "kwiver:gsd", double );
 create_type_trait( corner_points, "corner_points", kwiver::vital::geo_polygon );
 create_type_trait( image, "kwiver:image", kwiver::vital::image_container_sptr );
 create_type_trait( mask, "kwiver:mask", kwiver::vital::image_container_sptr );

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -444,7 +444,7 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
 
   // -- input ports --
   sprokit::process::ports_t const iports = proc->input_ports();
-  out_stream() << underline( "Input Ports", '-' ) << std::endl;
+  out_stream() << std::endl << underline( "Input Ports", '-' ) << std::endl;
 
   if ( iports.empty() )
   {
@@ -486,7 +486,7 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
 
   // -- output ports --
   sprokit::process::ports_t const oports = proc->output_ports();
-  out_stream() << underline( "Output Ports", '-' ) << std::endl;
+  out_stream() << std::endl << underline( "Output Ports", '-' ) << std::endl;
 
   if ( oports.empty() )
   {
@@ -544,7 +544,7 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
                << std::endl
 
                << " # ================================================================" << std::endl
-               << " process <this-name>" << std::endl
+               << " process <this-proc>" << std::endl
                << "   :: " << proc_type << std::endl;
 
   // loop over config
@@ -587,7 +587,7 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
   }
   else
   {
-    out_stream() << "# This process will consume the following input ports" << std::endl;
+    out_stream() << " # This process will consume the following input ports" << std::endl;
 
     for( sprokit::process::port_t const & port : iports )
     {
@@ -616,6 +616,8 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
   }
   else
   {
+    out_stream() << " # This process will produce the following output ports" << std::endl;
+
     for( sprokit::process::port_t const & port : oports )
     {
       if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -52,7 +52,14 @@ join( const ContainerT& vec, const char* delim )
   std::stringstream res;
   std::copy( vec.begin(), vec.end(), std::ostream_iterator< std::string > ( res, delim ) );
 
-  return res.str();
+  // remove trailing delim
+  std::string res_str = res.str();
+  if (res_str.size() > 1 )
+  {
+    res_str.erase(res_str.size() - 2 );
+  }
+
+  return res_str;
 }
 
 static std::string const hidden_prefix = "_";
@@ -60,7 +67,7 @@ static std::string const hidden_prefix = "_";
 } // end namespace
 
 
-// ----------------------------------------------------------------
+// ==================================================================
 /**
  * @brief plugin_explorer support for formatting processes.
  *
@@ -319,6 +326,169 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
 } // process_explorer_rst::explore
 
 
+// ==================================================================
+/**
+ * @brief plugin_explorer support for formatting processes.
+ *
+ * This class provides the special formatting for processes.
+ */
+class process_explorer_pipe
+  : public category_explorer
+{
+public:
+  process_explorer_pipe();
+  virtual ~process_explorer_pipe();
+
+  virtual bool initialize( explorer_context* context );
+  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact );
+
+  std::ostream& out_stream() { return m_context->output_stream(); }
+
+  // instance data
+  explorer_context* m_context;
+  bool opt_hidden;
+
+  // Need special indent prefix so we can not use normal text wrapper.
+  kwiver::vital::wrap_text_block m_wtb;
+
+}; // end class process_explorer_pipe
+
+
+// ==================================================================
+process_explorer_pipe::
+process_explorer_pipe()
+  :opt_hidden( false )
+{
+  m_wtb.set_indent_string( "#   " );
+}
+
+
+process_explorer_pipe::
+~process_explorer_pipe()
+{ }
+
+
+// ------------------------------------------------------------------
+bool
+process_explorer_pipe::
+initialize( explorer_context* context )
+{
+  m_context = context;
+
+  // Add plugin specific command line option.
+  auto cla = m_context->command_line_args();
+
+  // The problem here is that the address of these strings are copied
+  // into a control block. This is a problem since they are on the stack. ???
+  cla->AddArgument( "--hidden",
+                    kwiversys::CommandLineArguments::NO_ARGUMENT,
+                    &this->opt_hidden,
+                    "Display hidden properties and ports" );
+  return true;
+}
+
+
+// ------------------------------------------------------------------
+void
+process_explorer_pipe::
+explore( const kwiver::vital::plugin_factory_handle_t fact )
+{
+  std::string proc_type = "-- Not Set --";
+
+  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, proc_type );
+
+  std::string descrip = "-- Not_Set --";
+  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, descrip );
+  descrip = m_wtb.wrap_text( descrip );
+
+  sprokit::process_factory* pf = dynamic_cast< sprokit::process_factory* > ( fact.get() );
+
+  sprokit::process_t const proc = pf->create_object( kwiver::vital::config_block::empty_config() );
+
+  sprokit::process::properties_t const properties = proc->properties();
+  std::string const properties_str = join( properties, ", " );
+
+  out_stream() << std::endl
+               << "# -----------------------------" << std::endl
+               << "process " << proc_type << " :: <local-proc-name>" << std::endl
+               << "#   Properties: " << properties_str << std::endl
+               << descrip << std::endl;
+
+  kwiver::vital::config_block_keys_t const keys = proc->available_config();
+
+  for( kwiver::vital::config_block_key_t const & key : keys )
+  {
+    if ( ! opt_hidden && ( key.substr( 0, hidden_prefix.size() ) == hidden_prefix ) )
+    {
+      // skip hidden items
+      continue;
+    }
+
+    sprokit::process::conf_info_t const info = proc->config_info( key );
+
+    kwiver::vital::config_block_value_t const& def = info->def;
+    kwiver::vital::config_block_description_t const& conf_desc =  m_wtb.wrap_text( info->description );
+    bool const& tunable = info->tunable;
+    char const* const tunable_str = tunable ? "yes" : "no";
+
+    out_stream() << "    " << key << " = " << def << std::endl
+                 << conf_desc
+                 << "#   Tunable    : " << tunable_str << std::endl
+                 << std::endl;
+  }
+
+  sprokit::process::ports_t const iports = proc->input_ports();
+
+  for( sprokit::process::port_t const & port : iports )
+  {
+    if ( ! opt_hidden && ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix ) )
+    {
+      // skip hidden item
+      continue;
+    }
+
+    sprokit::process::port_info_t const info = proc->input_port_info( port );
+
+    sprokit::process::port_type_t const& type = info->type;
+    sprokit::process::port_flags_t const& flags = info->flags;
+    sprokit::process::port_description_t const& port_desc = m_wtb.wrap_text( info->description );
+
+    std::string const flags_str = join( flags, ", " );
+
+    out_stream() << "    connect from <upstream_port> to " << port << std::endl
+                 << "#   Type       : " << type << std::endl
+                 << "#   Flags      : " << flags_str << std::endl
+                 << port_desc << std::endl;
+
+  }   // end foreach
+
+  sprokit::process::ports_t const oports = proc->output_ports();
+
+  for( sprokit::process::port_t const & port : oports )
+  {
+    if ( ! opt_hidden && ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix ) )
+    {
+      continue;
+    }
+
+    sprokit::process::port_info_t const info = proc->output_port_info( port );
+
+    sprokit::process::port_type_t const& type = info->type;
+    sprokit::process::port_flags_t const& flags = info->flags;
+    sprokit::process::port_description_t const& port_desc = m_wtb.wrap_text( info->description );
+
+    std::string const flags_str = join( flags, ", " );
+
+    out_stream() << "    connect from " << port << " to <downstream_port>" << std::endl
+                 << "#   Type       : " << type << std::endl
+                 << "#   Flags      : " << flags_str << std::endl
+                 << port_desc << std::endl;
+
+  }   // end foreach
+
+  out_stream()  << std::endl;
+
+} // process_explorer_pipe::explore
 
 
 } } // end namespace
@@ -347,5 +517,12 @@ void register_explorer_plugin( kwiver::vital::plugin_loader& vpm )
                     "Plugin explorer for process category rst format output" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
 
-  vpm.mark_module_as_loaded( module );
+
+  fact = vpm.ADD_FACTORY( kwiver::vital::category_explorer, kwiver::vital::process_explorer_pipe );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "process-pipe" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                    "Plugin explorer for process category pipeline format output" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+
+vpm.mark_module_as_loaded( module );
 }

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -39,6 +39,9 @@
 
 #include <sstream>
 #include <iterator>
+#include <fstream>
+#include <string>
+#include <regex>
 
 namespace kwiver {
 namespace vital {
@@ -280,11 +283,15 @@ public:
   virtual bool initialize( explorer_context* context );
   virtual void explore( const kwiver::vital::plugin_factory_handle_t fact );
 
-  std::ostream& out_stream() { return m_context->output_stream(); }
+  std::ostream& out_stream();
+  std::string wrap_rst_text( const std::string& txt );
 
   // instance data
   explorer_context* m_context;
   kwiver::vital::wrap_text_block m_wtb;
+  kwiver::vital::wrap_text_block m_comment_wtb;
+  bool opt_files;
+  std::ofstream m_out_stream;
 
 }; // end class process_explorer_rst
 
@@ -292,8 +299,10 @@ public:
 // ==================================================================
 process_explorer_rst::
 process_explorer_rst()
+  : opt_files( false )
 {
   m_wtb.set_indent_string( "" );
+  m_comment_wtb.set_indent_string( " # " );
 }
 
 
@@ -303,11 +312,51 @@ process_explorer_rst::
 
 
 // ------------------------------------------------------------------
+std::ostream&
+process_explorer_rst::
+out_stream()
+{
+  if (opt_files)
+  {
+    return m_out_stream;
+  }
+
+  return m_context->output_stream();
+}
+
+
+// ------------------------------------------------------------------
+std::string
+process_explorer_rst::
+wrap_rst_text( const std::string& txt )
+{
+  std::string wtxt = m_wtb.wrap_text( txt );
+
+  // trim trailing whitesapce new line
+  wtxt.erase( wtxt.find_last_not_of( " \t\n\r\f\v" ) + 1 );
+
+  return std::regex_replace( wtxt, std::regex("\n"), " |br|\\ " );
+}
+
+
+// ------------------------------------------------------------------
 bool
 process_explorer_rst::
 initialize( explorer_context* context )
 {
   m_context = context;
+
+  // Add plugin specific command line option.
+  auto cla = m_context->command_line_args();
+
+  static char flag_name[]("--sep-proc-files");
+  static char help_text[]("Generate .rst output for processes in separate files." );
+
+  cla->AddArgument( flag_name,
+                    kwiversys::CommandLineArguments::NO_ARGUMENT,
+                    &this->opt_files,
+                    help_text );
+
   return true;
 }
 
@@ -318,12 +367,14 @@ process_explorer_rst::
 explore( const kwiver::vital::plugin_factory_handle_t fact )
 {
   std::string proc_type = "-- Not Set --";
-
-  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, proc_type );
+  if ( fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, proc_type ) && opt_files )
+  {
+    m_out_stream.open( proc_type + "-config.rst", std::ios_base::trunc);
+  }
 
   std::string descrip = "-- Not_Set --";
   fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, descrip );
-  descrip = m_wtb.wrap_text( descrip );
+  descrip = wrap_rst_text( descrip );
 
   std::string proc_class = "-- Not Set --";
   if ( fact->get_attribute( kwiver::vital::plugin_factory::CONCRETE_TYPE, proc_class ) )
@@ -331,14 +382,15 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
     proc_class = kwiver::vital::demangle( proc_class );
   }
 
-  out_stream() << std::endl
-               << underline( proc_type, '=' )
+  // output some magic to ehable maintaining newlines
+  out_stream() << "  .. |br| raw:: html" << std::endl
                << std::endl
+               << "   <br />" << std::endl
+               << std::endl;
+
+  out_stream() << underline( proc_type, '=' ) << std::endl
                << descrip << std::endl
-               << "..  doxygenclass:: " << proc_class << std::endl
-               << "    :project: kwiver" << std::endl
-               << std::endl
-    ;
+               << std::endl;
 
   sprokit::process_factory* pf = dynamic_cast< sprokit::process_factory* > ( fact.get() );
 
@@ -349,8 +401,153 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
 
   // -- config --
   kwiver::vital::config_block_keys_t const keys = proc->available_config();
-  out_stream() << underline( "Configuration", '-' );
+  out_stream() << underline( "Configuration", '-' ) << std::endl;
 
+  if ( keys.empty() )
+  {
+    out_stream() << "*There are no configuration items for this process.*" << std::endl
+                 << std::endl;
+  }
+  else
+  {
+    // generate header text
+    out_stream() << ".. csv-table::" << std::endl
+                 << "   :header: \"Variable\", \"Default\", \"Tunable\", \"Description\"" << std::endl
+                 << "   :align: left" << std::endl
+                 << "   :widths: auto" << std::endl
+                 << std::endl;
+
+    for( kwiver::vital::config_block_key_t const & key : keys )
+    {
+      if ( key.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+      {
+        // skip hidden items
+        continue;
+      }
+
+      sprokit::process::conf_info_t const info = proc->config_info( key );
+
+      kwiver::vital::config_block_value_t def = info->def;
+      kwiver::vital::config_block_description_t const  conf_desc =  wrap_rst_text( info->description );
+      bool const& tunable = info->tunable;
+      char const* const tunable_str = tunable ? "YES" : "NO";
+
+      if ( def.empty() )
+      {
+        def = "(no default value)";
+      }
+
+      out_stream() << "   \"" << key << "\", \"" << def << "\", \"" << tunable_str << "\", \""
+                   << conf_desc << "\"" << std::endl;
+    }
+  }
+
+  // -- input ports --
+  sprokit::process::ports_t const iports = proc->input_ports();
+  out_stream() << underline( "Input Ports", '-' ) << std::endl;
+
+  if ( iports.empty() )
+  {
+    out_stream() << "There are no input ports for this process." << std::endl
+                 << std::endl;
+  }
+  else
+  {
+    out_stream() << ".. csv-table::" << std::endl
+                 << "   :header: \"Port name\", \"Data Type\", \"Flags\", \"Description\"" << std::endl
+                 << "   :align: left" << std::endl
+                 << "   :widths: auto" << std::endl
+                 << std::endl;
+
+    for( sprokit::process::port_t const & port : iports )
+    {
+      if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+      {
+        // skip hidden item
+        continue;
+      }
+
+      sprokit::process::port_info_t const info = proc->input_port_info( port );
+
+      sprokit::process::port_type_t const& type = info->type;
+      sprokit::process::port_flags_t const& flags = info->flags;
+      sprokit::process::port_description_t const port_desc = wrap_rst_text( info->description );
+
+      std::string flags_str = join( flags, ", " );
+      if ( flags_str.empty() )
+      {
+        flags_str = "(none)";
+      }
+
+      out_stream() << "   \"" << port << "\", \"" << type << "\", \"" <<  flags_str
+                   << "\", \"" << port_desc << "\"" << std::endl;
+    }   // end foreach
+  }
+
+  // -- output ports --
+  sprokit::process::ports_t const oports = proc->output_ports();
+  out_stream() << underline( "Output Ports", '-' ) << std::endl;
+
+  if ( oports.empty() )
+  {
+    out_stream() << "There are no output ports for this process." << std::endl
+                 << std::endl;
+  }
+  else
+  {
+    out_stream() << ".. csv-table::" << std::endl
+                 << "   :header: \"Port name\", \"Data Type\", \"Flags\", \"Description\"" << std::endl
+                 << "   :align: left" << std::endl
+                 << "   :widths: auto" << std::endl
+                 << std::endl;
+
+    for( sprokit::process::port_t const & port : oports )
+    {
+      if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+      {
+        continue;
+      }
+
+      sprokit::process::port_info_t const info = proc->output_port_info( port );
+
+      sprokit::process::port_type_t const& type = info->type;
+      sprokit::process::port_flags_t const& flags = info->flags;
+      sprokit::process::port_description_t const port_desc = wrap_rst_text( info->description );
+
+      std::string flags_str = join( flags, ", " );
+      if ( flags_str.empty() )
+      {
+        flags_str = "(none)";
+      }
+
+      out_stream() << "   \"" << port << "\", \"" << type << "\", \"" <<  flags_str
+                   << "\", \"" << port_desc << "\"" << std::endl;
+    }   // end foreach
+  }
+  out_stream() << std::endl;
+
+  // ==================================================================
+  // -- pipefile usage --
+
+  // Switch to other file
+  if ( opt_files )
+  {
+    m_out_stream.close();
+    m_out_stream.open( proc_type + "-pipe.rst", std::ios_base::trunc);
+  }
+
+  out_stream() << underline( "Pipefile Usage", '-' ) << std::endl
+               << "The following sections describe the blocks needed ot use this process in a pipe file." << std::endl
+               << std::endl
+               << underline( "Pipefile block", '-' ) << std::endl
+               << ".. code::" << std::endl
+               << std::endl
+
+               << " # ================================================================" << std::endl
+               << " process <this-name>" << std::endl
+               << "   :: " << proc_type << std::endl;
+
+  // loop over config
   for( kwiver::vital::config_block_key_t const & key : keys )
   {
     if ( key.substr( 0, hidden_prefix.size() ) == hidden_prefix )
@@ -362,96 +559,83 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
     sprokit::process::conf_info_t const info = proc->config_info( key );
 
     kwiver::vital::config_block_value_t def = info->def;
-    kwiver::vital::config_block_description_t const  conf_desc =  m_wtb.wrap_text( info->description );
-    bool const& tunable = info->tunable;
-    char const* const tunable_str = tunable ? "*Tunable*" : "*Not tunable*";
+    kwiver::vital::config_block_description_t const  conf_desc =  m_comment_wtb.wrap_text( info->description );
 
     if ( def.empty() )
     {
-      def = "(no default value)";
+      def = "<value>";
     }
 
-    out_stream() << "**" << key << "**" << " = " << def << "       " << tunable_str << std::endl
-                 << conf_desc << std::endl
-      ;
-  }
+    out_stream() << conf_desc
+                 << "   " << key << " = " << def << std::endl;
+  } // end for
 
-  // -- input ports --
-  sprokit::process::ports_t const iports = proc->input_ports();
-  out_stream() << underline( "Input Ports", '-' ) << std::endl;
+  out_stream() << " # ================================================================" << std::endl
+               << std::endl;
 
-  for( sprokit::process::port_t const & port : iports )
-  {
-    if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
-    {
-      // skip hidden item
-      continue;
-    }
+  out_stream() << underline( "Process connections", '~' )
+               << std::endl
+               << underline( "The following Input ports will need to be set" , '^')
+               << ".. code::" << std::endl
+               << std::endl;
 
-    sprokit::process::port_info_t const info = proc->input_port_info( port );
-
-    sprokit::process::port_type_t const& type = info->type;
-    sprokit::process::port_flags_t const& flags = info->flags;
-    sprokit::process::port_description_t const port_desc = m_wtb.wrap_text( info->description );
-
-    std::string flags_str = join( flags, ", " );
-    if ( flags_str.empty() )
-    {
-      flags_str = "(none)";
-    }
-
-    out_stream() << "**" << port << "**" << std::endl
-                 << port_desc << std::endl
-                 << "Data type  : " << type << std::endl
-                 << "Flags      : " << flags_str << std::endl
-                 << std::endl
-      ;
-
-  }   // end foreach
-
+  // loop over input ports
   if ( iports.empty() )
   {
-    out_stream() << "(none)" << std::endl
+    out_stream() << " # There are no input port's for this process" << std::endl
                  << std::endl;
   }
-
-  // -- output ports --
-  sprokit::process::ports_t const oports = proc->output_ports();
-  out_stream() << underline( "Output Ports", '-' ) << std::endl;
-
-  for( sprokit::process::port_t const & port : oports )
+  else
   {
-    if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+    out_stream() << "# This process will consume the following input ports" << std::endl;
+
+    for( sprokit::process::port_t const & port : iports )
     {
-      continue;
-    }
+      if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+      {
+        // skip hidden item
+        continue;
+      }
 
-    sprokit::process::port_info_t const info = proc->output_port_info( port );
+      out_stream() << " connect from <this-proc>." << port << std::endl
+                   <<"          to   <upstream-proc>." << port << std::endl;
+    }   // end for
+  }
+  out_stream() << std::endl;
 
-    sprokit::process::port_type_t const& type = info->type;
-    sprokit::process::port_flags_t const& flags = info->flags;
-    sprokit::process::port_description_t const port_desc = m_wtb.wrap_text( info->description );
 
-    std::string flags_str = join( flags, ", " );
-    if ( flags_str.empty() )
-    {
-      flags_str = "(none)";
-    }
+  // loop over output ports
+  out_stream() << underline( "The following Output ports will need to be set" , '^')
+               << ".. code::" << std::endl
+               << std::endl;
 
-    out_stream() << "**" << port << "**" << std::endl
-                 << port_desc << std::endl
-                 << "Data Type  : " << type << std::endl
-                 << "Flags      : " << flags_str << std::endl
-                 << std::endl
-      ;
-
-  }   // end foreach
-
-    if ( oports.empty() )
+  if ( oports.empty() )
   {
-    out_stream() << "(none)" << std::endl
+    out_stream() << " # There are no output port's for this process" << std::endl
                  << std::endl;
   }
+  else
+  {
+    for( sprokit::process::port_t const & port : oports )
+    {
+      if ( port.substr( 0, hidden_prefix.size() ) == hidden_prefix )
+      {
+        continue;
+      }
+
+      out_stream() << " connect from <this-proc>." << port << std::endl
+                   <<"          to   <downstream-proc>." << port << std::endl;
+    }   // end foreach
+  }
+
+  out_stream() << std::endl
+               << underline( "Class Description", '-' ) << std::endl
+               << ".. doxygenclass:: " << proc_class << std::endl
+               << "   :project: kwiver" << std::endl
+               << std::endl;
+
+  // close file just in case it was open
+  m_out_stream.close();
 
 } // process_explorer_rst::explore
 

--- a/vital/algo/algo_explorer_plugin.cxx
+++ b/vital/algo/algo_explorer_plugin.cxx
@@ -181,13 +181,19 @@ public:
 
   // instance data
   explorer_context* m_context;
+
+  // Need special indent prefix so we can not use normal text wrapper.
+  kwiver::vital::wrap_text_block m_wtb;
+
 }; // end class algo_explorer_pipe
 
 
 // ==================================================================
 algo_explorer_pipe::
 algo_explorer_pipe()
-{ }
+{
+  m_wtb.set_indent_string( "#      " );
+}
 
 
 algo_explorer_pipe::
@@ -221,14 +227,9 @@ algo_explorer_pipe::
     return;
   }
 
-  // Need special indent prefix so we can not use normal text wrapper.
-  kwiver::vital::wrap_text_block wtb;
-  wtb.set_indent_string( "#      " );
-
-
   std::string descrip = "-- Not_Set --";
   fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, descrip );
-  descrip = wtb.wrap_text( descrip );
+  descrip = m_wtb.wrap_text( descrip );
 
   std::string impl = "-- not set --";
   fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, impl );
@@ -252,7 +253,7 @@ algo_explorer_pipe::
     m_context->output_stream() << "    " << key << " = " << val << std::endl;
 
     kwiver::vital::config_block_description_t descr = config->get_description( key );
-    m_context->output_stream() << wtb.wrap_text( descr ) << std::endl;
+    m_context->output_stream() << m_wtb.wrap_text( descr ) << std::endl;
   } // end foreach over config
 
   m_context->output_stream() << "endblock\n" << std::endl;

--- a/vital/algo/algo_explorer_plugin.cxx
+++ b/vital/algo/algo_explorer_plugin.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,8 +56,6 @@ public:
   virtual void explore( const kwiver::vital::plugin_factory_handle_t fact );
 
   void display_algo( std::shared_ptr< kwiver::vital::algorithm_factory > fact );
-  void gen_pipefile_algo( std::shared_ptr< kwiver::vital::algorithm_factory > fact );
-
 
   // instance data
   explorer_context* m_context;
@@ -101,14 +99,7 @@ algo_explorer::
     return;
   }
 
-  if (m_context->if_pipeline_format() )
-  {
-    gen_pipefile_algo( pf );
-  }
-  else
-  {
-    display_algo( pf );
-  }
+  display_algo( pf );
 }
 
 
@@ -167,11 +158,69 @@ display_algo( std::shared_ptr< kwiver::vital::algorithm_factory > fact )
 } // algo_explorer::explore
 
 
+
+
+// ==================================================================
+/**
+ * @brief Plugin to provide detailed dsplay of algorithm plugins.
+ *
+ * This class implements a plugin category formatter for the plugin_explorer
+ * tool generating output in pipeline file format.
+ */
+class algo_explorer_pipe
+  : public category_explorer
+{
+public:
+  // -- CONSTRUCTORS --
+  algo_explorer_pipe();
+  virtual ~algo_explorer_pipe();
+
+  virtual bool initialize( explorer_context* context );
+  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact );
+
+
+  // instance data
+  explorer_context* m_context;
+}; // end class algo_explorer_pipe
+
+
+// ==================================================================
+algo_explorer_pipe::
+algo_explorer_pipe()
+{ }
+
+
+algo_explorer_pipe::
+~algo_explorer_pipe()
+{ }
+
+
+// ------------------------------------------------------------------
+bool
+algo_explorer_pipe::
+initialize( explorer_context* context )
+{
+  m_context = context;
+  return true;
+}
+
+
 // ------------------------------------------------------------------
 void
-algo_explorer::
-gen_pipefile_algo( std::shared_ptr< kwiver::vital::algorithm_factory > fact )
+algo_explorer_pipe::
+  explore( const kwiver::vital::plugin_factory_handle_t pf )
 {
+  // downcast to correct factory type.
+  std::shared_ptr< kwiver::vital::algorithm_factory > fact =
+    std::dynamic_pointer_cast< kwiver::vital::algorithm_factory > ( pf );
+
+  if ( ! fact )
+  {
+    // Wrong type of factory returned.
+    m_context->output_stream() << "Factory for algorithm could not be converted to algorithm_factory type.";
+    return;
+  }
+
   // Need special indent prefix so we can not use normal text wrapper.
   kwiver::vital::wrap_text_block wtb;
   wtb.set_indent_string( "#      " );
@@ -225,6 +274,12 @@ void register_explorer_plugin( kwiver::vital::plugin_loader& vpm )
   auto fact = vpm.ADD_FACTORY( kwiver::vital::category_explorer, kwiver::vital::algo_explorer );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "algorithm" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Plugin explorer for algorithm category." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+
+  fact = vpm.ADD_FACTORY( kwiver::vital::category_explorer, kwiver::vital::algo_explorer_pipe );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "algorithm-pipe" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                    "Plugin explorer for algorithm category. Generates pipeline format output." )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
 
     vpm.mark_module_as_loaded( module );

--- a/vital/tools/explorer_context.cxx
+++ b/vital/tools/explorer_context.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,6 +67,15 @@ command_line_args()
 
 
 // ------------------------------------------------------------------
+const std::string&
+explorer_context::
+formatting_type() const
+{
+  return p->formatting_type;
+}
+
+
+// ------------------------------------------------------------------
 std::string
 explorer_context::
 wrap_text( const std::string& text ) const
@@ -88,6 +97,5 @@ display_attr( const kwiver::vital::plugin_factory_handle_t fact ) const
 // ------------------------------------------------------------------
 bool explorer_context::if_detail() const { return p->opt_detail; }
 bool explorer_context::if_brief() const { return p->opt_brief; }
-bool explorer_context::if_pipeline_format() const { return p->opt_pipe_format; }
 
 } } // end namespace

--- a/vital/tools/explorer_context_priv.h
+++ b/vital/tools/explorer_context_priv.h
@@ -57,7 +57,6 @@ public:
   bool opt_scheduler;
   bool opt_summary;
   bool opt_attrs;
-  bool opt_pipe_format;
 
   std::ostream* m_out_stream;
 
@@ -79,6 +78,11 @@ public:
   bool opt_type_filt;
   std::string opt_type_regex;
 
+  // Formatting type string. This is used as a suffix to the category
+  // name to select specific explorer plugin when different formatting
+  // styles are requested.
+  std::string formatting_type;
+
   std::string opt_load_module;
 
   std::function<void(kwiver::vital::plugin_factory_handle_t const)> display_attr;
@@ -97,7 +101,6 @@ public:
 
     opt_attr_filter = false;
     opt_fact_filt = false;
-    opt_pipe_format = false;
 
     m_out_stream = 0;
   }

--- a/vital/tools/explorer_plugin.h
+++ b/vital/tools/explorer_plugin.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,6 +90,16 @@ public:
   std::string wrap_text( const std::string& text ) const;
 
   /**
+   * @brief Return formatting type string.
+   *
+   * This method returns the formatting type string that was specified
+   * on the commane line.
+   *
+   * @return Formatting type string.
+   */
+  const std::string& formatting_type() const;
+
+  /**
    * @brief Display all factory attributes.
    *
    * This method displays all the attributes in the supplied
@@ -101,7 +111,6 @@ public:
 
   bool if_detail() const;
   bool if_brief() const;
-  bool if_pipeline_format() const;
 
   class priv;
 

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -157,43 +157,6 @@ struct print_functor
 
 
 // ------------------------------------------------------------------
-void usage( const std::string& prog_name )
-{
-  // This is not the best way to do this because plugins can add command line options which are not known at this point.
-  pe_out() << "Usage: " << prog_name << "[options]\n"
-           << "\nThis tool displays the attributes of plugins. Each plugin file contains one or more factories.\n"
-
-           << "    --help -h     Display usage information\n"
-           << "    --detail -d   Display detailed information about plugins\n"
-           << "    --factory --fact  regexp    Only display factories whose interface type matches specified regexp\n"
-           << "    --type   regexp    Only display factories whose instance name matches the specified regexp\n"
-           << "    --brief -b    Generate brief display\n"
-
-           << "    --files       Display list of loaded files\n"
-           << "    --mod         Display list of loaded modules\n"
-           << "    --all         Display all plugins\n"
-           << "    --algorithm --algo type   Display only algorithm type plugins.\n"
-           << "                  If type is specified as \"all\", then all algorithms are listed. Otherwise, the type\n"
-           << "                  will be treated as a regexp and only algorithm types that match the regexp will be displayed.\n"
-           << "    --process --proc type     Display only sprokit process type plugins.\n"
-           << "                  If type is specified as \"all\", then all processes are listed. Otherwise, the type\n"
-           << "                  will be treated as a regexp and only processes names that match the regexp will be displayed.\n"
-           << "    --scheduler  Display scheduler type plugins\n"
-
-           << "    --filter  attr-name regex    Filter factories based on attribute name and value.\n"
-           << "    --summary       Display summary of all factories loaded\n"
-           << "    --attrs         Display raw attributes for factories without calling any category specific plugins\n"
-
-           << "    -Ipath       Add path to loadable module search path\n"
-           << "    --path       Display loadable module search path list\n"
-           << "    --load   file-name   Load only specified plugin file for inspection. No other plugins are loaded\n"
-           << "    --fmt    fmt-type    Generate display using alternative format, such as 'rst' or 'pipe'\n"
-
-           << std::endl;
-}
-
-
-// ------------------------------------------------------------------
 std::string
 join( const std::vector< std::string >& vec, const char* delim )
 {
@@ -546,43 +509,73 @@ main( int argc, char* argv[] )
 
   G_context.m_args.AddArgument( "--help",    argT::NO_ARGUMENT, &G_context.opt_help, "Display usage information" );
   G_context.m_args.AddArgument( "-h",        argT::NO_ARGUMENT, &G_context.opt_help, "Display usage information" );
-  G_context.m_args.AddArgument( "--detail",  argT::NO_ARGUMENT, &G_context.opt_detail, "Display detailed information about plugins" );
-  G_context.m_args.AddArgument( "-d",        argT::NO_ARGUMENT, &G_context.opt_detail, "Display detailed information about plugins" );
+  G_context.m_args.AddArgument( "--detail",  argT::NO_ARGUMENT, &G_context.opt_detail,
+                                "Display detailed information about plugins" );
+
+  G_context.m_args.AddArgument( "-d",        argT::NO_ARGUMENT, &G_context.opt_detail,
+                                "Display detailed information about plugins" );
+
   G_context.m_args.AddArgument( "--path",    argT::NO_ARGUMENT, &G_context.opt_path_list, "Display plugin search path" );
   G_context.m_args.AddCallback( "-I",        argT::CONCAT_ARGUMENT, path_callback, 0, "Add directory to plugin search path" );
-  G_context.m_args.AddArgument( "--factory", argT::SPACE_ARGUMENT, &G_context.opt_fact_regex, "Filter factories by interface type based on regexp" );
-  G_context.m_args.AddArgument( "--fact",    argT::SPACE_ARGUMENT, &G_context.opt_fact_regex, "Filter factories by interface type based on regexp" );
-  G_context.m_args.AddArgument( "--type",    argT::SPACE_ARGUMENT, &G_context.opt_type_regex, "Filter factories by instance name based on regexp" );
-  G_context.m_args.AddArgument( "--brief",   argT::NO_ARGUMENT, &G_context.opt_brief, "Brief display" );
-  G_context.m_args.AddArgument( "-b",        argT::NO_ARGUMENT, &G_context.opt_brief, "Brief display" );
+  G_context.m_args.AddArgument( "--factory", argT::SPACE_ARGUMENT, &G_context.opt_fact_regex,
+                                "Only display factories whose interface type matches specified regexp" );
+
+  G_context.m_args.AddArgument( "--fact",    argT::SPACE_ARGUMENT, &G_context.opt_fact_regex,
+                                "Only display factories whose interface type matches specified regexp" );
+
+  G_context.m_args.AddArgument( "--type",    argT::SPACE_ARGUMENT, &G_context.opt_type_regex,
+                                "Only display factories whose instance name matches the specified regexp" );
+
+  G_context.m_args.AddArgument( "--brief",   argT::NO_ARGUMENT, &G_context.opt_brief, "Generate brief display" );
+  G_context.m_args.AddArgument( "-b",        argT::NO_ARGUMENT, &G_context.opt_brief, "Generate brief display" );
   G_context.m_args.AddArgument( "--files",   argT::NO_ARGUMENT, &G_context.opt_files, "Display list of loaded files" );
   G_context.m_args.AddArgument( "--mod",     argT::NO_ARGUMENT, &G_context.opt_modules, "Display list of loaded modules" );
-  G_context.m_args.AddArgument( "--all",     argT::NO_ARGUMENT, &G_context.opt_all, "Display all plugins" );
+  G_context.m_args.AddArgument( "--all",     argT::NO_ARGUMENT, &G_context.opt_all, "Display all plugin types" );
 
   std::string algo_arg;
-  G_context.m_args.AddArgument( "--algorithm", argT::SPACE_ARGUMENT, &algo_arg, "Display all algorithms" );
-  G_context.m_args.AddArgument( "--algo",    argT::SPACE_ARGUMENT, &algo_arg, "Display all algorithms" );
+  G_context.m_args.AddArgument( "--algorithm", argT::SPACE_ARGUMENT, &algo_arg,
+                                "Display only algorithm type plugins. "
+                                "If type is specified as \"all\", then all algorithms are listed. Otherwise, the type "
+                                "will be treated as a regexp and only algorithm types that match the regexp will be displayed.");
+
+  G_context.m_args.AddArgument( "--algo",    argT::SPACE_ARGUMENT, &algo_arg,
+                                "Display only algorithm type plugins. "
+                                "If type is specified as \"all\", then all algorithms are listed. Otherwise, the type "
+                                "will be treated as a regexp and only algorithm types that match the regexp will be displayed.");
 
   std::string proc_arg;
-  G_context.m_args.AddArgument( "--process",   argT::SPACE_ARGUMENT, &proc_arg, "Select only processes" );
-  G_context.m_args.AddArgument( "--proc",      argT::SPACE_ARGUMENT, &proc_arg, "Select only processes" );
+  G_context.m_args.AddArgument( "--process",   argT::SPACE_ARGUMENT, &proc_arg,
+                                "Display only sprokit process type plugins. "
+                                "If type is specified as \"all\", then all processes are listed. Otherwise, the type "
+                                "will be treated as a regexp and only processes names that match the regexp will be displayed." );
+  G_context.m_args.AddArgument( "--proc",      argT::SPACE_ARGUMENT, &proc_arg,
+                                "Display only sprokit process type plugins. "
+                                "If type is specified as \"all\", then all processes are listed. Otherwise, the type "
+                                "will be treated as a regexp and only processes names that match the regexp will be displayed." );
 
-  G_context.m_args.AddArgument( "--scheduler", argT::NO_ARGUMENT, &G_context.opt_scheduler, "Select only schedulers" );
+  G_context.m_args.AddArgument( "--scheduler", argT::NO_ARGUMENT, &G_context.opt_scheduler, "Displat scheduler type plugins" );
 
   std::vector< std::string > filter_args;
   G_context.m_args.AddArgument( "--filter",  argT::MULTI_ARGUMENT, &filter_args,
                                 "Filter factories based on attribute name and value. "
                                 "Only two fields must follow: <attr-name> <attr-value>" );
 
-  G_context.m_args.AddArgument( "--summary", argT::NO_ARGUMENT, &G_context.opt_summary, "Display summary of factories" );
+  G_context.m_args.AddArgument( "--summary", argT::NO_ARGUMENT, &G_context.opt_summary,
+                                "Display summary of all plugin types" );
 
   G_context.m_args.AddArgument( "--attrs",   argT::NO_ARGUMENT, &G_context.opt_attrs,
-                                "Display raw attributes for factories without calling any category specific plugins" );
+                                "Display raw attributes for plugins without calling any category specific formatting" );
 
   G_context.m_args.AddArgument( "--load",    argT::SPACE_ARGUMENT, &G_context.opt_load_module,
-                                "Load only specified plugin file for inspection." );
+                                "Load only specified plugin file for inspection. No other pluigins are loaded." );
 
-  G_context.m_args.AddArgument( "--fmt",     argT::SPACE_ARGUMENT, &G_context.formatting_type, "Select alternate formatting type." );
+  G_context.m_args.AddArgument( "--fmt",     argT::SPACE_ARGUMENT, &G_context.formatting_type,
+                                "Generate display using alternative format, such as 'rst' or 'pipe'" );
+
+
+  // Need to load plugins before we display help since they can add
+  // command line options.
+  load_explorer_plugins( DEFAULT_MODULE_PATHS );
 
   // See if there are no args specified. If so, then default to full listing
   if ( argc == 1 )
@@ -599,15 +592,10 @@ main( int argc, char* argv[] )
 
   if ( G_context.opt_help )
   {
-    usage( argv[0] );
+    pe_out() << "Usage for " << argv[0] << std::endl
+             << G_context.m_args.GetHelp() << std::endl;
+    //+ usage( argv[0] );
     exit( 0 );
-  }
-
-  // Save some time by not loading the plugins if we know we will not
-  // be using them.
-  if ( ! G_context.opt_attrs )
-  {
-    load_explorer_plugins( DEFAULT_MODULE_PATHS );
   }
 
   // Handle process type parameter

--- a/vital/util/wrap_text_block.cxx
+++ b/vital/util/wrap_text_block.cxx
@@ -90,7 +90,7 @@ wrap_text( const std::string& text )
     // Counter of additional spaces to place in front of the next non-empty
     // word added to the line buffer. There is always at least one space
     // between words.
-    size_t spaces = 1;
+    size_t spaces = 0;
 
     std::list< std::string > words;
     // Not using token-compress in case there is purposeful use of multiple
@@ -115,8 +115,9 @@ wrap_text( const std::string& text )
           line_buffer = m_indent;
           // On a line split, it makes sense to me that leading spaces are
           // treated as trailing white-space, which should not be output.
-          spaces = 1;
+          spaces = 0;
         }
+
         line_buffer += std::string( spaces, ' ' ) + cur_word;
         spaces = 1;
       }


### PR DESCRIPTION
Expand explorer plugin architecture. Explorer plugins provide a way to generate custom formatting
for specific plugin categories. Currently only `process` and `algorithm` are supported. Plugin categories are stored in an attribute of the plugin factory object.

A new `--fmt xxx` command line option is added to specify an  alternate output format. If the `--fmt`
option is not specified, the factory category name is used to select the formatting plugin. For example, the explorer plugin named "process" is used to format factories that have the "process" category. If the `--fmt xxx` command line option is present, plugin explorer will use the "process-xxx" plugin for format processes. This provides a flexible way to extend the plugin formatting operation.

Added support for generating process documentation in rst and pipe file format.
Added support for generating algorithm documentation in pipeline format.