### PR TITLE
Convert and refactor OpenCV image test

### DIFF
--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -14,5 +14,5 @@ kwiver_discover_tests(ocv_distortion          test_libraries test_distortion.cxx
 kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv estimate_homography         LIBRARIES ${test_libraries})
 kwiver_discover_tests(ocv_feature_set         test_libraries test_feature_set.cxx)
-kwiver_discover_tests(ocv_image               test_libraries test_image.cxx)
+kwiver_discover_gtests(ocv image                       LIBRARIES ${test_libraries})
 kwiver_discover_tests(ocv_match_set           test_libraries test_match_set.cxx)

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,51 +33,45 @@
  * \brief test OCV image class
  */
 
-#include <test_common.h>
-#include <vital/plugin_loader/plugin_manager.h>
+#include <test_tmpfn.h>
+
+#include <arrows/tests/test_image.h>
 
 #include <arrows/ocv/image_container.h>
 #include <arrows/ocv/image_io.h>
 
-#define TEST_ARGS ()
+#include <vital/plugin_loader/plugin_manager.h>
 
-DECLARE_TEST_MAP();
-
-int
-main(int argc, char* argv[])
-{
-  CHECK_ARGS(1);
-
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
-}
+#include <gtest/gtest.h>
 
 using namespace kwiver::vital;
+using namespace kwiver::arrows;
 
-IMPLEMENT_TEST(factory)
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
 {
-  using namespace kwiver::arrows;
-
-  kwiver::vital::plugin_manager::instance().load_all_plugins();
-
-  algo::image_io_sptr img_io = kwiver::vital::algo::image_io::create("ocv");
-  if (!img_io)
-  {
-    TEST_ERROR("Unable to create image_io algorithm of type ocv");
-  }
-  algo::image_io* img_io_ptr = img_io.get();
-  if (typeid(*img_io_ptr) != typeid(ocv::image_io))
-  {
-    TEST_ERROR("Factory method did not construct the correct type");
-  }
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
 }
 
+// ----------------------------------------------------------------------------
+TEST(image, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  std::shared_ptr<algo::image_io> img_io;
+  ASSERT_NE(nullptr, img_io = algo::image_io::create("ocv"));
+
+  algo::image_io* img_io_ptr = img_io.get();
+  EXPECT_EQ(typeid(ocv::image_io), typeid(*img_io_ptr))
+    << "Factory method did not construct the correct type";
+}
 
 namespace {
 
-// helper function to populate the image with a pattern
-// the dynamic range is stretched between minv and maxv
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern; the dynamic range is
+// stretched between minv and maxv
 template <typename T>
 void
 populate_ocv_image(cv::Mat& img, T minv, T maxv)
@@ -91,16 +85,15 @@ populate_ocv_image(cv::Mat& img, T minv, T maxv)
     {
       for( unsigned int i=0; i<static_cast<unsigned int>(img.cols); ++i )
       {
-        const double pi = 3.14159265358979323846;
-        double val = ((std::sin(pi*double(i)*(p+1)/10) * std::sin(pi*double(j)*(p+1)/10))+1) / 2;
-        img.template ptr<T>(j)[num_c * i + p] = static_cast<T>(val * range + offset);
+        auto const val = static_cast<T>(value_at(i, j, p) * range + offset);
+        img.template ptr<T>(j)[num_c * i + p] = val;
       }
     }
   }
 }
 
-
-// helper function to populate the image with a pattern
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern
 template <typename T>
 void
 populate_ocv_image(cv::Mat& img)
@@ -110,299 +103,245 @@ populate_ocv_image(cv::Mat& img)
   populate_ocv_image(img, minv, maxv);
 }
 
-
-// helper function to populate the image with a pattern
-// the dynamic range is stretched between minv and maxv
-template <typename T>
-void
-populate_vital_image(kwiver::vital::image& img, T minv, T maxv)
-{
-  const double range = static_cast<double>(maxv) - static_cast<double>(minv);
-  const double offset = - minv;
-  for( unsigned int p=0; p<img.depth(); ++p )
-  {
-    for( unsigned int j=0; j<img.height(); ++j )
-    {
-      for( unsigned int i=0; i<img.width(); ++i )
-      {
-        const double pi = 3.14159265358979323846;
-        double val = ((std::sin(pi*double(i)*(p+1)/10) * std::sin(pi*double(j)*(p+1)/10))+1) / 2;
-        img.at<T>(i,j,p) = static_cast<T>(val * range + offset);
-      }
-    }
-  }
-}
-
-
-// helper function to populate the image with a pattern
-template <typename T>
-void
-populate_vital_image(kwiver::vital::image& img)
-{
-  const T minv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::min() : T(0);
-  const T maxv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::max() : T(1);
-  populate_vital_image<T>(img, minv, maxv);
-}
-
-
-template <typename T>
-void
-run_ocv_conversion_tests(const cv::Mat& img, const std::string& type_str)
-{
-  using namespace kwiver::arrows;
-  // convert to a vital image and verify that the properties are correct
-  kwiver::vital::image vimg =  ocv::image_container::ocv_to_vital(img);
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the correct bit depth",
-             vimg.pixel_traits().num_bytes, sizeof(T));
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the correct pixel type",
-             vimg.pixel_traits().type, image_pixel_traits_of<T>::static_type);
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the correct number of planes",
-             vimg.depth(), static_cast< size_t >(img.channels()));
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the correct width",
-             vimg.height(), static_cast< size_t >(img.rows));
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the correct height",
-             vimg.width(), static_cast< size_t >(img.cols));
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the same memory",
-             vimg.first_pixel() == img.data, true);
-  bool equal_data = true;
-  const unsigned num_c = img.channels();
-  for( unsigned int d=0; equal_data && d<vimg.depth(); ++d )
-  {
-    for( unsigned int j=0; equal_data && j<vimg.height(); ++j )
-    {
-      for( unsigned int i=0; equal_data && i<vimg.width(); ++i )
-      {
-        if( img.ptr<T>(j)[num_c * i + d] != vimg.at<T>(i,j,d) )
-        {
-          equal_data = false;
-        }
-      }
-    }
-  }
-  TEST_EQUAL("OpenCV image conversion of type "+type_str+" has the same values",
-             equal_data, true);
-
-  // convert back to cv::Mat and test again
-  cv::Mat img2 = ocv::image_container::vital_to_ocv(vimg);
-  if( !img2.data)
-  {
-    TEST_ERROR("OpenCV image re-conversion of type "+type_str+" did not produce a valid cv::Mat");
-    return;
-  }
-
-  TEST_EQUAL("OpenCV image re-conversion of type "+type_str+" has the correct pixel format",
-             img.type(), img2.type());
-  std::vector<cv::Mat> channels1(img.channels()), channels2(img2.channels());
-  cv::split(img, channels1);
-  cv::split(img2, channels2);
-  unsigned int num_diff = 0;
-  for (unsigned d=0; d<channels1.size(); ++d)
-  {
-    num_diff += cv::countNonZero( channels1[d] != channels2[d]);
-  }
-  TEST_EQUAL("OpenCV image re-conversion of type "+type_str+" is identical",
-             num_diff, 0);
-  TEST_EQUAL("OpenCV image re-conversion of type "+type_str+" has the same memory",
-             img.data == img2.data, true);
-}
-
-
-template <typename T>
-void
-run_vital_conversion_tests(const kwiver::vital::image_of<T>& img,
-                           const std::string& type_str,
-                           bool requires_copy = false)
-{
-  using namespace kwiver::arrows;
-  // convert to a cv::Mat and verify that the properties are correct
-  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img);
-  if( !ocv_img.data )
-  {
-    TEST_ERROR("Vital image conversion of type "+type_str+" did not produce a valid cv::Mat");
-    return;
-  }
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct pixel format",
-             ocv_img.type()%8, cv::Mat_<T>(1,1).type()%8);
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct number of planes",
-             static_cast< size_t >(ocv_img.channels()), img.depth());
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct width",
-             static_cast< size_t >(ocv_img.rows), img.height());
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the correct height",
-             static_cast< size_t >(ocv_img.cols), img.width());
-  if( !requires_copy )
-  {
-    TEST_EQUAL("Vital image conversion of type "+type_str+" has the same memory",
-               reinterpret_cast<T *>(ocv_img.data) == img.first_pixel(), true);
-  }
-  bool equal_data = true;
-  const unsigned num_c = ocv_img.channels();
-  for( unsigned int d=0; equal_data && d<img.depth(); ++d )
-  {
-    for( unsigned int j=0; equal_data && j<img.height(); ++j )
-    {
-      for( unsigned int i=0; equal_data && i<img.width(); ++i )
-      {
-        if( img(i,j,d) != ocv_img.ptr<T>(j)[num_c * i + d] )
-        {
-          std::cout << "Pixel "<<i<<", "<<j<<", "<<d<<" has values "
-                    <<int(img(i,j,d))<<" != "<< int(ocv_img.ptr<T>(j)[num_c * i + d]) <<std::endl;
-          equal_data = false;
-        }
-      }
-    }
-  }
-  TEST_EQUAL("Vital image conversion of type "+type_str+" has the same values",
-             equal_data, true);
-
-  // convert back to vital::image and test again
-  kwiver::vital::image img2 = ocv::image_container::ocv_to_vital(ocv_img);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the correct bit depth",
-             img2.pixel_traits().num_bytes, sizeof(T));
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the correct pixel type",
-             img2.pixel_traits().type, image_pixel_traits_of<T>::static_type);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" is identical",
-             kwiver::vital::equal_content(img, img2), true);
-  TEST_EQUAL("Vital image re-conversion of type "+type_str+" has the same memory",
-             reinterpret_cast<T *>(ocv_img.data) == img2.first_pixel(), true);
-}
-
-
-template <typename T>
-void
-test_conversion(const std::string& type_str)
-{
-  // create cv::Mat and convert to an from vital images
-  {
-    std::cout << "Testing single channel cv::Mat of type " << type_str << std::endl;
-    cv::Mat_<T> img(100,200);
-    populate_ocv_image<T>(img);
-    run_ocv_conversion_tests<T>(img, type_str);
-  }
-
-  {
-    std::cout << "Testing three channel cv::Mat of type " << type_str << std::endl;
-    cv::Mat_<cv::Vec<T,3> > img(100,200);
-    populate_ocv_image<T>(img);
-    run_ocv_conversion_tests<T>(img, type_str);
-  }
-
-  {
-    std::cout << "Testing cropped cv::Mat of type " << type_str << std::endl;
-    cv::Mat_<T> img(200,300);
-    populate_ocv_image<T>(img);
-    cv::Rect window( cv::Point(40,50), cv::Point(240, 150) );
-    cv::Mat_<T> img_crop(img, window);
-    run_ocv_conversion_tests<T>(img_crop, type_str+" (cropped)");
-  }
-
-  // create vital images and convert to an from cv::Mat
-  // Note: different code paths are taken depending on whether the image
-  // is natively created as OpenCV or vital, so we need to test both ways.
-  {
-    std::cout << "Testing single channel vital::image of type " << type_str << std::endl;
-    kwiver::vital::image_of<T> img(200, 300, 1);
-    populate_vital_image<T>(img);
-    run_vital_conversion_tests(img, type_str);
-  }
-
-  {
-    std::cout << "Testing three channel vital::image of type " << type_str << std::endl;
-    kwiver::vital::image_of<T> img(200, 300, 3);
-    populate_vital_image<T>(img);
-    run_vital_conversion_tests(img, type_str, true);
-  }
-
-  {
-    std::cout << "Testing interleaved vital::image of type " << type_str << std::endl;
-    kwiver::vital::image_of<T> img(200, 300, 3, true);
-    populate_vital_image<T>(img);
-    run_vital_conversion_tests(img, type_str+" (interleaved)");
-  }
-}
-
 } // end anonymous namespace
 
-
-IMPLEMENT_TEST(image_convert)
+// ----------------------------------------------------------------------------
+template <typename T, int Depth>
+struct image_type
 {
-  using namespace kwiver;
-  using namespace kwiver::arrows;
-  test_conversion<uint8_t>("uint8");
-  test_conversion<int8_t>("int8");
-  test_conversion<uint16_t>("uint16");
-  test_conversion<int16_t>("int16");
-  test_conversion<int32_t>("int32");
-  test_conversion<float>("float");
-  test_conversion<double>("double");
+  using pixel_type = T;
+  static constexpr int depth = Depth;
+};
 
-  // some types not supported by OpenCV and should throw an exception
-  std::cout << "Test conversion of types not supported by OpenCV" << std::endl;
-  EXPECT_EXCEPTION(vital::image_type_mismatch_exception,
-                   ocv::image_container::vital_to_ocv(vital::image_of<uint32_t>(200, 300)),
-                   "converting uint32_t image to cv::Mat");
-  EXPECT_EXCEPTION(vital::image_type_mismatch_exception,
-                   ocv::image_container::vital_to_ocv(vital::image_of<int64_t>(200, 300)),
-                   "converting int64_t image to cv::Mat");
-  EXPECT_EXCEPTION(vital::image_type_mismatch_exception,
-                   ocv::image_container::vital_to_ocv(vital::image_of<uint64_t>(200, 300)),
-                   "converting uint64_t image to cv::Mat");
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_io : public ::testing::Test
+{
+};
+
+using io_types = ::testing::Types<
+  image_type<byte, 1>,
+  image_type<byte, 3>,
+  image_type<byte, 4>,
+  image_type<uint16_t, 1>,
+  image_type<uint16_t, 3>,
+  image_type<uint16_t, 4>
+  >;
+
+TYPED_TEST_CASE(image_io, io_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_io, type)
+{
+  using pix_t = typename TypeParam::pixel_type;
+  kwiver::vital::image_of<pix_t> img( 200, 300, TypeParam::depth );
+  populate_vital_image<pix_t>( img );
+
+  auto const image_path = kwiver::testing::temp_file_name( "test-", ".tiff" );
+
+  auto c = std::make_shared<simple_image_container>( img );
+  ocv::image_io io;
+  io.save( image_path, c );
+  image_container_sptr c2 = io.load( image_path );
+  kwiver::vital::image img2 = c2->get_image();
+  EXPECT_EQ( img.pixel_traits(), img2.pixel_traits() );
+  EXPECT_EQ( img.depth(), img2.depth() );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( 0, std::remove( image_path.c_str() ) )
+    << "Failed to delete temporary image file.";
 }
-
 
 namespace {
 
+// ----------------------------------------------------------------------------
 template <typename T>
 void
-run_image_io_tests(kwiver::vital::image_of<T> const& img, std::string const& type_str)
+run_ocv_conversion_tests( cv::Mat const& img )
 {
-  using namespace kwiver::arrows;
-  const std::string image_path = "test_"+type_str+".png";
-  image_container_sptr c(new simple_image_container(img));
-  ocv::image_io io;
-  io.save(image_path, c);
-  image_container_sptr c2 = io.load(image_path);
-  kwiver::vital::image img2 = c2->get_image();
-  TEST_EQUAL("Image of type "+type_str+" has same type after saving and loading",
-             img2.pixel_traits(), img.pixel_traits());
-  TEST_EQUAL("Image of type "+type_str+" has same number of channels after saving and loading",
-             img2.depth(), img.depth());
-  TEST_EQUAL("Image of type "+type_str+" has same content after saving and loading",
-             equal_content(img, img2), true);
+  // Convert to a vital image and verify that the properties are correct
+  image const& vimg = ocv::image_container::ocv_to_vital( img );
+  EXPECT_EQ( sizeof(T), vimg.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, vimg.pixel_traits().type );
+  EXPECT_EQ( static_cast<size_t>( img.channels() ), vimg.depth() );
+  EXPECT_EQ( static_cast<size_t>( img.rows ), vimg.height() );
+  EXPECT_EQ( static_cast<size_t>( img.cols ), vimg.width() );
+  EXPECT_EQ( img.data, vimg.first_pixel() )
+    << "vital::image should share memory with cv::Mat";
 
-  if( std::remove(image_path.c_str()) != 0 )
+  // Don't try to compare images if they don't have the same layout!
+  ASSERT_FALSE( ::testing::Test::HasNonfatalFailure() );
+
+  [&]{
+    unsigned int const num_c = img.channels();
+    for( unsigned int c = 0; c < num_c; ++c )
+    {
+      for( unsigned int j = 0; j < img.rows; ++j )
+      {
+        for( unsigned int i = 0; i < img.cols; ++i )
+        {
+          ASSERT_EQ( img.ptr<T>( j )[ num_c * i + c ], vimg.at<T>( i, j, c ) );
+        }
+      }
+    }
+  }();
+
+  // Convert back to cv::Mat and test again
+  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg );
+  ASSERT_NE( nullptr, img2.data )
+    << "OpenCV re-conversion did not produce a valid cv::Mat";
+
+  EXPECT_EQ( img.type(), img2.type() );
+  ASSERT_EQ( img.channels(), img2.channels() );
+
+  std::vector<cv::Mat> channels1( img.channels() );
+  std::vector<cv::Mat> channels2( img2.channels() );
+  cv::split( img, channels1 );
+  cv::split( img2, channels2 );
+  unsigned int diffs = 0;
+  for ( unsigned c = 0; c < channels1.size(); ++c )
   {
-    TEST_ERROR("Unable to delete temporary image file.");
+    SCOPED_TRACE( "In channel " + std::to_string(c) );
+    EXPECT_EQ( 0, cv::countNonZero( channels1[c] != channels2[c] ) );
+  }
+
+  EXPECT_EQ( img2.data, img.data )
+    << "re-converted cv::Mat should share memory with original";
+}
+
+// ----------------------------------------------------------------------------
+template <typename T>
+void
+run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
+                            bool requires_copy = false )
+{
+  // convert to a cv::Mat and verify that the properties are correct
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img);
+  ASSERT_NE( nullptr, ocv_img.data )
+    << "Vital image conversion did not produce a valid cv::Mat";
+
+  EXPECT_EQ( cv::Mat_<T>{}.type() & 0x7, ocv_img.type() & 0x7 );
+  EXPECT_EQ( img.depth(), ocv_img.channels() );
+  EXPECT_EQ( img.height(), ocv_img.rows );
+  EXPECT_EQ( img.width(), ocv_img.cols );
+  if ( !requires_copy )
+  {
+    EXPECT_EQ( img.first_pixel(), reinterpret_cast<T*>( ocv_img.data ) )
+      << "cv::Mat should share memory with vital::image";
+  }
+
+  [&]{
+    unsigned int const num_c = ocv_img.channels();
+    for( unsigned int c = 0; c < num_c; ++c )
+    {
+      for( unsigned int j = 0; j < ocv_img.rows; ++j )
+      {
+        for( unsigned int i = 0; i < ocv_img.cols; ++i )
+        {
+          ASSERT_EQ( img( i, j, c ), ocv_img.ptr<T>( j )[ num_c * i + c ] )
+            << "Pixels differ at " << i << ", " << j << ", " << c;
+        }
+      }
+    }
+  }();
+
+  // Convert back to vital::image and test again
+  image img2 = ocv::image_container::ocv_to_vital( ocv_img );
+  EXPECT_EQ( sizeof(T), img2.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, img2.pixel_traits().type );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( reinterpret_cast<T*>( ocv_img.data ), img2.first_pixel() );
+  if ( !requires_copy )
+  {
+    EXPECT_EQ( img.first_pixel(), img2.first_pixel() )
+      << "re-converted vital::image should share memory with original";
   }
 }
 
 } // end anonymous namespace
 
-
-IMPLEMENT_TEST(image_io_types)
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_conversion : public ::testing::Test
 {
-  {
-    kwiver::vital::image_of<uint8_t> img(200,300,1);
-    populate_vital_image<uint8_t>(img);
-    run_image_io_tests(img, "uint8_C1");
-  }
-  {
-    kwiver::vital::image_of<uint8_t> img(200,300,3);
-    populate_vital_image<uint8_t>(img);
-    run_image_io_tests(img, "uint8_C3");
-  }
-  {
-    kwiver::vital::image_of<uint8_t> img(200,300,4);
-    populate_vital_image<uint8_t>(img);
-    run_image_io_tests(img, "uint8_C4");
-  }
-  {
-    kwiver::vital::image_of<uint16_t> img(200,300,1);
-    populate_vital_image<uint16_t>(img);
-    run_image_io_tests(img, "uint16_C1");
-  }
-  {
-    kwiver::vital::image_of<uint16_t> img(200,300,3);
-    populate_vital_image<uint16_t>(img);
-    run_image_io_tests(img, "uint16_C3");
-  }
+};
+
+using conversion_types =
+  ::testing::Types<uint8_t, int8_t, uint16_t, int16_t, int32_t, float, double>;
+TYPED_TEST_CASE(image_conversion, conversion_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_single_channel)
+{
+  // Create single-channel cv::Mat and convert to and from vital images
+  cv::Mat_<TypeParam> img{ cv::Size{ 100, 200 } };
+  populate_ocv_image<TypeParam>( img );
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_multi_channel)
+{
+  // Create multi-channel cv::Mat and convert to and from vital images
+  cv::Mat_<cv::Vec<TypeParam, 3>> img{ cv::Size{ 100, 200 } };
+  populate_ocv_image<TypeParam>( img );
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_cropped)
+{
+  // Create cropped cv::Mat and convert to and from vital images
+  cv::Mat_<cv::Vec<TypeParam, 3>> img{ cv::Size{ 200, 300 } };
+  populate_ocv_image<TypeParam>( img );
+  cv::Rect window( cv::Point{ 40, 50 }, cv::Point{ 140, 250 } );
+  cv::Mat_<cv::Vec<TypeParam, 3>> img_crop{ img, window };
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_single_channel)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 1 };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_multi_channel)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img, true );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_interleaved)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3, true };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TEST(image, bad_conversions)
+{
+  // Some types not supported by OpenCV and should throw an exception
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<uint32_t>( 200, 300 ) ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int64_t>( 200, 300 ) ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<uint64_t>( 200, 300 ) ),
+                image_type_mismatch_exception );
 }

--- a/arrows/tests/test_image.h
+++ b/arrows/tests/test_image.h
@@ -1,0 +1,85 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test VXL image class functionality
+ */
+
+#include <vital/types/image.h>
+
+#include <cmath>
+
+namespace {
+
+// ----------------------------------------------------------------------------
+double value_at( int i, int j, int p )
+{
+  static constexpr double pi = 3.14159265358979323846;
+
+  auto const w = 0.1 * static_cast<double>( p + 1 );
+  auto const u = std::sin( pi * static_cast<double>( i ) * w );
+  auto const v = std::sin( pi * static_cast<double>( j ) * w );
+  return 0.5 * ( ( u * v ) + 1.0 );
+}
+
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern; the dynamic range is
+// stretched between minv and maxv
+template <typename T>
+void
+populate_vital_image(kwiver::vital::image& img, T minv, T maxv)
+{
+  const double range = static_cast<double>(maxv) - static_cast<double>(minv);
+  const double offset = - static_cast<double>(minv);
+  for( unsigned int p=0; p<img.depth(); ++p )
+  {
+    for( unsigned int j=0; j<img.height(); ++j )
+    {
+      for( unsigned int i=0; i<img.width(); ++i )
+      {
+        img.at<T>(i,j,p) = static_cast<T>(value_at(i, j, p) * range + offset);
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// helper function to populate the image with a pattern
+template <typename T>
+void
+populate_vital_image(kwiver::vital::image& img)
+{
+  const T minv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::min() : T(0);
+  const T maxv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::max() : T(1);
+  populate_vital_image<T>(img, minv, maxv);
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
Convert OpenCV image test to Google Test. Factor out some code that is shared with the VXL image test into a helper header. Refactor how the VXL image test sets up type parameters for the `image_io` test so that the number of channels is part of the type parameter. Add additional pixel type and channel count combinations to some VXL image tests to more closely match the available OpenCV tests.