### PR TITLE
README updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ grow as we expand Arrows.
 
 Vital has minimal required dependencies (only Eigen_).
 Sprokit additionally relies on Boost_.
+C++ tests additionally rely on `Google Test`_.
 Arrows and Sprokit processes are structured so that
 the code that depends on an external package is in a directory with
 the major dependency name (e.g. vxl, ocv). The dependencies can be
@@ -95,7 +96,7 @@ The following are the most important CMake configuration options for KWIVER.
 ``KWIVER_ENABLE_LOG4CPLUS``   Enable log4cplus logger back end
 ``KWIVER_ENABLE_PYTHON``      Enable the Vital Python bindings (requires KWIVER_ENABLE_C_BINDINGS)
 ``KWIVER_ENABLE_SPROKIT``     Enable the Stream Processing Toolkit
-``KWIVER_ENABLE_TESTS``       Build the unit tests
+``KWIVER_ENABLE_TESTS``       Build the unit tests (requires Google Test)
 ``KWIVER_ENABLE_TOOLS``       Build the command line tools (e.g. plugin_explorer)
 ``fletch_DIR``                Install directory of a Fletch build.
 ============================= ====================================================================
@@ -176,6 +177,17 @@ folder will be populated with all binaries, libraries, headers, and other files
 you will need to develop your application with kwiver.  MSVC users note, this
 install directory is for a single build configuration and their will not be configuration 
 named directories in this directory structure. (i.e. no /bin/release, only /bin)
+
+.. note::
+
+  If you are on Windows and enable tests (``KWIVER_ENABLE_TESTS=ON``),
+  and are building shared libraries (``BUILD_SHARED_LIBS=ON``), you will
+  need to add the path to ``gtest.dll`` to the ``PATH`` in your environment
+  in order to build and run the tests.
+
+  The easiest way to achieve this is to use the ``setup_KWIVER.bat`` script
+  (described in the next session), and to run builds and/or launch Visual
+  Studio from a command prompt which has been so configured.
 
 
 Running KWIVER
@@ -287,6 +299,7 @@ NOAA Fisheries Strategic Initiative on Automated Image Analysis.
 .. _Darknet: https://pjreddie.com/darknet/yolo/
 .. _Eigen: http://eigen.tuxfamily.org/
 .. _Fletch: https://github.com/Kitware/fletch
+.. _Google Test: https://github.com/google/googletest
 .. _Kitware: http://www.kitware.com/
 .. _MAP-Tk: https://github.com/Kitware/maptk
 .. _OpenCV: http://opencv.org/

--- a/README.rst
+++ b/README.rst
@@ -174,9 +174,10 @@ this is typically running ``make``.
 There is also a build target, INSTALL. This target will build all code,
 then create an install directory inside the build directory.  This install
 folder will be populated with all binaries, libraries, headers, and other files
-you will need to develop your application with kwiver.  MSVC users note, this
-install directory is for a single build configuration and their will not be configuration 
-named directories in this directory structure. (i.e. no /bin/release, only /bin)
+you will need to develop your application with kwiver. MSVC users, note that
+this install directory is for a single build configuration; there will not be
+configuration named directories in this directory structure
+(i.e. no ``/bin/release``, only ``/bin``).
 
 .. note::
 

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,8 @@ turned ON or OFF through CMake variables.
 To make it easier to build KWIVER, especially
 on systems like Microsoft Windows that do not have package manager,
 Fletch_ was developed to gather, configure and build dependent packages
-for use with KWIVER.  Fletch is a CMake_ based "super-build" that
-takes care of most of the build details for you.
+for use with KWIVER.  Fletch is a |cmake_link|_ based
+"super-build" that takes care of most of the build details for you.
 
 For building Fletch_, refer to the README file in that repository.
 
@@ -283,7 +283,7 @@ NOAA Fisheries Strategic Initiative on Automated Image Analysis.
 .. _Boost: http://www.boost.org/
 .. _`Ceres Solver`: http://ceres-solver.org/
 .. _CDash: http://www.cdash.org/
-.. _CMake: http://www.cmake.org/
+.. _cmake_link: http://www.cmake.org/
 .. _Darknet: https://pjreddie.com/darknet/yolo/
 .. _Eigen: http://eigen.tuxfamily.org/
 .. _Fletch: https://github.com/Kitware/fletch
@@ -298,6 +298,11 @@ NOAA Fisheries Strategic Initiative on Automated Image Analysis.
 
 .. Appendix II: Text Substitutions
 .. ===============================
+
+.. Use a different target name to avoid conflict with `<CMake>`_ link to the
+   source tree.
+
+.. |cmake_link| replace:: CMake
 
 .. |>=| unicode:: U+02265 .. greater or equal sign
 


### PR DESCRIPTION
Fix CMake link in README (see commit message for more detailed explanation). Update README to note the C++ tests' dependency on Google Test. (In particular, add a note that Windows users will need their environment to be properly set up in order to avoid build problems.)