### PR TITLE
Add vital type: image_container_set

### DIFF
--- a/doc/manuals/vital/common.rst
+++ b/doc/manuals/vital/common.rst
@@ -106,3 +106,14 @@ definitions:
 .. _How to implement an stl style iterator: https://stackoverflow.com/questions/8054273/how-to-implement-an-stl-style-iterator-and-avoid-common-pitfalls
 .. _cplusplus.com\: Iterator Traits: http://www.cplusplus.com/reference/iterator/iterator_traits/
 .. _cplusplus.com\: Input Iterator: http://www.cplusplus.com/reference/iterator/InputIterator/
+
+.. _vital_iterable:
+
+Iterable Mixin
+--------------
+This mixin is intended to allow containers implemented in Vital to expose an
+iteration interface via the C++ standard ``begin`` and ``end`` methods.
+
+.. doxygenclass:: kwiver::vital::iterable
+   :project: kwiver
+   :members:

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -11,6 +11,9 @@ Updates since v1.2.0
 Vital
 
 
+ * Added iterator, const_iterator and iterable classes to support container-
+   independent iteration.
+
 Vital Bindings
 
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -14,6 +14,9 @@ Vital
  * Added iterator, const_iterator and iterable classes to support container-
    independent iteration.
 
+ * Added image_container_set type to contain multiple image_container shared
+   pointer instances.
+
 Vital Bindings
 
 

--- a/sprokit/processes/kwiver_type_traits.h
+++ b/sprokit/processes/kwiver_type_traits.h
@@ -46,6 +46,7 @@
 #include <vital/types/image_container.h>
 #include <vital/types/matrix.h>
 #include <vital/types/metadata.h>
+#include <vital/types/image_container_set.h>
 #include <vital/types/object_track_set.h>
 #include <vital/types/track_descriptor_set.h>
 #include <vital/types/uid.h>
@@ -81,6 +82,7 @@ create_type_trait( timestamp, "kwiver:timestamp", kwiver::vital::timestamp );
 create_type_trait( gsd, "kwiver:gsd", double );
 create_type_trait( corner_points, "corner_points", kwiver::vital::geo_polygon );
 create_type_trait( image, "kwiver:image", kwiver::vital::image_container_sptr );
+create_type_trait( image_set, "kwiver:image_set", kwiver::vital::image_container_set_sptr );
 create_type_trait( mask, "kwiver:mask", kwiver::vital::image_container_sptr );
 create_type_trait( feature_set, "kwiver:feature_set", kwiver::vital::feature_set_sptr );
 create_type_trait( descriptor_set, "kwiver:descriptor_set", kwiver::vital::descriptor_set_sptr );
@@ -114,6 +116,7 @@ create_port_trait( image, image, "Single frame image." );
 create_port_trait( left_image, image, "Single frame left image." );
 create_port_trait( right_image, image, "Single frame right image." );
 create_port_trait( depth_map, image, "Depth map stored in image form." );
+create_port_trait( image_set, image_set, "A collection of images, typically sub images." );
 create_port_trait( feature_set, feature_set, "Set of detected image features." );
 create_port_trait( descriptor_set, descriptor_set, "Set of descriptors." );
 create_port_trait( string_vector, string_vector, "Vector of strings." );

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -109,6 +109,8 @@ set( vital_public_headers
   types/homography_f2w.h
   types/image.h
   types/image_container.h
+  types/image_container_set.h
+  types/image_container_set_simple.h
   types/landmark.h
   types/landmark_map.h
   types/match_set.h

--- a/vital/iterator.h
+++ b/vital/iterator.h
@@ -477,6 +477,72 @@ public:
   }
 };
 
+/**
+ * Pure-virtual mixin class to add iteration support to a class.
+ *
+ * \tparam Type to iterate over.
+ */
+template< typename T >
+class iterable
+{
+public:
+  using iterator       = vital::iterator< T >;
+  using const_iterator = vital::const_iterator< T >;
+
+  /// Constructor
+  iterable() = default;
+  /// Destructor
+  virtual ~iterable() = default;
+
+  /** @name Iterator Accessors
+   * Accessors for const and non-const iterators
+   */
+  ///@{
+  /**
+   * Get the non-const iterator to the beginning of the collection.
+   * @return An iterator over the objects in this collection.
+   */
+  virtual iterator begin()
+  {
+    return vital::iterator< T >( get_iter_next_func() );
+  }
+
+  /**
+   * Get the non-const iterator past the end of the collection
+   * @return An iterator base the end of this collection.
+   */
+  virtual iterator end()
+  {
+    return vital::iterator< T >();
+  }
+
+  /**
+   * Get the const iterator to the beginning of the collection.
+   * @return An iterator over the objects in this collection.
+   */
+  virtual const_iterator cbegin()
+  {
+    return vital::const_iterator< T >( get_const_iter_next_func() );
+  }
+
+  /**
+   * Get the const iterator past the end of the collection
+   * @return An iterator base the end of this collection.
+   */
+  virtual const_iterator cend()
+  {
+    return vital::const_iterator< T >();
+  }
+  ///@}
+
+protected:
+  virtual typename iterator::next_value_func_t
+    get_iter_next_func() = 0;
+
+  virtual typename const_iterator::next_value_func_t
+    get_const_iter_next_func() const = 0;
+};
+
 } } // end namespaces
 
 #endif //KWIVER_VITAL_ITERATOR_H_

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ kwiver_discover_gtests(vital geo_polygon                    LIBRARIES ${test_lib
 kwiver_discover_gtests(vital geodesy                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital homography                     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital image                          LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital iterable                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterator                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital metadata_io                    LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vital polygon                        LIBRARIES ${test_libraries})

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ kwiver_discover_gtests(vital geo_polygon                    LIBRARIES ${test_lib
 kwiver_discover_gtests(vital geodesy                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital homography                     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital image                          LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital image_container_set            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterable                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterator                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital metadata_io                    LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -1,0 +1,409 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vital/types/image.h>
+#include <vital/types/image_container_set_simple.h>
+
+
+namespace {
+
+auto test_logger = kwiver::vital::get_logger( "vital.tests.test_image_container_set" );
+
+}
+
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char* argv[] )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+// Helper functions / classes for tests
+namespace {
+
+using ic_vec_t = std::vector< kwiver::vital::image_container_sptr >;
+
+/**
+ * Create simple vector of image_container_sptr instances.
+ *
+ * Output will consist of 3 image container sptrs of slightly increasing size:
+ * - 1x1
+ * - 2x2
+ * - 3x3
+ */
+ic_vec_t make_simple_ic_vec()
+{
+  using namespace kwiver::vital;
+
+  using img_vec_t = std::vector< image_container_sptr >;
+  img_vec_t img_vec;
+  img_vec.push_back( std::make_shared< simple_image_container >( image( 1, 1 ) ) );
+  img_vec.push_back( std::make_shared< simple_image_container >( image( 2, 2 ) ) );
+  img_vec.push_back( std::make_shared< simple_image_container >( image( 3, 3 ) ) );
+  return img_vec;
+}
+
+} // end namespace: anonymous
+
+// ----------------------------------------------------------------------------
+TEST( simple_image_container_set, empty )
+{
+  kwiver::vital::image_container_set_sptr empty_set;
+  empty_set = std::make_shared<kwiver::vital::simple_image_container_set>();
+
+  // Check size is reported as zero
+  EXPECT_EQ(0, empty_set->size()) << "Set empty";
+}
+
+// ----------------------------------------------------------------------------
+// Test construction with a non-empty vector of image_container_sptrs
+TEST( simple_image_container_set, construct_nonempty )
+{
+  using namespace kwiver::vital;
+  // Make a vector of empty images.
+  ic_vec_t img_vec = make_simple_ic_vec();
+  simple_image_container_set sics( img_vec );
+}
+
+// ----------------------------------------------------------------------------
+// Test size return from default construction
+TEST( simple_image_container_set, size_empty )
+{
+  using namespace kwiver::vital;
+  simple_image_container_set sics;
+  EXPECT_EQ( sics.size(), 0 );
+}
+
+// ----------------------------------------------------------------------------
+// Test set non-const iteration
+TEST( simple_image_container_set, expected_iteration )
+{
+  using namespace kwiver::vital;
+  // Make a vector of empty images.
+  ic_vec_t img_vec = make_simple_ic_vec();
+  simple_image_container_set sics( img_vec );
+
+  // We should be able to iterate 3 times with img_vec and the returns should
+  // be equivalent to the direct vector iterator
+  ic_vec_t::iterator                   vec_it = img_vec.begin();
+  simple_image_container_set::iterator sic_it = sics.begin();
+
+  LOG_INFO( test_logger, "Testing iter pos 0" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_EQ( *sic_it, img_vec[0] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 1 );
+  EXPECT_EQ( (*sic_it)->height(), 1 );
+
+  LOG_INFO( test_logger, "Incrementing to pos 1" );
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing iter pos 1" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_EQ( *sic_it, img_vec[1] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 2 );
+  EXPECT_EQ( (*sic_it)->height(), 2 );
+
+  LOG_INFO( test_logger, "Incrementing to pos 2" );
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing iter pos 2" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_EQ( *sic_it, img_vec[2] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 3 );
+  EXPECT_EQ( (*sic_it)->height(), 3 );
+
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing end pos" );
+  EXPECT_EQ( vec_it, img_vec.end() );
+  EXPECT_EQ( sic_it, sics.end() );
+}
+
+// ----------------------------------------------------------------------------
+// Test set const iteration
+TEST( simple_image_container_set, expected_iteration_const )
+{
+  using namespace kwiver::vital;
+
+  // Make a vector of empty images.
+  ic_vec_t img_vec = make_simple_ic_vec();
+  simple_image_container_set sics( img_vec );
+
+  // We should be able to iterate 3 times with img_vec and the returns should
+  // be equivalent to the direct vector iterator
+  ic_vec_t::const_iterator                   vec_it = img_vec.cbegin();
+  simple_image_container_set::const_iterator sic_it = sics.cbegin();
+
+  LOG_INFO( test_logger, "Testing iter pos 0" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.cend() );
+  EXPECT_EQ( *sic_it, img_vec[0] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 1 );
+  EXPECT_EQ( (*sic_it)->height(), 1 );
+
+  LOG_INFO( test_logger, "Incrementing to pos 1" );
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing iter pos 1" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.cend() );
+  EXPECT_EQ( *sic_it, img_vec[1] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 2 );
+  EXPECT_EQ( (*sic_it)->height(), 2 );
+
+  LOG_INFO( test_logger, "Incrementing to pos 2" );
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing iter pos 2" );
+  EXPECT_NE( vec_it, img_vec.end() );
+  EXPECT_NE( sic_it, sics.cend() );
+  EXPECT_EQ( *sic_it, img_vec[2] );
+  EXPECT_EQ( *sic_it, *vec_it );
+  EXPECT_EQ( (*sic_it)->width(), 3 );
+  EXPECT_EQ( (*sic_it)->height(), 3 );
+
+  LOG_INFO( test_logger, "Incrementing to iter end" );
+  ++vec_it;
+  ++sic_it;
+  LOG_INFO( test_logger, "Testing end pos" );
+  EXPECT_EQ( vec_it, img_vec.end() );
+  EXPECT_EQ( sic_it, sics.cend() );
+}
+
+// ----------------------------------------------------------------------------
+// Test that creating and iterating through multiple iterators does not affect
+// each other.
+TEST( simple_image_container_set, multiple_iterators )
+{
+  using namespace kwiver::vital;
+  // Make a vector of empty images.
+  ic_vec_t img_vec = make_simple_ic_vec();
+  simple_image_container_set sics( img_vec );
+
+  simple_image_container_set::iterator it1 = sics.begin();
+  simple_image_container_set::iterator it2 = sics.begin();
+
+  EXPECT_EQ( *it1, img_vec[0] );
+  EXPECT_EQ( (*it1)->width(), 1 );
+  EXPECT_NE( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[0] );
+  EXPECT_EQ( (*it2)->width(), 1 );
+  EXPECT_NE( it2, sics.end() );
+
+  // Move one iterator forward two and the other just one.
+  ++it1; ++it1;
+  ++it2;
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.end() );
+
+  // Make new iterator, which should point to the beginning.
+  simple_image_container_set::iterator it3 = sics.begin();
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.end() );
+
+  EXPECT_EQ( *it3, img_vec[0] );
+  EXPECT_EQ( (*it3)->width(), 1 );
+  EXPECT_NE( it3, sics.end() );
+
+  // Only move the newest iterator forward one.
+  ++it3;
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.end() );
+
+  EXPECT_EQ( *it3, img_vec[1] );
+  EXPECT_EQ( (*it3)->width(), 2 );
+  EXPECT_NE( it3, sics.end() );
+
+  // Move it1 forward to end.
+  ++it1;
+  EXPECT_EQ( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.end() );
+
+  EXPECT_EQ( *it3, img_vec[1] );
+  EXPECT_EQ( (*it3)->width(), 2 );
+  EXPECT_NE( it3, sics.end() );
+
+  // Move it3 to end.
+  ++it3; ++it3;
+  EXPECT_EQ( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.end() );
+
+  EXPECT_EQ( it3, sics.end() );
+
+  // Move it2 forward one.
+  ++it2;
+  EXPECT_EQ( it1, sics.end() );
+
+  EXPECT_EQ( *it2, img_vec[2] );
+  EXPECT_EQ( (*it2)->width(), 3 );
+  EXPECT_NE( it2, sics.end() );
+
+  EXPECT_EQ( it3, sics.end() );
+
+  // Move it2 to end
+  ++it2;
+  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it2, sics.end() );
+  EXPECT_EQ( it3, sics.end() );
+}
+
+// ----------------------------------------------------------------------------
+// Test that creating and iterating through multiple iterators does not affect
+// each other. (const version)
+TEST( simple_image_container_set, multiple_iterators_const )
+{
+  using namespace kwiver::vital;
+  // Make a vector of empty images.
+  ic_vec_t img_vec = make_simple_ic_vec();
+  simple_image_container_set sics( img_vec );
+
+  simple_image_container_set::const_iterator it1 = sics.cbegin();
+  simple_image_container_set::const_iterator it2 = sics.cbegin();
+
+  EXPECT_EQ( *it1, img_vec[0] );
+  EXPECT_EQ( (*it1)->width(), 1 );
+  EXPECT_NE( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[0] );
+  EXPECT_EQ( (*it2)->width(), 1 );
+  EXPECT_NE( it2, sics.cend() );
+
+  // Move one iterator forward two and the other just one.
+  ++it1; ++it1;
+  ++it2;
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.cend() );
+
+  // Make new iterator, which should point to the beginning.
+  simple_image_container_set::iterator it3 = sics.begin();
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.cend() );
+
+  EXPECT_EQ( *it3, img_vec[0] );
+  EXPECT_EQ( (*it3)->width(), 1 );
+  EXPECT_NE( it3, sics.cend() );
+
+  // Only move the newest iterator forward one.
+  ++it3;
+  EXPECT_EQ( *it1, img_vec[2] );
+  EXPECT_EQ( (*it1)->width(), 3 );
+  EXPECT_NE( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.cend() );
+
+  EXPECT_EQ( *it3, img_vec[1] );
+  EXPECT_EQ( (*it3)->width(), 2 );
+  EXPECT_NE( it3, sics.cend() );
+
+  // Move it1 forward to end.
+  ++it1;
+  EXPECT_EQ( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.cend() );
+
+  EXPECT_EQ( *it3, img_vec[1] );
+  EXPECT_EQ( (*it3)->width(), 2 );
+  EXPECT_NE( it3, sics.cend() );
+
+  // Move it3 to end.
+  ++it3; ++it3;
+  EXPECT_EQ( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[1] );
+  EXPECT_EQ( (*it2)->width(), 2 );
+  EXPECT_NE( it2, sics.cend() );
+
+  EXPECT_EQ( it3, sics.cend() );
+
+  // Move it2 forward one.
+  ++it2;
+  EXPECT_EQ( it1, sics.cend() );
+
+  EXPECT_EQ( *it2, img_vec[2] );
+  EXPECT_EQ( (*it2)->width(), 3 );
+  EXPECT_NE( it2, sics.cend() );
+
+  EXPECT_EQ( it3, sics.cend() );
+
+  // Move it2 to end
+  ++it2;
+  EXPECT_EQ( it1, sics.cend() );
+  EXPECT_EQ( it2, sics.cend() );
+  EXPECT_EQ( it3, sics.cend() );
+}

--- a/vital/tests/test_iterable.cxx
+++ b/vital/tests/test_iterable.cxx
@@ -1,0 +1,107 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <vital/iterator.h>
+
+using namespace kwiver;
+
+// ----------------------------------------------------------------------------
+int main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+// Test iterable interface with range-based loop.
+namespace {
+
+// Simple iterable over a vector of integers.
+class SimpleIterable
+  : public kwiver::vital::iterable< int >
+{
+public:
+  SimpleIterable( std::vector<int> v )
+    : v_( v )
+  {}
+  ~SimpleIterable() = default;
+
+protected:
+  iterator::next_value_func_t get_iter_next_func()
+  {
+    std::vector<int>::iterator it = v_.begin();
+    return [=] () mutable ->iterator::reference {
+      if( it == v_.end() ) throw kwiver::vital::stop_iteration_exception();
+      return *(it++);
+    };
+  }
+
+  const_iterator::next_value_func_t get_const_iter_next_func() const
+  {
+    std::vector<int>::const_iterator it = v_.begin();
+    return [=] () mutable ->const_iterator::reference {
+      if( it == v_.end() ) throw kwiver::vital::stop_iteration_exception();
+      return *(it++);
+    };
+  }
+
+private:
+  std::vector<int> v_;
+};
+
+}
+
+TEST( iterable, range_based_loop )
+{
+  using namespace std;
+  using namespace kwiver::vital;
+
+  // Make a simple vector of ints
+  vector<int> v;
+  v.push_back(0);
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+  v.push_back(4);
+
+  SimpleIterable si( v );
+  int i = 0;
+  for( int const & j : si )
+  {
+    EXPECT_EQ( j, i );
+    ++i;
+  }
+  // We should have exited when i == 5.
+  EXPECT_EQ( i, 5 );
+}

--- a/vital/types/image_container.h
+++ b/vital/types/image_container.h
@@ -97,6 +97,8 @@ typedef std::shared_ptr<image_container> image_container_sptr;
 
 
 /// List of image_container shared pointers
+// NOTE(paul.tunison): This should be deprecated in favor of
+//                     vital::image_container_set_sptr.
 typedef std::vector<image_container_sptr> image_container_sptr_list;
 
 

--- a/vital/types/image_container_set.h
+++ b/vital/types/image_container_set.h
@@ -1,0 +1,81 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief core image_container_set interface
+ */
+
+#ifndef VITAL_IMAGE_CONTAINER_SET_H_
+#define VITAL_IMAGE_CONTAINER_SET_H_
+
+
+#include "image_container.h"
+#include <vital/vital_config.h>
+#include <vital/iterator.h>
+#include <vital/logger/logger.h>
+#include <vital/noncopyable.h>
+
+namespace kwiver {
+namespace vital {
+
+/// An abstract ordered collection of feature images.
+/**
+ * The base class image_container_set is abstract and provides an interface
+ * for returning a vector of images.  There is a simple derived class
+ * that stores the data as a vector of images and returns it.  Other
+ * derived classes can store the data in other formats and convert on demand.
+ */
+class image_container_set
+  : public iterable< image_container_sptr >
+  , private noncopyable
+{
+public:
+  /// Destructor
+  virtual ~image_container_set() = default;
+
+  /// Return the number of images in the set
+  virtual size_t size() const = 0;
+
+protected:
+  image_container_set()
+   : m_logger( kwiver::vital::get_logger( "vital.image_container_set" ) )
+  {}
+
+  kwiver::vital::logger_handle_t m_logger;
+};
+
+/// Shared pointer for base image_container_set type
+typedef std::shared_ptr< image_container_set > image_container_set_sptr;
+
+
+} } // end namespace vital
+
+#endif // VITAL_IMAGE_CONTAINER_SET_H_

--- a/vital/types/image_container_set_simple.h
+++ b/vital/types/image_container_set_simple.h
@@ -1,0 +1,106 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for simple implementation of image_container_set
+ */
+
+#ifndef VITAL_IMAGE_CONTAINER_SET_SIMPLE_H_
+#define VITAL_IMAGE_CONTAINER_SET_SIMPLE_H_
+
+#include <vital/types/image_container_set.h>
+
+
+namespace kwiver {
+namespace vital {
+
+
+/// A concrete image container set that simply wraps a vector of images.
+class simple_image_container_set
+  : public image_container_set
+{
+public:
+  /// Default Constructor
+  simple_image_container_set() { }
+
+  /// Constructor from a vector of images
+  explicit simple_image_container_set( std::vector< image_container_sptr > const& images )
+    : data_( images ) { }
+
+  /// Return the number of items
+  virtual size_t size() const { return data_.size(); }
+
+protected:
+  using vec_t = std::vector< image_container_sptr >;
+
+  /// The vector of images
+  vec_t data_;
+
+  /// Implement next function for non-const iterator.
+  iterator::next_value_func_t
+  get_iter_next_func()
+  {
+    vec_t::iterator v_it = data_.begin();
+    // Lambda notes:
+    // - [=] capture by copy
+    // - mutable: modify the parameters captured by copy
+    return [=] () mutable ->iterator::reference {
+      if( v_it == data_.end() )
+      {
+        throw stop_iteration_exception();
+      }
+      return *(v_it++);
+    };
+  }
+
+  /// Implement next function for const iterator.
+  const_iterator::next_value_func_t
+  get_const_iter_next_func() const
+  {
+    vec_t::const_iterator v_cit = data_.begin();
+    // Lambda notes:
+    // - [=] capture by copy
+    // - mutable: modify the parameters captured by copy
+    return [=] () mutable ->const_iterator::reference {
+      if( v_cit == data_.end()  )
+      {
+        throw stop_iteration_exception();
+      }
+      return *(v_cit++);
+    };
+  }
+};
+
+
+} } // end namespaces
+
+
+#endif //VITAL_IMAGE_CONTAINER_SET_SIMPLE_H_


### PR DESCRIPTION
This is part of my work on getting the tracker in. I'm going to try to make each new piece that I add as self-contained as possible.  

This piece is a new vital type to represent a set of multiple images. This will be used for holding a set of image chips that I will extract from a `detected_object_set`.

This is a WIP. I've only done a basic copy-paste-search-replace followed by a first pass of testing and cmake integration. I'm putting it up as a PR to allow for input while I work on the larger goal of porting the tracker from VIAME. 

-------------------

As an aside, I've noticed that there are a lot of `*_set` classes:
```
descriptor_set.h       feature_set.h        image_container_set.h  object_track_set.h      track_set.h
detected_object_set.h  feature_track_set.h  match_set.h            track_descriptor_set.h
```

I'm wondering if it might be a good idea to implement some sort of templated `*_set` base class that offers basic iterating, indexing, and vector based storage.  This could allow for some of the more complex container interfaces to exist while making it easy to wrap a new class with a collection interface.