### PR TITLE
Fix loading plugins from built-in paths on multi-config generators

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -386,7 +386,7 @@ macro( kwiver_make_module_path    root subdir )
   if (WIN32)
     set(kwiver_module_path_result   "${root}/lib/${subdir}" )
     if(KWIVER_USE_CONFIGURATION_SUBDIRECTORY)
-      list( APPEND  kwiver_module_path_result   "${root}/lib/$<CONFIGURATION>${subdir}" )
+      list( APPEND  kwiver_module_path_result   "${root}/lib/$<CONFIGURATION>/${subdir}" )
     endif()
   else()  # Other Unix systems
     set(kwiver_module_path_result  "${root}/lib${LIB_SUFFIX}/${subdir}" )

--- a/vital/plugin_loader/plugin_manager.cxx
+++ b/vital/plugin_loader/plugin_manager.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,6 +122,12 @@ plugin_manager()
 
   // Add the built-in search path
   ST::Split( default_module_paths, m_priv->m_search_paths, PATH_SEPARATOR_CHAR );
+#ifdef CMAKE_INTDIR
+  for ( auto& p : m_priv->m_search_paths )
+  {
+    ST::ReplaceString( p, "$<CONFIGURATION>", CMAKE_INTDIR );
+  }
+#endif
 
   // Add paths to the real loader
   m_priv->m_loader->add_search_path( m_priv->m_search_paths );


### PR DESCRIPTION
Fix two problems with the built-in plugin paths on multi-generator builds:

- The configuration and path suffix were missing a path separator between them, resulting in paths like `Releasemodules` rather than the intended `Release/modules`.
- Generator expressions are not expanded in configured files (which is how we are injecting the built-in paths, since using a compile flag to directly inject the paths would run afoul of quoting issues), and so must be manually expanded in the C++ code.

This should fix about 80% – 90% of the failing tests on Windows CI.