### PR TITLE
Make thread_pool::available_backends static

### DIFF
--- a/vital/util/tests/test_thread_pool.cxx
+++ b/vital/util/tests/test_thread_pool.cxx
@@ -93,4 +93,4 @@ TEST_P(thread_pool_backend, run_jobs)
 INSTANTIATE_TEST_CASE_P(
   ,
   thread_pool_backend,
-  ::testing::ValuesIn( thread_pool::instance().available_backends() ) );
+  ::testing::ValuesIn( thread_pool::available_backends() ) );

--- a/vital/util/thread_pool.cxx
+++ b/vital/util/thread_pool.cxx
@@ -59,13 +59,6 @@ public:
   priv()
     : logger( kwiver::vital::get_logger( "vital.thread_pool" ) )
   {
-    available_backends = {
-#if __APPLE__
-      thread_pool_gcd_backend::static_name,
-#endif
-      thread_pool_builtin_backend::static_name,
-      thread_pool_sync_backend::static_name
-    };
     backend.reset( new thread_pool_builtin_backend() );
   }
 
@@ -74,9 +67,6 @@ public:
 
   // a pointer to the active backend
   std::unique_ptr<thread_pool::backend> backend;
-
-  // a vector of names of the available backends
-  std::vector<std::string> available_backends;
 };
 
 
@@ -113,9 +103,17 @@ thread_pool::active_backend() const
 
 /// Return the names of the available backends
 std::vector<std::string>
-thread_pool::available_backends() const
+thread_pool::available_backends()
 {
-  return d_->available_backends;
+  static std::vector<std::string> available_backends_list = {
+#if __APPLE__
+    thread_pool_gcd_backend::static_name,
+#endif
+    thread_pool_builtin_backend::static_name,
+    thread_pool_sync_backend::static_name
+  };
+
+  return available_backends_list;
 }
 
 

--- a/vital/util/thread_pool.h
+++ b/vital/util/thread_pool.h
@@ -97,7 +97,7 @@ public:
   const char* active_backend() const;
 
   /// Return the names of the available backends
-  std::vector<std::string> available_backends() const;
+  static std::vector<std::string> available_backends();
 
   /// Set the backend
   /**


### PR DESCRIPTION
Change `thread_pool::available_backends` to be a static method. There really is no reason that this needs an instance of the `thread_pool`, and requiring one can get... awkward for the unit test, which needs the list of available backends in order to set up the test cases.

In particular, this works around, but does not really solve, #407, and should be sufficient to get the Windows builds working (at least with respect to this particular issue).