### PR TITLE
Add timeout to Google Test discovery

### DIFF
--- a/CMake/future/3.10/GoogleTestAddTests.cmake
+++ b/CMake/future/3.10/GoogleTestAddTests.cmake
@@ -29,6 +29,7 @@ if(NOT EXISTS "${TEST_EXECUTABLE}")
 endif()
 execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --gtest_list_tests
+  TIMEOUT 30
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
 )


### PR DESCRIPTION
Tweak Google Test discovery to abort if the test executable fails to complete within 30 seconds. This is a work-around for the `thread_pool` test which is currently hanging on our Windows dashboard build for reasons not-yet-known. (Curiously, it only hangs when given `--gtest_list_tests`; when the tests actually run, they pass, and the executable exits normally.)

This is not currently upstream, but I intend to submit a version of this for inclusion in CMake 3.10.1.