### PR TITLE
Remove header includes from the extern C

### DIFF
--- a/vital/bindings/c/types/descriptor.h
+++ b/vital/bindings/c/types/descriptor.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,17 +36,15 @@
 #ifndef VITAL_C_DESCRIPTOR_H_
 #define VITAL_C_DESCRIPTOR_H_
 
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <cstddef>
 
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // General Descriptor functions

--- a/vital/bindings/c/types/descriptor_set.h
+++ b/vital/bindings/c/types/descriptor_set.h
@@ -36,17 +36,16 @@
 #ifndef VITAL_C_DESCRIPTOR_SET_H_
 #define VITAL_C_DESCRIPTOR_SET_H_
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <cstddef>
 
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
 #include <vital/bindings/c/types/descriptor.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 /// Base opaque descriptor instance type
 typedef struct vital_descriptor_set_s vital_descriptor_set_t;

--- a/vital/bindings/c/types/feature_track_set.h
+++ b/vital/bindings/c/types/feature_track_set.h
@@ -36,16 +36,15 @@
 #ifndef VITAL_C_FEATURE_TRACK_SET_H_
 #define VITAL_C_FEATURE_TRACK_SET_H_
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include "track.h"
 
 #include <vital/bindings/c/types/descriptor.h>
 #include <vital/bindings/c/types/feature.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Feature Track State


### PR DESCRIPTION
This patch fixes the vs 2017 error "templates cannot be declared to have
'C' linkage" when c_bindings is enabled.