### PR TITLE
Remove explicit setting of logger from all processes.

### DIFF
--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -64,8 +64,6 @@ input_adapter_process
 ::input_adapter_process( kwiver::vital::config_block_sptr const& config )
   : process( config )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
 }
 
 

--- a/sprokit/processes/adapters/output_adapter_process.cxx
+++ b/sprokit/processes/adapters/output_adapter_process.cxx
@@ -77,9 +77,6 @@ output_adapter_process
   : process( config )
   , d( new output_adapter_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   declare_config_using_trait( wait_on_queue_full );
 }
 

--- a/sprokit/processes/core/compute_homography_process.cxx
+++ b/sprokit/processes/core/compute_homography_process.cxx
@@ -101,9 +101,6 @@ compute_homography_process
   : process( config ),
     d( new compute_homography_process::priv )//
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/compute_stereo_depth_map_process.cxx
+++ b/sprokit/processes/core/compute_stereo_depth_map_process.cxx
@@ -84,9 +84,6 @@ compute_stereo_depth_map_process( kwiver::vital::config_block_sptr const& config
   : process( config ),
     d( new compute_stereo_depth_map_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/detect_features_process.cxx
+++ b/sprokit/processes/core/detect_features_process.cxx
@@ -99,9 +99,6 @@ detect_features_process
   : process( config ),
     d( new detect_features_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/detected_object_filter_process.cxx
+++ b/sprokit/processes/core/detected_object_filter_process.cxx
@@ -93,9 +93,6 @@ detected_object_filter_process
   : process( config )
   , d( new detected_object_filter_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/detected_object_input_process.cxx
+++ b/sprokit/processes/core/detected_object_input_process.cxx
@@ -73,9 +73,6 @@ detected_object_input_process
   : process( config ),
     d( new detected_object_input_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/detected_object_output_process.cxx
+++ b/sprokit/processes/core/detected_object_output_process.cxx
@@ -99,9 +99,6 @@ detected_object_output_process
   : process( config ),
     d( new detected_object_output_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/draw_detected_object_set_process.cxx
+++ b/sprokit/processes/core/draw_detected_object_set_process.cxx
@@ -88,9 +88,6 @@ draw_detected_object_set_process
   : process( config ),
     d( new draw_detected_object_set_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/draw_tracks_process.cxx
+++ b/sprokit/processes/core/draw_tracks_process.cxx
@@ -73,9 +73,6 @@ draw_tracks_process
   : process( config ),
     d( new draw_tracks_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/extract_descriptors_process.cxx
+++ b/sprokit/processes/core/extract_descriptors_process.cxx
@@ -71,9 +71,6 @@ extract_descriptors_process
   : process( config ),
     d( new extract_descriptors_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/frame_list_process.cxx
+++ b/sprokit/processes/core/frame_list_process.cxx
@@ -112,9 +112,6 @@ frame_list_process
   : process( config ),
     d( new frame_list_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -127,9 +127,6 @@ image_file_reader_process
   : process( config ),
     d( new image_file_reader_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/image_filter_process.cxx
+++ b/sprokit/processes/core/image_filter_process.cxx
@@ -58,9 +58,6 @@ image_filter_process( kwiver::vital::config_block_sptr const& config )
   : process( config ),
     d( new image_filter_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/image_object_detector_process.cxx
+++ b/sprokit/processes/core/image_object_detector_process.cxx
@@ -58,9 +58,6 @@ image_object_detector_process( kwiver::vital::config_block_sptr const& config )
   : process( config ),
     d( new image_object_detector_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/image_writer_process.cxx
+++ b/sprokit/processes/core/image_writer_process.cxx
@@ -98,9 +98,6 @@ image_writer_process
   : process( config ),
     d( new image_writer_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/matcher_process.cxx
+++ b/sprokit/processes/core/matcher_process.cxx
@@ -84,9 +84,6 @@ matcher_process
   : process( config ),
     d( new matcher_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/read_descriptor_process.cxx
+++ b/sprokit/processes/core/read_descriptor_process.cxx
@@ -69,9 +69,6 @@ read_descriptor_process
   : process( config ),
     d( new read_descriptor_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/refine_detections_process.cxx
+++ b/sprokit/processes/core/refine_detections_process.cxx
@@ -58,9 +58,6 @@ refine_detections_process( kwiver::vital::config_block_sptr const& config )
   : process( config ),
     d( new refine_detections_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/split_image_process.cxx
+++ b/sprokit/processes/core/split_image_process.cxx
@@ -62,8 +62,6 @@ split_image_process
   : process( config ),
     d( new split_image_process::priv )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/stabilize_image_process.cxx
+++ b/sprokit/processes/core/stabilize_image_process.cxx
@@ -78,8 +78,6 @@ stabilize_image_process
   : process( config ),
     d( new stabilize_image_process::priv )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/track_descriptor_input_process.cxx
+++ b/sprokit/processes/core/track_descriptor_input_process.cxx
@@ -73,9 +73,6 @@ track_descriptor_input_process
   : process( config ),
     d( new track_descriptor_input_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/track_descriptor_output_process.cxx
+++ b/sprokit/processes/core/track_descriptor_output_process.cxx
@@ -74,9 +74,6 @@ track_descriptor_output_process
   : process( config ),
     d( new track_descriptor_output_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/video_input_process.cxx
+++ b/sprokit/processes/core/video_input_process.cxx
@@ -94,9 +94,6 @@ video_input_process
   : process( config ),
     d( new video_input_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/examples/process_template/algo_wrapper_process.cxx
+++ b/sprokit/processes/examples/process_template/algo_wrapper_process.cxx
@@ -68,9 +68,6 @@ algo_wrapper_process( kwiver::vital::config_block_sptr const& config )
   : process( config ),
     d( new algo_wrapper_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
+++ b/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
@@ -111,7 +111,6 @@ template_algo_wrapper
   : process( config ),
     d( new template_algo_wrapper::priv )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) );
   make_ports(); // create process ports
   make_config(); // declare process configuration
 }

--- a/sprokit/processes/examples/process_template/template_process.cxx
+++ b/sprokit/processes/examples/process_template/template_process.cxx
@@ -110,7 +110,6 @@ template_process
   : process( config ),
     d( new template_process::priv )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) );
   make_ports(); // create process ports
   make_config(); // declare process configuration
 }

--- a/sprokit/processes/matlab/matlab_process.cxx
+++ b/sprokit/processes/matlab/matlab_process.cxx
@@ -107,7 +107,6 @@ matlab_process
   : process( config ),
     d( new matlab_process::priv( this ) )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) );
   make_ports(); // create process ports
   make_config(); // declare process configuration
 }

--- a/sprokit/processes/ocv/image_viewer_process.cxx
+++ b/sprokit/processes/ocv/image_viewer_process.cxx
@@ -203,7 +203,6 @@ image_viewer_process
   : process( config ),
     d( new image_viewer_process::priv )
 {
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
   make_ports();
   make_config();
 }

--- a/sprokit/processes/vxl/kw_archive_writer_process.cxx
+++ b/sprokit/processes/vxl/kw_archive_writer_process.cxx
@@ -136,8 +136,6 @@ kw_archive_writer_process
   : process(config),
     d( new kw_archive_writer_process::priv( this ) )
 {
-  // Attach our logger name to process logger
-  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
   make_ports();
   make_config();
 }

--- a/sprokit/src/sprokit/pipeline/pipeline.h
+++ b/sprokit/src/sprokit/pipeline/pipeline.h
@@ -224,6 +224,7 @@ class SPROKIT_PIPELINE_EXPORT pipeline
      * \returns True if the pipeline has been setup, false otherwise.
      */
     bool is_setup() const;
+
     /**
      * \brief Query whether the pipeline has been setup successfully.
      *

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -643,7 +643,7 @@ process
   }
 
   // Set default logger name
-  attach_logger( kwiver::vital::get_logger( std::string( "process." ) + name() ) );
+  attach_logger( kwiver::vital::get_logger( std::string( "sprokit.process." ) + name() ) );
 }
 
 


### PR DESCRIPTION
The default logger name is already set by the base class and also doing
it in the derived class leads to non-standard logger names.