### PR TITLE
Port last Ceres test to Google Test

### DIFF
--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -18,4 +18,4 @@ endif()
 ##############################
 kwiver_discover_gtests(ceres bundle_adjust      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ceres optimize_cameras   LIBRARIES ${test_libraries})
-kwiver_discover_tests(ceres_reprojection_error  test_libraries test_reprojection_error.cxx)
+kwiver_discover_gtests(ceres reprojection_error LIBRARIES ${test_libraries})


### PR DESCRIPTION
Port the Ceres `reprojection_error` test to Google Test. This is the last of the Ceres tests to be ported (and is, in fact, the last of the arrows tests that are going to be ported at this time). This one was just screaming to be parameterized, and has been, although this does result in test names that are just a bit lengthy.