### PR TITLE
fix config bug

### DIFF
--- a/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
@@ -324,6 +324,12 @@ extract_configuration_from_decls( bakery_base::config_decls_t& configs )
     // create config entry
     conf->set_value( key, val );
 
+    // Set location if available
+    if ( info.defined_loc.valid() )
+    {
+      conf->set_location( key, info.defined_loc );
+    }
+
     if ( info.read_only )
     {
       conf->mark_read_only( key );

--- a/sprokit/src/sprokit/tools/build_pipeline_from_options.cxx
+++ b/sprokit/src/sprokit/tools/build_pipeline_from_options.cxx
@@ -55,8 +55,6 @@ build_pipeline_from_options( boost::program_options::variables_map const& vm,
   kwiver::vital::path_t const ipath = vm["pipeline"].as<kwiver::vital::path_t>();
   istream_t const istr = open_istream(ipath);
 
-  /// \todo Include paths?
-
   this->load_pipeline(*istr, ipath);
   this->load_from_options(vm);
 }

--- a/vital/algo/algorithm.cxx
+++ b/vital/algo/algorithm.cxx
@@ -173,8 +173,20 @@ algorithm
     }
     else
     {
-      LOG_WARN( logger, "Could not find implementation \"" << iname
-                << "\" for \"" << type_name << "\"." );
+      std::stringstream msg;
+      msg << "Could not find implementation \"" << iname
+          << "\" for \"" << type_name << "\"";
+
+      // Add line number if known
+      std::string file;
+      int line(0);
+      if ( config->get_location( type_key, file, line ) )
+      {
+        msg << " as requested from "
+                << file << ":" << line;
+      }
+
+      LOG_WARN( logger, msg.str() );
     }
   }
   else


### PR DESCRIPTION
This PR fixes the problem where the location of the definition of a config item was not copied to the config block made available to the process. Also improved error message to include location of config entry (if available) when algorithm configuration fails.