### PR TITLE
Get rid of extra dll import/exports

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -66,7 +66,7 @@ static std::vector< std::string > process_names();
 // ============================================================================
 typedef std::function< pybind11::object( kwiver::vital::config_block_sptr const& config ) > py_process_factory_func_t;
 
-class SPROKIT_PIPELINE_EXPORT python_process_factory
+class python_process_factory
   : public sprokit::process_factory
 {
   /**

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -62,7 +62,7 @@ static std::string get_default_type();
 typedef std::function< pybind11::object( sprokit::pipeline_t const& pipe,
                                kwiver::vital::config_block_sptr const& config ) > py_scheduler_factory_func_t;
 
-class SPROKIT_PIPELINE_EXPORT python_scheduler_factory
+class python_scheduler_factory
   : public sprokit::scheduler_factory
 {
   public:


### PR DESCRIPTION
The SPROKIT_PIPELINE_EXPORT is unnecessary in the python binding cxx files, but prevent successful Windows builds. I've removed them from the factory code that was moved over to the binding files.