### PR TITLE
Robustly set argv in sprokit C++ python entrypoint

### DIFF
--- a/sprokit/src/bindings/python/__init__.py
+++ b/sprokit/src/bindings/python/__init__.py
@@ -4,19 +4,6 @@ The base SPROKIT package initialization
 """
 # flake8: noqa
 from __future__ import print_function, unicode_literals, absolute_import
-import sys
-
-
-# Handle issues when called from pybind11 modules
-def _pybind11_argv_workaround():
-    """
-    If this module is imported by pybind11, argv will not be populated.  This
-    can cause issues with other modules, so set it as an attribute here.
-    """
-    if not hasattr(sys, 'argv'):
-        sys.argv = []
-_pybind11_argv_workaround()
-
 
 # Configure logging and initialize the root sprokit logger
 from sprokit import sprokit_logging

--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -80,10 +80,17 @@ register_factories(kwiver::vital::plugin_loader& vpm)
     return;
   }
 
-  Py_Initialize();
-  // Set Python interpeter attribute: sys.argv = []
-  // parameters are: (argc, argv, updatepath)
-  PySys_SetArgvEx(0, NULL, 0);
+  // Check if a python interpreter already exists so we don't clobber sys.argv
+  // (e.g. if sprokit is initialized from python)
+  if (not Py_IsInitialized())
+  {
+    // Embed a python interpretter if one does not exist
+    Py_Initialize();
+
+    // Set Python interpeter attribute: sys.argv = []
+    // parameters are: (argc, argv, updatepath)
+    PySys_SetArgvEx(0, NULL, 0);
+  }
 
 #ifdef SPROKIT_LOAD_PYLIB_SYM
   const char *pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );

--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -51,7 +51,7 @@
   #include <dlfcn.h>
 #endif
 
-using namespace pybind11;
+namespace py = pybind11;
 
 static void load();
 static bool is_suppressed();
@@ -103,8 +103,8 @@ register_factories(kwiver::vital::plugin_loader& vpm)
 void
 load()
 {
-  object const modules = module::import("sprokit.modules.modules");
-  object const loader = modules.attr("load_python_modules");
+  py::object const modules = py::module::import("sprokit.modules.modules");
+  py::object const loader = modules.attr("load_python_modules");
 
   loader();
 }

--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -81,6 +81,9 @@ register_factories(kwiver::vital::plugin_loader& vpm)
   }
 
   Py_Initialize();
+  // Set Python interpeter attribute: sys.argv = []
+  // parameters are: (argc, argv, updatepath)
+  PySys_SetArgvEx(0, NULL, 0);
 
 #ifdef SPROKIT_LOAD_PYLIB_SYM
   const char *pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );


### PR DESCRIPTION
By default pybind11 does not set `sys.argv`, which caused my to add a workaround to `sprokit/__init__.py`. While debugging other python issues I found a better way to accomplish this by calling `PySys_SetArgvEx` immediately after the call to `Py_Initialize` in the sprokit code that registers python modules. 

While making this change I also removed `using namespace  pybind11` in favor of the `namespace py = pybind11;` pattern that is present in the pybind11 tutorials. This helps clarify what code is coming from the pybind11 headers. 