### PR TITLE
Convert and refactor Ceres optimize_cameras test

### DIFF
--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -17,5 +17,5 @@ endif()
 # Algorithms Ceres tests
 ##############################
 kwiver_discover_gtests(ceres bundle_adjust      LIBRARIES ${test_libraries})
-kwiver_discover_tests(ceres_optimize_cameras    test_libraries test_optimize_cameras.cxx)
+kwiver_discover_gtests(ceres optimize_cameras   LIBRARIES ${test_libraries})
 kwiver_discover_tests(ceres_reprojection_error  test_libraries test_reprojection_error.cxx)

--- a/arrows/ceres/tests/test_optimize_cameras.cxx
+++ b/arrows/ceres/tests/test_optimize_cameras.cxx
@@ -28,225 +28,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iostream>
-#include <sstream>
-
-#include <test_common.h>
-#include <test_math.h>
-#include <test_scene.h>
-
-#include <vital/types/camera_map.h>
-#include <vital/types/landmark_map.h>
-#include <vital/types/track_set.h>
-#include <vital/exceptions.h>
-#include <vital/plugin_loader/plugin_manager.h>
-
-#include <arrows/core/projected_track_set.h>
 #include <arrows/ceres/optimize_cameras.h>
 
+#include <vital/plugin_loader/plugin_manager.h>
 
-
-#define TEST_ARGS ()
-DECLARE_TEST_MAP();
-
-int main(int argc, char* argv[])
-{
-  CHECK_ARGS(1);
-  kwiver::vital::plugin_manager::instance().load_all_plugins();
-
-  testname_t const testname = argv[1];
-  RUN_TEST(testname);
-}
+#include <gtest/gtest.h>
 
 using namespace kwiver::vital;
 
-IMPLEMENT_TEST(creation)
+using kwiver::arrows::ceres::optimize_cameras;
+
+static constexpr double noisy_center_tolerance = 1e-9;
+static constexpr double noisy_rotation_tolerance = 1e-11;
+static constexpr double noisy_intrinsics_tolerance = 1e-7;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
 {
-  using namespace kwiver::arrows;
-  algo::optimize_cameras_sptr cam_optimizer = algo::optimize_cameras::create("ceres");
-  if (!cam_optimizer)
-  {
-    TEST_ERROR("Unable to create ceres::optimize_cameras by impl name.");
-  }
+  ::testing::InitGoogleTest( &argc, argv );
+
+  kwiver::vital::plugin_manager::instance().load_all_plugins();
+
+  return RUN_ALL_TESTS();
 }
 
-
-IMPLEMENT_TEST(uninitialized)
+// ----------------------------------------------------------------------------
+TEST(optimize_cameras, create)
 {
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  camera_map_sptr cam_map;
-  landmark_map_sptr lm_map;
-  feature_track_set_sptr trk_set;
-
-  ceres::optimize_cameras optimizer;
-  config_block_sptr cfg = optimizer.get_configuration();
-  cfg->set_value("verbose", "true");
-  optimizer.set_configuration(cfg);
-
-  cerr << "cam_map before: " << cam_map << endl;
-
-  EXPECT_EXCEPTION(
-    kwiver::vital::invalid_value,
-      optimizer.optimize(cam_map, trk_set, lm_map),
-      "Running camera optimization with null input"
-      );
-
-  cerr << "cam_map after: " << cam_map << endl;
-
-  TEST_EQUAL("cam_map", cam_map, 0);
+  EXPECT_NE( nullptr, algo::optimize_cameras::create("ceres") );
 }
 
-
-IMPLEMENT_TEST(empty_input)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  camera_map_sptr cam_map(new simple_camera_map());
-  landmark_map_sptr lm_map(new simple_landmark_map());
-  feature_track_set_sptr trk_set(new feature_track_set());
-
-  ceres::optimize_cameras optimizer;
-  config_block_sptr cfg = optimizer.get_configuration();
-  cfg->set_value("verbose", "true");
-  optimizer.set_configuration(cfg);
-
-  camera_map_sptr orig_map = cam_map;
-
-  cerr << "cam_map before: " << cam_map << endl;
-  optimizer.optimize(cam_map, trk_set, lm_map);
-  cerr << "cam_map after : " << cam_map << endl;
-  cerr << "orig map      : " << orig_map << endl;
-
-  // make sure that a new camera map was created, but nothing was put in it.
-  TEST_EQUAL("cam_map reference",
-      cam_map == orig_map,
-      false);
-  TEST_EQUAL("cam_map size", cam_map->size(), 0);
-  TEST_EQUAL("orig map size", orig_map->size(), 0);
-}
-
-
-IMPLEMENT_TEST(no_noise)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  // Create cameras, landmarks and tracks.
-  // Optimize already optimimal elements to make sure they don't get changed
-  // much.
-
-  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
-
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-  camera_map_sptr working_cam_map(new simple_camera_map(original_cams));
-  feature_track_set_sptr tracks = projected_tracks(landmarks,
-                                                   working_cam_map);
-
-  ceres::optimize_cameras optimizer;
-  config_block_sptr cfg = optimizer.get_configuration();
-  cfg->set_value("verbose", "true");
-  optimizer.set_configuration(cfg);
-
-  optimizer.optimize(working_cam_map, tracks, landmarks);
-
-  vector_3d zero_3d_vec(0,0,0);
-  matrix_3x3d zero_mat = matrix_3x3d::Zero();
-  ostringstream ss;
-
-  double ep = 1e-14;
-  for (camera_map::map_camera_t::value_type const& p :
-       working_cam_map->cameras())
-  {
-    // difference in camera center
-    vector_3d a_c = p.second->center(),
-              b_c = original_cams[p.first]->center(),
-              c_c;
-    c_c = a_c - b_c;
-    //cerr << "frm[" << p.first << "]\t:: center delta     :: " << c_c << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] center delta check";
-    TEST_NEAR(ss.str(), c_c, zero_3d_vec, ep);
-
-    // difference in camera rotation
-    rotation_d a_r = p.second->rotation(),
-               b_r = original_cams[p.first]->rotation();
-    vector_3d c_r = (a_r * b_r.inverse()).rodrigues();
-    //cerr << "frm[" << p.first << "]\t:: quaternion delta :: " << c_r << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] quaternion delta check";
-    TEST_NEAR(ss.str(), c_r, zero_3d_vec, ep);
-
-    // difference in camera intrinsics
-    camera_intrinsics_sptr a_k = p.second->intrinsics(),
-                           b_k = original_cams[p.first]->intrinsics();
-    matrix_3x3d c_k = a_k->as_matrix() - b_k->as_matrix();
-    //cerr << "frm[" << p.first << "]\t:: intrinsics delta :: " << c_k << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] intrinsics";
-    TEST_NEAR(ss.str(), c_k, zero_mat, ep);
-  }
-}
-
-
-IMPLEMENT_TEST(noisy_cameras)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  // Same as above, but create an analogous set of cameras with noise added.
-  // Check that optimized cameras are close to the original cameras.
-
-  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
-
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-  camera_map_sptr working_cam_map(new simple_camera_map(original_cams));
-  feature_track_set_sptr tracks = projected_tracks(landmarks, working_cam_map);
-
-  working_cam_map = kwiver::testing::noisy_cameras(working_cam_map, 0.1, 0.1);
-
-  ceres::optimize_cameras optimizer;
-  config_block_sptr cfg = optimizer.get_configuration();
-  cfg->set_value("verbose", "true");
-  optimizer.set_configuration(cfg);
-
-  optimizer.optimize(working_cam_map, tracks, landmarks);
-
-  vector_3d zero_3d_vec(0,0,0);
-  matrix_3x3d zero_mat = matrix_3x3d::Zero();
-  ostringstream ss;
-
-  for (camera_map::map_camera_t::value_type const& p :
-       working_cam_map->cameras())
-  {
-    // difference in camera center
-    vector_3d a_c = p.second->center(),
-              b_c = original_cams[p.first]->center(),
-              c_c;
-    c_c = a_c - b_c;
-    //cerr << "frm[" << p.first << "]\t:: center delta     :: " << c_c << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] center delta check";
-    TEST_NEAR(ss.str(), c_c, zero_3d_vec, 1e-8);
-
-    // difference in camera rotation
-    rotation_d a_r = p.second->rotation(),
-               b_r = original_cams[p.first]->rotation();
-    vector_3d c_r = (a_r * b_r.inverse()).rodrigues();
-    //cerr << "frm[" << p.first << "]\t:: quaternion delta :: " << c_r << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] quaternion delta check";
-    TEST_NEAR(ss.str(), c_r, zero_3d_vec, 1e-8);
-
-    // difference in camera intrinsics
-    camera_intrinsics_sptr a_k = p.second->intrinsics(),
-                           b_k = original_cams[p.first]->intrinsics();
-    matrix_3x3d c_k = a_k->as_matrix() - b_k->as_matrix();
-    //cerr << "frm[" << p.first << "]\t:: intrinsics delta :: " << c_k << endl;
-    ss.str("");
-    ss << "frm[" << p.first << "] intrinsics";
-    TEST_NEAR(ss.str(), c_k, zero_mat, 1e-5);
-  }
-}
+// ----------------------------------------------------------------------------
+#include <arrows/tests/test_optimize_cameras.h>

--- a/arrows/tests/test_estimate_fundamental_matrix.h
+++ b/arrows/tests/test_estimate_fundamental_matrix.h
@@ -112,18 +112,13 @@ TEST(estimate_fundamental_matrix, ideal_points)
 
   // compute the fundamental matrix from the corresponding points
   std::vector<bool> inliers;
-  auto estimated_F_sptr = est_f.estimate( pts1, pts2, inliers, 1.5 );
-  matrix_3x3d estimated_F = estimated_F_sptr->matrix();
-  // check for sign difference
-  if( true_F->matrix().cwiseProduct(estimated_F).sum() < 0.0 )
-  {
-    estimated_F *= -1;
-  }
+  auto estimated_F = est_f.estimate( pts1, pts2, inliers, 1.5 );
 
   // compare true and computed fundamental matrices
-  std::cout << "true F = "<<*true_F<<std::endl;
-  std::cout << "Estimated F = "<< estimated_F <<std::endl;
-  EXPECT_MATRIX_NEAR( true_F->matrix(), estimated_F, ideal_tolerance );
+  std::cout << "true F = " << *true_F << std::endl;
+  std::cout << "Estimated F = "<< *estimated_F << std::endl;
+  EXPECT_MATRIX_SIMILAR( true_F->matrix(), estimated_F->matrix(),
+                         ideal_tolerance );
 
   std::cout << "num inliers " << inliers.size() << std::endl;
   EXPECT_EQ( pts1.size(), inliers.size() )
@@ -178,18 +173,12 @@ TEST(estimate_fundamental_matrix, noisy_points)
 
   // compute the fundamental matrix from the corresponding points
   std::vector<bool> inliers;
-  auto estimated_F_sptr = est_f.estimate( pts1, pts2, inliers, 1.5 );
-  matrix_3x3d estimated_F = estimated_F_sptr->matrix();
-  // check for sign difference
-  if( true_F->matrix().cwiseProduct(estimated_F).sum() < 0.0 )
-  {
-    estimated_F *= -1;
-  }
+  auto estimated_F = est_f.estimate( pts1, pts2, inliers, 1.5 );
 
   // compare true and computed fundamental matrices
-  std::cout << "true F = "<<*true_F<<std::endl;
-  std::cout << "Estimated F = "<< estimated_F <<std::endl;
-  EXPECT_MATRIX_NEAR( true_F->matrix(), estimated_F, 0.01 );
+  std::cout << "true F = " << *true_F << std::endl;
+  std::cout << "Estimated F = "<< *estimated_F << std::endl;
+  EXPECT_MATRIX_SIMILAR( true_F->matrix(), estimated_F->matrix(), 0.01 );
 
   std::cout << "num inliers " << inliers.size() << std::endl;
   EXPECT_GT( inliers.size(), pts1.size() / 2 )
@@ -253,18 +242,13 @@ TEST(estimate_fundamental_matrix, outlier_points)
 
   // compute the fundamental matrix from the corresponding points
   std::vector<bool> inliers;
-  auto estimated_F_sptr = est_f.estimate( pts1, pts2, inliers, 1.5 );
-  matrix_3x3d estimated_F = estimated_F_sptr->matrix();
-  // check for sign difference
-  if( true_F->matrix().cwiseProduct(estimated_F).sum() < 0.0 )
-  {
-    estimated_F *= -1;
-  }
+  auto estimated_F = est_f.estimate( pts1, pts2, inliers, 1.5 );
 
   // compare true and computed fundamental matrices
-  std::cout << "true F = "<<*true_F<<std::endl;
-  std::cout << "Estimated F = "<< estimated_F << std::endl;
-  EXPECT_MATRIX_NEAR( true_F->matrix(), estimated_F, outlier_tolerance );
+  std::cout << "true F = " << *true_F << std::endl;
+  std::cout << "Estimated F = "<< *estimated_F << std::endl;
+  EXPECT_MATRIX_SIMILAR( true_F->matrix(), estimated_F->matrix(),
+                         outlier_tolerance );
 
   std::cout << "num inliers " << inliers.size() << std::endl;
   EXPECT_GT( inliers.size(), pts1.size() / 3 )

--- a/arrows/tests/test_optimize_cameras.h
+++ b/arrows/tests/test_optimize_cameras.h
@@ -1,0 +1,173 @@
+/*ckwg +29
+ * Copyright 2014-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <test_eigen.h>
+#include <test_scene.h>
+
+#include <arrows/core/projected_track_set.h>
+
+#include <vital/types/camera_map.h>
+#include <vital/types/landmark_map.h>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+TEST(optimize_cameras, uninitialized)
+{
+  camera_map_sptr cam_map;
+  landmark_map_sptr lm_map;
+  feature_track_set_sptr trk_set;
+
+  optimize_cameras optimizer;
+  config_block_sptr cfg = optimizer.get_configuration();
+  cfg->set_value( "verbose", "true" );
+  optimizer.set_configuration( cfg );
+
+  EXPECT_THROW(
+    optimizer.optimize( cam_map, trk_set, lm_map ),
+    kwiver::vital::invalid_value )
+    << "Running camera optimization with null input";
+
+  EXPECT_EQ( nullptr, cam_map );
+}
+
+// ----------------------------------------------------------------------------
+TEST(optimize_cameras, empty_input)
+{
+  camera_map_sptr cam_map = std::make_shared<simple_camera_map>();
+  landmark_map_sptr lm_map = std::make_shared<simple_landmark_map>();
+  feature_track_set_sptr trk_set = std::make_shared<feature_track_set>();
+
+  optimize_cameras optimizer;
+  config_block_sptr cfg = optimizer.get_configuration();
+  cfg->set_value( "verbose", "true" );
+  optimizer.set_configuration( cfg );
+
+  camera_map_sptr orig_map = cam_map;
+
+  std::cerr << "cam_map before: " << cam_map << std::endl;
+  optimizer.optimize(cam_map, trk_set, lm_map);
+  std::cerr << "cam_map after : " << cam_map << std::endl;
+  std::cerr << "orig map      : " << orig_map << std::endl;
+
+  // Make sure that a new camera map was created, but nothing was put in it.
+  EXPECT_NE( orig_map, cam_map );
+  EXPECT_EQ( 0, cam_map->size() );
+  EXPECT_EQ( 0, orig_map->size() );
+}
+
+// ----------------------------------------------------------------------------
+TEST(optimize_cameras, no_noise)
+{
+  // Create cameras, landmarks and tracks.
+  // Optimize already optimimal elements to make sure they don't get changed
+  // much.
+
+  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
+
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+  camera_map_sptr working_cam_map =
+    std::make_shared<simple_camera_map>( original_cams );
+  feature_track_set_sptr tracks = projected_tracks( landmarks, working_cam_map );
+
+  optimize_cameras optimizer;
+  config_block_sptr cfg = optimizer.get_configuration();
+  cfg->set_value( "verbose", "true" );
+  optimizer.set_configuration( cfg );
+
+  optimizer.optimize(working_cam_map, tracks, landmarks);
+
+  double const ep = 1e-14;
+  for( auto const& p : working_cam_map->cameras() )
+  {
+    SCOPED_TRACE( "At camera " + std::to_string( p.first ) );
+
+    // Difference in camera center
+    EXPECT_MATRIX_NEAR( original_cams[p.first]->center(),
+                        p.second->center(), ep );
+
+    // Difference in camera rotation
+    EXPECT_MATRIX_NEAR(
+      vector_4d{ original_cams[p.first]->rotation().quaternion().coeffs() },
+      vector_4d{ p.second->rotation().quaternion().coeffs() }, ep );
+
+    // difference in camera intrinsics
+    EXPECT_MATRIX_NEAR( original_cams[p.first]->intrinsics()->as_matrix(),
+                        p.second->intrinsics()->as_matrix(), ep );
+  }
+}
+
+// ----------------------------------------------------------------------------
+TEST(optimize_cameras, noisy_cameras)
+{
+  // Same as above, but create an analogous set of cameras with noise added.
+  // Check that optimized cameras are close to the original cameras.
+
+  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
+
+  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
+  camera_map_sptr working_cam_map =
+    std::make_shared<simple_camera_map>( original_cams );
+  feature_track_set_sptr tracks = projected_tracks(landmarks, working_cam_map);
+
+  working_cam_map = kwiver::testing::noisy_cameras(working_cam_map, 0.1, 0.1);
+
+  optimize_cameras optimizer;
+  config_block_sptr cfg = optimizer.get_configuration();
+  cfg->set_value( "verbose", "true" );
+  optimizer.set_configuration( cfg );
+
+  optimizer.optimize(working_cam_map, tracks, landmarks);
+
+  for( auto const& p : working_cam_map->cameras() )
+  {
+    SCOPED_TRACE( "At camera " + std::to_string( p.first ) );
+
+    // Difference in camera center
+    EXPECT_MATRIX_NEAR( original_cams[p.first]->center(),
+                        p.second->center(), noisy_center_tolerance );
+
+    // Difference in camera rotation
+    EXPECT_MATRIX_SIMILAR(
+      vector_4d{ original_cams[p.first]->rotation().quaternion().coeffs() },
+      vector_4d{ p.second->rotation().quaternion().coeffs() },
+      noisy_rotation_tolerance );
+
+    // difference in camera intrinsics
+    EXPECT_MATRIX_NEAR( original_cams[p.first]->intrinsics()->as_matrix(),
+                        p.second->intrinsics()->as_matrix(),
+                        noisy_intrinsics_tolerance );
+  }
+}

--- a/arrows/vxl/tests/test_estimate_essential_matrix.cxx
+++ b/arrows/vxl/tests/test_estimate_essential_matrix.cxx
@@ -129,18 +129,12 @@ TEST(estimate_essential_matrix, ideal_points)
 
   // compute the essential matrix from the corresponding points
   std::vector<bool> inliers;
-  auto estimated_E_sptr = est_e.estimate(pts1, pts2, cal1, cal2, inliers, 1.5);
-  matrix_3x3d estimated_E = estimated_E_sptr->matrix();
-  // check for sign difference
-  if( true_E->matrix().cwiseProduct(estimated_E).sum() < 0.0 )
-  {
-    estimated_E *= -1;
-  }
+  auto estimated_E = est_e.estimate(pts1, pts2, cal1, cal2, inliers, 1.5);
 
   // compare true and computed essential matrices
-  std::cout << "true E = "<< *true_E << std::endl;
-  std::cout << "Estimated E = "<< estimated_E << std::endl;
-  EXPECT_MATRIX_NEAR( true_E->matrix(), estimated_E, 1e-8 );
+  std::cout << "true E = " << *true_E << std::endl;
+  std::cout << "Estimated E = " << *estimated_E << std::endl;
+  EXPECT_MATRIX_SIMILAR( true_E->matrix(), estimated_E->matrix(), 1e-8 );
 
   std::cout << "num inliers " << inliers.size() << std::endl;
   EXPECT_EQ( pts1.size(), inliers.size() )
@@ -196,18 +190,12 @@ TEST(estimate_essential_matrix, noisy_points)
 
   // compute the essential matrix from the corresponding points
   std::vector<bool> inliers;
-  auto estimated_E_sptr = est_e.estimate(pts1, pts2, cal1, cal2, inliers, 1.5);
-  matrix_3x3d estimated_E = estimated_E_sptr->matrix();
-  // check for sign difference
-  if( true_E->matrix().cwiseProduct(estimated_E).sum() < 0.0 )
-  {
-    estimated_E *= -1;
-  }
+  auto estimated_E = est_e.estimate(pts1, pts2, cal1, cal2, inliers, 1.5);
 
   // compare true and computed essential matrices
   std::cout << "true E = "<< *true_E << std::endl;
-  std::cout << "Estimated E = "<< estimated_E << std::endl;
-  EXPECT_MATRIX_NEAR( true_E->matrix(), estimated_E, 1e-2 );
+  std::cout << "Estimated E = "<< *estimated_E << std::endl;
+  EXPECT_MATRIX_SIMILAR( true_E->matrix(), estimated_E->matrix(), 1e-2 );
 
   std::cout << "num inliers " << inliers.size() << std::endl;
   EXPECT_GT( inliers.size(), pts1.size() / 3 )

--- a/arrows/vxl/tests/test_optimize_cameras.cxx
+++ b/arrows/vxl/tests/test_optimize_cameras.cxx
@@ -28,30 +28,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <test_eigen.h>
-#include <test_scene.h>
-
-#include <arrows/core/projected_track_set.h>
 #include <arrows/vxl/optimize_cameras.h>
 
 #include <vital/plugin_loader/plugin_manager.h>
 
-#include <vital/types/camera_map.h>
-#include <vital/types/landmark_map.h>
-#include <vital/types/feature_track_set.h>
-#include <vital/exceptions.h>
-
 #include <gtest/gtest.h>
 
-#include <iostream>
-#include <sstream>
-
 using namespace kwiver::vital;
+
+using kwiver::arrows::vxl::optimize_cameras;
+
+static constexpr double noisy_center_tolerance = 2e-10;
+static constexpr double noisy_rotation_tolerance = 2e-10;
+static constexpr double noisy_intrinsics_tolerance = 2e-10;
 
 // ----------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest( &argc, argv );
+
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
   return RUN_ALL_TESTS();
@@ -64,130 +59,4 @@ TEST(optimize_cameras, create)
 }
 
 // ----------------------------------------------------------------------------
-TEST(optimize_cameras, uninitialized)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  camera_map_sptr cam_map;
-  landmark_map_sptr lm_map;
-  feature_track_set_sptr trk_set;
-
-  vxl::optimize_cameras optimizer;
-
-  cerr << "cam_map before: " << cam_map << endl;
-
-  EXPECT_THROW(
-    optimizer.optimize( cam_map, trk_set, lm_map ),
-    kwiver::vital::invalid_value )
-    << "Running camera optimization with null input";
-
-  cerr << "cam_map after: " << cam_map << endl;
-
-  EXPECT_EQ( nullptr, cam_map );
-}
-
-// ----------------------------------------------------------------------------
-TEST(optimize_cameras, empty_input)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  camera_map_sptr cam_map(new simple_camera_map());
-  landmark_map_sptr lm_map(new simple_landmark_map());
-  auto trk_set = std::make_shared<feature_track_set>();
-
-  vxl::optimize_cameras optimizer;
-
-  camera_map_sptr orig_map = cam_map;
-
-  cerr << "cam_map before: " << cam_map << endl;
-  optimizer.optimize(cam_map, trk_set, lm_map);
-  cerr << "cam_map after : " << cam_map << endl;
-  cerr << "orig map      : " << orig_map << endl;
-
-  // Make sure that a new camera map was created, but nothing was put in it.
-  EXPECT_NE( orig_map, cam_map );
-  EXPECT_EQ( 0, cam_map->size() );
-  EXPECT_EQ( 0, orig_map->size() );
-}
-
-// ----------------------------------------------------------------------------
-TEST(optimize_cameras, no_noise)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  // Create cameras, landmarks and tracks.
-  // Optimize already optimimal elements to make sure they don't get changed
-  // much.
-
-  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
-
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-  camera_map_sptr working_cam_map(new simple_camera_map(original_cams));
-  feature_track_set_sptr tracks = projected_tracks(landmarks,
-                                                   working_cam_map);
-
-  vxl::optimize_cameras optimizer;
-  optimizer.optimize(working_cam_map, tracks, landmarks);
-
-  double const ep = 1e-14;
-  for( auto const& p : working_cam_map->cameras() )
-  {
-    SCOPED_TRACE( "At camera " + std::to_string( p.first ) );
-
-    // Difference in camera center
-    EXPECT_MATRIX_NEAR( original_cams[p.first]->center(),
-                        p.second->center(), ep );
-
-    // Difference in camera rotation
-    EXPECT_MATRIX_NEAR(
-      vector_4d{ original_cams[p.first]->rotation().quaternion().coeffs() },
-      vector_4d{ p.second->rotation().quaternion().coeffs() }, ep );
-
-    // difference in camera intrinsics
-    EXPECT_MATRIX_NEAR( original_cams[p.first]->intrinsics()->as_matrix(),
-                        p.second->intrinsics()->as_matrix(), ep );
-  }
-}
-
-// ----------------------------------------------------------------------------
-TEST(optimize_cameras, noisy_cameras)
-{
-  using namespace kwiver::arrows;
-  using namespace std;
-
-  // Same as above, but create an analogous set of cameras with noise added.
-  // Check that optimized cameras are close to the original cameras.
-
-  camera_map::map_camera_t original_cams = kwiver::testing::camera_seq()->cameras();
-
-  landmark_map_sptr landmarks = kwiver::testing::cube_corners(2.0);
-  camera_map_sptr working_cam_map(new simple_camera_map(original_cams));
-  feature_track_set_sptr tracks = projected_tracks(landmarks, working_cam_map);
-
-  working_cam_map = kwiver::testing::noisy_cameras(working_cam_map, 0.1, 0.1);
-
-  vxl::optimize_cameras optimizer;
-  optimizer.optimize(working_cam_map, tracks, landmarks);
-
-  double ep = 2e-10;
-  for( auto const& p : working_cam_map->cameras() )
-  {
-    SCOPED_TRACE( "At camera " + std::to_string( p.first ) );
-
-    // Difference in camera center
-    EXPECT_MATRIX_NEAR( original_cams[p.first]->center(),
-                        p.second->center(), ep );
-
-    // Difference in camera rotation
-    EXPECT_MATRIX_NEAR(
-      vector_4d{ original_cams[p.first]->rotation().quaternion().coeffs() },
-      vector_4d{ p.second->rotation().quaternion().coeffs() }, ep );
-
-    // difference in camera intrinsics
-    EXPECT_MATRIX_NEAR( original_cams[p.first]->intrinsics()->as_matrix(),
-                        p.second->intrinsics()->as_matrix(), ep );
-  }
-}
+#include <arrows/tests/test_optimize_cameras.h>

--- a/tests/test_eigen.h
+++ b/tests/test_eigen.h
@@ -115,11 +115,30 @@ struct matrix_comparator
   }
 };
 
+// ----------------------------------------------------------------------------
+struct similar_matrix_comparator : matrix_comparator
+{
+  template <typename T, int M, int N>
+  bool operator()( Eigen::Matrix<T, M, N> const& a,
+                   Eigen::Matrix<T, M, N> const& b,
+                   double epsilon )
+  {
+    if ( a.cwiseProduct( b ).sum() < 0.0 )
+    {
+      return matrix_comparator::operator()( a, ( b * -1.0 ).eval(), epsilon );
+    }
+    return matrix_comparator::operator()( a, b, epsilon );
+  }
+};
+
 #define EXPECT_MATRIX_EQ(a, b) \
   EXPECT_PRED2(::kwiver::testing::matrix_comparator{}, a, b)
 
 #define EXPECT_MATRIX_NEAR(a, b, eps) \
   EXPECT_PRED3(::kwiver::testing::matrix_comparator{}, a, b, eps)
+
+#define EXPECT_MATRIX_SIMILAR(a, b, eps) \
+  EXPECT_PRED3(::kwiver::testing::similar_matrix_comparator{}, a, b, eps)
 
 } // end namespace testing
 } // end namespace kwiver


### PR DESCRIPTION
Add additional test helper to compare Eigen in case of sign ambiguity (see 1b7163c for details). Convert Ceres `optimize_cameras` test to Google Test. Factor out test cases that are shared with the VXL `optimize_cameras` test into a helper header.