### PR TITLE
Add nested config macros that use config traits.

### DIFF
--- a/sprokit/processes/trait_utils.h
+++ b/sprokit/processes/trait_utils.h
@@ -135,6 +135,17 @@ declare_configuration_key( KEY ## _config_trait::key,                   \
 #define reconfig_value_using_trait(CONF,KEY) CONF->get_value< KEY ## _config_trait::type >( KEY ## _config_trait::key )
 
 
+// Algorithm interface using traits
+#define check_nested_algo_configuration_using_trait(KEY, ALGO) \
+  check_nested_algo_configuration( KEY ## _config_trait::key, ALGO )
+
+#define set_nested_algo_configuration_using_trait(KEY, CONFIG, ALGO)     \
+  set_nested_algo_configuration( KEY ## _config_trait::key, CONFIG, ALGO )
+
+#define get_nested_algo_configuration_using_trait(KEY, CONFIG, ALGO)     \
+  get_nested_algo_configuration( KEY ## _config_trait::key, CONFIG, ALGO )
+
+
 /**
  * \brief Create type trait.
  *


### PR DESCRIPTION
These macros simplify working with loadable algorithms when the
config key is defined using a trait.