### PR TITLE
Visual studio fixes

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
@@ -30,16 +30,8 @@
 
 #include <vital/config/config_block.h>
 
-#if WIN32
-#pragma warning (push)
-#pragma warning (disable : 4267)
-#pragma warning (disable : 4244)
-#endif
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
-#if WIN32
-#pragma warning (pop)
-#endif
 
 #include <sstream>
 
@@ -48,18 +40,6 @@
  *
  * \brief Python bindings for \link kwiver::vital::config \endlink.
  */
-
-#ifdef WIN32
-// Windows get_pointer const volatile workaround
-namespace boost
-{
-  template <> inline kwiver::vital::config_block const volatile*
-  get_pointer( class kwiver::vital::config_block const volatile* cb )
-  {
-    return cb;
-  }
-}
-#endif
 
 namespace kwiver {
 namespace vital {

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -48,24 +48,6 @@
 #include <pybind11/stl_bind.h>
 #include "python_wrappers.cxx"
 
-#ifdef WIN32
- // Windows get_pointer const volatile workaround
-namespace boost
-{
-  template <> inline sprokit::process const volatile*
-  get_pointer(class sprokit::process const volatile* p)
-  {
-    return p;
-  }
-
-  template <> inline sprokit::process_cluster const volatile*
-  get_pointer(class sprokit::process_cluster const volatile* p)
-  {
-    return p;
-  }
-}
-#endif
-
 using namespace pybind11;
 
 // We need our own factory for inheritance to work

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -47,23 +47,6 @@
 
 #include <pybind11/stl_bind.h>
 
-#ifdef WIN32
- // Windows get_pointer const volatile workaround
-namespace boost
-{
-  template <> inline sprokit::scheduler const volatile*
-  get_pointer(class sprokit::scheduler const volatile* p)
-  {
-    return p;
-  }
-  template <> inline sprokit::scheduler_factory const volatile*
-  get_pointer(class sprokit::scheduler_factory const volatile* p)
-  {
-    return p;
-  }
-}
-#endif
-
 using namespace pybind11;
 
 typedef std::function< object( sprokit::pipeline_t const& pipe,


### PR DESCRIPTION
It looks like we'll need a few fixes for Visual Studio. I've started off by getting rid of some code that worked in VS14 but is broken in VS15 (and has become unnecessary anyway). Some other changes will have to be made as well. At the very minimum, C bindings are broken in VS15 (haven't checked VS14, but I assume they worked at some point) and some of the new GTest code is not windows friendly. 