### PR TITLE
fix detector bugs

### DIFF
--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -129,6 +129,7 @@ darknet_detector()
 {
   // set darknet global GPU index
   gpu_index = d->m_gpu_index;
+  d->m_logger = logger();
 }
 
 

--- a/vital/types/detected_object_set.cxx
+++ b/vital/types/detected_object_set.cxx
@@ -127,8 +127,8 @@ void
 detected_object_set::
 add( detected_object_set_sptr detections )
 {
-  auto ie = cend();
-  for ( auto ix = cbegin(); ix != ie; ++ix )
+  auto ie = detections->cend();
+  for ( auto ix = detections->cbegin(); ix != ie; ++ix )
   {
     this->add( *ix );
   }


### PR DESCRIPTION
The m_logger was null.
Adding a set did nothing because it was iterating over itself instead of the desired set.