### PR TITLE
Fix the broken envvar tests

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -254,22 +254,10 @@ std::string get_description( const std::string& type )
 // ------------------------------------------------------------------
 std::vector< std::string > process_names()
 {
-  kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
-  auto py_fact_list = vpm.get_factories<object>();
+  std::vector< std::string > name_list;
 
-  std::vector<std::string> name_list;
-  for( auto fact : py_fact_list )
-  {
-    std::string buf;
-    if (fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, buf ))
-    {
-      name_list.push_back( buf );
-    }
-  } // end foreach
-
-  auto fact_list = vpm.get_factories<sprokit::process>();
-
-  for( auto fact : py_fact_list )
+  auto fact_list = sprokit::get_process_list();
+  for( auto fact : fact_list )
   {
     std::string buf;
     if (fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, buf ))

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -231,19 +231,9 @@ std::string get_description( const std::string& type )
 // ------------------------------------------------------------------
 std::vector< std::string > scheduler_names()
 {
+  std::vector< std::string > name_list;
+
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
-  auto py_fact_list = vpm.get_factories<object>();
-
-  std::vector<std::string> name_list;
-  for( auto fact : py_fact_list )
-  {
-    std::string buf;
-    if (fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, buf ))
-    {
-      name_list.push_back( buf );
-    }
-  } // end foreach
-
   auto fact_list = vpm.get_factories<sprokit::scheduler>();
   for( auto fact : fact_list )
   {

--- a/sprokit/tests/bindings/python/modules/sprokit/processes/pythonpath_test_process.py
+++ b/sprokit/tests/bindings/python/modules/sprokit/processes/pythonpath_test_process.py
@@ -40,7 +40,7 @@ class TestPythonProcess(process.PythonProcess):
 def __sprokit_register__():
     from sprokit.pipeline import process_factory
 
-    module_name = 'python:test.pythonpath.test'
+    module_name = 'python:test.pythonpath.process_test'
 
     if process_factory.is_process_module_loaded(module_name):
         return

--- a/sprokit/tests/bindings/python/modules/sprokit/schedulers/pythonpath_test_scheduler.py
+++ b/sprokit/tests/bindings/python/modules/sprokit/schedulers/pythonpath_test_scheduler.py
@@ -41,7 +41,7 @@ class TestPythonScheduler(scheduler.PythonScheduler):
 def __sprokit_register__():
     from sprokit.pipeline import scheduler_factory
 
-    module_name = 'python:test.pythonpath.test'
+    module_name = 'python:test.pythonpath.scheduler_test'
 
     if scheduler_factory.is_scheduler_module_loaded(module_name):
         return


### PR DESCRIPTION
Fixing two issues in python tests.

First is that the process_names and scheduler_names functions weren't updated to match the new organization of the appropriate factories.

Second is that the example process and scheduler for the PYTHONPATH test used the same name, so the example scheduler couldn't be loaded.