### PR TITLE
Remove obsolete description() method.

### DIFF
--- a/arrows/core/close_loops_bad_frames_only.cxx
+++ b/arrows/core/close_loops_bad_frames_only.cxx
@@ -63,17 +63,8 @@ close_loops_bad_frames_only
 }
 
 
-std::string
-close_loops_bad_frames_only
-::description() const
-{
-  return "Attempts short-term loop closure based on percentage of feature "
-    "points tracked.";
-}
-
-
-/// Get this alg's \link vital::config_block configuration block \endlink
-  vital::config_block_sptr
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
 close_loops_bad_frames_only
 ::get_configuration() const
 {
@@ -109,6 +100,7 @@ close_loops_bad_frames_only
 }
 
 
+// ----------------------------------------------------------------------------
 /// Set this algo's properties via a config block
 void
 close_loops_bad_frames_only
@@ -134,7 +126,8 @@ close_loops_bad_frames_only
 }
 
 
-bool
+// ----------------------------------------------------------------------------
+  bool
 close_loops_bad_frames_only
 ::check_configuration(vital::config_block_sptr config) const
 {
@@ -146,6 +139,7 @@ close_loops_bad_frames_only
 }
 
 
+// ----------------------------------------------------------------------------
 /// Handle track bad frame detection if enabled
 vital::feature_track_set_sptr
 close_loops_bad_frames_only

--- a/arrows/core/close_loops_bad_frames_only.h
+++ b/arrows/core/close_loops_bad_frames_only.h
@@ -69,9 +69,6 @@ public:
   /// Destructor
   virtual ~close_loops_bad_frames_only() = default;
 
-  /// Returns implementation description
-  virtual std::string description() const;
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**
    * This base virtual function implementation returns an empty configuration

--- a/arrows/core/close_loops_exhaustive.cxx
+++ b/arrows/core/close_loops_exhaustive.cxx
@@ -77,6 +77,7 @@ public:
 };
 
 
+// ----------------------------------------------------------------------------
 /// Constructor
 close_loops_exhaustive
 ::close_loops_exhaustive()
@@ -92,15 +93,7 @@ close_loops_exhaustive
 }
 
 
-std::string
-close_loops_exhaustive
-::description() const
-{
-  return "Exhaustive matching of all frame pairs, "
-         "or all frames within a moving window";
-}
-
-
+// ----------------------------------------------------------------------------
 /// Get this alg's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 close_loops_exhaustive
@@ -124,6 +117,7 @@ close_loops_exhaustive
 }
 
 
+// ----------------------------------------------------------------------------
 /// Set this algo's properties via a config block
 void
 close_loops_exhaustive
@@ -143,6 +137,7 @@ close_loops_exhaustive
 }
 
 
+// ----------------------------------------------------------------------------
 bool
 close_loops_exhaustive
 ::check_configuration(vital::config_block_sptr config) const

--- a/arrows/core/close_loops_exhaustive.h
+++ b/arrows/core/close_loops_exhaustive.h
@@ -67,9 +67,6 @@ public:
   /// Destructor
   virtual ~close_loops_exhaustive() noexcept;
 
-  /// Returns implementation description
-  virtual std::string description() const;
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**
    * This base virtual function implementation returns an empty configuration

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -95,6 +95,7 @@ public:
 };
 
 
+// ----------------------------------------------------------------------------
 /// Constructor
 close_loops_keyframe
 ::close_loops_keyframe()
@@ -110,14 +111,7 @@ close_loops_keyframe
 }
 
 
-std::string
-close_loops_keyframe
-::description() const
-{
-  return "Establishes keyframes matches to all keyframes";
-}
-
-
+// ----------------------------------------------------------------------------
 /// Get this alg's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 close_loops_keyframe
@@ -152,6 +146,7 @@ close_loops_keyframe
 }
 
 
+// ----------------------------------------------------------------------------
 /// Set this algo's properties via a config block
 void
 close_loops_keyframe
@@ -173,6 +168,7 @@ close_loops_keyframe
 }
 
 
+// ----------------------------------------------------------------------------
 bool
 close_loops_keyframe
 ::check_configuration(vital::config_block_sptr config) const
@@ -186,6 +182,7 @@ close_loops_keyframe
 }
 
 
+// ----------------------------------------------------------------------------
 /// Frame stitching using keyframe-base matching
 vital::feature_track_set_sptr
 close_loops_keyframe

--- a/arrows/core/close_loops_keyframe.h
+++ b/arrows/core/close_loops_keyframe.h
@@ -62,9 +62,6 @@ public:
   /// Destructor
   virtual ~close_loops_keyframe() noexcept;
 
-  /// Returns implementation description
-  virtual std::string description() const;
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**
    * This base virtual function implementation returns an empty configuration

--- a/arrows/core/close_loops_multi_method.cxx
+++ b/arrows/core/close_loops_multi_method.cxx
@@ -76,16 +76,8 @@ close_loops_multi_method
 }
 
 
-/// Returns implementation description string
-std::string
-close_loops_multi_method
-::description() const
-{
-  return "Iteratively run multiple loop closure algorithms";
-}
-
-
-  vital::config_block_sptr
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
 close_loops_multi_method
 ::get_configuration() const
 {
@@ -107,6 +99,7 @@ close_loops_multi_method
 }
 
 
+// ----------------------------------------------------------------------------
 void
 close_loops_multi_method
 ::set_configuration( vital::config_block_sptr in_config )
@@ -130,6 +123,7 @@ close_loops_multi_method
 }
 
 
+// ----------------------------------------------------------------------------
 bool
 close_loops_multi_method
 ::check_configuration( vital::config_block_sptr config ) const
@@ -148,6 +142,7 @@ close_loops_multi_method
 }
 
 
+// ----------------------------------------------------------------------------
 feature_track_set_sptr
 close_loops_multi_method
 ::stitch( frame_id_t frame_number, feature_track_set_sptr input,

--- a/arrows/core/close_loops_multi_method.h
+++ b/arrows/core/close_loops_multi_method.h
@@ -68,9 +68,6 @@ public:
   /// Destructor
   virtual ~close_loops_multi_method() = default;
 
-  /// Returns implementation description string
-  virtual std::string description() const;
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**
    * This base virtual function implementation returns an empty configuration

--- a/arrows/core/compute_ref_homography_core.cxx
+++ b/arrows/core/compute_ref_homography_core.cxx
@@ -104,6 +104,7 @@ typedef std::vector< track_info_t > track_info_buffer_t;
 typedef std::shared_ptr< track_info_buffer_t > track_info_buffer_sptr;
 
 
+// ----------------------------------------------------------------------------
 // Helper function for sorting tis
 bool
 compare_ti( const track_info_t& c1, const track_info_t& c2 )
@@ -112,6 +113,7 @@ compare_ti( const track_info_t& c1, const track_info_t& c2 )
 }
 
 
+// ----------------------------------------------------------------------------
 // Find a track in a given buffer
 track_info_buffer_t::iterator
 find_track( const track_sptr& trk, track_info_buffer_sptr buffer )
@@ -122,6 +124,7 @@ find_track( const track_sptr& trk, track_info_buffer_sptr buffer )
 }
 
 
+// ----------------------------------------------------------------------------
 // Reset all is found flags
 void
 reset_active_flags( track_info_buffer_sptr buffer )
@@ -282,6 +285,7 @@ public:
 };
 
 
+// ----------------------------------------------------------------------------
 compute_ref_homography_core
 ::compute_ref_homography_core()
 : d_( new priv() )
@@ -297,15 +301,8 @@ compute_ref_homography_core
 }
 
 
-std::string
-compute_ref_homography_core
-::description() const
-{
-  return "Default online sequential-frame reference homography estimator";
-}
-
-
-  vital::config_block_sptr
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
 compute_ref_homography_core
 ::get_configuration() const
 {
@@ -343,6 +340,7 @@ compute_ref_homography_core
 }
 
 
+// ----------------------------------------------------------------------------
 void
 compute_ref_homography_core
 ::set_configuration( vital::config_block_sptr in_config )
@@ -371,6 +369,7 @@ compute_ref_homography_core
 }
 
 
+// ----------------------------------------------------------------------------
 bool
 compute_ref_homography_core
 ::check_configuration(vital::config_block_sptr config) const
@@ -382,6 +381,7 @@ compute_ref_homography_core
 }
 
 
+// ----------------------------------------------------------------------------
 // Perform actual current to reference frame estimation
 f2f_homography_sptr
 compute_ref_homography_core

--- a/arrows/core/compute_ref_homography_core.h
+++ b/arrows/core/compute_ref_homography_core.h
@@ -76,9 +76,6 @@ public:
   /// Default Destructor
   virtual ~compute_ref_homography_core();
 
-  /// Return implementation description string
-  virtual std::string description() const;
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   /**
    * This base virtual function implementation returns an empty configuration

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -116,6 +116,9 @@ Arrows: Core
  * Renamed merge_tracks.h to match_tracks.h and removed all track merging
    functions.  Track merging is now a function of the track_set itself.
 
+ * Removed description() methods from some implementations. This
+   method is no longer used.
+
 Sprokit
 
  * Removed the CMake function sprokit_add_plugin and replaced it with the more


### PR DESCRIPTION
The description method was a vestige of a bygone base class that
handled the algorithm description. The description is now part
of the factory.