### PR TITLE
Fix race condition in thread_pool

### DIFF
--- a/vital/util/thread_pool_builtin_backend.h
+++ b/vital/util/thread_pool_builtin_backend.h
@@ -125,10 +125,16 @@ void thread_pool_builtin_backend::thread_worker_loop()
 
     {
       std::unique_lock<std::mutex> lock(this->queue_mutex);
-      this->condition.wait(lock,
-        [this]{ return this->stop || !this->tasks.empty(); });
+
+      if (!this->stop)
+      {
+        this->condition.wait(lock,
+          [this]{ return this->stop || !this->tasks.empty(); });
+      }
+
       if(this->stop && this->tasks.empty())
         return;
+
       task = std::move(this->tasks.front());
       this->tasks.pop();
     }


### PR DESCRIPTION
Fix a potential race condition in the `thread_pool` built-in backend, where we could try to notify the worker threads to shut down before they are waiting on the condition variable, leading to a deadlock.

See also https://stackoverflow.com/questions/15912322.

This is part of an unsuccessful attempt at addressing #407, but does not seem to help. However, it looks to me like this is nevertheless a correct change. However, this is my first time using C++11 `conditional_variable`, and my threading in general is a little rusty, so please ***review this carefully***. Since this does *not* solve #407, there is no urgency as far as when this lands.