### PR TITLE
Converting boost::any to vital::any

### DIFF
--- a/sprokit/processes/bindings/c/vital_type_converters.cxx
+++ b/sprokit/processes/bindings/c/vital_type_converters.cxx
@@ -48,7 +48,7 @@ more python friendly types.
 
 #include <sprokit/pipeline/datum.h>
 
-#include <boost/any.hpp>
+#include <vital/any.h>
 
 #include <vector>
 #include <memory>
@@ -126,17 +126,17 @@ vital_image_container_from_datum( PyObject* args )
 
   try
   {
-    // Get boost::any from the datum
-    boost::any const any = dptr->get_datum< boost::any > ();
+    // Get kwiver::vital::any from the datum
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any > ();
 
-    // Get sptr from boost::any
-    kwiver::vital::image_container_sptr sptr = boost::any_cast< kwiver::vital::image_container_sptr > ( any );
+    // Get sptr from kwiver::vital::any
+    kwiver::vital::image_container_sptr sptr = kwiver::vital::any_cast< kwiver::vital::image_container_sptr > ( any );
 
     // Register this object with the main image_container interface
     vital_image_container_t* ptr =  vital_image_container_from_sptr( sptr );
     return ptr;
   }
-  catch ( boost::bad_any_cast const& e )
+  catch ( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an
@@ -198,17 +198,17 @@ vital_detected_object_set_from_datum( PyObject* args )
 
   try
   {
-    // Get boost::any from the datum
-    boost::any const any = dptr->get_datum< boost::any > ();
+    // Get kwiver::vital::any from the datum
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any > ();
 
-    // Get sptr from boost::any
-    kwiver::vital::detected_object_set_sptr sptr = boost::any_cast< kwiver::vital::detected_object_set_sptr > ( any );
+    // Get sptr from kwiver::vital::any
+    kwiver::vital::detected_object_set_sptr sptr = kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr > ( any );
 
     // Register this object with the main detected_object_set interface
     vital_detected_object_set_t* ptr = vital_detected_object_set_from_sptr( sptr );
     return ptr;
   }
-  catch ( boost::bad_any_cast const& e )
+  catch ( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an
@@ -265,11 +265,11 @@ double_vector_from_datum( PyObject* args )
 
   try
   {
-    // Get boost::any from the datum
-    boost::any const any = dptr->get_datum< boost::any > ();
+    // Get kwiver::vital::any from the datum
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any > ();
 
-    // Get sptr from boost::any
-    double_vector_sptr sptr = boost::any_cast< double_vector_sptr > ( any );
+    // Get sptr from kwiver::vital::any
+    double_vector_sptr sptr = kwiver::vital::any_cast< double_vector_sptr > ( any );
     size_t num_elem = sptr->size();
 
     // make C compatible array of doubles
@@ -283,7 +283,7 @@ double_vector_from_datum( PyObject* args )
 
     return retval;
   }
-  catch ( boost::bad_any_cast const& e )
+  catch ( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an
@@ -355,14 +355,14 @@ vital_trackset_from_datum( PyObject* args )
 
   try
   {
-    boost::any const any = dptr->get_datum< boost::any > ();
-    kwiver::vital::track_set_sptr sptr = boost::any_cast< kwiver::vital::track_set_sptr > ( any );
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any > ();
+    kwiver::vital::track_set_sptr sptr = kwiver::vital::any_cast< kwiver::vital::track_set_sptr > ( any );
 
     // Register this object with the main track_set interface
     vital_trackset_t* ptr =  vital_trackset_from_sptr( reinterpret_cast< void* > ( &sptr ) );
     return ptr;
   }
-  catch ( boost::bad_any_cast const& e )
+  catch ( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an
@@ -384,10 +384,10 @@ vital_string_vector_from_datum( PyObject *args,
 
   try
   {
-    // Get boost::any from the datum
-    boost::any const any = dptr->get_datum< boost::any >();
-    // Get sptr from boost::any
-    string_vector_sptr sptr = boost::any_cast< string_vector_sptr >( any );
+    // Get kwiver::vital::any from the datum
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any >();
+    // Get sptr from kwiver::vital::any
+    string_vector_sptr sptr = kwiver::vital::any_cast< string_vector_sptr >( any );
 
     // Set size and allocate output array memory
     (*out_size) = sptr->size();
@@ -409,7 +409,7 @@ vital_string_vector_from_datum( PyObject *args,
 
     return;
   }
-  catch ( boost::bad_any_cast const& e )
+  catch ( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an
@@ -455,9 +455,9 @@ vital_descriptor_set_from_datum( PyObject *args )
 
   try
   {
-    boost::any const any = dptr->get_datum< boost::any >();
+    kwiver::vital::any const any = dptr->get_datum< kwiver::vital::any >();
     kwiver::vital::descriptor_set_sptr sptr =
-      boost::any_cast< kwiver::vital::descriptor_set_sptr >( any );
+      kwiver::vital::any_cast< kwiver::vital::descriptor_set_sptr >( any );
 
     eh = vital_eh_new();
     if( NULL == eh )
@@ -474,7 +474,7 @@ vital_descriptor_set_from_datum( PyObject *args )
       throw eh->message;
     }
   }
-  catch( boost::bad_any_cast const& e )
+  catch( kwiver::vital::bad_any_cast const& e )
   {
     // This is a warning because this converter should only be called
     // if there is good reason to believe that the object really is an

--- a/sprokit/processes/bindings/c/vital_type_converters.h
+++ b/sprokit/processes/bindings/c/vital_type_converters.h
@@ -71,7 +71,7 @@ PyObject* double_vector_to_datum( PyObject* list );
 VITAL_TYPE_CONVERTERS_EXPORT
 vital_trackset_t* vital_trackset_from_datum( PyObject* dptr );
 
-/// Convert a sprokit::datum boost::any value into an array of null-terminated
+/// Convert a sprokit::datum vital::any value into an array of null-terminated
 /// strings.
 /**
  * \param args sprokit datum wrapped in a PyCapsule object.

--- a/sprokit/processes/bindings/python/kwiver/kwiver_process.py
+++ b/sprokit/processes/bindings/python/kwiver/kwiver_process.py
@@ -60,7 +60,7 @@ class KwiverProcess(process.PythonProcess):
         """This class represents a single type trait. It binds together
         trait_name: name of this type specification used with other
         traits canonical type name: official system level type name
-        string.  conv: function to convert data from boost::any to
+        string.  conv: function to convert data from vital::any to
         real type.
 
         The convert function takes in a "datum" and returns the correct type/

--- a/sprokit/src/bindings/python/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/bindings/python/sprokit/pipeline/CMakeLists.txt
@@ -12,7 +12,8 @@ _sprokit_add_python_library(datum
   datum.cxx)
 target_link_libraries(python-sprokit.pipeline-datum
   PRIVATE             sprokit_pipeline
-                      sprokit_python_util)
+                      sprokit_python_util
+                      vital_util)
 
 _sprokit_add_python_library(edge
   sprokit/pipeline
@@ -43,7 +44,8 @@ _sprokit_add_python_library(process
   process.cxx)
 target_link_libraries(python-sprokit.pipeline-process
   PRIVATE             sprokit_pipeline
-                      sprokit_python_util)
+                      sprokit_python_util
+                      vital_util)
 
 _sprokit_add_python_library(process_cluster
   sprokit/pipeline

--- a/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
@@ -33,7 +33,7 @@
 #pragma warning (disable : 4244)
 #endif
 #include <pybind11/pybind11.h>
-#include <boost/any.hpp>
+#include <vital/any.h>
 #include <boost/cstdint.hpp>
 #if WIN32
 #pragma warning (pop)
@@ -134,7 +134,7 @@ PYBIND11_MODULE(datum, m)
 // ------------------------------------------------------------------
 
 // For now, we need to manually specify how we want to cast our datum
-// This should be fixed when we move away from boost::any
+// This should be fixed when we move away from kwiver::vital::any
 sprokit::datum
 new_datum(object const& obj)
 {
@@ -201,8 +201,8 @@ datum_get_datum(sprokit::datum const& self)
   object dat = none();
   if ( self.type() == sprokit::datum::data )
   {
-    boost::any const any = self.get_datum<boost::any>();
-    dat = boost::any_cast<object>(any);
+    kwiver::vital::any const any = self.get_datum<kwiver::vital::any>();
+    dat = kwiver::vital::any_cast<object>(any);
   }
 
   return dat;
@@ -211,7 +211,7 @@ datum_get_datum(sprokit::datum const& self)
 std::string
 datum_datum_type(sprokit::datum const& self)
 {
-  boost::any const any = self.get_datum<boost::any>();
+  kwiver::vital::any const any = self.get_datum<kwiver::vital::any>();
 
   return any.type().name();
 }

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -781,34 +781,34 @@ grab_value_from_port(sprokit::process &self, sprokit::process::port_t const& por
 {
   sprokit::process* self_ptr = &self;
   sprokit::datum_t const dat = ((wrap_process*) self_ptr)->grab_datum_from_port(port);
-  boost::any const any = dat->get_datum<boost::any>();
+  kwiver::vital::any const any = dat->get_datum<kwiver::vital::any>();
 
-  //boost::any and pybind11::object don't play nice, so we have to try different types
-  //TODO: fix this! preferably by making datum no longer use boost::any
+  //kwiver::vital::any and pybind11::object don't play nice, so we have to try different types
+  //TODO: fix this! preferably by making datum no longer use kwiver::vital::any
   object return_val = none();
   try
   {
-    return_val = boost::any_cast<object>(any);
+    return_val = kwiver::vital::any_cast<object>(any);
   } catch(...){}
   try
   {
-    return_val = cast(boost::any_cast<int>(any));
+    return_val = cast(kwiver::vital::any_cast<int>(any));
   } catch(...){}
   try
   {
-    return_val = cast(boost::any_cast<long>(any));
+    return_val = cast(kwiver::vital::any_cast<long>(any));
   } catch(...){}
   try
   {
-    return_val = cast(boost::any_cast<float>(any));
+    return_val = cast(kwiver::vital::any_cast<float>(any));
   } catch(...){}
   try
   {
-    return_val = cast(boost::any_cast<std::string>(any));
+    return_val = cast(kwiver::vital::any_cast<std::string>(any));
   } catch(...){}
   try
   {
-    return_val = cast(boost::any_cast<char*>(any));
+    return_val = cast(kwiver::vital::any_cast<char*>(any));
   } catch(...){}
 
   return return_val;
@@ -824,7 +824,7 @@ push_datum_to_port(sprokit::process &self, sprokit::process::port_t const& port,
 void
 push_value_to_port(sprokit::process &self, sprokit::process::port_t const& port, object const& obj)
 {
-  boost::any const any = obj;
+  kwiver::vital::any const any = obj;
   sprokit::datum_t const dat = sprokit::datum::new_datum(any);
 
   sprokit::process* self_ptr = &self;

--- a/sprokit/src/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/sprokit/pipeline/datum.cxx
@@ -42,7 +42,7 @@ namespace sprokit {
 
 // ------------------------------------------------------------------
 datum_t
-datum::new_datum(boost::any const& dat)
+datum::new_datum(kwiver::vital::any const& dat)
 {
   return datum_t(new datum(dat));
 }
@@ -101,7 +101,7 @@ datum
   return m_error;
 }
 
-static bool any_equal(boost::any const& a, boost::any const& b);
+static bool any_equal(kwiver::vital::any const& a, kwiver::vital::any const& b);
 
 
 // ------------------------------------------------------------------
@@ -169,7 +169,7 @@ datum
 
 // ------------------------------------------------------------------
 datum
-::datum(boost::any const& dat)
+::datum(kwiver::vital::any const& dat)
   : m_type(data)
   , m_error()
   , m_datum(dat)
@@ -245,7 +245,7 @@ bad_datum_cast_exception
 
 // ------------------------------------------------------------------
 bool
-any_equal(boost::any const& a, boost::any const& b)
+any_equal(kwiver::vital::any const& a, kwiver::vital::any const& b)
 {
   if (a.empty() && b.empty())
   {

--- a/sprokit/src/sprokit/pipeline/datum.h
+++ b/sprokit/src/sprokit/pipeline/datum.h
@@ -35,7 +35,7 @@
 
 #include "types.h"
 
-#include <boost/any.hpp>
+#include <vital/any.h>
 #include <boost/operators.hpp>
 
 #include <string>
@@ -83,14 +83,14 @@ class SPROKIT_PIPELINE_EXPORT datum
     /**
      * \brief Create a datum with the #data type.
      *
-     * This method is for bindings to be able to create boost::any objects
+     * This method is for bindings to be able to create kwiver::vital::any objects
      * manually.
      *
      * \param dat The data to pass through the edge.
      *
      * \returns A new datum containing a result.
      */
-    static datum_t new_datum(boost::any const& dat);
+    static datum_t new_datum(kwiver::vital::any const& dat);
 
     /**
      * \brief Create a datum with the #data type.
@@ -166,7 +166,7 @@ class SPROKIT_PIPELINE_EXPORT datum
      * \brief Compare two data for equality.
      *
      * \note This returns false for two data packets which point to the same
-     * internal data since \c boost::any does not give access to it without
+     * internal data since \c kwiver::vital::any does not give access to it without
      * knowing the type.
      *
      * \param dat The datum to compare to.
@@ -178,11 +178,11 @@ class SPROKIT_PIPELINE_EXPORT datum
   private:
     SPROKIT_PIPELINE_NO_EXPORT datum(type_t ty);
     SPROKIT_PIPELINE_NO_EXPORT datum(error_t const& err);
-    SPROKIT_PIPELINE_NO_EXPORT datum(boost::any const& dat);
+    SPROKIT_PIPELINE_NO_EXPORT datum(kwiver::vital::any const& dat);
 
     type_t const m_type;
     error_t const m_error;
-    boost::any const m_datum;
+    kwiver::vital::any const m_datum;
 };
 
 /**
@@ -248,7 +248,7 @@ template <typename T>
 datum_t
 datum::new_datum(T const& dat)
 {
-  return new_datum(boost::any(dat));
+  return new_datum(kwiver::vital::any(dat));
 }
 
 template <typename T>
@@ -257,9 +257,9 @@ datum::get_datum() const
 {
   try
   {
-    return boost::any_cast<T>(m_datum);
+    return kwiver::vital::any_cast<T>(m_datum);
   }
-  catch (boost::bad_any_cast const& e)
+  catch (kwiver::vital::bad_any_cast const& e)
   {
     std::string const req_type_name = typeid(T).name();
     std::string const type_name = m_datum.type().name();
@@ -270,7 +270,7 @@ datum::get_datum() const
 
 template <>
 inline
-boost::any
+kwiver::vital::any
 datum::get_datum() const
 {
   return m_datum;

--- a/sprokit/tests/sprokit/pipeline/test_datum.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_datum.cxx
@@ -167,10 +167,10 @@ IMPLEMENT_TEST(equality)
   sprokit::datum_t const error1b = sprokit::datum::error_datum(errorb);
   sprokit::datum_t const error2b = sprokit::datum::error_datum(errorb);
 
-  boost::any const dummy1 = boost::any();
-  boost::any const dummy2 = boost::any();
-  boost::any const in_value1 = boost::any(1);
-  boost::any const in_value2 = boost::any(2);
+  kwiver::vital::any const dummy1 = kwiver::vital::any();
+  kwiver::vital::any const dummy2 = kwiver::vital::any();
+  kwiver::vital::any const in_value1 = kwiver::vital::any(1);
+  kwiver::vital::any const in_value2 = kwiver::vital::any(2);
   sprokit::datum_t const value_dummy1 = sprokit::datum::new_datum(dummy1);
   sprokit::datum_t const value_dummy2 = sprokit::datum::new_datum(dummy2);
   sprokit::datum_t const value1 = sprokit::datum::new_datum(in_value1);

--- a/vital/any.h
+++ b/vital/any.h
@@ -265,8 +265,15 @@ public:
                 std::string const& to_type )
   {
     // Construct helpful message
-    m_message = "vital::bad_any_cast: failed conversion using kwiver::vital::any_cast from type \""
-      + demangle( from_type ) + "\" to type \"" + demangle( to_type ) + "\"";
+    if( from_type != "")
+    {
+      m_message = "vital::bad_any_cast: failed conversion using kwiver::vital::any_cast from type \""
+        + demangle( from_type ) + "\" to type \"" + demangle( to_type ) + "\"";
+    }
+    else
+    {
+      m_message = "vital::bad_any_cast: attempted to cast an uninitialized kwiver::vital::any object";
+    }
   }
 
   virtual ~bad_any_cast() noexcept {}
@@ -338,12 +345,17 @@ inline T
 any_cast( any const& aval )
 {
   // Is the type requested compatible with the type represented.
-  if ( typeid( T ) == aval.m_content->type() )
+  if (aval.m_content)
   {
-    return ( ( any::internal_typed< T >* )aval.m_content )->m_any_data;
+    if ( typeid( T ) == aval.m_content->type() )
+    {
+      return ( ( any::internal_typed< T >* )aval.m_content )->m_any_data;
+    }
+
+    throw bad_any_cast( aval.m_content->type().name(), typeid( T ).name() );
   }
 
-  throw bad_any_cast( aval.m_content->type().name(), typeid( T ).name() );
+  throw bad_any_cast( "", typeid( T ).name() );
 }
 
 } }  // end namespace


### PR DESCRIPTION
For the most part this was a straightforward change. I had to do a minor update to any_cast to make sure the object has actually been instantiated, with a corresponding update to the bad_any_cast error message.