### PR TITLE
Fix test build error on Windows/macOS

### DIFF
--- a/vital/tests/test_track_set.h
+++ b/vital/tests/test_track_set.h
@@ -54,7 +54,7 @@ namespace testing {
 
 // ----------------------------------------------------------------------------
 template <>
-Message& Message::operator<<( std::set<long> const& s )
+Message& Message::operator<<( std::set<int64_t> const& s )
 {
   (*ss_) << "{ ";
   for ( auto const i : s )
@@ -85,7 +85,7 @@ namespace vital {
 namespace testing {
 
 // ----------------------------------------------------------------------------
-bool compare_ids( std::set<long> const& a, std::set<long> const& b )
+bool compare_ids( std::set<int64_t> const& a, std::set<int64_t> const& b )
 {
   return std::equal( a.begin(), a.end(), b.begin() );
 }


### PR DESCRIPTION
Fix type mismatch between track set id comparison helper (which was using `long`) and actual track id's (`track_id_t`), which are `long` on some platforms (Linux), but `long long` on others.