### PR TITLE
Fix misordered lines in registration.cxx

### DIFF
--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -114,8 +114,8 @@ register_factories(kwiver::vital::plugin_loader& vpm)
  */
 void _load_python_library_symbols()
 {
-#ifdef SPROKIT_LOAD_PYLIB_SYM
   auto logger = kwiver::vital::get_logger("sprokit.python_modules");
+#ifdef SPROKIT_LOAD_PYLIB_SYM
 
   const char *env_pylib = kwiversys::SystemTools::GetEnv( "PYTHON_LIBRARY" );
 


### PR DESCRIPTION
"logger" is defined within an ifdef, but is later used in the else block. The definition was moved before the ifdef so both blocks can use it.