### PR TITLE
Fix logger "sameness" assertion

### DIFF
--- a/vital/logger/tests/test_logger.cxx
+++ b/vital/logger/tests/test_logger.cxx
@@ -78,8 +78,17 @@ TEST(logger, levels)
 
   EXPECT_EQ( kwiver_logger::LEVEL_DEBUG, log2->get_level() );
 
-  // test to see if we get the same logger back
-  EXPECT_EQ( log2, get_logger( "main.logger2" ) );
+  // Test to see if we get the same logger back
+  // Note: some implementations may give back an identical pointer, but others
+  // may not, so instead compare that their log level is synchronized
+  auto log = get_logger( "main.logger2" );
+
+  EXPECT_EQ( kwiver_logger::LEVEL_DEBUG, log->get_level() );
+
+  log2->set_level( kwiver_logger::LEVEL_INFO );
+
+  EXPECT_EQ( kwiver_logger::LEVEL_INFO, log2->get_level() );
+  EXPECT_EQ( kwiver_logger::LEVEL_INFO, log->get_level() );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Relax assertion that requesting a logger by name multiple times gives back the same pointer, as this is apparently not true for all implementations. Instead, restore the pre-#311 assertion that the second reference has the same log level, and extend this to verifying that the second reference's log level changes when the log level is changed via the first reference.

(Supersedes #397.)