### PR TITLE
This test fails or succeeds depending on which logger back end is used.

### DIFF
--- a/vital/logger/tests/test_logger.cxx
+++ b/vital/logger/tests/test_logger.cxx
@@ -77,9 +77,6 @@ TEST(logger, levels)
   EXPECT_TRUE( IS_FATAL_ENABLED( log2 ) );
 
   EXPECT_EQ( kwiver_logger::LEVEL_DEBUG, log2->get_level() );
-
-  // test to see if we get the same logger back
-  EXPECT_EQ( log2, get_logger( "main.logger2" ) );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If the test can not reliably pass, then it should be removed.
Getting the same pointer from two get_logger() calls is making too
many assumptions about the logger implementation.