### PR TITLE
Force C++ schedulers to check for python processes

### DIFF
--- a/sprokit/src/bindings/python/processes/test/examples.py
+++ b/sprokit/src/bindings/python/processes/test/examples.py
@@ -75,5 +75,6 @@ class PythonPrintNumberProcess(process.PythonProcess):
         num = self.grab_value_from_port('input')
 
         self.fout.write('%d\n' % num)
+        self.fout.flush()
 
         self._base_step()

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -105,6 +105,7 @@ class process_trampoline
     void _step() override;
     void _reconfigure(kwiver::vital::config_block_sptr const& config) override;
     sprokit::process::properties_t _properties() const override;
+    sprokit::process::properties_t _properties_over() const;
     sprokit::process::ports_t _input_ports() const override;
     sprokit::process::ports_t _output_ports() const override;
     port_info_t _input_port_info(port_t const& port) override;
@@ -592,13 +593,22 @@ process_trampoline
 
 sprokit::process::properties_t
 process_trampoline
-::_properties() const
+::_properties_over() const
 {
   PYBIND11_OVERLOAD(
     sprokit::process::properties_t,
     process,
     _properties,
   );
+}
+
+sprokit::process::properties_t
+process_trampoline
+::_properties() const
+{
+  sprokit::process::properties_t consts = _properties_over();
+  consts.insert("_python");
+  return consts;
 }
 
 sprokit::process::ports_t

--- a/sprokit/src/schedulers/sync_scheduler.cxx
+++ b/sprokit/src/schedulers/sync_scheduler.cxx
@@ -85,11 +85,20 @@ sync_scheduler
   , d(new priv)
 {
   pipeline_t const p = pipeline();
+
+  process_t proc = p->get_python_process();
+  if(proc)
+  {
+      std::string const reason = "The process \'" + proc->name() + "\' is "
+                                 "a python process and is not supported by this scheduler.";
+      throw incompatible_pipeline_exception(reason);
+  }
+
   process::names_t const names = p->process_names();
 
   for (process::name_t const& name : names)
   {
-    process_t const proc = p->process_by_name(name);
+    proc = p->process_by_name(name);
     process::properties_t const consts = proc->properties();
 
     if (consts.count(process::property_unsync_output))

--- a/sprokit/src/schedulers/thread_per_process_scheduler.cxx
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.cxx
@@ -77,11 +77,20 @@ thread_per_process_scheduler
   , d(new priv)
 {
   pipeline_t const p = pipeline();
+
+  process_t proc = p->get_python_process();
+  if(proc)
+  {
+      std::string const reason = "The process \'" + proc->name() + "\' is "
+                                 "a python process and is not supported by this scheduler.";
+      throw incompatible_pipeline_exception(reason);
+  }
+
   process::names_t const names = p->process_names();
 
   for (process::name_t const& name : names)
   {
-    process_t const proc = p->process_by_name(name);
+    proc = p->process_by_name(name);
     process::properties_t const consts = proc->properties();
 
     if (consts.count(process::property_no_threads))

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -1130,6 +1130,27 @@ pipeline
 
 
 // ------------------------------------------------------------------
+process_t
+pipeline
+::get_python_process() const
+{
+  // Run through each process, checking to see if any are python
+  process_t python_process; // Start with a null pointer, return it if no python procs are found
+  for (priv::process_map_t::value_type const& process_index : d->process_map)
+  {
+    process_t proc = process_index.second;
+    auto properties = proc->properties();
+    if ( properties.find("_python") != properties.end() )
+    {
+      python_process = proc;
+      break;
+    }
+  }
+
+  return python_process;
+}
+
+// ------------------------------------------------------------------
 pipeline::priv
 ::priv(pipeline* pipe, kwiver::vital::config_block_sptr conf)
   : q(pipe)

--- a/sprokit/src/sprokit/pipeline/pipeline.h
+++ b/sprokit/src/sprokit/pipeline/pipeline.h
@@ -490,6 +490,13 @@ class SPROKIT_PIPELINE_EXPORT pipeline
      */
     edges_t output_edges_for_port(process::name_t const& name, process::port_t const& port) const;
 
+    /**
+     * \brief Check to see if the pipeline has any python processes.
+     *
+     * \returns Return a python process if any exist, or a null pointer otherwise
+     */
+    process_t get_python_process() const;
+
   private:
     friend class scheduler;
     SPROKIT_PIPELINE_NO_EXPORT void start();

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
@@ -30,6 +30,9 @@
 
 #include "scheduler_factory.h"
 #include "scheduler_registry_exception.h"
+#include "scheduler_exception.h"
+
+#include "pipeline.h"
 
 #include <vital/logger/logger.h>
 
@@ -70,6 +73,18 @@ create_object( pipeline_t const& pipe,
                kwiver::vital::config_block_sptr const& config )
 {
   // Call sprokit factory function.
+  process::names_t names = pipe->process_names();
+  for ( name : names )
+  {
+    auto process = pipe->process_by_name(name);
+    auto properties = process->properties();
+    if ( properties.find("_python") != properties.end() )
+    {
+      std::string const reason = "The process \'" + name + "\' is "
+                                 "a python process and is not supported by this scheduler.";
+      throw incompatible_pipeline_exception(reason);
+    }
+  }
   return m_factory( pipe, config );
 }
 

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
@@ -30,9 +30,6 @@
 
 #include "scheduler_factory.h"
 #include "scheduler_registry_exception.h"
-#include "scheduler_exception.h"
-
-#include "pipeline.h"
 
 #include <vital/logger/logger.h>
 
@@ -73,18 +70,6 @@ create_object( pipeline_t const& pipe,
                kwiver::vital::config_block_sptr const& config )
 {
   // Call sprokit factory function.
-  process::names_t names = pipe->process_names();
-  for ( process::name_t const& name : names )
-  {
-    auto process = pipe->process_by_name(name);
-    auto properties = process->properties();
-    if ( properties.find("_python") != properties.end() )
-    {
-      std::string const reason = "The process \'" + name + "\' is "
-                                 "a python process and is not supported by this scheduler.";
-      throw incompatible_pipeline_exception(reason);
-    }
-  }
   return m_factory( pipe, config );
 }
 

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.cxx
@@ -74,7 +74,7 @@ create_object( pipeline_t const& pipe,
 {
   // Call sprokit factory function.
   process::names_t names = pipe->process_names();
-  for ( name : names )
+  for ( process::name_t const& name : names )
   {
     auto process = pipe->process_by_name(name);
     auto properties = process->properties();

--- a/sprokit/tests/bindings/python/sprokit/pipeline/test-run.py
+++ b/sprokit/tests/bindings/python/sprokit/pipeline/test-run.py
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+cpp_scheds = ["sync","thread_per_process"] # One shop stop if we add any more c++ schedulers to the tests
 
 def make_source(conf):
     from sprokit.pipeline import process
@@ -125,16 +126,26 @@ def run_pipeline(sched_type, pipe, conf):
     from sprokit.pipeline import config
     from sprokit.pipeline import modules
     from sprokit.pipeline import scheduler_factory
+    import sys
 
     modules.load_known_modules()
 
-    s = scheduler_factory.create_scheduler(sched_type, pipe, conf)
+    if sched_type in cpp_scheds:
+        expect_exception("trying to run a python process on a C++ scheduler", RuntimeError,
+                         scheduler_factory.create_scheduler, sched_type, pipe, conf)
 
-    s.start()
-    s.wait()
+    else:
+        s = scheduler_factory.create_scheduler(sched_type, pipe, conf)
+
+        s.start()
+        s.wait()
 
 
 def check_file(fname, expect):
+    # Don't check for c++ scheds--we shouldn't have produced a file, and don't want to get caught up with leftovers
+    if sched_type in cpp_scheds:
+        return
+
     with open(fname, 'r') as fin:
         ints = list([int(l.strip()) for l in list(fin)])
 

--- a/sprokit/tests/sprokit/pipeline/test_run.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_run.cxx
@@ -37,6 +37,7 @@
 #include <sprokit/pipeline/process.h>
 #include <sprokit/pipeline/process_factory.h>
 #include <sprokit/pipeline/scheduler.h>
+#include <sprokit/pipeline/scheduler_exception.h>
 #include <sprokit/pipeline/scheduler_factory.h>
 
 #include <boost/cstdint.hpp>
@@ -217,44 +218,56 @@ IMPLEMENT_TEST(pysimple_pipeline)
 
     pipeline->setup_pipeline();
 
-    sprokit::scheduler_t const scheduler = sprokit::create_scheduler(scheduler_type, pipeline);
-
-    scheduler->start();
-    scheduler->wait();
-  }
-
-  std::ifstream fin(output_path.c_str());
-
-  if (!fin.good())
-  {
-    TEST_ERROR("Could not open the output file");
-  }
-
-  std::string line;
-
-  for (int32_t i = start_value; i < end_value; ++i)
-  {
-    if (!std::getline(fin, line))
+    if(scheduler_type == "pythread_per_process")
     {
-      TEST_ERROR("Failed to read a line from the file");
+      sprokit::scheduler_t const scheduler = sprokit::create_scheduler(scheduler_type, pipeline);
+
+      scheduler->start();
+      scheduler->wait();
     }
-
-    if (kwiver::vital::config_block_value_t(line) != boost::lexical_cast<kwiver::vital::config_block_value_t>(i))
+    else
     {
-      TEST_ERROR("Did not get expected value: "
-                 "Expected: " << i << " "
-                 "Received: " << line);
+      EXPECT_EXCEPTION(sprokit::incompatible_pipeline_exception,
+                       sprokit::create_scheduler(scheduler_type, pipeline),
+                       "using python processes with a C++ scheduler");
     }
   }
 
-  if (std::getline(fin, line))
+  if(scheduler_type == "pythread_per_process")
   {
-    TEST_ERROR("More results than expected in the file");
-  }
+    std::ifstream fin(output_path.c_str());
 
-  if (!fin.eof())
-  {
-    TEST_ERROR("Not at end of file");
+    if (!fin.good())
+    {
+      TEST_ERROR("Could not open the output file");
+    }
+
+    std::string line;
+
+    for (int32_t i = start_value; i < end_value; ++i)
+    {
+      if (!std::getline(fin, line))
+      {
+        TEST_ERROR("Failed to read a line from the file");
+      }
+
+      if (kwiver::vital::config_block_value_t(line) != boost::lexical_cast<kwiver::vital::config_block_value_t>(i))
+      {
+        TEST_ERROR("Did not get expected value: "
+                   "Expected: " << i << " "
+                   "Received: " << line);
+      }
+    }
+
+    if (std::getline(fin, line))
+    {
+      TEST_ERROR("More results than expected in the file");
+    }
+
+    if (!fin.eof())
+    {
+      TEST_ERROR("Not at end of file");
+    }
   }
 }
 


### PR DESCRIPTION
This forces C++ schedulers to check for any python processes. I haven't really taken a look at #376, this may need updating to match.