### PR TITLE
process property handling

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -101,6 +101,16 @@ Vital
  * Added at() method to detected_object_set to provide bounds checked
    direct indexing.
 
+ * Added process properties that are bound to the process
+   object. Process properties were created based on the process class
+   hierarchy, where the derived process would create the set of
+   properties. There are cases where the derived process does not know
+   all the properties, such as when process instrumentation is
+   enabled. The solution is to add a set of properties that is part of
+   the process object that can accumulate these condition based
+   properties. Properties from the derived class are merged with the
+   fixed set of properties when the set of properties is requested.
+
 Vital Bindings
 
  * Vital C and Python bindings have been updated with respect the refactoring

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -160,6 +160,10 @@ Sprokit
 
      $plugin_explorer --fact instrumentation
 
+ * Added test to threaded scheduler to detect when a python process is
+   in the pipeline. If a python process is found, an exception is
+   thrown.
+
 Unit Tests
 
  * KWIVER is in the process of transitioning to Google Test as its primary

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -110,6 +110,8 @@ public:
   explorer_context* m_context;
 
   bool opt_hidden;
+
+  kwiver::vital::logger_handle_t m_logger;
 }; // end class process_explorer
 
 
@@ -117,6 +119,7 @@ public:
 process_explorer::
 process_explorer()
   :opt_hidden( false )
+  , m_logger( kwiver::vital::get_logger( "process_explorer_plugin" ) )
 { }
 
 
@@ -174,6 +177,12 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
   }
 
   sprokit::process_factory* pf = dynamic_cast< sprokit::process_factory* > ( fact.get() );
+
+  if ( ! pf )
+  {
+    LOG_ERROR( m_logger, "Could not convert factory to process_factory" );
+    return;
+  }
 
   sprokit::process_t const proc = pf->create_object( kwiver::vital::config_block::empty_config() );
 

--- a/sprokit/src/schedulers/sync_scheduler.cxx
+++ b/sprokit/src/schedulers/sync_scheduler.cxx
@@ -92,8 +92,9 @@ sync_scheduler
   process_t proc = p->get_python_process();
   if(proc)
   {
-      std::string const reason = "The process \'" + proc->name() + "\' is "
-                                 "a python process and is not supported by this scheduler.";
+        std::string const reason = "The process \'" + proc->name() + "\' of type \'" + proc->type()
+      + "\' is a python process and that type of process is not supported by this scheduler.";
+
       throw incompatible_pipeline_exception(reason);
   }
 

--- a/sprokit/src/schedulers/thread_per_process_scheduler.cxx
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.cxx
@@ -84,9 +84,10 @@ thread_per_process_scheduler
   process_t proc = p->get_python_process();
   if(proc)
   {
-      std::string const reason = "The process \'" + proc->name() + "\' is "
-                                 "a python process and is not supported by this scheduler.";
-      throw incompatible_pipeline_exception(reason);
+    std::string const reason = "The process \'" + proc->name() + "\' of type \'" + proc->type()
+      + "\' is a python process and that type of process is not supported by this scheduler.";
+
+    throw incompatible_pipeline_exception(reason);
   }
 
   process::names_t const names = p->process_names();
@@ -102,18 +103,6 @@ thread_per_process_scheduler
     {
       std::string const reason =
         "The process \'" + name + "\' does not support being in its own thread.";
-
-      throw incompatible_pipeline_exception(reason);
-    }
-
-    // Test for a python process in the pipeline. This scheduler does
-    // not support running python processes and bad things happen if
-    // you try.
-    if ( consts.count( process::property_python) )
-    {
-      std::string const reason = "The process \'" + name + "\' of type \'" + proc->type()
-        + "\' is "
-        "a python process and that type of process is not supported by this scheduler.";
 
       throw incompatible_pipeline_exception(reason);
     }

--- a/sprokit/src/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/sprokit/pipeline/edge.cxx
@@ -97,6 +97,9 @@ edge_datum_t
           pointers_equal(stamp, rhs.stamp));
 }
 
+// This config parameter is used internally to signal that the edge
+// has no dependency. See process::flag_input_nodep for additional
+// description.
 kwiver::vital::config_block_key_t const edge::config_dependency = kwiver::vital::config_block_key_t("_dependency");
 kwiver::vital::config_block_key_t const edge::config_capacity   = kwiver::vital::config_block_key_t("capacity");
 kwiver::vital::config_block_key_t const edge::config_blocking   = kwiver::vital::config_block_key_t("blocking");
@@ -115,9 +118,18 @@ class edge::priv
 
     bool push(edge_datum_t const& datum, boost::optional<duration_t> const& duration = boost::none);
     boost::optional<edge_datum_t> pop(boost::optional<duration_t> const& duration = boost::none);
+
+    /// This flag indicates that this edge connection should or should
+    /// not imply a dependency. Generally set to false if a backwards
+    /// edge.
     bool const depends;
+
+    /// Size of the buffer in this edge.
     size_t const capacity;
+
+    /// Set to indicate if this edge will block if its buffer is full.
     bool const blocking;
+
     bool downstream_complete;
 
     process_ref_t upstream;
@@ -139,7 +151,7 @@ class edge::priv
     mutable mutex_t mutex;
     mutable mutex_t complete_mutex;
 
-  kwiver::vital::logger_handle_t m_logger;
+    kwiver::vital::logger_handle_t m_logger;
 };
 
 

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -72,6 +72,7 @@ process::property_t const process::property_no_reentrancy = property_t("_no_reen
 process::property_t const process::property_unsync_input = property_t("_unsync_input");
 process::property_t const process::property_unsync_output = property_t("_unsync_output");
 process::property_t const process::property_instrumented = property_t("_instrumented");
+process::property_t const process::property_python = property_t("_python");
 
 process::port_t const process::port_heartbeat = port_t("_heartbeat");
 
@@ -215,7 +216,7 @@ class process::priv
     mutable mutex_t output_edges_mut;
 
     process* const q;
-   kwiver::vital::config_block_sptr conf;
+    kwiver::vital::config_block_sptr conf;
 
     typedef std::set<port_t> port_set_t;
 
@@ -245,6 +246,9 @@ class process::priv
 
     kwiver::vital::logger_handle_t m_logger;
     std::unique_ptr< sprokit::process_instrumentation > m_proc_instrumentation; // instrumentation provider
+
+    // List of properties that are associated with this object
+    properties_t m_properties;
 
     static kwiver::vital::config_block_value_t const default_name;
 };
@@ -382,12 +386,29 @@ process
 }
 
 
+// ----------------------------------------------------------------------------
+void
+process
+::add_property( const property_t& prop )
+{
+  d->m_properties.insert( prop );
+}
+
+
 // ------------------------------------------------------------------
 process::properties_t
 process
 ::properties() const
 {
-  return _properties();
+  // Fetch property set from this
+  properties_t result( d->m_properties );
+
+  // Get properties from derived class
+  properties_t derived = _properties();
+
+  result.insert( derived.begin(), derived.end() );
+
+  return result;
 }
 
 
@@ -639,6 +660,9 @@ process
 
       kwiver::vital::config_block_sptr prov_block = instr_block->subblock_view( instr_prov );
       d->m_proc_instrumentation->configure( instr_block );
+
+      // Add this as a property
+      add_property( property_instrumented );
     }
   }
 

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -549,6 +549,8 @@ class SPROKIT_PIPELINE_EXPORT process
     static property_t const property_unsync_output;
     /// Indicates that the process supports instrumentation call
     static property_t const property_instrumented;
+    /// Indicates the process is written in Python
+    static property_t const property_python;
 
     /// The name of the heartbeat port.
     static port_t const port_heartbeat;
@@ -1375,8 +1377,12 @@ SCOPED_INSTRUMENTATION(reconfigure);
 
     friend class process_cluster;
     SPROKIT_PIPELINE_NO_EXPORT void reconfigure_with_provides(kwiver::vital::config_block_sptr const& conf);
+
+    friend class process_factory;
+    SPROKIT_PIPELINE_NO_EXPORT void add_property ( const property_t& prop );
 };
 
+// ----------------------------------------------------------------------------
 template <typename T>
 T
 process

--- a/sprokit/src/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/process_factory.cxx
@@ -31,6 +31,7 @@
 #include "process_factory.h"
 #include "process_registry_exception.h"
 
+#include <vital/util/tokenize.h>
 #include <vital/logger/logger.h>
 
 #include <algorithm>
@@ -49,7 +50,27 @@ process_factory( const std::string& type,
 }
 
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+void
+process_factory::
+copy_attributes( sprokit::process_t proc )
+{
+  // Add any properties from the factory attributes
+  std::string props;
+  if ( get_attribute( kwiver::vital::plugin_factory::PLUGIN_PROCESS_PROPERTIES, props ) )
+  {
+    // split props by " " or "," then add to process props.
+    std::vector< std::string > fact_props;
+    kwiver::vital::tokenize( props, fact_props, ", ", kwiver::vital::TokenizeTrimEmpty );
+    for ( std::string a_prop : fact_props )
+    {
+      proc->add_property( a_prop );
+    }
+  }
+}
+
+
+// ============================================================================
 cpp_process_factory::
 cpp_process_factory( const std::string& type,
                  const std::string& itype,
@@ -70,7 +91,12 @@ create_object(kwiver::vital::config_block_sptr const& config)
 {
   // Call sprokit factory function. Need to use this factory
   // function approach to handle clusters transparently.
-  return m_factory( config );
+  sprokit::process_t proc = m_factory( config );
+
+  // Copy attributes from factory to process.
+  copy_attributes( proc );
+
+  return proc;
 }
 
 
@@ -112,9 +138,10 @@ create_process( const sprokit::process::type_t&         type,
     throw no_such_process_type_exception( type );
   }
 
+  sprokit::process_t proc;
   try
   {
-    return pf->create_object( config );
+    proc = pf->create_object( config );
   }
   catch ( const std::exception &e )
   {
@@ -122,6 +149,8 @@ create_process( const sprokit::process::type_t&         type,
     LOG_ERROR( logger, "Exception from creating process: " << e.what() );
     throw;
   }
+
+  return proc;
 }
 
 
@@ -155,6 +184,5 @@ kwiver::vital::plugin_factory_vector_t const& get_process_list()
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   return vpm.get_factories<sprokit::process>();
 }
-
 
 } // end namespace

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -105,6 +105,8 @@ public:
   virtual ~process_factory() = default;
 
   virtual sprokit::process_t create_object(kwiver::vital::config_block_sptr const& config) = 0;
+
+  void copy_attributes( sprokit::process_t proc );
 };
 
 

--- a/sprokit/src/sprokit/pipeline/scheduler.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2013 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,8 +45,7 @@
  * \brief Implementation of the base class for \link sprokit::scheduler schedulers\endlink.
  */
 
-namespace sprokit
-{
+namespace sprokit {
 
 class scheduler::priv
 {
@@ -72,14 +71,18 @@ class scheduler::priv
     mutex_t mut;
 };
 
+
+// ============================================================================
 scheduler
 ::~scheduler()
 {
 }
 
+
 scheduler
 ::scheduler(pipeline_t const& pipe, kwiver::vital::config_block_sptr const& config)
-  : d()
+  : m_logger( kwiver::vital::get_logger( "scheduler.base" ) )
+  , d()
 {
   if (!config)
   {
@@ -94,6 +97,8 @@ scheduler
   d.reset(new priv(this, pipe));
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::start()
@@ -114,6 +119,8 @@ scheduler
   d->running = true;
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::wait()
@@ -150,6 +157,8 @@ scheduler
   }
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::pause()
@@ -175,6 +184,8 @@ scheduler
   d->paused = true;
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::resume()
@@ -198,6 +209,8 @@ scheduler
   d->paused = false;
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::stop()
@@ -214,6 +227,8 @@ scheduler
   d->stop();
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler
 ::shutdown()
@@ -228,6 +243,8 @@ scheduler
   }
 }
 
+
+// ----------------------------------------------------------------------------
 pipeline_t
 scheduler
 ::pipeline() const
@@ -235,6 +252,17 @@ scheduler
   return d->p;
 }
 
+
+// ----------------------------------------------------------------------------
+kwiver::vital::logger_handle_t
+scheduler
+::logger()
+{
+  return m_logger;
+}
+
+
+// ============================================================================
 scheduler::priv
 ::priv(scheduler* sched, pipeline_t const& pipe)
   : q(sched)
@@ -250,6 +278,8 @@ scheduler::priv
 {
 }
 
+
+// ----------------------------------------------------------------------------
 void
 scheduler::priv
 ::stop()

--- a/sprokit/src/sprokit/pipeline/scheduler.h
+++ b/sprokit/src/sprokit/pipeline/scheduler.h
@@ -35,6 +35,7 @@
 
 #include "types.h"
 #include <vital/config/config_block.h>
+#include <vital/logger/logger.h>
 #include <boost/noncopyable.hpp>
 
 /**
@@ -161,7 +162,18 @@ class SPROKIT_PIPELINE_EXPORT scheduler
      */
     pipeline_t pipeline() const;
 
+    /**
+     * \brief Get logger handle
+     *
+     * \returns Logger handle so log messages can be generated.
+     */
+    kwiver::vital::logger_handle_t logger();
+
+    // The logger handle
+    kwiver::vital::logger_handle_t m_logger;
+
   private:
+
     class SPROKIT_PIPELINE_NO_EXPORT priv;
     std::unique_ptr<priv> d;
 };

--- a/vital/plugin_loader/plugin_factory.cxx
+++ b/vital/plugin_loader/plugin_factory.cxx
@@ -45,6 +45,7 @@ const std::string plugin_factory::PLUGIN_AUTHOR( "plugin-author" );
 const std::string plugin_factory::PLUGIN_ORGANIZATION( "plugin-organization" );
 const std::string plugin_factory::PLUGIN_LICENSE( "plugin-license" );
 const std::string plugin_factory::PLUGIN_CATEGORY( "plugin-category" );
+const std::string plugin_factory::PLUGIN_PROCESS_PROPERTIES( "plugin-process-properties" );
 
 
 // ------------------------------------------------------------------

--- a/vital/plugin_loader/plugin_factory.h
+++ b/vital/plugin_loader/plugin_factory.h
@@ -84,6 +84,7 @@ public:
   static const std::string PLUGIN_ORGANIZATION;
   static const std::string PLUGIN_LICENSE;
   static const std::string PLUGIN_CATEGORY;
+  static const std::string PLUGIN_PROCESS_PROPERTIES;
 
 
   /**


### PR DESCRIPTION
Added process properties that are bound to the process object. Process properties were created based on the process class hierarchy, where the derived process would create the set of properties. There are cases where the derived process does not know all the properties, such as when process instrumentation is enabled. The solution is to add a set of properties that is part of the process object that can accumulate these condition based properties. Properties from the derived class are merged with the set of properties from the base class when the set of properties is requested

Add attribute to plugin factory to allow process properties to be forwarded to the created process. This allows the process registration operation to specify specific attributes for a process and to communicate those properties to the process.

