### PR TITLE
Convert and refactor Ceres bundle_adjust test

### DIFF
--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -16,6 +16,6 @@ endif()
 ##############################
 # Algorithms Ceres tests
 ##############################
-kwiver_discover_tests(ceres_bundle_adjust       test_libraries test_bundle_adjust.cxx)
+kwiver_discover_gtests(ceres bundle_adjust      LIBRARIES ${test_libraries})
 kwiver_discover_tests(ceres_optimize_cameras    test_libraries test_optimize_cameras.cxx)
 kwiver_discover_tests(ceres_reprojection_error  test_libraries test_reprojection_error.cxx)

--- a/arrows/ceres/tests/test_bundle_adjust.cxx
+++ b/arrows/ceres/tests/test_bundle_adjust.cxx
@@ -33,420 +33,49 @@
  * \brief test Ceres bundle adjustment functionality
  */
 
-#include <test_common.h>
+#include <test_eigen.h>
 #include <test_scene.h>
-
-#include <vital/plugin_loader/plugin_manager.h>
 
 #include <arrows/core/metrics.h>
 #include <arrows/ceres/bundle_adjust.h>
 #include <arrows/core/projected_track_set.h>
 
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <gtest/gtest.h>
+
 using namespace kwiver::vital;
+using namespace kwiver::arrows;
 
-#define TEST_ARGS ()
+using kwiver::arrows::ceres::bundle_adjust;
 
-DECLARE_TEST_MAP();
-
-int
-main(int argc, char* argv[])
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
 {
-  CHECK_ARGS(1);
+  ::testing::InitGoogleTest( &argc, argv );
 
-  // Register ceres algorithm implementations
   kwiver::vital::plugin_manager::instance().load_all_plugins();
-  testname_t const testname = argv[1];
 
-  RUN_TEST(testname);
+  return RUN_ALL_TESTS();
 }
 
-
-IMPLEMENT_TEST(create)
+// ----------------------------------------------------------------------------
+TEST(bundle_adjust, create)
 {
-  using namespace kwiver::arrows;
-  algo::bundle_adjust_sptr ba = algo::bundle_adjust::create("ceres");
-  if (!ba)
-  {
-    TEST_ERROR("Unable to create ceres::bundle_adjust by name");
-  }
+  EXPECT_NE( nullptr, algo::bundle_adjust::create("ceres") );
 }
 
+// ----------------------------------------------------------------------------
+#include <arrows/tests/test_bundle_adjust.h>
 
-// input to SBA is the ideal solution, make sure it doesn't diverge
-IMPLEMENT_TEST(from_solution)
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras and tracks before input to SBA; select
+// a subset of tracks_states to make outliers (large observation noise); add a
+// small amount of noise to all track states; and select a subset of
+// tracks/track_states to constrain the problem
+TEST(bundle_adjust, outlier_tracks)
 {
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse > 1e-12)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be small");
-  }
-
-  ba.optimize(cameras, landmarks, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-12);
-}
-
-
-// add noise to landmarks before input to SBA
-IMPLEMENT_TEST(noisy_landmarks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// add noise to landmarks and cameras before input to SBA
-IMPLEMENT_TEST(noisy_landmarks_noisy_cameras)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// initialize all landmarks to the origin as input to SBA
-IMPLEMENT_TEST(zero_landmarks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // initialize all landmarks to the origin
-  landmark_id_t num_landmarks = static_cast<landmark_id_t>(landmarks->size());
-  landmark_map_sptr landmarks0 = kwiver::testing::init_landmarks(num_landmarks);
-
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// add noise to landmarks and cameras before input to SBA
-// select a subset of cameras to optimize
-IMPLEMENT_TEST(subset_cameras)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  camera_map::map_camera_t cam_map = cameras0->cameras();
-  camera_map::map_camera_t cam_map2;
-  for(camera_map::map_camera_t::value_type& p : cam_map)
-  {
-    /// take every third camera
-    if(p.first % 3 == 0)
-    {
-      cam_map2.insert(p);
-    }
-  }
-  cameras0 = camera_map_sptr(new simple_camera_map(cam_map2));
-
-
-  TEST_EQUAL("Reduced number of cameras", cameras0->size(), 7);
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// add noise to landmarks and cameras before input to SBA
-// select a subset of landmarks to optimize
-IMPLEMENT_TEST(subset_landmarks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some landmarks
-  landmark_map::map_landmark_t lm_map = landmarks0->landmarks();
-  lm_map.erase(1);
-  lm_map.erase(4);
-  lm_map.erase(5);
-  landmarks0 = landmark_map_sptr(new simple_landmark_map(lm_map));
-
-  TEST_EQUAL("Reduced number of landmarks", landmarks0->size(), 5);
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// add noise to landmarks and cameras before input to SBA
-// select a subset of tracks/track_states to constrain the problem
-IMPLEMENT_TEST(subset_tracks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some tracks/track_states
-  feature_track_set_sptr tracks0 = kwiver::testing::subset_tracks(tracks, 0.5);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks0->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras0, landmarks0, tracks0);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks0->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
-}
-
-
-// add noise to landmarks and cameras and tracks before input to SBA
-// select a subset of tracks/track_states and add observation noise
-IMPLEMENT_TEST(noisy_tracks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some tracks/track_states and add Gaussian noise
-  const double track_stdev = 1.0;
-  feature_track_set_sptr tracks0 = kwiver::testing::noisy_tracks(
-                               kwiver::testing::subset_tracks(tracks, 0.5),
-                               track_stdev);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks0->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
-
-  ba.optimize(cameras0, landmarks0, tracks0);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks0->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, track_stdev);
-}
-
-
-// add noise to landmarks and cameras and tracks before input to SBA
-// select a subset of tracks_states to make outliers (large observation noise)
-// add a small amount of noise to all track states
-// select a subset of tracks/track_states to constrain the problem
-IMPLEMENT_TEST(outlier_tracks)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
+  bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
   cfg->set_value("verbose", "true");
   cfg->set_value("max_num_iterations", 100);
@@ -473,33 +102,31 @@ IMPLEMENT_TEST(outlier_tracks)
 
   // remove some tracks/track_states and add Gaussian noise
   const double track_stdev = 1.0;
-  feature_track_set_sptr tracks0 = kwiver::testing::noisy_tracks(
-                               kwiver::testing::subset_tracks(tracks_w_outliers, 0.5),
-                               track_stdev);
+  feature_track_set_sptr tracks0 =
+    kwiver::testing::noisy_tracks(
+      kwiver::testing::subset_tracks(tracks_w_outliers, 0.5), track_stdev);
 
 
   double init_rmse = reprojection_rmse(cameras0->cameras(),
                                        landmarks0->landmarks(),
                                        tracks0->tracks());
   std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
 
   double init_med_err = reprojection_median_error(cameras0->cameras(),
                                                   landmarks0->landmarks(),
                                                   tracks0->tracks());
   std::cout << "initial reprojection median error: "
             << init_med_err << std::endl;
-  if (init_med_err < 10.0)
-  {
-    TEST_ERROR("Initial reprojection median_error should be large before SBA");
-  }
+  EXPECT_GE(init_med_err, 10.0)
+    << "Initial reprojection median error should be large before SBA";
 
   // make a copy of the initial cameras and landmarks
-  landmark_map_sptr landmarks1(new simple_landmark_map(landmarks0->landmarks()));
-  camera_map_sptr cameras1(new simple_camera_map(cameras0->cameras()));
+  landmark_map_sptr landmarks1 =
+    std::make_shared<simple_landmark_map>(landmarks0->landmarks());
+  camera_map_sptr cameras1 =
+    std::make_shared<simple_camera_map>(cameras0->cameras());
 
   // run bundle adjustement with the default, non-robust, trivial loss function
   ba.optimize(cameras0, landmarks0, tracks0);
@@ -513,10 +140,8 @@ IMPLEMENT_TEST(outlier_tracks)
 
   std::cout << "Non-robust SBA mean/median reprojection error: "
             << trivial_loss_rmse << "/" << trivial_loss_med_err << std::endl;
-  if ( trivial_loss_med_err < track_stdev )
-  {
-    TEST_ERROR("Non-robust SBA should have a large median residual");
-  }
+  EXPECT_GE( trivial_loss_med_err, track_stdev )
+    << "Non-robust SBA should have a large median residual";
 
   // run bundle adjustment with a robust loss function
   cfg->set_value("loss_function_type", "HUBER_LOSS");
@@ -532,25 +157,20 @@ IMPLEMENT_TEST(outlier_tracks)
 
   std::cout << "Robust SBA mean/median reprojection error: "
             << robust_loss_rmse << "/" << robust_loss_med_err << std::endl;
-  if ( trivial_loss_rmse > robust_loss_rmse )
-  {
-    TEST_ERROR("Robust SBA should increase RMSE error");
-  }
-  if ( trivial_loss_med_err <= robust_loss_med_err )
-  {
-    TEST_ERROR("Robust SBA should decrease median error");
-  }
-  TEST_NEAR("median error after robust SBA", robust_loss_med_err, 0.0, track_stdev);
-
+  EXPECT_LE( trivial_loss_rmse, robust_loss_rmse )
+    << "Robust SBA should increase RMSE error";
+  EXPECT_GT( trivial_loss_med_err, robust_loss_med_err )
+    << "Robust SBA should decrease median error";
+  EXPECT_NEAR( robust_loss_med_err, 0.0, track_stdev );
 }
 
-
-// helper for tests using distortion models in bundle adjustment
-void test_ba_using_distortion(kwiver::vital::config_block_sptr cfg,
-                              const Eigen::VectorXd& dc,
-                              bool clear_init_distortion)
+// ----------------------------------------------------------------------------
+// Helper for tests using distortion models in bundle adjustment
+static void
+test_ba_using_distortion( kwiver::vital::config_block_sptr cfg,
+                          Eigen::VectorXd const& dc,
+                          double estimate_tolerance = 0.0 )
 {
-  using namespace kwiver::arrows;
   ceres::bundle_adjust ba;
   cfg->set_value("verbose", "true");
   ba.set_configuration(cfg);
@@ -571,7 +191,7 @@ void test_ba_using_distortion(kwiver::vital::config_block_sptr cfg,
   // add Gaussian noise to the landmark positions
   landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
 
-  if( clear_init_distortion )
+  if ( estimate_tolerance != 0.0 )
   {
     // regenerate cameras without distortion so we can try to recover it
     K.set_dist_coeffs(Eigen::VectorXd());
@@ -585,245 +205,171 @@ void test_ba_using_distortion(kwiver::vital::config_block_sptr cfg,
                                        landmarks0->landmarks(),
                                        tracks->tracks());
   std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
 
   ba.optimize(cameras0, landmarks0, tracks);
 
   double end_rmse = reprojection_rmse(cameras0->cameras(),
                                       landmarks0->landmarks(),
                                       tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-7);
+  EXPECT_NEAR( 0.0, end_rmse, 1e-7 );
 
   // compare actual to estimated distortion parameters
-  if( clear_init_distortion )
+  if ( estimate_tolerance != 0.0 )
   {
-    std::vector<double> vdc2 = cameras0->cameras()[0]->intrinsics()->dist_coeffs();
-    Eigen::VectorXd dc2(Eigen::Map<Eigen::VectorXd>(&vdc2[0], vdc2.size()));
-    // The estimated parameter vector can be longer and zero padded
-    if( dc2.size() > dc.size() )
-    {
-      dc2 = dc2.head(dc.size());
-    }
-    Eigen::VectorXd diff = (dc2-dc).cwiseAbs();
+    auto vdc2 = cameras0->cameras()[0]->intrinsics()->dist_coeffs();
+    // The estimated parameter vector can be longer and zero padded; lop off
+    // any additional trailing values
+    ASSERT_GE( vdc2.size(), dc.size() );
+    Eigen::VectorXd dc2{ Eigen::Map<Eigen::VectorXd>{ &vdc2[0], dc.size() } };
+
+    Eigen::VectorXd diff = ( dc2 - dc ).cwiseAbs();
     std::cout << "distortion parameters\n"
               << "  actual:   " << dc.transpose() << "\n"
               << "  estimated: " << dc2.transpose() << "\n"
               << "  difference: " << diff.transpose() << std::endl;
+    EXPECT_MATRIX_NEAR( dc, dc2, estimate_tolerance );
   }
 }
 
-
-// use 1 lens distortion coefficent in bundle adjustment
-IMPLEMENT_TEST(use_lens_distortion_1)
+// ----------------------------------------------------------------------------
+static Eigen::VectorXd distortion_coefficients( int k )
 {
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type", "POLYNOMIAL_RADIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", false);
-  cfg->set_value("optimize_dist_k2", false);
+  Eigen::VectorXd dc;
+  switch (k)
+  {
+    case 1:
+      dc.resize( 1 );
+      dc << -0.01;
+      return dc;
 
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(1);
-  dc << -0.01;
+    case 2:
+      dc.resize( 2 );
+      dc << -0.01, 0.002;
+      return dc;
 
-  test_ba_using_distortion(cfg, dc, false);
+    case 3:
+      dc.resize( 5 );
+      dc << -0.01, 0.002, 0, 0, -0.005;
+      return dc;
+
+    case 5:
+      dc.resize( 5 );
+      dc << -0.01, 0.002, -0.0005, 0.001, -0.005;
+      return dc;
+
+    case 8:
+      dc.resize( 8 );
+      dc << -0.01, 0.002, -0.0005, 0.001, -0.005, 0.02, 0.0007, -0.003;
+      return dc;
+
+    default:
+      throw std::range_error{ "Invalid number of coefficients" };
+  }
 }
 
-
-// use 2 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(use_lens_distortion_2)
+// ----------------------------------------------------------------------------
+static char const* distortion_type( int k )
 {
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type", "POLYNOMIAL_RADIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", false);
-  cfg->set_value("optimize_dist_k2", false);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(2);
-  dc << -0.01, 0.002;
-
-  test_ba_using_distortion(cfg, dc, false);
+  switch (k)
+  {
+    case 1:
+    case 2:
+      return "POLYNOMIAL_RADIAL_DISTORTION";
+    case 3:
+    case 5:
+      return "POLYNOMIAL_RADIAL_TANGENTIAL_DISTORTION";
+    case 8:
+      return "RATIONAL_RADIAL_TANGENTIAL_DISTORTION";
+    default:
+      throw std::range_error{ "Invalid number of coefficients" };
+  }
 }
 
-
-// use 3 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(use_lens_distortion_3)
+// ----------------------------------------------------------------------------
+static double distortion_estimation_tolerance( int k )
 {
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "POLYNOMIAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", false);
-  cfg->set_value("optimize_dist_k2", false);
-  cfg->set_value("optimize_dist_k3", false);
-  cfg->set_value("optimize_dist_p1_p2", false);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(5);
-  dc << -0.01, 0.002, 0, 0, -0.005;
-
-  test_ba_using_distortion(cfg, dc, false);
+  switch (k)
+  {
+    case 1:
+      return 1e-9;
+    case 2:
+      return 1e-7;
+    case 3:
+    case 5:
+      return 1e-5;
+    case 8:
+      return 1e-2;
+    default:
+      throw std::range_error{ "Invalid number of coefficients" };
+  }
 }
 
-
-// use 5 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(use_lens_distortion_5)
+// ----------------------------------------------------------------------------
+class bundle_adjust_with_lens_distortion : public ::testing::TestWithParam<int>
 {
-  using namespace kwiver::arrows;
+};
+
+// ----------------------------------------------------------------------------
+TEST_P(bundle_adjust_with_lens_distortion, use_coefficients)
+{
+  auto const k = GetParam();
+  auto const& dc = distortion_coefficients( k );
+
   ceres::bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "POLYNOMIAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", false);
-  cfg->set_value("optimize_dist_k2", false);
-  cfg->set_value("optimize_dist_k3", false);
-  cfg->set_value("optimize_dist_p1_p2", false);
+  cfg->set_value( "lens_distortion_type", distortion_type( k ) );
+  cfg->set_value( "optimize_dist_k1", false );
+  cfg->set_value( "optimize_dist_k2", false );
+  if ( k > 2 )
+  {
+    cfg->set_value( "optimize_dist_k3", false );
+    cfg->set_value( "optimize_dist_p1_p2", false );
+    if ( k > 5 )
+    {
+      cfg->set_value("optimize_dist_k4_k5_k6", false );
+    }
+  }
 
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(5);
-  dc << -0.01, 0.002, -0.0005, 0.001, -0.005;
-
-  test_ba_using_distortion(cfg, dc, false);
+  test_ba_using_distortion( cfg, dc );
 }
 
-
-// use 8 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(use_lens_distortion_8)
+// ----------------------------------------------------------------------------
+TEST_P(bundle_adjust_with_lens_distortion, estimate_coefficients)
 {
-  using namespace kwiver::arrows;
+  auto const k = GetParam();
+  auto const& dc = distortion_coefficients( k );
+
   ceres::bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "RATIONAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", false);
-  cfg->set_value("optimize_dist_k2", false);
-  cfg->set_value("optimize_dist_k3", false);
-  cfg->set_value("optimize_dist_p1_p2", false);
-  cfg->set_value("optimize_dist_k4_k5_k6", false);
+  cfg->set_value( "lens_distortion_type", distortion_type( k ) );
+  cfg->set_value( "optimize_dist_k1", true );
+  cfg->set_value( "optimize_dist_k2", ( k > 1 ) );
+  if ( k > 2 )
+  {
+    cfg->set_value( "optimize_dist_k3", true );
+    cfg->set_value( "optimize_dist_p1_p2", ( k > 3 ) );
+    if ( k > 5 )
+    {
+      cfg->set_value("optimize_dist_k4_k5_k6", true );
+    }
+  }
 
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(8);
-  dc << -0.01, 0.002, -0.0005, 0.001, -0.005, 0.02, 0.0007, -0.003;
-
-  test_ba_using_distortion(cfg, dc, false);
+  test_ba_using_distortion( cfg, dc, distortion_estimation_tolerance( k ) );
 }
 
+// ----------------------------------------------------------------------------
+INSTANTIATE_TEST_CASE_P(, bundle_adjust_with_lens_distortion,
+                        ::testing::Values(1, 2, 3, 5, 8));
 
-// estimate 1 lens distortion coefficent in bundle adjustment
-IMPLEMENT_TEST(est_lens_distortion_1)
+// ----------------------------------------------------------------------------
+// Helper for tests of intrinsics sharing models in bundle adjustment; returns
+// the number of unique camera intrinsics objects in the optimized cameras
+static unsigned int
+test_ba_intrinsic_sharing( camera_map_sptr cameras,
+                           kwiver::vital::config_block_sptr cfg )
 {
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type", "POLYNOMIAL_RADIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", true);
-  cfg->set_value("optimize_dist_k2", false);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(1);
-  dc << -0.01;
-
-  test_ba_using_distortion(cfg, dc, true);
-}
-
-
-// estimate 2 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(est_lens_distortion_2)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type", "POLYNOMIAL_RADIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", true);
-  cfg->set_value("optimize_dist_k2", true);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(2);
-  dc << -0.01, 0.002;
-
-  test_ba_using_distortion(cfg, dc, true);
-}
-
-
-// estimate 3 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(est_lens_distortion_3)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "POLYNOMIAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", true);
-  cfg->set_value("optimize_dist_k2", true);
-  cfg->set_value("optimize_dist_k3", true);
-  cfg->set_value("optimize_dist_p1_p2", false);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(5);
-  dc << -0.01, 0.002, 0, 0, -0.005;
-
-  test_ba_using_distortion(cfg, dc, true);
-}
-
-
-// estimate 5 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(est_lens_distortion_5)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "POLYNOMIAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", true);
-  cfg->set_value("optimize_dist_k2", true);
-  cfg->set_value("optimize_dist_k3", true);
-  cfg->set_value("optimize_dist_p1_p2", true);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(5);
-  dc << -0.01, 0.002, -0.0005, 0.001, -0.005;
-
-  test_ba_using_distortion(cfg, dc, true);
-}
-
-
-// estimate 8 lens distortion coefficents in bundle adjustment
-IMPLEMENT_TEST(est_lens_distortion_8)
-{
-  using namespace kwiver::arrows;
-  ceres::bundle_adjust ba;
-  config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("lens_distortion_type",
-                 "RATIONAL_RADIAL_TANGENTIAL_DISTORTION");
-  cfg->set_value("optimize_dist_k1", true);
-  cfg->set_value("optimize_dist_k2", true);
-  cfg->set_value("optimize_dist_k3", true);
-  cfg->set_value("optimize_dist_p1_p2", true);
-  cfg->set_value("optimize_dist_k4_k5_k6", true);
-
-  // The lens distortion parameters to use
-  Eigen::VectorXd dc(8);
-  dc << -0.01, 0.002, -0.0005, 0.001, -0.005, 0.02, 0.0007, -0.003;
-
-  test_ba_using_distortion(cfg, dc, true);
-}
-
-
-// helper for tests of intrinsics sharing models in bundle adjustment
-// returns the number of unique camera intrinsics objects
-// in the optimized cameras
-unsigned int
-test_ba_intrinsic_sharing(camera_map_sptr cameras,
-                          kwiver::vital::config_block_sptr cfg)
-{
-  using namespace kwiver::arrows;
   ceres::bundle_adjust ba;
   ba.set_configuration(cfg);
 
@@ -844,20 +390,18 @@ test_ba_intrinsic_sharing(camera_map_sptr cameras,
                                        landmarks0->landmarks(),
                                        tracks->tracks());
   std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  if (init_rmse < 10.0)
-  {
-    TEST_ERROR("Initial reprojection RMSE should be large before SBA");
-  }
+  EXPECT_GE( init_rmse, 10.0 )
+    << "Initial reprojection RMSE should be large before SBA";
 
   ba.optimize(cameras0, landmarks0, tracks);
 
   double end_rmse = reprojection_rmse(cameras0->cameras(),
                                       landmarks0->landmarks(),
                                       tracks->tracks());
-  TEST_NEAR("RMSE after SBA", end_rmse, 0.0, 1e-5);
+  EXPECT_NEAR( 0.0, end_rmse, 1e-5 );
 
   std::set<camera_intrinsics_sptr> intrin_set;
-  for (const camera_map::map_camera_t::value_type& ci : cameras0->cameras())
+  for ( auto const& ci : cameras0->cameras() )
   {
     intrin_set.insert(ci.second->intrinsics());
   }
@@ -865,11 +409,10 @@ test_ba_intrinsic_sharing(camera_map_sptr cameras,
   return static_cast<unsigned int>(intrin_set.size());
 }
 
-
-// test bundle adjustment with forcing unique intrinsics
-IMPLEMENT_TEST(unique_intrinsics)
+// ----------------------------------------------------------------------------
+// Test bundle adjustment with forcing unique intrinsics
+TEST(bundle_adjust, unique_intrinsics)
 {
-  using namespace kwiver::arrows;
   ceres::bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
   cfg->set_value("verbose", "true");
@@ -880,16 +423,14 @@ IMPLEMENT_TEST(unique_intrinsics)
 
   // create a camera sequence (elliptical path)
   camera_map_sptr cameras = kwiver::testing::camera_seq(20, K);
-  unsigned int num_intrinsics = test_ba_intrinsic_sharing(cameras, cfg);
-  TEST_EQUAL("Resulting camera intrinsics are unique",
-             num_intrinsics, cameras->size());
+  EXPECT_EQ( cameras->size(), test_ba_intrinsic_sharing( cameras, cfg ) )
+    << "Resulting camera intrinsics should be unique";
 }
 
-
-// test bundle adjustment with forcing common intrinsics
-IMPLEMENT_TEST(common_intrinsics)
+// ----------------------------------------------------------------------------
+// Test bundle adjustment with forcing common intrinsics
+TEST(bundle_adjust, common_intrinsics)
 {
-  using namespace kwiver::arrows;
   ceres::bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
   cfg->set_value("verbose", "true");
@@ -900,16 +441,14 @@ IMPLEMENT_TEST(common_intrinsics)
 
   // create a camera sequence (elliptical path)
   camera_map_sptr cameras = kwiver::testing::camera_seq(20, K);
-  unsigned int num_intrinsics = test_ba_intrinsic_sharing(cameras, cfg);
-  TEST_EQUAL("Resulting camera intrinsics are unique",
-             num_intrinsics, 1);
+  EXPECT_EQ( 1, test_ba_intrinsic_sharing( cameras, cfg ) )
+    << "Resulting camera intrinsics should be unique";
 }
 
-
-// test bundle adjustment with multiple shared intrinics models
-IMPLEMENT_TEST(auto_share_intrinsics)
+// ----------------------------------------------------------------------------
+// Test bundle adjustment with multiple shared intrinics models
+TEST(bundle_adjust, auto_share_intrinsics)
 {
-  using namespace kwiver::arrows;
   ceres::bundle_adjust ba;
   config_block_sptr cfg = ba.get_configuration();
   cfg->set_value("verbose", "true");
@@ -925,13 +464,12 @@ IMPLEMENT_TEST(auto_share_intrinsics)
   // combine the camera maps and offset the frame numbers
   const unsigned int offset = static_cast<unsigned int>(cameras1->size());
   camera_map::map_camera_t cams = cameras1->cameras();
-  for(camera_map::map_camera_t::value_type ci : cameras2->cameras())
+  for ( auto const& ci : cameras2->cameras() )
   {
     cams[ci.first + offset] = ci.second;
   }
 
-  camera_map_sptr cameras = camera_map_sptr(new simple_camera_map(cams));
-  unsigned int num_intrinsics = test_ba_intrinsic_sharing(cameras, cfg);
-  TEST_EQUAL("Resulting camera intrinsics are unique",
-             num_intrinsics, 2);
+  auto cameras = std::make_shared<simple_camera_map>( cams );
+  EXPECT_EQ( 2, test_ba_intrinsic_sharing( cameras, cfg ) )
+    << "Resulting camera intrinsics should be unique";
 }

--- a/arrows/tests/test_bundle_adjust.h
+++ b/arrows/tests/test_bundle_adjust.h
@@ -1,0 +1,387 @@
+/*ckwg +29
+ * Copyright 2014-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <test_scene.h>
+
+#include <arrows/core/metrics.h>
+#include <arrows/core/projected_track_set.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+// Input to SBA is the ideal solution, make sure it doesn't diverge
+TEST(bundle_adjust, from_solution)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  double init_rmse = reprojection_rmse(cameras->cameras(),
+                                       landmarks->landmarks(),
+                                       tracks->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_LE(init_rmse, 1e-12) << "Initial reprojection RMSE should be small";
+
+  ba.optimize(cameras, landmarks, tracks);
+
+  double end_rmse = reprojection_rmse(cameras->cameras(),
+                                      landmarks->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-12) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks before input to SBA
+TEST(bundle_adjust, noisy_landmarks)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+
+  double init_rmse = reprojection_rmse(cameras->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks->tracks());
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras, landmarks0, tracks);
+
+  double end_rmse = reprojection_rmse(cameras->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras before input to SBA
+TEST(bundle_adjust, noisy_landmarks_noisy_cameras)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+  // add Gaussian noise to the camera positions and orientations
+  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
+
+
+  double init_rmse = reprojection_rmse(cameras0->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras0, landmarks0, tracks);
+
+  double end_rmse = reprojection_rmse(cameras0->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Initialize all landmarks to the origin as input to SBA
+TEST(bundle_adjust, zero_landmarks)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // initialize all landmarks to the origin
+  landmark_id_t num_landmarks = static_cast<landmark_id_t>(landmarks->size());
+  landmark_map_sptr landmarks0 = kwiver::testing::init_landmarks(num_landmarks);
+
+
+  double init_rmse = reprojection_rmse(cameras->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras, landmarks0, tracks);
+
+  double end_rmse = reprojection_rmse(cameras->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras before input to SBA; select a subset of
+// cameras to optimize
+TEST(bundle_adjust, subset_cameras)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+  // add Gaussian noise to the camera positions and orientations
+  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
+
+  camera_map::map_camera_t cam_map = cameras0->cameras();
+  camera_map::map_camera_t cam_map2;
+  for ( auto const& p : cam_map )
+  {
+    /// take every third camera
+    if(p.first % 3 == 0)
+    {
+      cam_map2.insert(p);
+    }
+  }
+  cameras0 = std::make_shared<simple_camera_map>(cam_map2);
+
+
+  EXPECT_EQ(7, cameras0->size()) << "Reduced number of cameras";
+
+  double init_rmse = reprojection_rmse(cameras0->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras0, landmarks0, tracks);
+
+  double end_rmse = reprojection_rmse(cameras0->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras before input to SBA; select a subset of
+// landmarks to optimize
+TEST(bundle_adjust, subset_landmarks)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+  // add Gaussian noise to the camera positions and orientations
+  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
+
+  // remove some landmarks
+  landmark_map::map_landmark_t lm_map = landmarks0->landmarks();
+  lm_map.erase(1);
+  lm_map.erase(4);
+  lm_map.erase(5);
+  landmarks0 = std::make_shared<simple_landmark_map>(lm_map);
+
+  EXPECT_EQ(5, landmarks0->size()) << "Reduced number of landmarks";
+
+  double init_rmse = reprojection_rmse(cameras0->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras0, landmarks0, tracks);
+
+  double end_rmse = reprojection_rmse(cameras0->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras before input to SBA; select a subset of
+// tracks/track_states to constrain the problem
+TEST(bundle_adjust, subset_tracks)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+  // add Gaussian noise to the camera positions and orientations
+  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
+
+  // remove some tracks/track_states
+  feature_track_set_sptr tracks0 = kwiver::testing::subset_tracks(tracks, 0.5);
+
+
+  double init_rmse = reprojection_rmse(cameras0->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks0->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras0, landmarks0, tracks0);
+
+  double end_rmse = reprojection_rmse(cameras0->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks0->tracks());
+  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
+}
+
+// ----------------------------------------------------------------------------
+// Add noise to landmarks and cameras and tracks before input to SBA; select a
+// subset of tracks/track_states to constrain the problem
+TEST(bundle_adjust, noisy_tracks)
+{
+  bundle_adjust ba;
+  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
+  cfg->set_value("verbose", "true");
+  cfg->set_value("g_tolerance", "1e-12");
+  ba.set_configuration(cfg);
+
+  // create landmarks at the corners of a cube
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+
+  // create a camera sequence (elliptical path)
+  camera_map_sptr cameras = kwiver::testing::camera_seq();
+
+  // create tracks from the projections
+  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
+
+  // add Gaussian noise to the landmark positions
+  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
+
+  // add Gaussian noise to the camera positions and orientations
+  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
+
+  // remove some tracks/track_states and add Gaussian noise
+  const double track_stdev = 1.0;
+  feature_track_set_sptr tracks0 = kwiver::testing::noisy_tracks(
+                               kwiver::testing::subset_tracks(tracks, 0.5),
+                               track_stdev);
+
+
+  double init_rmse = reprojection_rmse(cameras0->cameras(),
+                                       landmarks0->landmarks(),
+                                       tracks0->tracks());
+  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
+  EXPECT_GE(init_rmse, 10.0)
+    << "Initial reprojection RMSE should be large before SBA";
+
+  ba.optimize(cameras0, landmarks0, tracks0);
+
+  double end_rmse = reprojection_rmse(cameras0->cameras(),
+                                      landmarks0->landmarks(),
+                                      tracks0->tracks());
+  EXPECT_NEAR(0.0, end_rmse, track_stdev) << "RMSE after SBA";
+}

--- a/arrows/tests/test_estimate_fundamental_matrix.h
+++ b/arrows/tests/test_estimate_fundamental_matrix.h
@@ -31,8 +31,6 @@
 #include <test_eigen.h>
 #include <test_scene.h>
 
-#include <vital/plugin_loader/plugin_manager.h>
-
 #include <arrows/core/projected_track_set.h>
 #include <arrows/core/metrics.h>
 #include <arrows/core/epipolar_geometry.h>

--- a/arrows/vxl/tests/test_bundle_adjust.cxx
+++ b/arrows/vxl/tests/test_bundle_adjust.cxx
@@ -33,10 +33,6 @@
  * \brief test VXL bundle adjustment functionality
  */
 
-#include <test_scene.h>
-
-#include <arrows/core/metrics.h>
-#include <arrows/core/projected_track_set.h>
 #include <arrows/vxl/bundle_adjust.h>
 
 #include <vital/plugin_loader/plugin_manager.h>
@@ -45,12 +41,13 @@
 
 using namespace kwiver::vital;
 
+using kwiver::arrows::vxl::bundle_adjust;
+
 // ----------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest( &argc, argv );
 
-  // VXL algorithm implementations
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
   return RUN_ALL_TESTS();
@@ -63,157 +60,7 @@ TEST(bundle_adjust, create)
 }
 
 // ----------------------------------------------------------------------------
-// Input to SBA is the ideal solution, make sure it doesn't diverge
-TEST(bundle_adjust, from_solution)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_LE(init_rmse, 1e-12) << "Initial reprojection RMSE should be small";
-
-  ba.optimize(cameras, landmarks, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-12) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks before input to SBA
-TEST(bundle_adjust, noisy_landmarks)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks and cameras before input to SBA
-TEST(bundle_adjust, noisy_landmarks_noisy_cameras)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Initialize all landmarks to the origin as input to SBA
-TEST(bundle_adjust, zero_landmarks)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // initialize all landmarks to the origin
-  landmark_id_t num_landmarks = static_cast<landmark_id_t>(landmarks->size());
-  landmark_map_sptr landmarks0 = kwiver::testing::init_landmarks(num_landmarks);
-
-
-  double init_rmse = reprojection_rmse(cameras->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
+#include <arrows/tests/test_bundle_adjust.h>
 
 // ----------------------------------------------------------------------------
 // Initialize all landmarks to the origin and all cameras to same location as
@@ -221,7 +68,7 @@ TEST(bundle_adjust, zero_landmarks)
 TEST(bundle_adjust, zero_landmarks_same_cameras)
 {
   using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
+  bundle_adjust ba;
   kwiver::vital::config_block_sptr cfg = ba.get_configuration();
   cfg->set_value("verbose", "true");
   cfg->set_value("g_tolerance", "1e-12");
@@ -258,207 +105,4 @@ TEST(bundle_adjust, zero_landmarks_same_cameras)
                                       landmarks0->landmarks(),
                                       tracks->tracks());
   EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks and cameras before input to SBA; select a subset of
-// cameras to optimize
-TEST(bundle_adjust, subset_cameras)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  camera_map::map_camera_t cam_map = cameras0->cameras();
-  camera_map::map_camera_t cam_map2;
-  for ( auto const& p : cam_map )
-  {
-    /// take every third camera
-    if(p.first % 3 == 0)
-    {
-      cam_map2.insert(p);
-    }
-  }
-  cameras0 = camera_map_sptr(new simple_camera_map(cam_map2));
-
-
-  EXPECT_EQ(7, cameras0->size()) << "Reduced number of cameras";
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks and cameras before input to SBA; select a subset of
-// landmarks to optimize
-TEST(bundle_adjust, subset_landmarks)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some landmarks
-  landmark_map::map_landmark_t lm_map = landmarks0->landmarks();
-  lm_map.erase(1);
-  lm_map.erase(4);
-  lm_map.erase(5);
-  landmarks0 = landmark_map_sptr(new simple_landmark_map(lm_map));
-
-  EXPECT_EQ(5, landmarks0->size()) << "Reduced number of landmarks";
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras0, landmarks0, tracks);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks and cameras before input to SBA; select a subset of
-// tracks/track_states to constrain the problem
-TEST(bundle_adjust, subset_tracks)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some tracks/track_states
-  feature_track_set_sptr tracks0 = kwiver::testing::subset_tracks(tracks, 0.5);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks0->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras0, landmarks0, tracks0);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks0->tracks());
-  EXPECT_NEAR(0.0, end_rmse, 1e-5) << "RMSE after SBA";
-}
-
-// ----------------------------------------------------------------------------
-// Add noise to landmarks and cameras and tracks before input to SBA; select a
-// subset of tracks/track_states to constrain the problem
-TEST(bundle_adjust, noisy_tracks)
-{
-  using namespace kwiver::arrows;
-  vxl::bundle_adjust ba;
-  kwiver::vital::config_block_sptr cfg = ba.get_configuration();
-  cfg->set_value("verbose", "true");
-  cfg->set_value("g_tolerance", "1e-12");
-  ba.set_configuration(cfg);
-
-  // create landmarks at the corners of a cube
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-
-  // create a camera sequence (elliptical path)
-  camera_map_sptr cameras = kwiver::testing::camera_seq();
-
-  // create tracks from the projections
-  feature_track_set_sptr tracks = projected_tracks(landmarks, cameras);
-
-  // add Gaussian noise to the landmark positions
-  landmark_map_sptr landmarks0 = kwiver::testing::noisy_landmarks(landmarks, 0.1);
-
-  // add Gaussian noise to the camera positions and orientations
-  camera_map_sptr cameras0 = kwiver::testing::noisy_cameras(cameras, 0.1, 0.1);
-
-  // remove some tracks/track_states and add Gaussian noise
-  const double track_stdev = 1.0;
-  feature_track_set_sptr tracks0 = kwiver::testing::noisy_tracks(
-                               kwiver::testing::subset_tracks(tracks, 0.5),
-                               track_stdev);
-
-
-  double init_rmse = reprojection_rmse(cameras0->cameras(),
-                                       landmarks0->landmarks(),
-                                       tracks0->tracks());
-  std::cout << "initial reprojection RMSE: " << init_rmse << std::endl;
-  EXPECT_GE(init_rmse, 10.0)
-    << "Initial reprojection RMSE should be large before SBA";
-
-  ba.optimize(cameras0, landmarks0, tracks0);
-
-  double end_rmse = reprojection_rmse(cameras0->cameras(),
-                                      landmarks0->landmarks(),
-                                      tracks0->tracks());
-  EXPECT_NEAR(0.0, end_rmse, track_stdev) << "RMSE after SBA";
 }

--- a/tests/test_eigen.h
+++ b/tests/test_eigen.h
@@ -92,6 +92,27 @@ struct matrix_comparator
     }
     return true;
   }
+
+  // --------------------------------------------------------------------------
+  template <typename T>
+  bool operator()( Eigen::Matrix<T, Eigen::Dynamic, 1> const& a,
+                   Eigen::Matrix<T, Eigen::Dynamic, 1> const& b,
+                   double epsilon )
+  {
+    if ( a.size() != b.size() )
+    {
+      return false;
+    }
+
+    for ( unsigned i = 0; i < a.size(); ++i )
+    {
+      if ( std::abs( a[i] - b[i] ) > epsilon )
+      {
+        return false;
+      }
+    }
+    return true;
+  }
 };
 
 #define EXPECT_MATRIX_EQ(a, b) \


### PR DESCRIPTION
Convert Ceres `bundle_adjust` test to Google Test. Factor out test cases that are shared with the VXL `bundle_adjust` test into a helper header.