### PR TITLE
Fix two Sprokit python-related link errors

### DIFF
--- a/sprokit/src/sprokit/CMakeLists.txt
+++ b/sprokit/src/sprokit/CMakeLists.txt
@@ -75,14 +75,14 @@ sprokit_configure_file_always(version.h
 
 set(configure_code)
 
+if (KWIVER_ENABLE_PYTHON)
+  add_subdirectory(python)
+endif ()
+
 add_subdirectory(pipeline)
 add_subdirectory(pipeline_util)
 add_subdirectory(scoring)
 add_subdirectory(tools)
-
-if (KWIVER_ENABLE_PYTHON)
-  add_subdirectory(python)
-endif ()
 
 install(
   FILES       "${CMAKE_CURRENT_BINARY_DIR}/config.h"

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -112,7 +112,6 @@ target_link_libraries(sprokit_pipeline
                       vital_logger
                       ${Boost_CHRONO_LIBRARY}
                       ${Boost_SYSTEM_LIBRARY}
-                      sprokit_python_util
   PRIVATE             ${Boost_FILESYSTEM_LIBRARY}
                       ${Boost_DATE_TIME_LIBRARY}
                       ${Boost_THREAD_LIBRARY}
@@ -120,6 +119,9 @@ target_link_libraries(sprokit_pipeline
                       ${CMAKE_THREAD_LIBS_INIT}
                       vital_vpm kwiversys
   )
+if (KWIVER_ENABLE_PYTHON)
+  target_link_libraries(sprokit_pipeline PUBLIC sprokit_python_util)
+endif()
 
 set_target_properties(sprokit_pipeline
   PROPERTIES


### PR DESCRIPTION
Fix two issues with `sprokit_pipeline` linking to `sprokit_python_util`. First, this link was happening unconditionally, despite that the latter library is not built (or needed) if Python support is not enabled. Second, the latter library was being declared later, such that it is not known when the former's link dependencies are declared.

This fixes build failures introduced by #341 (139962dc5bfb).