### PR TITLE
Removed python related code from main sprokit library.

### DIFF
--- a/sprokit/src/sprokit/CMakeLists.txt
+++ b/sprokit/src/sprokit/CMakeLists.txt
@@ -75,14 +75,14 @@ sprokit_configure_file_always(version.h
 
 set(configure_code)
 
+if (KWIVER_ENABLE_PYTHON)
+  add_subdirectory(python)
+endif ()
+
 add_subdirectory(pipeline)
 add_subdirectory(pipeline_util)
 add_subdirectory(scoring)
 add_subdirectory(tools)
-
-if (KWIVER_ENABLE_PYTHON)
-  add_subdirectory(python)
-endif ()
 
 install(
   FILES       "${CMAKE_CURRENT_BINARY_DIR}/config.h"

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -112,7 +112,6 @@ target_link_libraries(sprokit_pipeline
                       vital_logger
                       ${Boost_CHRONO_LIBRARY}
                       ${Boost_SYSTEM_LIBRARY}
-                      sprokit_python_util
   PRIVATE             ${Boost_FILESYSTEM_LIBRARY}
                       ${Boost_DATE_TIME_LIBRARY}
                       ${Boost_THREAD_LIBRARY}
@@ -126,10 +125,6 @@ set_target_properties(sprokit_pipeline
     VERSION       ${KWIVER_VERSION}
     SOVERSION     0
     DEFINE_SYMBOL MAKE_SPROKIT_PIPELINE_LIB)
-
-if(APPLE AND KWIVER_ENABLE_PYTHON)
-  set_target_properties(sprokit_pipeline PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-endif()
 
 add_dependencies(sprokit_pipeline     configure-version.h)
 

--- a/sprokit/src/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/process_factory.cxx
@@ -157,37 +157,4 @@ kwiver::vital::plugin_factory_vector_t const& get_process_list()
 }
 
 
-// ------------------------------------------------------------------
-#ifdef SPROKIT_ENABLE_PYTHON
-python_process_factory::
-python_process_factory( const std::string& type,
-                        const std::string& itype,
-                        py_process_factory_func_t factory )
-  : process_factory( type, itype )
-  , m_factory( factory )
-{
-  this->add_attribute( CONCRETE_TYPE, type)
-    .add_attribute( PLUGIN_FACTORY_TYPE, typeid(* this ).name() )
-    .add_attribute( PLUGIN_CATEGORY, "process" );
-}
-
-python_process_factory::
-~python_process_factory()
-{ }
-
-sprokit::process_t
-python_process_factory::
-create_object(kwiver::vital::config_block_sptr const& config)
-{
-  // Call sprokit factory function.
-  pybind11::object obj = m_factory(config);
-
-    // We need to do it this way because of how pybind11 handles memory
-obj.inc_ref();
-  sprokit::process_t proc_ptr = obj.cast<sprokit::process_t>();
-  return proc_ptr;
-}
-
-#endif
-
 } // end namespace

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -47,10 +47,6 @@
 #include <functional>
 #include <memory>
 
-#ifdef SPROKIT_ENABLE_PYTHON
-  #include <pybind11/pybind11.h>
-#endif
-
 namespace sprokit {
 
 // returns: process_t - shared_ptr<process>
@@ -194,38 +190,6 @@ kwiver::vital::plugin_factory_vector_t const& get_process_list();
   add_factory( new sprokit::cpp_process_factory( typeid( proc_type ).name(), \
                                                  typeid( sprokit::process ).name(), \
                                                  sprokit::create_new_process< proc_type > ) )
-
-#ifdef SPROKIT_ENABLE_PYTHON
-
-typedef std::function< pybind11::object( kwiver::vital::config_block_sptr const& config ) > py_process_factory_func_t;
-
-class SPROKIT_PIPELINE_EXPORT python_process_factory
-  : public sprokit::process_factory
-{
-  /**
-   * @brief CTOR for factory object
-   *
-   * This CTOR is designed to work in conjunction with pybind11
-   *
-   * @param type Type name of the process
-   * @param itype Type name of interface type.
-   * @param factory The Factory function
-   */
-  public:
-
-  python_process_factory( const std::string& type,
-                          const std::string& itype,
-                          py_process_factory_func_t factory );
-
-  virtual ~python_process_factory();
-
-  virtual sprokit::process_t create_object(kwiver::vital::config_block_sptr const& config);
-
-private:
-  py_process_factory_func_t m_factory;
-};
-
-#endif
 
 } // end namespace
 

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
@@ -139,35 +139,4 @@ is_scheduler_module_loaded( kwiver::vital::plugin_loader& vpl,
   return vpl.is_module_loaded( mod );
 }
 
-// ------------------------------------------------------------------
-#ifdef SPROKIT_ENABLE_PYTHON
-
-python_scheduler_factory::
-python_scheduler_factory( const std::string& type,
-                          const std::string& itype,
-                          py_scheduler_factory_func_t factory )
-  : scheduler_factory( type, itype )
-  , m_factory( factory )
-{
-  this->add_attribute( CONCRETE_TYPE, type)
-    .add_attribute( PLUGIN_FACTORY_TYPE, typeid(* this ).name() )
-    .add_attribute( PLUGIN_CATEGORY, "scheduler" );
-}
-
-
-// ----------------------------------------------------------------------------
-scheduler_t
-python_scheduler_factory::
-create_object(sprokit::pipeline_t const& pipe, kwiver::vital::config_block_sptr const& config)
-{
-  // Call sprokit factory function.
-  pybind11::object obj = m_factory(pipe, config);
-  obj.inc_ref();
-  sprokit::scheduler_t schd_ptr = obj.cast<sprokit::scheduler_t>();
-  return schd_ptr;
-}
-
-#endif
-
-
 } // end namespace

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -47,10 +47,6 @@
 #include <functional>
 #include <memory>
 
-#ifdef SPROKIT_ENABLE_PYTHON
-  #include <pybind11/pybind11.h>
-#endif
-
 namespace sprokit {
 
 // returns: scheduler_t - shared_ptr<scheduler>
@@ -191,32 +187,6 @@ bool is_scheduler_module_loaded( kwiver::vital::plugin_loader& vpl,
   add_factory( new sprokit::cpp_scheduler_factory( typeid( type ).name(), \
                                                    typeid( sprokit::scheduler ).name(), \
                                                    sprokit::create_new_scheduler< type > ) )
-
-#ifdef SPROKIT_ENABLE_PYTHON
-
-typedef std::function< pybind11::object( sprokit::pipeline_t const& pipe,
-                               kwiver::vital::config_block_sptr const& config ) > py_scheduler_factory_func_t;
-
-class SPROKIT_PIPELINE_EXPORT python_scheduler_factory
-: public scheduler_factory
-{
-
-  public:
-
-  python_scheduler_factory( const std::string& type,
-                            const std::string& itype,
-                            py_scheduler_factory_func_t factory );
-
-  virtual ~python_scheduler_factory() = default;
-
-  virtual scheduler_t create_object(sprokit::pipeline_t const& pipe,
-                                    kwiver::vital::config_block_sptr const& config);
-
-private:
-  py_scheduler_factory_func_t m_factory;
-};
-
-#endif
 
 } // end namespace
 


### PR DESCRIPTION
Having the python code in the main library caused a unwanted
dependency on python libraries. The python related code is moved
to the python bindings.

Moved python factories to the bindings directory.

Alternate solution to PR #380