### PR TITLE
Add process timing instrumentation

### DIFF
--- a/examples/pipelines/descriptor.pipe.in
+++ b/examples/pipelines/descriptor.pipe.in
@@ -25,12 +25,6 @@ process descriptor
   algorithm = algo
 
 # ================================================================
-# global pipeline config
-#
-config _pipeline:_edge
-       capacity = 10
-
-# ================================================================
 # connections
 connect from input.image
         to   descriptor.image

--- a/extras/RightTrack/register_plugin.cxx
+++ b/extras/RightTrack/register_plugin.cxx
@@ -54,7 +54,8 @@ register_factories( kwiver::vital::plugin_loader& vpm )
                     "Sprokit process instrumentation implementation using RightTrack.")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, "process-instrumentation" )
+   ;
 
   // - - - - - - - - - - - - - - - - - - - - - - -
   vpm.mark_module_as_loaded( module_name );

--- a/extras/RightTrack/rt_process_instrumentation.cxx
+++ b/extras/RightTrack/rt_process_instrumentation.cxx
@@ -31,6 +31,7 @@
 #include "rt_process_instrumentation.h"
 
 #include <sprokit/pipeline/process.h>
+#include <cstdlib>
 
 namespace sprokit {
 
@@ -58,25 +59,61 @@ rt_process_instrumentation::
 // ------------------------------------------------------------------
 void
 rt_process_instrumentation::
-configure( kwiver::vital::config_block_sptr const config )
+configure( kwiver::vital::config_block_sptr const conf )
 {
-  m_init_event.reset( new RightTrack::BoundedEvent( process().name() + ".init",
-                                                    process().name(), INIT_COLOR ) );
+  // Starting with our generated vital::config_block to ensure that assumed values are present
+  // An alternative is to check for key presence before performing a get_value() call.
+  auto local_config = get_configuration();
+  local_config->merge_config( conf );
 
-  m_reset_event.reset( new RightTrack::BoundedEvent( process().name() + ".reset",
-                                                     process().name(), RESET_COLOR ) );
+  char* end;
+  std::string rgb_str = local_config->get_value<std::string>("init_color", INIT_COLOR );
+  int rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_init_event.reset( new RightTrack::BoundedEvent( process()->name() + ".init",
+                                                    process()->name(), rgb ) );
 
-  m_flush_event.reset( new RightTrack::BoundedEvent( process().name() + ".flush",
-                                                     process().name(), FLUSH_COLOR ) );
+  rgb_str = local_config->get_value<std::string>("reset_color", RESET_COLOR );
+  rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_reset_event.reset( new RightTrack::BoundedEvent( process()->name() + ".reset",
+                                                     process()->name(), rgb ) );
 
-  m_step_event.reset( new RightTrack::BoundedEvent( process().name()+ ".step",
-                                                    process().name(), STEP_COLOR ) );
+  rgb_str = local_config->get_value<std::string>("flush_color", FLUSH_COLOR );
+  rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_flush_event.reset( new RightTrack::BoundedEvent( process()->name() + ".flush",
+                                                     process()->name(), rgb ) );
 
-  m_configure_event.reset( new RightTrack::BoundedEvent( process().name() + ".configure",
-                                                         process().name(), CONFIGURE_COLOR ) );
+  rgb_str = local_config->get_value<std::string>("step_color", STEP_COLOR );
+  rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_step_event.reset( new RightTrack::BoundedEvent( process()->name()+ ".step",
+                                                    process()->name(), rgb ) );
 
-  m_reconfigure_event.reset( new RightTrack::BoundedEvent( process().name() + ".reconfigure",
-                                                           process().name(), RECONFIGURE_COLOR ) );
+  rgb_str = local_config->get_value<std::string>("configure_color", CONFIGURE_COLOR );
+  rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_configure_event.reset( new RightTrack::BoundedEvent( process()->name() + ".configure",
+                                                         process()->name(), rgb ) );
+
+  rgb_str = local_config->get_value<std::string>("reconfigure_color", RECONFIGURE_COLOR );
+  rgb = strtol( rgb_str.c_str(), &end, 10 );
+  m_reconfigure_event.reset( new RightTrack::BoundedEvent( process()->name() + ".reconfigure",
+                                                           process()->name(), rgb ) );
+}
+
+
+// ------------------------------------------------------------------
+kwiver::vital::config_block_sptr
+rt_process_instrumentation::
+get_configuration() const
+{
+  auto conf = kwiver::vital::config_block::empty_config();
+
+  conf->set_value( "init_color",        -1, "Color for the init event display. Color is specified as 0x00rrggbb." );
+  conf->set_value( "reset_color",       -1, "Color for the reset event display. Color is specified as 0x00rrggbb." );
+  conf->set_value( "flush_color",       -1, "Color for the flush event display. Color is specified as 0x00rrggbb." );
+  conf->set_value( "step_color",        -1, "Color for the step event display. Color is specified as 0x00rrggbb." );
+  conf->set_value( "configure_color",   -1, "Color for the configure event display. Color is specified as 0x00rrggbb." );
+  conf->set_value( "reconfigure_color", -1, "Color for the reconfigure event display. Color is specified as 0x00rrggbb." );
+
+  return conf;
 }
 
 

--- a/extras/RightTrack/rt_process_instrumentation.h
+++ b/extras/RightTrack/rt_process_instrumentation.h
@@ -32,12 +32,12 @@ f * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef KWIVER_EXTRAS_RT_PROCESS_INSTRUMENTATION_H
 #define KWIVER_EXTRAS_RT_PROCESS_INSTRUMENTATION_H
 
+#include "righttrack_plugin_export.h"
 #include <sprokit/pipeline/process_instrumentation.h>
 
 #include <RightTrack/BoundedEvent.h>
 
 #include <memory>
-
 
 namespace sprokit {
 
@@ -46,7 +46,7 @@ namespace sprokit {
  * @brief Process instrumentation using RightTrack tool.
  *
  */
-class rt_process_instrumentation
+class RIGHTTRACK_PLUGIN_NO_EXPORT rt_process_instrumentation
 : public process_instrumentation
 {
 public:
@@ -55,6 +55,7 @@ public:
   virtual ~rt_process_instrumentation();
 
   virtual void configure( kwiver::vital::config_block_sptr const config );
+  virtual kwiver::vital::config_block_sptr get_configuration() const;
 
   virtual void start_init_processing( std::string const& data );
   virtual void stop_init_processing();

--- a/extras/process_instrumentation/CMakeLists.txt
+++ b/extras/process_instrumentation/CMakeLists.txt
@@ -4,10 +4,12 @@
 set( sources
   register_plugin.cxx
   logger_process_instrumentation.cxx
+  timing_process_instrumentation.cxx
   )
 
 set( headers
   logger_process_instrumentation.h
+  timing_process_instrumentation.h
   )
 
 include_directories ( "${CMAKE_CURRENT_BINARY_DIR}" )
@@ -19,7 +21,23 @@ kwiver_add_plugin( instrumentation_plugin
                    ${CMAKE_CURRENT_BINARY_DIR}/instrumentation_plugin_export.h
   PRIVATE          vital
                    vital_vpm
+                   vital_util
                    vital_logger
                    sprokit_pipeline
   SUBDIR           modules
   )
+
+
+if (KWIVER_ENABLE_TOOLS)
+###
+#     plugins for plugin explorer
+kwiver_add_plugin( process_instrumentation_plugin
+  SUBDIR   modules/plugin_explorer
+  SOURCES  process_instrumentation_plugin.cxx
+  PRIVATE  vital
+           vital_vpm
+           vital_config
+           vital_algo
+           explorer_plugin
+           sprokit_pipeline)
+endif()

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -51,7 +51,7 @@ void
 logger_process_instrumentation::
   start_init_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": start_init_processing" );
+  LOG_INFO( m_logger, process()->name() << ": start_init_processing" );
 }
 
 
@@ -60,7 +60,7 @@ void
 logger_process_instrumentation::
 stop_init_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_init_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_init_processing" );
 }
 
 
@@ -69,7 +69,7 @@ void
 logger_process_instrumentation::
 start_reset_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": stop_init_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_init_processing" );
 }
 
 
@@ -78,7 +78,7 @@ void
 logger_process_instrumentation::
 stop_reset_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_reset_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_reset_processing" );
 }
 
 
@@ -87,7 +87,7 @@ void
 logger_process_instrumentation::
 start_flush_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": start_reset_processing" );
+  LOG_INFO( m_logger, process()->name() << ": start_reset_processing" );
 }
 
 
@@ -96,7 +96,7 @@ void
 logger_process_instrumentation::
 stop_flush_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_flush_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_flush_processing" );
 }
 
 
@@ -105,7 +105,7 @@ void
 logger_process_instrumentation::
 start_step_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": start_step_processing" );
+  LOG_INFO( m_logger, process()->name() << ": start_step_processing" );
 }
 
 
@@ -114,7 +114,7 @@ void
 logger_process_instrumentation::
 stop_step_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_step_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_step_processing" );
 }
 
 
@@ -123,7 +123,7 @@ void
 logger_process_instrumentation::
 start_configure_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": start_configure_processing" );
+  LOG_INFO( m_logger, process()->name() << ": start_configure_processing" );
 }
 
 
@@ -132,7 +132,7 @@ void
 logger_process_instrumentation::
 stop_configure_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_configure_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_configure_processing" );
 }
 
 
@@ -141,7 +141,7 @@ void
 logger_process_instrumentation::
 start_reconfigure_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process().name() << ": start_reconfigure_processing" );
+  LOG_INFO( m_logger, process()->name() << ": start_reconfigure_processing" );
 }
 
 
@@ -150,7 +150,7 @@ void
 logger_process_instrumentation::
 stop_reconfigure_processing()
 {
-  LOG_INFO( m_logger, process().name() << ": stop_reconfigure_processing" );
+  LOG_INFO( m_logger, process()->name() << ": stop_reconfigure_processing" );
 }
 
 

--- a/extras/process_instrumentation/logger_process_instrumentation.h
+++ b/extras/process_instrumentation/logger_process_instrumentation.h
@@ -36,11 +36,9 @@
 #ifndef SPROKIT_LOGGER_PROCESS_INSTRUMENTATION_H
 #define SPROKIT_LOGGER_PROCESS_INSTRUMENTATION_H
 
-
+#include "instrumentation_plugin_export.h"
 #include <sprokit/pipeline/process_instrumentation.h>
 #include <vital/logger/logger.h>
-
-#include <string>
 
 namespace sprokit {
 
@@ -51,7 +49,7 @@ namespace sprokit {
  * This class provides an implementation of process instrumentation
  * where each event is recorded to the logger.
  */
-class logger_process_instrumentation
+class INSTRUMENTATION_PLUGIN_NO_EXPORT logger_process_instrumentation
   : public process_instrumentation
 {
 public:

--- a/extras/process_instrumentation/process_instrumentation_plugin.cxx
+++ b/extras/process_instrumentation/process_instrumentation_plugin.cxx
@@ -1,0 +1,172 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "process_instrumentation_plugin_export.h"
+
+#include "timing_process_instrumentation.h"
+
+#include <vital/tools/explorer_plugin.h>
+#include <vital/plugin_loader/plugin_loader.h>
+#include <vital/util/wrap_text_block.h>
+#include <vital/util/string.h>
+
+#include <sstream>
+#include <iterator>
+#include <fstream>
+#include <string>
+#include <regex>
+
+namespace kwiver {
+namespace vital {
+
+// ==================================================================
+/**
+ * @brief plugin_explorer support for formatting processes.
+ *
+ * This class provides the special formatting for processes.
+ */
+class PROCESS_INSTRUMENTATION_PLUGIN_NO_EXPORT process_instrumentation_explorer
+  : public category_explorer
+{
+public:
+  process_instrumentation_explorer();
+  virtual ~process_instrumentation_explorer();
+
+  virtual bool initialize( explorer_context* context );
+  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact );
+
+  std::ostream& out_stream() { return m_context->output_stream(); }
+
+  // instance data
+  explorer_context* m_context;
+}; // end class process_instrumentation_explorer
+
+
+// ==================================================================
+process_instrumentation_explorer::
+process_instrumentation_explorer()
+{ }
+
+
+process_instrumentation_explorer::
+~process_instrumentation_explorer()
+{ }
+
+
+// ------------------------------------------------------------------
+bool
+process_instrumentation_explorer::
+initialize( explorer_context* context )
+{
+  m_context = context;
+
+  return true;
+}
+
+
+// ------------------------------------------------------------------
+void
+process_instrumentation_explorer::
+explore( const kwiver::vital::plugin_factory_handle_t fact )
+{
+  const std::string indent( "    " );
+  std::string instr_name = "-- Not Set --";
+
+  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, instr_name );
+
+  std::string descrip = "-- Not_Set --";
+  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, descrip );
+  descrip = m_context->wrap_text( descrip );
+
+  if ( m_context->if_brief() )
+  {
+    out_stream() << "    Instrumentation type: " << instr_name << "   " << descrip << std::endl;
+    return;
+  }
+
+  out_stream()  << "---------------------\n"
+                << "  Instrumentation type: " << instr_name << std::endl
+                << "  Description         : " << descrip << std::endl;
+
+  if ( ! m_context->if_detail() )
+  {
+    return;
+  }
+
+  auto proc_instr = fact->create_object<sprokit::process_instrumentation>();
+  auto config = proc_instr->get_configuration();
+  auto all_keys = config->available_values();
+
+  // -- config --
+  out_stream() << "    -- Configuration --" << std::endl;
+  kwiver::vital::config_block_keys_t const keys = config->available_values();
+  bool config_displayed( false );
+
+  for( kwiver::vital::config_block_key_t const & key : all_keys )
+  {
+    config_displayed = true;
+    auto  val = config->get_value< kwiver::vital::config_block_value_t > ( key );
+
+    m_context->output_stream() << indent << "\"" << key << "\" = \"" << val << "\"\n";
+
+    kwiver::vital::config_block_description_t descr = config->get_description( key );
+    m_context->output_stream() << indent << "Description: " << m_context->wrap_text( descr ) << std::endl;
+  }
+
+  if ( ! config_displayed )
+  {
+    out_stream() << "    No configuration entries" << std::endl
+                 << std::endl;
+  }
+
+} // process_instrumentation_explorer::explore
+
+
+} }
+
+
+// ==================================================================
+extern "C"
+PROCESS_INSTRUMENTATION_PLUGIN_EXPORT
+void register_explorer_plugin( kwiver::vital::plugin_loader& vpm )
+{
+  static std::string module("process_instrumentation_explorer_plugin" );
+  if ( vpm.is_module_loaded( module ) )
+  {
+    return;
+  }
+
+  auto fact = vpm.ADD_FACTORY( kwiver::vital::category_explorer, kwiver::vital::process_instrumentation_explorer );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "process-instrumentation" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Plugin explorer for process category." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+
+vpm.mark_module_as_loaded( module );
+}

--- a/extras/process_instrumentation/register_plugin.cxx
+++ b/extras/process_instrumentation/register_plugin.cxx
@@ -33,6 +33,7 @@
 #include <instrumentation_plugin_export.h>
 
 #include "logger_process_instrumentation.h"
+#include "timing_process_instrumentation.h"
 
 extern "C"
 INSTRUMENTATION_PLUGIN_EXPORT
@@ -46,14 +47,26 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     return;
   }
 
-  kwiver::vital::plugin_factory_handle_t fact =
-    vpm.ADD_FACTORY( sprokit::process_instrumentation, sprokit::logger_process_instrumentation );
+  kwiver::vital::plugin_factory_handle_t
+    fact = vpm.ADD_FACTORY( sprokit::process_instrumentation, sprokit::logger_process_instrumentation );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "logger")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                        "Sprokit process instrumentation implementation using logger.")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, "process-instrumentation" )
+    ;
+
+
+      fact = vpm.ADD_FACTORY( sprokit::process_instrumentation, sprokit::timing_process_instrumentation );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "timing")
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Sprokit process instrumentation implementation using timer.")
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, "process-instrumentation" )
     ;
 
   // - - - - - - - - - - - - - - - - - - - - - - -

--- a/extras/process_instrumentation/timing_process_instrumentation.cxx
+++ b/extras/process_instrumentation/timing_process_instrumentation.cxx
@@ -1,0 +1,275 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "timing_process_instrumentation.h"
+
+#include <vital/util/enum_converter.h>
+
+#include <sprokit/pipeline/process.h>
+#include <fstream>
+#include <iomanip>
+
+namespace sprokit {
+
+namespace {
+
+enum timer_type
+{
+  timer_wall,
+  timer_cpu
+};
+
+  ENUM_CONVERTER( timer_converter, timer_type,
+                  { "wall", timer_wall },
+                  { "cpu", timer_cpu }
+    )
+}
+// ------------------------------------------------------------------
+timing_process_instrumentation::
+timing_process_instrumentation()
+  : m_timer( std::make_shared<kwiver::vital::wall_timer>() )
+  , m_output_file(0)
+  , m_logger( kwiver::vital::get_logger( "sprokit.timing_process_instrumentation" ) )
+{ }
+
+
+timing_process_instrumentation::
+~timing_process_instrumentation()
+{
+  if (m_output_file)
+  {
+    m_output_file->close();
+    delete m_output_file;
+    m_output_file = 0;
+  }
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+  start_init_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_init_processing()
+{
+  // stop timer
+  m_timer->stop();
+
+  // write elapsed time
+  write_interval( "init", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_reset_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_reset_processing()
+{
+  m_timer->stop();
+  write_interval( "reset", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_flush_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_flush_processing()
+{
+  m_timer->stop();
+  write_interval( "flush", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_step_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_step_processing()
+{
+  m_timer->stop();
+  write_interval( "step", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_configure_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_configure_processing()
+{
+  m_timer->stop();
+  write_interval( "configure", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_reconfigure_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_reconfigure_processing()
+{
+  m_timer->stop();
+  write_interval( "reconfigure", m_timer->elapsed() );
+}
+
+
+// ----------------------------------------------------------------------------
+void timing_process_instrumentation::
+configure( kwiver::vital::config_block_sptr const conf )
+{
+  // Starting with our generated vital::config_block to ensure that assumed values are present
+  // An alternative is to check for key presence before performing a get_value() call.
+  auto local_config = get_configuration();
+  local_config->merge_config( conf );
+
+  timer_type tt = local_config->get_enum_value<timer_converter>( "type" );
+  std::string type_name;
+
+  switch (tt)
+  {
+  case timer_type::timer_wall:
+    m_timer = std::make_shared<kwiver::vital::wall_timer>();
+    type_name = "wall_clock_duration";
+    break;
+
+  case timer_type::timer_cpu:
+    m_timer = std::make_shared<kwiver::vital::cpu_timer>();
+    type_name = "cpu_clock_duration";
+    break;
+  } // end switch
+
+  // Get file name and create output file.
+  std::string fname = local_config->get_value<std::string>( "output_file" );
+  m_output_file = new std::ofstream( fname );
+  if (! *m_output_file)
+  {
+    LOG_WARN( m_logger, "Unable to open output file \"" << fname
+              << "\" for process " << process()->name()
+              <<". Disabling output." );
+    delete m_output_file;
+    m_output_file = 0; // disable output
+    return;
+  }
+
+  *m_output_file << "#  method," << type_name << std::endl;
+
+}
+
+
+// ----------------------------------------------------------------------------
+kwiver::vital::config_block_sptr
+timing_process_instrumentation::
+get_configuration() const
+{
+  auto conf = kwiver::vital::config_block::empty_config();
+
+  conf->set_value( "type", "wall",
+                   "Type of timer to use. Allowable values are 'wall', and 'cpu'. "
+                   "Wall timer measures the elapsed time within the process method. "
+                   "Cpu timer measures the amount of cpu time used in that method. "
+                   "This may be different from the wall time if multiple cpu's are being used." );
+
+  std::string process_name( "process" );
+  if (process())
+  {
+    process_name = process()->name();
+  }
+
+  conf->set_value( "output_file", process_name + "_timing.csv",
+                   "Name of the output file where the timing data is written." );
+
+  return conf;
+}
+
+
+// ----------------------------------------------------------------------------
+void
+timing_process_instrumentation::
+write_interval( const std::string& tag, double interval )
+{
+  if ( m_output_file == 0 )
+  {
+    return;
+  }
+
+  *m_output_file << tag << "," << std::fixed
+                 << interval << std::endl;
+}
+
+} // end namespace

--- a/extras/process_instrumentation/timing_process_instrumentation.h
+++ b/extras/process_instrumentation/timing_process_instrumentation.h
@@ -1,0 +1,102 @@
+/*ckwg +29
+ * Copyright 2016 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for process instrumentation.
+ */
+
+#ifndef SPROKIT_TIMING_PROCESS_INSTRUMENTATION_H
+#define SPROKIT_TIMING_PROCESS_INSTRUMENTATION_H
+
+#include "instrumentation_plugin_export.h"
+
+#include <sprokit/pipeline/process_instrumentation.h>
+#include <vital/logger/logger.h>
+#include <vital/util/wall_timer.h>
+#include <vital/util/cpu_timer.h>
+
+#include <memory>
+
+namespace sprokit {
+
+// -----------------------------------------------------------------
+/**
+ * \brief Process instrumentation using the logger.
+ *
+ * This class provides an implementation of process instrumentation
+ * where each event is recorded to the logger.
+ *
+ ** Note: The current implementation does not handle reentrant processes.
+ */
+class INSTRUMENTATION_PLUGIN_NO_EXPORT timing_process_instrumentation
+  : public process_instrumentation
+{
+public:
+  timing_process_instrumentation();
+  virtual ~timing_process_instrumentation();
+
+  virtual void start_init_processing( std::string const& data );
+  virtual void stop_init_processing();
+
+  virtual void start_reset_processing( std::string const& data );
+  virtual void stop_reset_processing();
+
+  virtual void start_flush_processing( std::string const& data );
+  virtual void stop_flush_processing();
+
+  virtual void start_step_processing( std::string const& data );
+  virtual void stop_step_processing();
+
+  virtual void start_configure_processing( std::string const& data );
+  virtual void stop_configure_processing();
+
+  virtual void start_reconfigure_processing( std::string const& data );
+  virtual void stop_reconfigure_processing();
+
+  virtual void configure( kwiver::vital::config_block_sptr const conf );
+  virtual kwiver::vital::config_block_sptr get_configuration() const;
+
+private:
+  void write_interval( const std::string& tag, double interval );
+
+  // The configured timer is allocated and stored here.
+  std::shared_ptr<kwiver::vital::timer> m_timer;
+
+  // The output file
+  std::ofstream* m_output_file;
+
+  kwiver::vital::logger_handle_t m_logger;
+
+}; // end class timing_process_instrumentation
+
+} // end namespace
+
+#endif // SPROKIT_TIMING_PROCESS_INSTRUMENTATION_H

--- a/sprokit/processes/core/draw_detected_object_set_process.h
+++ b/sprokit/processes/core/draw_detected_object_set_process.h
@@ -66,6 +66,6 @@ private:
 
   class priv;
   std::unique_ptr< priv > d;
-};   // end class stabilize_image
+};   // end class
 
 } // end namespace

--- a/sprokit/processes/python/homography_writer.py
+++ b/sprokit/processes/python/homography_writer.py
@@ -37,7 +37,7 @@ class HomographyWriterProcess(sprokit.pipeline.process.PythonProcess):
 
         #self.declare_input_port('homography', info)
         #                        name, type, flags, descrip
-        self.declare_input_port('homography', 's2r_homography', required, 'Input homographies' )
+        self.declare_input_port('homography', 'kwiver:s2r_homography', required, 'Input homographies' )
 
     # ----------------------------------------------------------------
     def _configure(self):

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,5 +60,14 @@ void
 process_instrumentation::
 configure( kwiver::vital::config_block_sptr const config )
 { }
+
+
+kwiver::vital::config_block_sptr
+process_instrumentation::
+get_configuration() const
+{
+  auto conf = kwiver::vital::config_block::empty_config();
+  return conf;
+}
 
 } // end namespace sprokit

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.h
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -86,16 +86,28 @@ public:
    * @brief Get process that is being instrumented.
    *
    *
-   * @return Reference to process object.
+   * @return Pointer to process object.
    */
-  sprokit::process const& process() const { return *m_process; }
+  sprokit::process const* process() const { return m_process; }
 
   /**
    * @brief Configure provider.
    *
+   * This method sends the config block to the implementation.
+   *
    * @param conf Configuration block.
    */
   virtual void configure( kwiver::vital::config_block_sptr const conf );
+
+  /**
+   * @brief Get default configuration block.
+   *
+   * This method returns the default configuration block for this
+   * instrumentation implementation.
+   *
+   * @return Pointer to config block.
+   */
+  virtual kwiver::vital::config_block_sptr get_configuration() const;
 
 private:
   sprokit::process const* m_process;

--- a/vital/util/enum_converter.h
+++ b/vital/util/enum_converter.h
@@ -75,7 +75,7 @@ std::string name = ec.to_string( one );
  *
 \code
 // Converter implemented as a derived type using MACRO helper
-ENUM_CONVERSION( my_ec, numbers,
+ENUM_CONVERTER( my_ec, numbers,
       { "ONE", one },
       { "TWO", two },
       { "THREE", three },


### PR DESCRIPTION
Added a new process instrumentation variant that writes the method time to a CSV file. This instrumentation type is designed to assist in doing process timing analysis. Process timing can be generated on a per-process basis by enabling process instrumentation for a process.  This is done in the pipe file as follows:

    process my_process :: image_reader
      block _instrumentation
        type = timer  # select timing instrumentation
        timer:type = cpu  # valid types are cpu and wall
      endblock

An optional config entry for "output_file" can be used to specify a non-default file name. The default name is <process-name>_timing.csv. In the above example, the file name would be "my_process_timing.csv"

  