### PR TITLE
Added PYTHON_LIBRARY to setup_KWIVER.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,17 +244,22 @@ endif()
 
 
 if (KWIVER_ENABLE_PYTHON)
+  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "# Python environment\n")
+  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export PYTHON_LIBRARY=\"${PYTHON_LIBRARY}\"\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export PYTHONPATH=$this_dir/${python_site_packages}:$PYTHONPATH\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "\n# additional python mudules to load, separated by ':'\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export SPROKIT_PYTHON_MODULES=kwiver.processes\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "\n# set to suppress loading python modules/processes\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "# export SPROKIT_NO_PYTHON_MODULES\n\n" )
 
+  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "# Python environment\n")
+  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set PYTHON_LIBRARY=${PYTHON_LIBRARY}\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set PYTHONPATH=%~dp0/lib/%config%/python2.7/site-packages\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n:: additional python mudules to load, separated by ':'\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set SPROKIT_PYTHON_MODULES=kwiver.processes\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n:: set to suppress loading python modules/processes\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "::set SPROKIT_NO_PYTHON_MODULES=false\n\n" )
+  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n# point to the python library")
 endif()
 
 if ( KWIVER_ENABLE_MATLAB )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,6 @@ if (KWIVER_ENABLE_PYTHON)
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set SPROKIT_PYTHON_MODULES=kwiver.processes\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n:: set to suppress loading python modules/processes\n" )
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "::set SPROKIT_NO_PYTHON_MODULES=false\n\n" )
-  file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "\n# point to the python library")
 endif()
 
 if ( KWIVER_ENABLE_MATLAB )

--- a/sprokit/src/bindings/python/modules/CMakeLists.txt
+++ b/sprokit/src/bindings/python/modules/CMakeLists.txt
@@ -30,6 +30,13 @@ kwiver_add_plugin(modules_python
                   ${PYTHON_LIBRARIES}
                   )
 
+
+# Add definition to tell registration.cxx the name of the python_library it was
+# compiled with. It will attempt to load symbols from this library dynamically.
+get_filename_component(PYTHON_LIBRARY_NAME "${PYTHON_LIBRARY}" NAME)
+target_compile_definitions(modules_python PRIVATE "-DPYTHON_LIBRARY=${PYTHON_LIBRARY_NAME}")
+
+
 sprokit_add_python_module("${CMAKE_CURRENT_SOURCE_DIR}/modules.py"
   sprokit/modules
   modules)

--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -51,10 +51,25 @@
   #include <dlfcn.h>
 #endif
 
+
+// Undefine macros that will double expand in case an definition has a value
+// something like: /usr/lib/x86_64-linux-gnu/libpython2.7.so
+#ifdef linux
+#define _orig_linux linux
+#undef linux
+#endif
+
+// for getting the value of a macro as a string literal
+#define MACRO_STR_VALUE(x) _TO_STRING0(x)
+#define _TO_STRING0(x) _TO_STRING1(x)
+#define _TO_STRING1(x) #x
+
+
 using namespace pybind11;
 
 static void load();
 static bool is_suppressed();
+static void _load_python_library_symbols();
 
 
 // ==================================================================
@@ -75,8 +90,6 @@ MODULES_PYTHON_EXPORT
 void
 register_factories(kwiver::vital::plugin_loader& vpm)
 {
-  auto logger = kwiver::vital::get_logger("sprokit.python_modules");
-
   if (is_suppressed())
   {
     return;
@@ -84,12 +97,53 @@ register_factories(kwiver::vital::plugin_loader& vpm)
 
   Py_Initialize();
 
+  _load_python_library_symbols();
+
+  sprokit::python::python_gil const gil;
+
+  (void)gil;
+
+  SPROKIT_PYTHON_IGNORE_EXCEPTION(load())
+}
+
+
+// ------------------------------------------------------------------
+/*
+ * Uses environment variables and compiler definitions to determine where the
+ * python shared library is and load its symbols.
+ */
+void _load_python_library_symbols()
+{
 #ifdef SPROKIT_LOAD_PYLIB_SYM
-  const char *pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );
-  if( pylib )
+  auto logger = kwiver::vital::get_logger("sprokit.python_modules");
+
+  const char *env_pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );
+
+  // cmake should provide this definition
+  #ifdef PYTHON_LIBRARY
+  const char *default_pylib = MACRO_STR_VALUE(PYTHON_LIBRARY);
+  #else
+  const char *default_pylib = NULL;
+  #endif
+
+  // First check if the PYTHON_LIBRARY environment variable is specified
+  if( env_pylib )
   {
-    LOG_DEBUG(logger, "Loading symbols from PYTHON_LIBRARY= " << pylib );
-    dlopen( pylib, RTLD_LAZY | RTLD_GLOBAL );
+    LOG_DEBUG(logger, "Loading symbols from PYTHON_LIBRARY=" << env_pylib );
+    void* handle = dlopen( env_pylib, RTLD_LAZY | RTLD_GLOBAL );
+    if (!handle) {
+      LOG_ERROR(logger, "Cannot load library: " << dlerror());
+    }
+  }
+  else if( default_pylib )
+  {
+    // If the PYTHON_LIBRARY environment variable is not specified, use the
+    // CMAKE definition of PYTHON_LIBRARY instead.
+    LOG_DEBUG(logger, "Loading symbols from default PYTHON_LIBRARY=" << default_pylib);
+    void* handle = dlopen( default_pylib, RTLD_LAZY | RTLD_GLOBAL );
+    if (!handle) {
+      LOG_ERROR(logger, "Cannot load library: " << dlerror());
+    }
   }
   else
   {
@@ -99,12 +153,6 @@ register_factories(kwiver::vital::plugin_loader& vpm)
 #else
   LOG_DEBUG(logger, "Not checking for python symbols");
 #endif
-
-  sprokit::python::python_gil const gil;
-
-  (void)gil;
-
-  SPROKIT_PYTHON_IGNORE_EXCEPTION(load())
 }
 
 
@@ -133,3 +181,11 @@ is_suppressed()
 
   return suppress_python_modules;
 }
+
+
+// Redefine values that we hacked away
+#ifdef _orig_linux
+#define linux _orig_linux
+#undef _orig_linux
+#endif
+

--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -75,6 +75,8 @@ MODULES_PYTHON_EXPORT
 void
 register_factories(kwiver::vital::plugin_loader& vpm)
 {
+  auto logger = kwiver::vital::get_logger("sprokit.python_modules");
+
   if (is_suppressed())
   {
     return;
@@ -84,11 +86,18 @@ register_factories(kwiver::vital::plugin_loader& vpm)
 
 #ifdef SPROKIT_LOAD_PYLIB_SYM
   const char *pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );
-
   if( pylib )
   {
+    LOG_DEBUG(logger, "Loading symbols from PYTHON_LIBRARY= " << pylib );
     dlopen( pylib, RTLD_LAZY | RTLD_GLOBAL );
   }
+  else
+  {
+    LOG_DEBUG(logger, "Unable to pre-load python symbols because " <<
+                      "PYTHON_LIBRARY is undefined.");
+  }
+#else
+  LOG_DEBUG(logger, "Not checking for python symbols");
 #endif
 
   sprokit::python::python_gil const gil;


### PR DESCRIPTION
This is a fix for Issue #385

Previously python symbols were not available to plugins unless the main executable linked to libpython. The `python_modules` library in sprokit  had a mechanism for preloading libpython using the `PYTHON_LIBRARY` environment variable, but this would fail unless that was set. 

I simply added `PYTHON_LIBRARY` to the setup_KWIVER.sh script to point to it. 

Note, this will not fix issues on deployment systems, because the `PYTHON_LIBRARY` variable is an absolute path found by CMake. This seems like an ok temporary solution, but a better one would make the `python_modules`  not rely on the environment variable to preload the python symbols. 

Honestly, I don't even know why it needs to be cause `ldd lib/sprokit/modules_python.so` shows that it is linked to libpython2.7. Is there a way to use `dlfcn.h` to dynamically get the path to whatever libpython it is being linked to and call `dlopen( pylib, RTLD_LAZY | RTLD_GLOBAL );` on whatever that path is? Then if `PYTHON_LIBRARY` we use it, otherwise we fallback to whatever python lib we are linked to. (or maybe we just always do the latter of the two choices?)