### PR TITLE
Crop Chips + Tests and Example Pipeline 

### DIFF
--- a/CMake/utils/kwiver-utils-tests.cmake
+++ b/CMake/utils/kwiver-utils-tests.cmake
@@ -193,9 +193,6 @@ endfunction ()
 
 # -----------------------------------------------------------------------------
 function (kwiver_discover_gtests MODULE NAME)
-  if (NOT KWIVER_ENABLE_GTESTS)
-    return()
-  endif()
   cmake_parse_arguments("" "" "" "SOURCES;LIBRARIES;ARGUMENTS" ${ARGN})
   if (NOT _SOURCES)
     set(_SOURCES test_${NAME}.cxx)

--- a/CMake/utils/kwiver-utils-tests.cmake
+++ b/CMake/utils/kwiver-utils-tests.cmake
@@ -193,6 +193,9 @@ endfunction ()
 
 # -----------------------------------------------------------------------------
 function (kwiver_discover_gtests MODULE NAME)
+  if (NOT KWIVER_ENABLE_GTESTS)
+    return()
+  endif()
   cmake_parse_arguments("" "" "" "SOURCES;LIBRARIES;ARGUMENTS" ${ARGN})
   if (NOT _SOURCES)
     set(_SOURCES test_${NAME}.cxx)

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -67,7 +67,6 @@
 #include <arrows/core/track_descriptor_set_output_csv.h>
 #include <arrows/core/dynamic_config_none.h>
 
-
 namespace kwiver {
 namespace arrows {
 namespace core {

--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set( ocv_headers_public
   analyze_tracks.h
+  crop_chips.h
   descriptor_set.h
   detect_features.h
   detect_features_AGAST.h
@@ -49,6 +50,7 @@ kwiver_install_headers(
 
 set( ocv_sources
   analyze_tracks.cxx
+  crop_chips.cxx
   descriptor_set.cxx
   detect_features.cxx
   detect_features_AGAST.cxx

--- a/arrows/ocv/crop_chips.cxx
+++ b/arrows/ocv/crop_chips.cxx
@@ -71,8 +71,10 @@ crop_chips
   cv::Mat cv_image = ocv::image_container::vital_to_ocv( img->get_image() );
   for (auto bbox : bboxes)
   {
-    cv::Mat chip = cv_image( cv::Rect( bbox.min_x(), bbox.min_y(), bbox.max_x(), bbox.max_y() ) );
-    auto chip_sptr = image_container_sptr( new ocv::image_container( chip.clone() ) );
+    cv::Mat chip = cv_image( cv::Rect( bbox.min_x(), bbox.min_y(),
+                                       bbox.width(), bbox.height() ) );
+    auto chip_sptr = image_container_sptr(
+            new ocv::image_container( chip.clone() ) );
     _chips.push_back( chip_sptr );
   }
 

--- a/arrows/ocv/crop_chips.h
+++ b/arrows/ocv/crop_chips.h
@@ -30,17 +30,17 @@
 
 /**
  * \file
- * \brief Header for OCV split_image algorithm
+ * \brief Header for OCV crop_chips algorithm
  */
 
-#ifndef KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
-#define KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
+#ifndef KWIVER_ARROWS_OCV_CROP_CHIPS_H_
+#define KWIVER_ARROWS_OCV_CROP_CHIPS_H_
 
 
 #include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
-#include <vital/algo/split_image.h>
+#include <vital/algo/crop_chips.h>
 
 #include <memory>
 
@@ -50,26 +50,25 @@ namespace ocv {
 
 /// A class for writing out image chips around detections, useful as a debugging process
 /// for ensuring that the refine detections process is running on desired ROIs.
-/// Note: this algorithm only splits an image in half. Use crop_chips
-/// for an implementation that takes external bounding boxes into consideration .
-class KWIVER_ALGO_OCV_EXPORT split_image
-: public vital::algorithm_impl<split_image, vital::algo::split_image>
+class KWIVER_ALGO_OCV_EXPORT crop_chips
+: public vital::algorithm_impl<crop_chips, vital::algo::crop_chips>
 {
 public:
 
   /// Constructor
-  split_image();
+  crop_chips();
 
   /// Destructor
-  virtual ~split_image();
+  virtual ~crop_chips();
 
   /// Split image
-  virtual std::vector< kwiver::vital::image_container_sptr >
-  split(kwiver::vital::image_container_sptr img) const;
+  virtual kwiver::vital::image_container_set_sptr
+      crop(kwiver::vital::image_container_sptr const img,
+           std::vector<kwiver::vital::bounding_box_d> const& bboxes) const;
 };
 
 } // end namespace ocv
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
+#endif // KWIVER_ARROWS_OCV_CROP_CHIPS_H_

--- a/arrows/ocv/crop_chips.h
+++ b/arrows/ocv/crop_chips.h
@@ -48,8 +48,7 @@ namespace kwiver {
 namespace arrows {
 namespace ocv {
 
-/// A class for writing out image chips around detections, useful as a debugging process
-/// for ensuring that the refine detections process is running on desired ROIs.
+/// A class for extracting subimages using bounding boxes.
 class KWIVER_ALGO_OCV_EXPORT crop_chips
 : public vital::algorithm_impl<crop_chips, vital::algo::crop_chips>
 {

--- a/arrows/ocv/register_algorithms.cxx
+++ b/arrows/ocv/register_algorithms.cxx
@@ -42,6 +42,7 @@
 #endif
 
 #include <arrows/ocv/analyze_tracks.h>
+#include <arrows/ocv/crop_chips.h>
 #include <arrows/ocv/detect_features_AGAST.h>
 #include <arrows/ocv/detect_features_FAST.h>
 #include <arrows/ocv/detect_features_GFTT.h>
@@ -374,6 +375,14 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::split_image );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                        "Split an image  into multiple smaller images using opencv functions" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
+    ;
+
+  fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::crop_chips );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Crop chips from a larger image using a set of bounding boxes" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )

--- a/arrows/ocv/register_algorithms.cxx
+++ b/arrows/ocv/register_algorithms.cxx
@@ -98,6 +98,14 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
     ;
 
+  fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::crop_chips );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Crop chips from a larger image using a set of bounding boxes" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
+    ;
+
 
   fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::draw_tracks );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
@@ -375,14 +383,6 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::split_image );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                        "Split an image  into multiple smaller images using opencv functions" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-  fact = vpm.ADD_ALGORITHM( "ocv", kwiver::arrows::ocv::crop_chips );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Crop chips from a larger image using a set of bounding boxes" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )

--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(test_libraries      vital vital_vpm kwiver_algo_ocv )
 ##############################
 kwiver_discover_tests(ocv_algo_config         test_libraries test_algo_config.cxx)
 kwiver_discover_tests(ocv_bounding_box        test_libraries test_bounding_box.cxx)
-kwiver_discover_gtests(ocv crop_chips         test_libraries test_crop_chips.cxx)
+kwiver_discover_gtests(ocv crop_chips                  LIBRARIES ${test_libraries} SOURCES test_crop_chips.cxx)
 kwiver_discover_tests(ocv_descriptor_set      test_libraries test_descriptor_set.cxx)
 kwiver_discover_tests(ocv_distortion          test_libraries test_distortion.cxx)
 kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})

--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(test_libraries      vital vital_vpm kwiver_algo_ocv )
 ##############################
 kwiver_discover_tests(ocv_algo_config         test_libraries test_algo_config.cxx)
 kwiver_discover_tests(ocv_bounding_box        test_libraries test_bounding_box.cxx)
-kwiver_discover_tests(ocv_crop_chip           test_libraries test_crop_chip.cxx)
+kwiver_discover_gtests(ocv crop_chips         test_libraries test_crop_chips.cxx)
 kwiver_discover_tests(ocv_descriptor_set      test_libraries test_descriptor_set.cxx)
 kwiver_discover_tests(ocv_distortion          test_libraries test_distortion.cxx)
 kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})

--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(test_libraries      vital vital_vpm kwiver_algo_ocv )
 ##############################
 kwiver_discover_tests(ocv_algo_config         test_libraries test_algo_config.cxx)
 kwiver_discover_tests(ocv_bounding_box        test_libraries test_bounding_box.cxx)
+kwiver_discover_tests(ocv_crop_chip           test_libraries test_crop_chip.cxx)
 kwiver_discover_tests(ocv_descriptor_set      test_libraries test_descriptor_set.cxx)
 kwiver_discover_tests(ocv_distortion          test_libraries test_distortion.cxx)
 kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})

--- a/arrows/ocv/tests/test_crop_chip.cxx
+++ b/arrows/ocv/tests/test_crop_chip.cxx
@@ -1,0 +1,172 @@
+/*ckwg +29
+ * Copyright 2013-2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV image class
+ */
+
+#include <test_common.h>
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <arrows/ocv/image_container.h>
+#include <arrows/ocv/image_container_set.h>
+#include <arrows/ocv/crop_chips.h>
+
+#define TEST_ARGS ()
+
+DECLARE_TEST_MAP();
+
+int
+main(int argc, char* argv[])
+{
+  CHECK_ARGS(1);
+
+  testname_t const testname = argv[1];
+
+  RUN_TEST(testname);
+}
+
+using namespace kwiver::vital;
+
+IMPLEMENT_TEST(factory)
+{
+  using namespace kwiver::arrows;
+
+  kwiver::vital::plugin_manager::instance().load_all_plugins();
+
+  //algo::crop_chips_sptr algo = kwiver::vital::algo::crop_chips_sptr::create("ocv");
+  auto algo = kwiver::vital::algo::crop_chips_sptr::create("ocv");
+  if (!algo)
+  {
+    TEST_ERROR("Unable to create crop_chips algorithm of type ocv");
+  }
+  algo::crop_chips* algo_ptr = algo.get();
+  if (typeid(*algo_ptr) != typeid(ocv::crop_chips))
+  {
+    TEST_ERROR("Factory method did not construct the correct type");
+  }
+}
+
+
+namespace {
+
+// TODO: add these as general test helpers
+
+// helper function to populate the image with a pattern
+// the dynamic range is stretched between minv and maxv
+template <typename T>
+void
+populate_ocv_image(cv::Mat& img, T minv, T maxv)
+{
+  const double range = static_cast<double>(maxv) - static_cast<double>(minv);
+  const double offset = - minv;
+  const unsigned num_c = img.channels();
+  for( unsigned int p=0; p<num_c; ++p )
+  {
+    for( unsigned int j=0; j<static_cast<unsigned int>(img.rows); ++j )
+    {
+      for( unsigned int i=0; i<static_cast<unsigned int>(img.cols); ++i )
+      {
+        const double pi = 3.14159265358979323846;
+        double val = ((std::sin(pi*double(i)*(p+1)/10) * std::sin(pi*double(j)*(p+1)/10))+1) / 2;
+        img.template ptr<T>(j)[num_c * i + p] = static_cast<T>(val * range + offset);
+      }
+    }
+  }
+}
+
+
+// helper function to populate the image with a pattern
+template <typename T>
+void
+populate_ocv_image(cv::Mat& img)
+{
+  const T minv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::min() : T(0);
+  const T maxv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::max() : T(1);
+  populate_ocv_image(img, minv, maxv);
+}
+
+
+// helper function to populate the image with a pattern
+// the dynamic range is stretched between minv and maxv
+template <typename T>
+void
+populate_vital_image(kwiver::vital::image& img, T minv, T maxv)
+{
+  const double range = static_cast<double>(maxv) - static_cast<double>(minv);
+  const double offset = - minv;
+  for( unsigned int p=0; p<img.depth(); ++p )
+  {
+    for( unsigned int j=0; j<img.height(); ++j )
+    {
+      for( unsigned int i=0; i<img.width(); ++i )
+      {
+        const double pi = 3.14159265358979323846;
+        double val = ((std::sin(pi*double(i)*(p+1)/10) * std::sin(pi*double(j)*(p+1)/10))+1) / 2;
+        img.at<T>(i,j,p) = static_cast<T>(val * range + offset);
+      }
+    }
+  }
+}
+
+
+// helper function to populate the image with a pattern
+template <typename T>
+void
+populate_vital_image(kwiver::vital::image& img)
+{
+  const T minv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::min() : T(0);
+  const T maxv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::max() : T(1);
+  populate_vital_image<T>(img, minv, maxv);
+}
+
+
+} // end anonymous namespace
+
+
+IMPLEMENT_TEST(test_crop_simple)
+{
+  using namespace kwiver;
+  using namespace kwiver::arrows;
+
+  auto type_str = "uint8";
+  std::cout << "Testing single channel cv::Mat of type " << type_str << std::endl;
+  cv::Mat_<T> img(100,200);
+  populate_ocv_image<T>(img);
+
+  image_container_sptr img_sptr(new simple_image_container(img));
+
+  std::vector< kwiver::vital::bounding_box_d > bboxes;
+
+  // TODO: expand this
+  ocv::image_io crop_chips;
+  auto output = crop_chips.crop(img_sptr, bboxes);
+}

--- a/arrows/ocv/tests/test_crop_chips.cxx
+++ b/arrows/ocv/tests/test_crop_chips.cxx
@@ -59,24 +59,23 @@ main(int argc, char* argv[])
 
 using namespace kwiver::vital;
 
-//IMPLEMENT_TEST(factory)
-//{
-//  using namespace kwiver::arrows;
+IMPLEMENT_TEST(factory)
+{
+  using namespace kwiver::arrows;
 
-//  kwiver::vital::plugin_manager::instance().load_all_plugins();
+  kwiver::vital::plugin_manager::instance().load_all_plugins();
 
-//  //algo::crop_chips_sptr algo = kwiver::vital::algo::crop_chips_sptr::create("ocv");
-//  auto algo = kwiver::vital::algo::crop_chips_sptr::create("ocv");
-//  if (!algo)
-//  {
-//    TEST_ERROR("Unable to create crop_chips algorithm of type ocv");
-//  }
-//  algo::crop_chips* algo_ptr = algo.get();
-//  if (typeid(*algo_ptr) != typeid(ocv::crop_chips))
-//  {
-//    TEST_ERROR("Factory method did not construct the correct type");
-//  }
-//}
+  algo::crop_chips_sptr algo = kwiver::vital::algo::crop_chips::create("ocv");
+  if (!algo)
+  {
+    TEST_ERROR("Unable to create crop_chips algorithm of type ocv");
+  }
+  algo::crop_chips* algo_ptr = algo.get();
+  if (typeid(*algo_ptr) != typeid(ocv::crop_chips))
+  {
+    TEST_ERROR("Factory method did not construct the correct type");
+  }
+}
 
 
 namespace {

--- a/arrows/ocv/tests/test_crop_chips.cxx
+++ b/arrows/ocv/tests/test_crop_chips.cxx
@@ -33,7 +33,6 @@
  * \brief test OCV image class
  */
 
-#include <test_common.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
 #include <vital/types/image_container.h>
@@ -43,38 +42,28 @@
 #include <arrows/ocv/image_container.h>
 #include <arrows/ocv/image_io.h>
 
-#define TEST_ARGS ()
+#include <gtest/gtest.h>
 
-DECLARE_TEST_MAP();
 
 int
 main(int argc, char* argv[])
 {
-  CHECK_ARGS(1);
-
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
 }
 
 using namespace kwiver::vital;
 
-IMPLEMENT_TEST(factory)
+TEST(crop_chips, factory)
 {
   using namespace kwiver::arrows;
 
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 
   algo::crop_chips_sptr algo = kwiver::vital::algo::crop_chips::create("ocv");
-  if (!algo)
-  {
-    TEST_ERROR("Unable to create crop_chips algorithm of type ocv");
-  }
+  EXPECT_NE(nullptr, algo) << "Unable to create crop_chips algorithm of type ocv";
   algo::crop_chips* algo_ptr = algo.get();
-  if (typeid(*algo_ptr) != typeid(ocv::crop_chips))
-  {
-    TEST_ERROR("Factory method did not construct the correct type");
-  }
+  ASSERT_TRUE(typeid(*algo_ptr) == typeid(ocv::crop_chips)) << "Factory method did not construct the correct type";
 }
 
 
@@ -157,7 +146,7 @@ populate_vital_image(kwiver::vital::image& img)
 } // end anonymous namespace
 
 
-IMPLEMENT_TEST(test_crop_simple)
+TEST(crop_chips, simple)
 {
   using namespace kwiver;
   using namespace kwiver::arrows;
@@ -172,8 +161,8 @@ IMPLEMENT_TEST(test_crop_simple)
   // TODO: expand this
   ocv::crop_chips algo;
   auto output0 = algo.crop(img_sptr, bboxes0);
-  TEST_EQUAL("bbox set size ", bboxes0.size(), 0);
-  TEST_EQUAL("image set size ", output0->size(), 0);
+  EXPECT_EQ(0, bboxes0.size());
+  EXPECT_EQ(0, output0->size());
 
   std::vector< kwiver::vital::bounding_box_d > bboxes3;
   bboxes3.push_back( kwiver::vital::bounding_box<double>( 1, 3, 10, 34 ) );
@@ -181,8 +170,8 @@ IMPLEMENT_TEST(test_crop_simple)
   bboxes3.push_back( kwiver::vital::bounding_box<double>( 5, 5, 5, 5 ) );
   auto output3 = algo.crop(img_sptr, bboxes3);
 
-  TEST_EQUAL("bbox set size ", bboxes3.size(), 3);
-  TEST_EQUAL("image set size ", output3->size(), 3);
+  EXPECT_EQ(3, bboxes3.size());
+  EXPECT_EQ(3, output3->size());
 
   // TODO: test to ensure cropped sizes agree with bounding box width / heights.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,7 @@ configure_file(pipelines/number_flow_python.pipe.in ${EXAMPLE_DIR}/pipelines/num
 configure_file(pipelines/video_display.pipe.in ${EXAMPLE_DIR}/pipelines/video_display.pipe)
 configure_file(pipelines/example_detector_on_image.pipe.in ${EXAMPLE_DIR}/pipelines/example_detector_on_image.pipe)
 configure_file(pipelines/example_detector_on_video.pipe.in ${EXAMPLE_DIR}/pipelines/example_detector_on_video.pipe)
+configure_file(pipelines/crop_chips.pipe.in ${EXAMPLE_DIR}/pipelines/crop_chips.pipe)
 
 configure_file(pipelines/descriptor.pipe.in ${EXAMPLE_DIR}/pipelines/descriptor.pipe)
 configure_file(pipelines/SMQTK.pipe.in ${EXAMPLE_DIR}/pipelines/SMQTK.pipe)

--- a/examples/pipelines/crop_chips.pipe.in
+++ b/examples/pipelines/crop_chips.pipe.in
@@ -1,0 +1,59 @@
+# ================================================================
+process input
+  :: frame_list_input
+  image_list_file   = @EXAMPLE_DIR@/pipelines/image_list.txt
+  frame_time        = .3333
+  image_reader:type = ocv
+
+# ================================================================
+process detector
+  :: image_object_detector
+  detector:type                    	= example_detector
+  detector:example_detector:center_x	= 100
+  detector:example_detector:center_y   	= 100
+  detector:example_detector:width	= 100
+  detector:example_detector:height	= 100
+
+# ================================================================
+process crop
+  :: crop_detections
+  type					= crop_chips
+  crop_chips:type 			= ocv
+
+# ================================================================
+process split
+  :: image_set_splitter
+
+# ================================================================
+process disp
+  :: image_viewer
+  annotate_image = true
+  pause_time     = 4  #  pause_time in seconds. 0 means wait for keystroke.
+  title          = images
+#  footer         = images
+#  header         = header-header
+
+# ================================================================
+# global pipeline config
+#
+config _pipeline:_edge
+       capacity = 3
+
+# ================================================================
+# connections
+connect from input.image
+        to   detector.image
+connect from input.image
+        to   crop.image
+
+connect from detector.detected_object_set
+        to crop.detected_object_set
+connect from crop.image_set
+	to split.image_set
+
+connect from input.timestamp
+        to   disp.timestamp
+connect from split.image
+        to   disp.image
+
+# -- end of file --

--- a/examples/pipelines/crop_chips.pipe.in
+++ b/examples/pipelines/crop_chips.pipe.in
@@ -9,10 +9,13 @@ process input
 process detector
   :: image_object_detector
   detector:type                    	= example_detector
-  detector:example_detector:center_x	= 100
-  detector:example_detector:center_y   	= 100
-  detector:example_detector:width	= 100
+  detector:example_detector:center_x	= 125
+  detector:example_detector:center_y   	= 125
+  detector:example_detector:width	= 150
   detector:example_detector:height	= 100
+  detector:example_detector:dx		= 20
+  detector:example_detector:dy		= 20
+  detector:example_detector:detections_per_image	= 2
 
 # ================================================================
 process crop
@@ -59,10 +62,15 @@ connect from crop.image_set
 	to split.image_set
 
 connect from input.timestamp
+	to split.timestamp
+connect from split.timestamp
         to   disp.timestamp
 connect from split.image
         to   disp.image
+
 connect from split.image
         to   writer.image
+connect from split.timestamp
+        to   writer.timestamp
 
 # -- end of file --

--- a/examples/pipelines/crop_chips.pipe.in
+++ b/examples/pipelines/crop_chips.pipe.in
@@ -34,6 +34,13 @@ process disp
 #  header         = header-header
 
 # ================================================================
+ process writer
+   :: image_writer
+   file_name_template 			= output/image%04d.jpg
+   image_writer:type  			= ocv
+
+       
+# ================================================================
 # global pipeline config
 #
 config _pipeline:_edge
@@ -55,5 +62,7 @@ connect from input.timestamp
         to   disp.timestamp
 connect from split.image
         to   disp.image
+connect from split.image
+        to   writer.image
 
 # -- end of file --

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -21,6 +21,7 @@ set( sources
   image_filter_process.cxx
   image_object_detector_process.cxx
   image_writer_process.cxx
+  image_set_splitter.cxx
   matcher_process.cxx
   read_descriptor_process.cxx
   refine_detections_process.cxx
@@ -47,6 +48,7 @@ set( private_headers
   image_filter_process.h
   image_object_detector_process.h
   image_writer_process.h
+  image_set_splitter.h
   matcher_process.h
   read_descriptor_process.h
   refine_detections_process.h

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -8,6 +8,7 @@ set( sources
 
   compute_homography_process.cxx
   compute_stereo_depth_map_process.cxx
+  crop_detections_process.cxx
   detect_features_process.cxx
   detected_object_output_process.cxx
   detected_object_input_process.cxx
@@ -33,6 +34,7 @@ set( sources
 set( private_headers
   compute_homography_process.h
   compute_stereo_depth_map_process.h
+  crop_detections_process.h
   detect_features_process.h
   detected_object_output_process.h
   detected_object_input_process.h

--- a/sprokit/processes/core/crop_detections_process.cxx
+++ b/sprokit/processes/core/crop_detections_process.cxx
@@ -64,8 +64,8 @@ public:
 
 crop_detections_process
 ::crop_detections_process( kwiver::vital::config_block_sptr const& config )
-  : process( config ),
-    d( new crop_detections_process::priv )
+  : process( config )
+  , d( new crop_detections_process::priv )
 {
   attach_logger( kwiver::vital::get_logger( name() ) );
 

--- a/sprokit/processes/core/crop_detections_process.cxx
+++ b/sprokit/processes/core/crop_detections_process.cxx
@@ -120,10 +120,10 @@ crop_detections_process
 
   // Transform detections into a vector of bounding boxes
   std::vector<kwiver::vital::bounding_box_d> in_bboxes;
-  //for (auto dobj : in_detections.get())
-  //{
-  //  in_bboxes.push_back(dobj.bounding_box())
-  //}
+  for (auto dobj : *in_detections.get())
+  {
+    in_bboxes.push_back(dobj->bounding_box());
+  }
 
   // Extract the chips
   kwiver::vital::image_container_set_sptr chips;

--- a/sprokit/processes/core/crop_detections_process.cxx
+++ b/sprokit/processes/core/crop_detections_process.cxx
@@ -37,7 +37,7 @@
 #include <vital/types/image_container.h>
 #include <vital/types/image_container_set.h>
 
-#include <vital/algo/crop_detections.h>
+#include <vital/algo/crop_chips.h>
 
 #include <kwiver_type_traits.h>
 
@@ -86,25 +86,24 @@ void crop_detections_process
 {
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  algo::crop_detections::set_nested_algo_configuration(
-    "crop_detections", algo_config, d->m_algo );
+  algo::crop_chips::set_nested_algo_configuration(
+    "crop_chips", algo_config, d->m_algo );
 
   if( !d->m_algo )
   {
     throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create \"crop_detections\"" );
+      name(), "Unable to create \"crop_chips\"" );
   }
-  algo::crop_detections::get_nested_algo_configuration(
-    "crop_detections", algo_config, d->m_algo );
+  algo::crop_chips::get_nested_algo_configuration(
+    "crop_chips", algo_config, d->m_algo );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::crop_detections::check_nested_algo_configuration(
-        "crop_detections", algo_config ) )
+  if( !algo::crop_chips::check_nested_algo_configuration(
+        "crop_chips", algo_config ) )
   {
     throw sprokit::invalid_configuration_exception( name(),
       "Configuration check failed." );
   }
-
 }
 
 
@@ -114,25 +113,24 @@ crop_detections_process
 ::_step()
 {
   // Get inputs
-  kwiver::vital::image_container_sptr _image;
-  kwiver::vital::detected_object_set _detections;
-  _image = grab_from_port_using_trait( image );
-  _detections = grab_from_port_using_trait( detections );
-
+  kwiver::vital::image_container_sptr in_img;
+  kwiver::vital::detected_object_set_sptr in_detections;
+  in_img = grab_from_port_using_trait( image );
+  in_detections = grab_from_port_using_trait( detected_object_set );
 
   // Transform detections into a vector of bounding boxes
-  std::vector<kwiver::vital::bounding_box> _bboxes;
-  for (auto obj : _detections)
-  {
-    _bboxes.push_back(obj.bounding_box())
-  }
+  std::vector<kwiver::vital::bounding_box_d> in_bboxes;
+  //for (auto dobj : in_detections.get())
+  //{
+  //  in_bboxes.push_back(dobj.bounding_box())
+  //}
 
   // Extract the chips
-  kwiver::vital::image_container_set_sptr _chips;
-  _chips = d->m_algo->crop( _image, _bboxes );
+  kwiver::vital::image_container_set_sptr chips;
+  chips = d->m_algo->crop( in_img, in_bboxes );
 
   // Push to the output port
-  push_to_port_using_trait( chips, _chips );
+  push_to_port_using_trait( image_set, chips );
 }
 
 
@@ -147,10 +145,10 @@ void crop_detections_process
 
   // -- input --
   declare_input_port_using_trait( image, required );
-  declare_input_port_using_trait( detections, required );
+  declare_input_port_using_trait( detected_object_set, required );
 
   // -- output --
-  declare_output_port_using_trait( chips, optional );
+  declare_output_port_using_trait( image_set, optional );
 }
 
 
@@ -158,7 +156,6 @@ void crop_detections_process
 void crop_detections_process
 ::make_config()
 {
-
 }
 
 

--- a/sprokit/processes/core/crop_detections_process.cxx
+++ b/sprokit/processes/core/crop_detections_process.cxx
@@ -1,0 +1,177 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS [yas] elisp error!AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "crop_detections_process.h"
+
+#include <vital/vital_types.h>
+
+#include <vital/types/bounding_box.h>
+#include <vital/types/detected_object_set.h>
+#include <vital/types/image_container.h>
+#include <vital/types/image_container_set.h>
+
+#include <vital/algo/crop_detections.h>
+
+#include <kwiver_type_traits.h>
+
+#include <sprokit/pipeline/process_exception.h>
+
+
+namespace algo = kwiver::vital::algo;
+
+namespace kwiver
+{
+
+//----------------------------------------------------------------
+// Private implementation class
+class crop_detections_process::priv
+{
+public:
+  priv();
+  ~priv();
+
+  algo::crop_chips_sptr m_algo;
+};
+
+// ================================================================
+
+crop_detections_process
+::crop_detections_process( kwiver::vital::config_block_sptr const& config )
+  : process( config ),
+    d( new crop_detections_process::priv )
+{
+  attach_logger( kwiver::vital::get_logger( name() ) );
+
+  make_ports();
+  make_config();
+}
+
+
+crop_detections_process
+::~crop_detections_process()
+{
+}
+
+
+// ----------------------------------------------------------------
+void crop_detections_process
+::_configure()
+{
+  kwiver::vital::config_block_sptr algo_config = get_config();
+
+  algo::crop_detections::set_nested_algo_configuration(
+    "crop_detections", algo_config, d->m_algo );
+
+  if( !d->m_algo )
+  {
+    throw sprokit::invalid_configuration_exception(
+      name(), "Unable to create \"crop_detections\"" );
+  }
+  algo::crop_detections::get_nested_algo_configuration(
+    "crop_detections", algo_config, d->m_algo );
+
+  // Check config so it will give run-time diagnostic of config problems
+  if( !algo::crop_detections::check_nested_algo_configuration(
+        "crop_detections", algo_config ) )
+  {
+    throw sprokit::invalid_configuration_exception( name(),
+      "Configuration check failed." );
+  }
+
+}
+
+
+// ----------------------------------------------------------------
+void
+crop_detections_process
+::_step()
+{
+  // Get inputs
+  kwiver::vital::image_container_sptr _image;
+  kwiver::vital::detected_object_set _detections;
+  _image = grab_from_port_using_trait( image );
+  _detections = grab_from_port_using_trait( detections );
+
+
+  // Transform detections into a vector of bounding boxes
+  std::vector<kwiver::vital::bounding_box> _bboxes;
+  for (auto obj : _detections)
+  {
+    _bboxes.push_back(obj.bounding_box())
+  }
+
+  // Extract the chips
+  kwiver::vital::image_container_set_sptr _chips;
+  _chips = d->m_algo->crop( _image, _bboxes );
+
+  // Push to the output port
+  push_to_port_using_trait( chips, _chips );
+}
+
+
+// ----------------------------------------------------------------
+void crop_detections_process
+::make_ports()
+{
+  // Set up for required ports
+  sprokit::process::port_flags_t optional;
+  sprokit::process::port_flags_t required;
+  required.insert( flag_required );
+
+  // -- input --
+  declare_input_port_using_trait( image, required );
+  declare_input_port_using_trait( detections, required );
+
+  // -- output --
+  declare_output_port_using_trait( chips, optional );
+}
+
+
+// ----------------------------------------------------------------
+void crop_detections_process
+::make_config()
+{
+
+}
+
+
+// ================================================================
+crop_detections_process::priv
+::priv()
+{
+}
+
+
+crop_detections_process::priv
+::~priv()
+{
+}
+
+} // end namespace

--- a/sprokit/processes/core/crop_detections_process.h
+++ b/sprokit/processes/core/crop_detections_process.h
@@ -1,0 +1,79 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_CROP_DETECTIONS_PROCESS_H_
+#define KWIVER_CROP_DETECTIONS_PROCESS_H_
+
+#include <sprokit/pipeline/process.h>
+
+#include "kwiver_processes_export.h"
+
+#include <memory>
+
+namespace kwiver
+{
+
+// ----------------------------------------------------------------
+/**
+ * \class crop_detections_process
+ *
+ * \brief Splits an image into multiple chips. One for each detection.
+ *
+ * \iports
+ * \iport{image}
+ *
+ * \oports
+ * \oport{image_set}
+ *
+ */
+class KWIVER_PROCESSES_NO_EXPORT crop_detections_process
+  : public sprokit::process
+{
+  public:
+    crop_detections_process( kwiver::vital::config_block_sptr const& config );
+    virtual ~crop_detections_process();
+
+  protected:
+    virtual void _configure();
+    virtual void _step();
+
+  private:
+    void make_ports();
+    void make_config();
+
+    class priv;
+    const std::unique_ptr<priv> d;
+ }; // end class crop_detections_process
+
+
+} // end namespace
+
+#endif /* KWIVER_CROP_DETECTIONS_PROCESS_H_ */
+

--- a/sprokit/processes/core/image_set_splitter.cxx
+++ b/sprokit/processes/core/image_set_splitter.cxx
@@ -1,0 +1,117 @@
+/*ckwg +29
+ * Copyright 2016-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "image_set_splitter.h"
+
+#include <kwiver_type_traits.h>
+
+#include <vital/algo/image_io.h>
+#include <vital/types/image_container.h>
+#include <vital/types/image_container_set.h>
+#include <vital/vital_types.h>
+#include <trait_utils.h>
+
+namespace kwiver {
+
+class image_set_splitter::priv
+{
+public:
+  priv() {}
+  ~priv() {}
+}; // end priv class
+
+// =============================================================================
+
+image_set_splitter
+::image_set_splitter( kwiver::vital::config_block_sptr const& config )
+        : process( config ),
+          d( new image_set_splitter::priv )
+{
+  // Attach our logger name to process logger
+  attach_logger( kwiver::vital::get_logger( name() ) ); // could use a better approach
+
+  make_ports();
+  make_config();
+}
+
+image_set_splitter
+::~image_set_splitter()
+{
+}
+
+
+// ----------------------------------------------------------------
+void
+image_set_splitter
+::_configure()
+{
+}
+
+
+// ----------------------------------------------------------------
+void
+image_set_splitter
+::_step()
+{
+  vital::image_container_set_sptr input = grab_from_port_using_trait( image_set );
+
+  for (auto img : input->images())
+    push_to_port_using_trait( image, img );
+}
+
+
+// -----------------------------------------------------------------------------
+void image_set_splitter
+::make_ports()
+{
+  // Set up for required ports
+  sprokit::process::port_flags_t optional;
+  sprokit::process::port_flags_t required;
+  required.insert( flag_required );
+
+  declare_input_port_using_trait( image_set, required );
+//  declare_input_port_using_trait( timestamp, optional,
+//    "Image timestamp, optional. The frame number from this timestamp is used "
+//    "to number the output files. If the timestamp is not connected or not "
+//    "valid, the output files are sequentially numbered from 1." );
+
+  declare_output_port_using_trait( image, required );
+}
+
+
+// -----------------------------------------------------------------------------
+void image_set_splitter
+::make_config()
+{
+}
+
+
+} // end namespace

--- a/sprokit/processes/core/image_set_splitter.h
+++ b/sprokit/processes/core/image_set_splitter.h
@@ -16,7 +16,7 @@
  *    to endorse or promote products derived from this software without specific
  *    prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
@@ -28,39 +28,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <vital/algo/algorithm.txx>
+#ifndef KWIVER_IMAGE_SET_SPLITTER_H
+#define KWIVER_IMAGE_SET_SPLITTER_H
 
-#include "crop_chips.h"
+#include <sprokit/pipeline/process.h>
+#include "kwiver_processes_export.h"
 
 namespace kwiver {
-namespace vital {
-namespace algo {
 
-crop_chips
-::crop_chips()
+class KWIVER_PROCESSES_NO_EXPORT image_set_splitter
+  : public sprokit::process
 {
-  attach_logger( "crop_chips" );
-}
+public:
+  image_set_splitter( kwiver::vital::config_block_sptr const& config );
+  ~image_set_splitter() override;
 
+protected:
+  void _configure() override;
+  void _step() override;
 
-/// Set this algorithm's properties via a config block
-void
-crop_chips
-::set_configuration(kwiver::vital::config_block_sptr config)
-{
-  (void) config;
-}
+private:
+  void make_ports();
+  void make_config();
 
-/// Check that the algorithm's current configuration is valid
-bool
-crop_chips
-::check_configuration(kwiver::vital::config_block_sptr config) const
-{
-  (void) config;
-  return true;
-}
+  class priv;
+  const std::unique_ptr<priv> d;
+};
 
+} // end namespace
 
-} } } // end namespace
-
-INSTANTIATE_ALGORITHM_DEF(kwiver::vital::algo::crop_chips);
+#endif //KWIVER_IMAGE_SET_SPLITTER_H

--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -36,6 +36,7 @@
 // -- list processes to register --
 #include "compute_homography_process.h"
 #include "compute_stereo_depth_map_process.h"
+#include "crop_detections_process.h"
 #include "detect_features_process.h"
 #include "detected_object_filter_process.h"
 #include "detected_object_input_process.h"
@@ -47,6 +48,7 @@
 #include "image_file_reader_process.h"
 #include "image_filter_process.h"
 #include "image_object_detector_process.h"
+#include "image_set_splitter.h"
 #include "image_writer_process.h"
 #include "matcher_process.h"
 #include "read_descriptor_process.h"
@@ -137,6 +139,12 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Refines detections for a given frame" );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
 
+  fact = vpm.ADD_PROCESS( kwiver::crop_detections_process );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "crop_detections" );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Crops the image corresponding to the detection" );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+
   fact = vpm.ADD_PROCESS( kwiver::image_object_detector_process );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "image_object_detector" );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
@@ -154,6 +162,12 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "image_writer" );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Write image to disk." );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+
+  fact = vpm.ADD_PROCESS( kwiver::image_set_splitter );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "image_set_splitter" );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Split image set to component images." );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
 
   fact = vpm.ADD_PROCESS( kwiver::image_file_reader_process );

--- a/sprokit/processes/kwiver_type_traits.h
+++ b/sprokit/processes/kwiver_type_traits.h
@@ -115,6 +115,7 @@ create_port_trait( image, image, "Single frame image." );
 create_port_trait( left_image, image, "Single frame left image." );
 create_port_trait( right_image, image, "Single frame right image." );
 create_port_trait( depth_map, image, "Depth map stored in image form." );
+create_port_trait( image_set, image_set, "A collection of images, typically sub images." );
 create_port_trait( feature_set, feature_set, "Set of detected image features." );
 create_port_trait( descriptor_set, descriptor_set, "Set of descriptors." );
 create_port_trait( string_vector, string_vector, "Vector of strings." );

--- a/sprokit/processes/kwiver_type_traits.h
+++ b/sprokit/processes/kwiver_type_traits.h
@@ -44,6 +44,7 @@
 #include <vital/types/feature_track_set.h>
 #include <vital/types/geo_polygon.h>
 #include <vital/types/image_container.h>
+#include <vital/types/image_container_set.h>
 #include <vital/types/object_track_set.h>
 #include <vital/types/track_descriptor_set.h>
 #include <vital/types/uid.h>
@@ -81,6 +82,7 @@ create_type_trait( timestamp, "kwiver:timestamp", kwiver::vital::timestamp );
 create_type_trait( gsd, "kwiver:gsd", double );
 create_type_trait( corner_points, "corner_points", kwiver::vital::geo_polygon );
 create_type_trait( image, "kwiver:image", kwiver::vital::image_container_sptr );
+create_type_trait( image_set, "kwiver:image_set", kwiver::vital::image_container_set_sptr );
 create_type_trait( mask, "kwiver:mask", kwiver::vital::image_container_sptr );
 create_type_trait( feature_set, "kwiver:feature_set", kwiver::vital::feature_set_sptr );
 create_type_trait( descriptor_set, "kwiver:descriptor_set", kwiver::vital::descriptor_set_sptr );

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -113,6 +113,7 @@ set( vital_public_headers
   types/homography_f2w.h
   types/image.h
   types/image_container.h
+  types/image_container_set.h
   types/landmark.h
   types/landmark_map.h
   types/match_set.h

--- a/vital/algo/CMakeLists.txt
+++ b/vital/algo/CMakeLists.txt
@@ -17,6 +17,7 @@ set( public_headers
   compute_stereo_depth_map.h
   compute_track_descriptors.h
   convert_image.h
+  crop_chips.h
   detect_features.h
   detected_object_filter.h
   detected_object_set_input.h
@@ -62,6 +63,7 @@ set( sources
   compute_stereo_depth_map.cxx
   compute_track_descriptors.cxx
   convert_image.cxx
+  crop_chips.cxx
   detect_features.cxx
   detected_object_filter.cxx
   detected_object_set_input.cxx

--- a/vital/algo/crop_chips.cxx
+++ b/vital/algo/crop_chips.cxx
@@ -1,0 +1,66 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vital/algo/algorithm.txx>
+
+#include "crop_chips.h"
+
+INSTANTIATE_ALGORITHM_DEF(kwiver::vital::algo::crop_chips);
+
+namespace kwiver {
+namespace vital {
+namespace algo {
+
+crop_chips
+::crop_chips()
+{
+  attach_logger( "crop_chips" );
+}
+
+
+/// Set this algorithm's properties via a config block
+void
+crop_chips
+::set_configuration(kwiver::vital::config_block_sptr config)
+{
+  (void) config;
+}
+
+/// Check that the algorithm's current configuration is valid
+bool
+crop_chips
+::check_configuration(kwiver::vital::config_block_sptr config) const
+{
+  (void) config;
+  return true;
+}
+
+
+} } } // end namespace

--- a/vital/algo/crop_chips.h
+++ b/vital/algo/crop_chips.h
@@ -67,8 +67,8 @@ public:
    *  @returns chips: a collection of cropped images, one for each bounding box
    */
   virtual kwiver::vital::image_container_set_sptr
-    crop(kwiver::vital::image_container_sptr img
-        std::vector<kwiver::vital::bounding_box> bboxes) const = 0;
+    crop(kwiver::vital::image_container_sptr const img,
+         std::vector<kwiver::vital::bounding_box_d> const& bboxes) const = 0;
 
 protected:
   crop_chips();

--- a/vital/algo/crop_chips.h
+++ b/vital/algo/crop_chips.h
@@ -61,13 +61,14 @@ public:
   /**
    * Extract multiple image chips from a source image.
    *
-   *  @param img: source image
-   *  @param bboxes: vector of bounding boxes to crop from the source image
+   *  \param img: source image
+   *  \param bboxes: vector of bounding boxes to crop from the source image
    *
-   *  @returns chips: a collection of cropped images, one for each bounding box
+   *  \returns chips: a collection of cropped images, one for each bounding box
    */
   virtual kwiver::vital::image_container_set_sptr
     crop(kwiver::vital::image_container_sptr const img,
+         // FIXME: should bounding boxes have a _set_sptr class too?
          std::vector<kwiver::vital::bounding_box_d> const& bboxes) const = 0;
 
 protected:

--- a/vital/algo/crop_chips.h
+++ b/vital/algo/crop_chips.h
@@ -1,0 +1,82 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef VITAL_ALGO_CROP_CHIPS_H_
+#define VITAL_ALGO_CROP_CHIPS_H_
+
+#include <vital/vital_config.h>
+
+#include <string>
+
+#include <vital/algo/algorithm.h>
+#include <vital/types/bounding_box.h>
+#include <vital/types/image_container.h>
+#include <vital/types/image_container_set.h>
+
+namespace kwiver {
+namespace vital {
+namespace algo {
+
+/// An abstract algorithm base class
+class VITAL_ALGO_EXPORT crop_chips
+  : public kwiver::vital::algorithm_def<crop_chips>
+{
+public:
+  /// Return the name of this algorithm
+  static std::string static_type_name() { return "crop_chips"; }
+
+  /// Set this algorithm's properties via a config block
+  virtual void set_configuration(kwiver::vital::config_block_sptr config);
+  /// Check that the algorithm's currently configuration is valid
+  virtual bool check_configuration(kwiver::vital::config_block_sptr config) const;
+
+  /// Crop out the bounding boxes
+  /**
+   * Extract multiple image chips from a source image.
+   *
+   *  @param img: source image
+   *  @param bboxes: vector of bounding boxes to crop from the source image
+   *
+   *  @returns chips: a collection of cropped images, one for each bounding box
+   */
+  virtual kwiver::vital::image_container_set_sptr
+    crop(kwiver::vital::image_container_sptr img
+        std::vector<kwiver::vital::bounding_box> bboxes) const = 0;
+
+protected:
+  crop_chips();
+
+};
+
+typedef std::shared_ptr<crop_chips> crop_chips_sptr;
+
+} } } // end namespace
+
+#endif // VITAL_ALGO_CROP_CHIPS_H_

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -34,10 +34,10 @@ kwiver_discover_tests(vital_algorithm_capabilities  test_libraries test_algorith
 kwiver_discover_tests(vital_detected_object_type     test_libraries    test_detected_object_type.cxx)
 kwiver_discover_tests(vital_detected_object          test_libraries    test_detected_object.cxx)
 kwiver_discover_tests(vital_detected_object_set      test_libraries    test_detected_object_set.cxx)
-kwiver_discover_tests(vital_image_container_set      test_libraries    test_image_container_set.cxx)
 
 kwiver_discover_gtests(vital  camera_io   LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}" )
 kwiver_discover_gtests(vital  geodesy     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital  geo_point   LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital  geo_polygon LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital  track_set   LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital  image_container_set LIBRARIES ${test_libraries})

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ kwiver_discover_tests(vital_algorithm_capabilities  test_libraries test_algorith
 kwiver_discover_tests(vital_detected_object_type     test_libraries    test_detected_object_type.cxx)
 kwiver_discover_tests(vital_detected_object          test_libraries    test_detected_object.cxx)
 kwiver_discover_tests(vital_detected_object_set      test_libraries    test_detected_object_set.cxx)
+kwiver_discover_tests(vital_image_container_set      test_libraries    test_image_container_set.cxx)
 
 kwiver_discover_gtests(vital  camera_io   LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}" )
 kwiver_discover_gtests(vital  geodesy     LIBRARIES ${test_libraries})

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -1,0 +1,67 @@
+/*ckwg +29
+ * Copyright 2014 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <test_common.h>
+
+
+#include <vital/types/image_container_set.h>
+#include <vital/types/image_container.h>
+
+namespace // anonymous
+{
+  // Helper methods for tests in this file
+}
+
+#define TEST_ARGS ()
+
+DECLARE_TEST_MAP();
+
+int
+main(int argc, char* argv[])
+{
+  CHECK_ARGS(1);
+
+  testname_t const testname = argv[1];
+
+  RUN_TEST(testname);
+}
+
+
+IMPLEMENT_TEST(simple_empty_container)
+{
+  kwiver::vital::image_container_set empty_set ;
+
+  // Check size is reported as zero
+  TEST_EQUAL("Set empty", test_set->size(), 0);
+
+  // Check underlying vector implementation exists and also reports zero size
+  std::vector< image_container_sptr > data_ = empty_set->data()
+  TEST_EQUAL("Vector empty", data_->size(), 0);
+}

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014 by Kitware, Inc.
+ * Copyright 2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -28,41 +28,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <test_common.h>
-
 
 #include <vital/types/image_container_set.h>
 #include <vital/types/image_container.h>
 
-namespace // anonymous
-{
-  // Helper methods for tests in this file
-}
+#include <gtest/gtest.h>
 
-#define TEST_ARGS ()
 
-DECLARE_TEST_MAP();
-
+// ----------------------------------------------------------------------------
 int
 main(int argc, char* argv[])
 {
-  CHECK_ARGS(1);
-
-  testname_t const testname = argv[1];
-
-  RUN_TEST(testname);
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+  return RUN_ALL_TESTS();
 }
 
 
-IMPLEMENT_TEST(simple_empty_container)
+// ----------------------------------------------------------------------------
+TEST(image_container_set, empty)
 {
   kwiver::vital::image_container_set_sptr empty_set;
   empty_set = std::make_shared<kwiver::vital::simple_image_container_set>();
 
   // Check size is reported as zero
-  TEST_EQUAL("Set empty", empty_set->size(), 0);
+  EXPECT_EQ(0, empty_set->size()) << "Set empty";
 
   // Check underlying vector implementation exists and also reports zero size
-  std::vector< kwiver::vital::image_container_sptr > data_ = empty_set->images();
-  TEST_EQUAL("Vector empty", data_.size(), 0);
+  EXPECT_EQ(0, empty_set->images().size()) << "Vector empty";
 }

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -56,12 +56,13 @@ main(int argc, char* argv[])
 
 IMPLEMENT_TEST(simple_empty_container)
 {
-  kwiver::vital::image_container_set empty_set ;
+  kwiver::vital::image_container_set_sptr empty_set;
+  empty_set = std::make_shared<kwiver::vital::simple_image_container_set>();
 
   // Check size is reported as zero
-  TEST_EQUAL("Set empty", test_set->size(), 0);
+  TEST_EQUAL("Set empty", empty_set->size(), 0);
 
   // Check underlying vector implementation exists and also reports zero size
-  std::vector< image_container_sptr > data_ = empty_set->data()
-  TEST_EQUAL("Vector empty", data_->size(), 0);
+  std::vector< kwiver::vital::image_container_sptr > data_ = empty_set->images();
+  TEST_EQUAL("Vector empty", data_.size(), 0);
 }

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -40,7 +40,6 @@ int
 main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest( &argc, argv );
-  TEST_LOAD_PLUGINS();
   return RUN_ALL_TESTS();
 }
 

--- a/vital/types/image_container_set.h
+++ b/vital/types/image_container_set.h
@@ -1,0 +1,105 @@
+/*ckwg +29
+ * Copyright 2013-2014 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief core image_container_set interface
+ */
+
+#ifndef VITAL_IMAGE_CONTAINER_SET_H_
+#define VITAL_IMAGE_CONTAINER_SET_H_
+
+
+#include "image_container.h"
+#include <vital/vital_config.h>
+#include <vital/logger/logger.h>
+#include <vital/noncopyable.h>
+
+namespace kwiver {
+namespace vital {
+
+/// An abstract ordered collection of feature images.
+/**
+ * The base class image_container_set is abstract and provides an interface
+ * for returning a vector of images.  There is a simple derived class
+ * that stores the data as a vector of images and returns it.  Other
+ * derived classes can store the data in other formats and convert on demand.
+ */
+class image_container_set : private noncopyable
+{
+public:
+  /// Destructor
+  virtual ~image_container_set() = default;
+
+  /// Return the number of images in the set
+  virtual size_t size() const = 0;
+
+  /// Return a vector of image shared pointers
+  virtual std::vector< image_container_sptr > images() const = 0;
+
+protected:
+  image_container_set()
+   : m_logger( kwiver::vital::get_logger( "vital.image_container_set" ) )
+  {}
+
+  kwiver::vital::logger_handle_t m_logger;
+};
+
+/// Shared pointer for base image_container_set type
+typedef std::shared_ptr< image_container_set > image_container_set_sptr;
+
+
+/// A concrete image set that simply wraps a vector of images.
+class simple_image_container_set :
+  public image_container_set
+{
+public:
+  /// Default Constructor
+  simple_image_container_set() { }
+
+  /// Constructor from a vector of images
+  explicit simple_image_container_set( std::vector< image_container_sptr > const& images )
+    : data_( images ) { }
+
+  /// Return the number of items
+  virtual size_t size() const { return data_.size(); }
+
+  /// Return the underlying vector container
+  virtual std::vector< image_container_sptr > images() const { return data_; }
+
+
+protected:
+  /// The vector of images
+  std::vector< image_container_sptr > data_;
+};
+
+} } // end namespace vital
+
+#endif // VITAL_IMAGE_CONTAINER_SET_H_

--- a/vital/types/image_container_set.h
+++ b/vital/types/image_container_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/vital/types/image_container_set.h
+++ b/vital/types/image_container_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2014 by Kitware, Inc.
+ * Copyright 2013-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This is an extension of #348 that implements an algorithm to extract sub-images (chips) from larger images using bounding boxes. There is also a process that uses this algorithm to extract sub-images of detections. 

The idea is that we can pass this image_container_set to another process that computes an image descriptor for each object chip. This will be useful for a tracking pipeline as well as other projects. 

Note: #345 should be merged before this is. However, this can probably be merged instead of #348. 