### PR TITLE
track-oracle plumbing for KPF geometry

### DIFF
--- a/CMake/kwiver-depends-kpf.cmake
+++ b/CMake/kwiver-depends-kpf.cmake
@@ -4,5 +4,8 @@ option( KWIVER_ENABLE_KPF
   "Enable kpf i/o for vital types"
   ${fletch_ENABLED_YAMLCPP}
 )
-# Mark this as advanced 
+# Mark this as advanced
 mark_as_advanced( KWIVER_ENABLE_KPF )
+if (KWIVER_ENABLE_KPF )
+  add_definitions( -DKWIVER_ENABLE_KPF )
+endif()

--- a/arrows/kpf/yaml/kpf_canonical_io.h
+++ b/arrows/kpf/yaml/kpf_canonical_io.h
@@ -119,6 +119,14 @@ struct KPF_YAML_EXPORT writer< canonical::conf_t >
 };
 
 template<>
+struct KPF_YAML_EXPORT writer< canonical::eval_t >
+{
+  writer( double c, int d ): eval(c), domain(d) {}
+  canonical::eval_t eval;
+  int domain;
+};
+
+template<>
 struct KPF_YAML_EXPORT writer< canonical::meta_t >
 {
   writer( const std::string& t ): meta(t) {}
@@ -210,6 +218,14 @@ struct KPF_YAML_EXPORT reader< canonical::conf_t >
 {
   reader( double& c, int d): conf(c), domain(d) {}
   double& conf;
+  int domain;
+};
+
+template <>
+struct KPF_YAML_EXPORT reader< canonical::eval_t >
+{
+  reader( double& s, int d): score(s), domain(d) {}
+  double& score;
   int domain;
 };
 

--- a/arrows/kpf/yaml/kpf_canonical_types.h
+++ b/arrows/kpf/yaml/kpf_canonical_types.h
@@ -89,6 +89,12 @@ struct KPF_YAML_EXPORT conf_t
   explicit conf_t( double conf ): d(conf) {}
 };
 
+struct KPF_YAML_EXPORT eval_t
+{
+  double d;
+  explicit eval_t( double score ): d(score) {}
+};
+
 struct KPF_YAML_EXPORT poly_t
 {
   enum {IMAGE_COORDS = 0};

--- a/arrows/kpf/yaml/kpf_packet.h
+++ b/arrows/kpf/yaml/kpf_packet.h
@@ -82,7 +82,7 @@ enum class KPF_YAML_EXPORT packet_style
  *
  */
 
-  struct KPF_YAML_EXPORT packet_header_t
+struct KPF_YAML_EXPORT packet_header_t
 {
   enum { NO_DOMAIN = -1 };
 
@@ -90,7 +90,7 @@ enum class KPF_YAML_EXPORT packet_style
   int domain;
   packet_header_t(): style( packet_style::INVALID ), domain( NO_DOMAIN ) {}
   packet_header_t( packet_style s, int d ): style(s), domain(d) {}
-  packet_header_t( packet_style s ): style(s), domain( NO_DOMAIN ) {}
+  explicit packet_header_t( packet_style s ): style(s), domain( NO_DOMAIN ) {}
 };
 
 /**

--- a/arrows/kpf/yaml/kpf_yaml_writer.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_writer.cxx
@@ -106,6 +106,14 @@ operator<<( record_yaml_writer& w, const writer< canonical::conf_t >& io)
 }
 
 record_yaml_writer&
+operator<<( record_yaml_writer& w, const writer< canonical::eval_t >& io)
+{
+  w.ensure_start();
+  w.s << "eval" << io.domain << ": " << io.eval.d << ", ";
+  return w;
+}
+
+record_yaml_writer&
 operator<<( record_yaml_writer& w, const writer< canonical::poly_t >& io)
 {
   w.ensure_start();

--- a/arrows/kpf/yaml/kpf_yaml_writer.h
+++ b/arrows/kpf/yaml/kpf_yaml_writer.h
@@ -59,6 +59,7 @@ public:
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::timestamp_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::kv_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::conf_t >& io );
+  friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::eval_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::poly_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::meta_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::timestamp_range_t >& io );
@@ -90,6 +91,9 @@ record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::
 
 KPF_YAML_EXPORT
 record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::conf_t >& io );
+
+KPF_YAML_EXPORT
+record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::eval_t >& io );
 
 KPF_YAML_EXPORT
 record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::poly_t >& io );

--- a/track_oracle/core/element_store.h
+++ b/track_oracle/core/element_store.h
@@ -35,6 +35,7 @@ public:
   virtual bool exists( const track_handle_type& h ) const;
   virtual bool exists( const frame_handle_type& h ) const;
   virtual bool exists( const oracle_entry_handle_type& h ) const;
+  virtual std::vector< bool > exists( const std::vector< oracle_entry_handle_type >& sorted_hlist ) const;
 
   virtual bool remove( const track_handle_type& h );
   virtual bool remove( const frame_handle_type& h );

--- a/track_oracle/core/element_store.txx
+++ b/track_oracle/core/element_store.txx
@@ -79,6 +79,57 @@ element_store<T>
   return (p != this->storage.end() );
 }
 
+template< typename T >
+vector< bool >
+element_store<T>
+::exists( const vector< oracle_entry_handle_type>& sorted_hlist ) const
+{
+  vector< bool > ret( sorted_hlist.size(), false );
+  if (sorted_hlist.empty())
+  {
+    return ret;
+  }
+
+  size_t ret_index(0), hlist_size( sorted_hlist.size() );
+  typename map<oracle_entry_handle_type, T>::const_iterator p = this->storage.lower_bound( sorted_hlist[0] );
+  typename map<oracle_entry_handle_type, T>::const_iterator e = this->storage.end();
+
+  bool keep_going = (p != e) && (ret_index < hlist_size);
+  while (keep_going)
+  {
+    //
+    // each time through the loop, we either
+    //
+    // 1) if p->first < sorted_hlist[ret_index], increment p
+    //
+    // or
+    //
+    // 2) if p->first == sorted_hlist[ret_index], set return flag and increment both
+    //
+    // or
+    //
+    // 3) if p->first > sorted_hlist[ret_index], increment ret_index
+
+    oracle_entry_handle_type left(p->first), right( sorted_hlist[ ret_index ]);
+    if (left < right)
+    {
+      keep_going = (++p != e);
+    }
+    else if (left == right)
+    {
+      ret[ ret_index ] = true;
+      keep_going = ((++p != e) && (++ret_index < hlist_size));
+    }
+    else
+    {
+      keep_going = (++ret_index < hlist_size);
+    }
+
+  }
+
+  return ret;
+}
+
 template< typename T>
 bool
 element_store<T>

--- a/track_oracle/core/element_store_base.h
+++ b/track_oracle/core/element_store_base.h
@@ -38,6 +38,7 @@ public:
   virtual bool exists( const track_handle_type& h ) const = 0;
   virtual bool exists( const frame_handle_type& h ) const = 0;
   virtual bool exists( const oracle_entry_handle_type& h ) const = 0;
+  virtual std::vector< bool > exists( const std::vector< oracle_entry_handle_type >& sorted_hlist ) const = 0;
 
   virtual bool copy_value( const oracle_entry_handle_type& src, const oracle_entry_handle_type& dst ) = 0;
   virtual std::ostream& emit_as_kwiver( std::ostream& os, const oracle_entry_handle_type& h, const std::string& indent ) const = 0;

--- a/track_oracle/core/track_oracle_core.cxx
+++ b/track_oracle/core/track_oracle_core.cxx
@@ -81,6 +81,13 @@ track_oracle_core
   return track_oracle_core::get_instance().fields_at_row( row );
 }
 
+vector< vector< field_handle_type > >
+track_oracle_core
+::fields_at_rows( const vector< oracle_entry_handle_type > rows )
+{
+  return track_oracle_core::get_instance().fields_at_rows( rows );
+}
+
 oracle_entry_handle_type
 track_oracle_core
 ::get_next_handle()

--- a/track_oracle/core/track_oracle_core.cxx
+++ b/track_oracle/core/track_oracle_core.cxx
@@ -39,6 +39,13 @@ track_oracle_core
   return *track_oracle_core::impl;
 }
 
+vector< field_handle_type >
+track_oracle_core
+::get_all_field_handles()
+{
+  return track_oracle_core::get_instance().get_all_field_handles();
+}
+
 field_handle_type
 track_oracle_core
 ::lookup_by_name( const string& name )

--- a/track_oracle/core/track_oracle_core.h
+++ b/track_oracle/core/track_oracle_core.h
@@ -41,6 +41,7 @@ public:
   // introducing new elements (aka inserting new columns)
   //
 
+  static std::vector<field_handle_type> get_all_field_handles();
   static field_handle_type lookup_by_name( const std::string& name );
   static element_descriptor get_element_descriptor( field_handle_type f );
   static const element_store_base* get_element_store_base( field_handle_type f );

--- a/track_oracle/core/track_oracle_core.h
+++ b/track_oracle/core/track_oracle_core.h
@@ -55,6 +55,7 @@ public:
 
   template< typename T > static void remove_field( oracle_entry_handle_type row, field_handle_type field );
   static std::vector< field_handle_type > fields_at_row( oracle_entry_handle_type row );
+  static std::vector< std::vector< field_handle_type > > fields_at_rows( const std::vector<oracle_entry_handle_type> rows );
 
   static handle_list_type get_domain( domain_handle_type domain );
   static domain_handle_type lookup_domain( const std::string& domain_name, bool create_if_not_found );

--- a/track_oracle/core/track_oracle_core_impl.cxx
+++ b/track_oracle/core/track_oracle_core_impl.cxx
@@ -143,6 +143,19 @@ track_oracle_core_impl
   }
 }
 
+vector< field_handle_type >
+track_oracle_core_impl
+::get_all_field_handles() const
+{
+ boost::unique_lock< boost::mutex > lock( this->api_lock );
+ vector< field_handle_type > ret;
+ for (const auto p: this->name_pool)
+ {
+   ret.push_back( p.second );
+ }
+ return ret;
+}
+
 field_handle_type
 track_oracle_core_impl
 ::unlocked_lookup_by_name( const string& name ) const

--- a/track_oracle/core/track_oracle_core_impl.cxx
+++ b/track_oracle/core/track_oracle_core_impl.cxx
@@ -248,6 +248,31 @@ track_oracle_core_impl
   return ret;
 }
 
+vector< vector< field_handle_type > >
+track_oracle_core_impl
+::fields_at_rows( const vector<oracle_entry_handle_type>& rows ) const
+{
+  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  vector< vector< field_handle_type > > ret( rows.size() );
+
+  vector< oracle_entry_handle_type > sorted_rows( rows );
+  std::sort( sorted_rows.begin(), sorted_rows.end() );
+
+  for (map< field_handle_type, element_store_base* >::const_iterator i = this->element_pool.begin();
+       i != this->element_pool.end();
+       ++i)
+  {
+    auto exists_list = i->second->exists( rows );
+    for (auto j=0; j<exists_list.size(); ++j)
+    {
+      if (exists_list[j])
+      {
+        ret[j].push_back( i->first );
+      }
+    }
+  }
+  return ret;
+}
 
 oracle_entry_handle_type
 track_oracle_core_impl

--- a/track_oracle/core/track_oracle_core_impl.h
+++ b/track_oracle/core/track_oracle_core_impl.h
@@ -139,6 +139,9 @@ public:
   // return fields which have entries at this row
   std::vector< field_handle_type > fields_at_row( oracle_entry_handle_type row ) const;
 
+  // return fields which have entries for these rows (faster than one-at-time calls to above)
+  std::vector< std::vector< field_handle_type > > fields_at_rows( const std::vector< oracle_entry_handle_type >& rows ) const;
+
   // return the row containing the value-- return first if multiple; probably should alert somehow
   template< typename T> oracle_entry_handle_type lookup( field_handle_type field, const T& val, domain_handle_type domain );
 

--- a/track_oracle/core/track_oracle_core_impl.h
+++ b/track_oracle/core/track_oracle_core_impl.h
@@ -108,6 +108,7 @@ public:
 
   template< typename T > field_handle_type create_element( const element_descriptor& e );
 
+  std::vector< field_handle_type > get_all_field_handles() const;
   field_handle_type lookup_by_name( const std::string& name ) const;
 
   element_descriptor get_element_descriptor( field_handle_type f ) const;

--- a/track_oracle/data_terms/data_term_instances.cxx
+++ b/track_oracle/data_terms/data_term_instances.cxx
@@ -21,6 +21,8 @@
 
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::utility::state_flags);
 
+TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::detection::detection_id );
+
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::tracking::external_id );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::tracking::timestamp_usecs );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::tracking::frame_number );

--- a/track_oracle/data_terms/data_terms.cxx
+++ b/track_oracle/data_terms/data_terms.cxx
@@ -55,6 +55,10 @@ namespace dt {
 #define DEF_DT(NAME) \
   context NAME::c( NAME::get_context_name(), NAME::get_context_description() );
 
+namespace detection {
+  DEF_DT( detection_id );
+}
+
 namespace tracking {
 
   DEF_DT( external_id );

--- a/track_oracle/data_terms/data_terms.h
+++ b/track_oracle/data_terms/data_terms.h
@@ -69,6 +69,9 @@ namespace dt {
 /// want to use custom XML attributes.)
 ///
 
+namespace detection {
+  DECL_DT( detection_id, unsigned long long, "detection ID; unique within a session but not a UUID" );
+}
 
 namespace tracking {
 

--- a/track_oracle/example/track_reader_example.cxx
+++ b/track_oracle/example/track_reader_example.cxx
@@ -54,6 +54,7 @@ int main( int argc, char *argv[] )
   vul_arg< string > kwiver_arg( "-kwiver", "write out as kwiver to this file" );
   vul_arg< string > kw18_arg( "-kw18", "write out as kw18 to this file" );
   vul_arg< string > csv_arg( "-csv", "write out as csv to this file" );
+  vul_arg< string > kpf_g_arg( "-kpf-g", "write out as KPF geometry to this file" );
   vul_arg< string > csv_v1_arg( "-csv-v1", "write out as old-style csv to this file" );
   vul_arg< string > kwxml_ts_arg( "-kwxml_ts", "if writing kwxml, set default track style to this", "trackObjectKitware" );
   vul_arg< string > tag_arg( "-tag", "if writing kwiver, test tags by setting track-level 'test' flag to this" );
@@ -142,6 +143,11 @@ int main( int argc, char *argv[] )
       {
         LOG_ERROR( main_logger, "Could not write CSV to '" << csv_arg() << "'" );
       }
+    }
+    if ( kpf_g_arg.set() )
+    {
+      bool okay = file_format_manager::get_format( TF_KPF_GEOM )->write( kpf_g_arg(), tracks );
+      LOG_INFO( main_logger, "Wrote KPF geometry to " << kpf_g_arg() << " success: " << okay );
     }
   }
   return rc;

--- a/track_oracle/file_formats/CMakeLists.txt
+++ b/track_oracle/file_formats/CMakeLists.txt
@@ -60,11 +60,21 @@ add_subdirectory( track_csv )
 add_subdirectory( track_kst )
 add_subdirectory( track_vatic )
 add_subdirectory( track_vpd )
+if( KWIVER_ENABLE_KPF )
+  add_subdirectory( track_kpf_geom )
+  # ...kpf_activity
+  set( TRACK_KPF_LIBRARIES track_kpf_geom )
+else()
+  set( TRACK_KPF_LIBRARIES "" )
+endif()
+
 if (KWIVER_ENABLE_TRACK_ORACLE_MGRS)
   add_subdirectory( track_scorable_mgrs )
   add_subdirectory( aoi_utils )
 endif()
+
 add_subdirectory( track_e2at_callout )
+
 if (KWIVER_ENABLE_TRACK_ORACLE_EVENT_ADAPTER)
   add_subdirectory( track_filter_kwe)
   set( TRACK_FILTER_KWE_LIBRARY track_filter_kwe )
@@ -118,7 +128,8 @@ target_link_libraries( track_oracle_file_formats
                        track_oracle_tokenizers
                        ${TRACK_FILTER_KWE_LIBRARY}
                        ${TRACK_ORACLE_APIX_LIBRARY}
-
+                       ${TRACK_KPF_LIBRARIES}
+                       
   PRIVATE              ${Boost_THREAD_LIBRARY}
                        vital
                        vul

--- a/track_oracle/file_formats/file_format_manager.cxx
+++ b/track_oracle/file_formats/file_format_manager.cxx
@@ -35,6 +35,9 @@
 #include <track_oracle/file_formats/track_vpd/file_format_vpd_track.h>
 #include <track_oracle/file_formats/track_vpd/file_format_vpd_event.h>
 #include <track_oracle/file_formats/track_e2at_callout/file_format_e2at_callout.h>
+#if KWIVER_ENABLE_KPF
+#include <track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.h>
+#endif
 #ifdef TRACK_4676_ENABLED
 #include <track_oracle/file_formats/track_4676/file_format_4676.h>
 #endif
@@ -120,6 +123,9 @@ file_format_manager_impl
 #endif
   formats[ TF_CSV ] = new file_format_csv();
   formats[ TF_KWIVER ] = new file_format_kwiver();
+#ifdef KWIVER_ENABLE_KPF
+  formats[ TF_KPF_GEOM ] = new file_format_kpf_geom();
+#endif
 
   // get instances of all the schemas, for introspection
   for (format_map_cit i = formats.begin(); i != formats.end(); ++i)

--- a/track_oracle/file_formats/file_format_type.cxx
+++ b/track_oracle/file_formats/file_format_type.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -38,6 +38,7 @@ file_format_type
   case TF_4676:           return "4676";
   case TF_CSV:            return "csv";
   case TF_KWIVER:         return "kwiver";
+  case TF_KPF_GEOM:       return "kpf-geom";
   case TF_INVALID_TYPE:   return "invalid";
   }
   return "invalid";
@@ -61,6 +62,7 @@ file_format_type
   else if ( s == file_format_type::to_string( TF_4676 ))   return TF_4676;
   else if ( s == file_format_type::to_string( TF_CSV ))    return TF_CSV;
   else if ( s == file_format_type::to_string( TF_KWIVER ))  return TF_KWIVER;
+  else if ( s == file_format_type::to_string( TF_KPF_GEOM ))    return TF_KPF_GEOM;
   else return TF_INVALID_TYPE;
 }
 

--- a/track_oracle/file_formats/file_format_type.h
+++ b/track_oracle/file_formats/file_format_type.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2012-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2012-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -55,6 +55,7 @@ enum file_format_enum
   TF_4676,
   TF_CSV,
   TF_KWIVER,
+  TF_KPF_GEOM,
   TF_INVALID_TYPE   // must always be last entry
 };
 

--- a/track_oracle/file_formats/track_csv/file_format_csv.cxx
+++ b/track_oracle/file_formats/track_csv/file_format_csv.cxx
@@ -221,7 +221,7 @@ file_format_csv
   // ends up in the element pool
   volatile track_field< dt::tracking::mgrs_pos > mgrs;
 #endif
-  
+
   // ...and state flags
   volatile track_field< dt::utility::state_flags > state_flags;
 
@@ -236,6 +236,8 @@ file_format_csv
   volatile track_field< dt::events::event_type > ev_type_field;
   volatile track_field< dt::events::event_probability > ev_prob_field;
   volatile track_field< dt::events::source_track_ids > src_trk_ids_field;
+
+  volatile track_field< dt::detection::detection_id > det_id_field;
 }
 
 file_format_csv

--- a/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
+++ b/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
@@ -42,5 +42,6 @@ target_link_libraries( track_kpf_geom
                        vgl
                        track_oracle_format_base
                        logging_map
+                       kwiversys
                        ${YAML_CPP_LIBRARIES}
 )

--- a/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
+++ b/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
@@ -37,11 +37,11 @@ target_link_libraries( track_kpf_geom
   PUBLIC               track_oracle
                        data_terms
                        kwiver_algo_kpf
+                       ${YAML_CPP_LIBRARIES}
   PRIVATE              vital_logger
                        vul
                        vgl
                        track_oracle_format_base
                        logging_map
                        kwiversys
-                       ${YAML_CPP_LIBRARIES}
 )

--- a/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
+++ b/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
@@ -1,0 +1,46 @@
+if(fletch_ENABLED_YAMLCPP)
+  find_package( yaml-cpp REQUIRED )
+else()
+  message(STATUS "Cannot build track_oracle KPF support without YAML in Fletch")
+  return()
+endif()
+#
+# KPF geometry
+#
+
+set( track_kpf_geom_public_headers
+  track_kpf_geom.h
+  file_format_kpf_geom.h
+)
+
+set( track_kpf_geom_sources
+  file_format_kpf_geom.cxx
+)
+
+kwiver_install_headers(
+  ${track_kpf_geom_public_headers}
+  SUBDIR     track_oracle/track_kpf_geom
+)
+
+kwiver_install_headers(
+  ${CMAKE_CURRENT_BINARY_DIR}/track_kpf_geom_export.h
+  NOPATH SUBDIR     track_oracle/track_kpf_geom
+)
+
+kwiver_add_library( track_kpf_geom
+  ${track_kpf_geom_public_headers}
+  ${track_kpf_geom_sources}
+  ${CMAKE_CURRENT_BINARY_DIR}/track_kpf_geom_export.h
+)
+
+target_link_libraries( track_kpf_geom
+  PUBLIC               track_oracle
+                       data_terms
+                       kwiver_algo_kpf
+  PRIVATE              vital_logger
+                       vul
+                       vgl
+                       track_oracle_format_base
+                       logging_map
+                       ${YAML_CPP_LIBRARIES}
+)

--- a/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
+++ b/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
@@ -103,6 +103,29 @@ struct kpf_geom_exception
   string what;
 };
 
+//
+// When looking in track_oracle's database for any optional fields
+// to emit, we select anything whose field name matches either
+//
+// XXX_nnn, where 'XXX' can be converted to a KPF style, and nnn is an
+// integer (interpreted as the domain), and the type is a double,
+//
+// OR
+//
+// key_KKK, where 'key' is the KPF style for a key/value pair; KKK is
+// taken as the key, and the track_oracle entry is the value, and the type
+// is a string.
+//
+// Another approach might be to store these packet headers when we read the
+// KPF in, but somehow doing it just-in-time here feels better, if more
+// convoluted.
+//
+
+//
+// Whoops, we have to store a whole packet because the KV packet
+// doesn't record the key in the header. Drat.
+//
+
 map< field_handle_type, KPF::packet_t >
 get_optional_fields()
 {
@@ -517,29 +540,6 @@ file_format_kpf_geom
   KPF::record_yaml_writer w( os );
   track_kpf_geom_type entry;
   vgl_box_adapter_t box_adapter;
-
-  //
-  // When looking in track_oracle's database for any optional fields
-  // to emit, we select anything whose field name matches either
-  //
-  // XXX_nnn, where 'XXX' can be converted to a KPF style, and nnn is an
-  // integer (interpreted as the domain), and the type is a double,
-  //
-  // OR
-  //
-  // key_KKK, where 'key' is the KPF style for a key/value pair; KKK is
-  // taken as the key, and the track_oracle entry is the value, and the type
-  // is a string.
-  //
-  // Another approach might be to store these packet headers when we read the
-  // KPF in, but somehow doing it just-in-time here feels better, if more
-  // convoluted.
-  //
-
-  //
-  // Whoops, we have to store a whole packet because the KV packet
-  // doesn't record the key in the header. Drat.
-  //
 
   auto optional_fields = get_optional_fields();
   for (auto i: optional_fields)

--- a/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
+++ b/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
@@ -1,0 +1,394 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * @file
+ * @brief The track_oracle file format implementation for KPF geometry.
+ *
+ */
+
+#include "file_format_kpf_geom.h"
+
+#include <vital/logger/logger.h>
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+
+#include <track_oracle/data_terms/data_terms.h>
+#include <arrows/kpf/yaml/kpf_reader.h>
+#include <arrows/kpf/yaml/kpf_yaml_parser.h>
+#include <vital/util/tokenize.h>
+#include <track_oracle/utils/logging_map.h>
+
+#include <yaml-cpp/yaml.h>
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <map>
+
+using std::string;
+using std::istream;
+using std::ifstream;
+using std::stringstream;
+using std::ostringstream;
+using std::map;
+
+namespace KPF=::kwiver::vital::kpf;
+
+namespace // anon
+{
+using namespace kwiver::track_oracle;
+
+
+
+struct kpf_geom_exception
+{
+  explicit kpf_geom_exception( const string& msg ): what(msg) {}
+  string what;
+};
+
+void
+add_to_row( kwiver::logging_map_type& log_map,
+            const oracle_entry_handle_type& row,
+            const KPF::packet_t& p )
+{
+  namespace KPFC = ::kwiver::vital::kpf::canonical;
+
+  //
+  // Step through the packet types and add them
+  //
+  switch (p.header.style)
+  {
+  case KPF::packet_style::ID:
+    {
+      unsigned id = p.id.d;
+      switch (p.header.domain)
+      {
+      case KPFC::id_t::DETECTION_ID:
+        {
+          track_field< dt::detection::detection_id > x;
+          x(row) = id;
+        }
+        break;
+      case KPFC::id_t::TRACK_ID:
+        {
+          track_field< dt::tracking::external_id > x;
+          x(row) = id;
+        }
+        break;
+      case KPFC::id_t::EVENT_ID:
+        {
+          track_field< dt::events::event_id > x;
+          x(row) = id;
+        }
+      default:
+        {
+          ostringstream oss;
+          oss << "Ignoring ID domain " << p.header.domain;
+          log_map.add_msg( oss.str() );
+        }
+      }
+    }
+    break;
+
+  case KPF::packet_style::TS:
+    {
+      switch (p.header.domain)
+      {
+      case KPFC::timestamp_t::FRAME_NUMBER:
+        {
+          track_field< dt::tracking::frame_number > x;
+          x(row) = static_cast< dt::tracking::frame_number::Type >( p.timestamp.d );
+        }
+        break;
+      default:
+        {
+          ostringstream oss;
+          oss << "Ignoring TS domain " << p.header.domain;
+          log_map.add_msg( oss.str() );
+        }
+      }
+    }
+    break;
+  case KPF::packet_style::GEOM:
+    {
+      switch (p.header.domain)
+      {
+      case KPFC::bbox_t::IMAGE_COORDS:
+        {
+          track_field< dt::tracking::bounding_box > x;
+          x(row) = vgl_box_2d<double>(
+            vgl_point_2d<double>( p.bbox.x1, p.bbox.y1 ),
+            vgl_point_2d<double>( p.bbox.x2, p.bbox.y2 ));
+        }
+        break;
+      default:
+        {
+          ostringstream oss;
+          oss << "Ignoring TS domain " << p.header.domain;
+          log_map.add_msg( oss.str() );
+        }
+      }
+    }
+    break;
+  case KPF::packet_style::CONF:
+    {
+      // since KPF's domains for confidence are open-ended, we don't
+      // hardwire this file's confidence values to fixed data_terms
+      // the way we do with (for example) the IDs or bounding boxes--
+      // that's the whole rationale for pre-defined domains, that we
+      // can assert their semantic interpretation. Not so with conf packets,
+      // so we'll just create their storage on-the-fly.
+
+      ostringstream oss;
+      oss << KPF::style2str( p.header.style ) << "_" << p.header.domain;
+      field_handle_type f = track_oracle_core::lookup_by_name( oss.str() );
+      if ( f == INVALID_FIELD_HANDLE )
+      {
+        element_descriptor e( oss.str(),
+                              "KPF ad-hoc",
+                              typeid( double(0) ).name(),
+                              element_descriptor::ADHOC );
+        f = track_oracle_core::create_element< double >( e );
+      }
+      track_oracle_core::get_field<double>( row, f ) = p.conf.d;
+    }
+    break;
+  case KPF::packet_style::KV:
+    {
+      // Like the conf values, but here we don't have a domain, and
+      // the type is string, not double.
+
+      ostringstream oss;
+      oss << KPF::style2str( p.header.style ) << "_" << p.kv.key;
+      field_handle_type f = track_oracle_core::lookup_by_name( oss.str() );
+      if ( f == INVALID_FIELD_HANDLE )
+      {
+        element_descriptor e( oss.str(),
+                              "KPF ad-hoc",
+                              typeid( string("") ).name(),
+                              element_descriptor::ADHOC );
+        f = track_oracle_core::create_element< string >( e );
+      }
+      track_oracle_core::get_field<string>( row, f ) = p.kv.val;
+    }
+    break;
+  default:
+    {
+      ostringstream oss;
+      oss << "Ignoring packet header " << p.header;
+      log_map.add_msg( oss.str() );
+    }
+  };
+}
+
+} // ...anon
+
+namespace kwiver {
+namespace track_oracle {
+
+file_format_kpf_geom
+::file_format_kpf_geom()
+  : file_format_base( TF_KPF_GEOM, "KPF geometry" )
+{
+  this->globs.push_back("*.geom.yml");
+
+}
+
+file_format_kpf_geom
+::~file_format_kpf_geom()
+{
+}
+
+bool
+file_format_kpf_geom
+::inspect_file( const string& fn ) const
+{
+  // This just checks that it's YAML, not that it's a geom schema
+  // (would have to trawl through metadata packets line-by-line)
+  ifstream is( fn.c_str() );
+  if ( ! is ) return false;
+
+  string s;
+  if ( ! std::getline( is, s )) return false;
+
+  stringstream ss(s);
+
+  bool parsed = true;
+  try
+  {
+    YAML::Load( ss );
+  }
+  // Can't catch the exact YAML exception on OSX
+  // see https://stackoverflow.com/questions/21737201/problems-throwing-and-catching-exceptions-on-os-x-with-fno-rtti
+  catch ( ... )
+  {
+    parsed = false;
+  }
+  return parsed;
+}
+
+bool
+file_format_kpf_geom
+::read( const string& fn, track_handle_list_type& tracks ) const
+{
+  ifstream is( fn.c_str() );
+  return is && this->read( is, tracks );
+}
+
+bool
+file_format_kpf_geom
+::read( istream& is, track_handle_list_type& tracks ) const
+{
+  LOG_INFO( main_logger, "KPF geometry YAML load start");
+  KPF::kpf_yaml_parser_t parser( is );
+  KPF::kpf_reader_t reader( parser );
+  LOG_INFO( main_logger, "KPF geometry YAML load end");
+  track_kpf_geom_type entry;
+
+  size_t rc = 0;
+  map< unsigned, track_handle_type > track_map;
+  logging_map_type wmsgs( main_logger, KWIVER_LOGGER_SITE );
+
+  while ( reader.next() )
+  {
+    //
+    // Where to store meta packets? Are they associated with the source
+    // file? Particular tracks? TBD!
+#if 0
+    for (auto m: reader.get_meta_packets() )
+    {
+    }
+#endif
+
+    ++rc;
+    try
+    {
+      namespace KPFC = ::kwiver::vital::kpf::canonical;
+
+      auto track_id_probe = reader.transfer_packet_from_buffer(
+        KPF::packet_header_t( KPF::packet_style::ID, KPFC::id_t::TRACK_ID ));
+      if ( ! track_id_probe.first )
+      {
+        ostringstream oss;
+        oss << "Missing packet ID1 on non-meta record line " << rc << "; skipping";
+        throw kpf_geom_exception( oss.str() );
+      }
+
+      auto track_probe = track_map.find( track_id_probe.second.id.d );
+      if (track_probe == track_map.end())
+      {
+        track_map[ track_id_probe.second.id.d ] = entry.create();
+      }
+      track_handle_type t = track_map[ track_id_probe.second.id.d ];
+
+      // the track ID is added to the track row;
+      // other packets are added to the frames
+      add_to_row( wmsgs, t.row, track_id_probe.second );
+
+      frame_handle_type f = entry(t).create_frame();
+
+      struct kpf_loader
+      {
+        KPF::packet_header_t h;
+        bool required;
+      };
+
+      kpf_loader fields[] = {
+        { KPF::packet_header_t( KPF::packet_style::GEOM, KPFC::bbox_t::IMAGE_COORDS ), true },
+        { KPF::packet_header_t( KPF::packet_style::TS, KPFC::timestamp_t::FRAME_NUMBER ), true },
+        { KPF::packet_header_t( KPF::packet_style::ID, KPFC::id_t::DETECTION_ID ), true }
+      };
+
+      for (const auto& field: fields)
+      {
+        auto probe = reader.transfer_packet_from_buffer( field.h );
+        if ( field.required && (! probe.first ))
+        {
+          ostringstream oss;
+          oss << "Missing packet " << KPF::style2str( field.h.style ) << ":"
+              << field.h.domain << " in non-meta record " << rc;
+          throw kpf_geom_exception( oss.str() );
+        }
+        add_to_row( wmsgs, f.row, probe.second );
+      }
+
+      //
+      // If any other packets are present (confidences, kv) then store them
+      // as well
+      //
+
+      for (const auto& p: reader.get_packet_buffer())
+      {
+        add_to_row( wmsgs, f.row, p.second );
+      }
+
+    }
+    catch ( const kpf_geom_exception& e )
+    {
+      LOG_ERROR( main_logger, "Error parsing KPF geom: " << e.what << "; skipping" );
+
+      // hmm, t and/or f "leak"; we never add them to the returned track set,
+      // but still, it's messy
+    }
+
+    reader.flush();
+  }
+  for (auto p: track_map)
+  {
+    tracks.push_back( p.second );
+  }
+  if (! wmsgs.empty() )
+  {
+    LOG_INFO( main_logger, "KPF geom parsing warnings begin" );
+    wmsgs.dump_msgs();
+    LOG_INFO( main_logger, "KPF geom parsing warnings end" );
+  }
+  return true;
+}
+
+bool
+file_format_kpf_geom
+::write( const std::string& fn,
+         const track_handle_list_type& tracks) const
+{
+  return false;
+}
+
+bool
+file_format_kpf_geom
+::write( std::ostream& os,
+         const track_handle_list_type& tracks) const
+{
+  return false;
+}
+
+} // ...track_oracle
+} // ...kwiver

--- a/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.h
+++ b/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.h
@@ -1,0 +1,82 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * @file
+ * @brief The track_oracle file format interface.
+ *
+ *
+ */
+
+#ifndef KWIVER_TRACK_ORACLE_FILE_FORMAT_KPF_H_
+#define KWIVER_TRACK_ORACLE_FILE_FORMAT_KPF_H_
+
+#include <vital/vital_config.h>
+#include <track_oracle/file_formats/track_kpf_geom/track_kpf_geom_export.h>
+
+#include <track_oracle/file_formats/track_kpf_geom/track_kpf_geom.h>
+#include <track_oracle/file_formats/file_format_base.h>
+
+namespace kwiver {
+namespace track_oracle {
+
+class TRACK_KPF_GEOM_EXPORT file_format_kpf_geom: public file_format_base
+{
+public:
+  file_format_kpf_geom();
+  virtual ~file_format_kpf_geom();
+
+  virtual int supported_operations() const { return FF_READ | FF_WRITE; }
+
+  // return a dynamically-allocated instance of the schema
+  virtual track_base_impl* schema_instance() const { return new track_kpf_geom_type(); }
+
+  // Inspect the file and return true if it is of this format
+  virtual bool inspect_file(const std::string& fn) const;
+
+  // read tracks from a file or stream
+  virtual bool read( const std::string& fn,
+                    track_handle_list_type& tracks) const;
+  virtual bool read( std::istream& is,
+                    track_handle_list_type& tracks) const;
+
+  // write tracks to a file or stream
+  virtual bool write( const std::string& fn,
+                      const track_handle_list_type& tracks) const;
+  virtual bool write( std::ostream& os,
+                      const track_handle_list_type& tracks) const;
+
+};
+
+} // ...track_oracle
+} // ...kwiver
+
+#endif

--- a/track_oracle/file_formats/track_kpf_geom/track_kpf_geom.h
+++ b/track_oracle/file_formats/track_kpf_geom/track_kpf_geom.h
@@ -1,0 +1,79 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief The track_oracle base class for KPF geometry files.
+ *
+ * We differentiate between geometry and activity files because the
+ * alternative, i.e. treating a KPF like a CSV or kwiver-xml file,
+ * would require infrastructure to resolve linkages between activities
+ * (which refer to, but do not contain, geometry) and the reference geometry.
+ *
+ * (We've never tried using CSV or kwiver-xml for activities; it would
+ * probably not work as-is.)
+ *
+ */
+
+#ifndef KWIVER_TRACK_ORACLE_TRACK_KPF_GEOM_H_
+#define KWIVER_TRACK_ORACLE_TRACK_KPF_GEOM_H_
+
+#include <vital/vital_config.h>
+#include <track_oracle/file_formats/track_kpf_geom/track_kpf_geom_export.h>
+
+#include <track_oracle/core/track_base.h>
+#include <track_oracle/core/track_field.h>
+#include <track_oracle/data_terms/data_terms.h>
+
+namespace kwiver {
+namespace track_oracle {
+
+struct TRACK_KPF_GEOM_EXPORT track_kpf_geom_type: public track_base< track_kpf_geom_type >
+{
+  track_field< dt::detection::detection_id > det_id;
+  track_field< dt::tracking::external_id > track_id;
+  track_field< dt::tracking::timestamp_usecs > timestamp_usecs;
+  track_field< dt::tracking::frame_number > frame_number;
+  track_field< dt::tracking::bounding_box > bounding_box;
+
+  track_kpf_geom_type()
+  {
+    Track.add_field( track_id );
+    Frame.add_field( det_id );
+    Frame.add_field( timestamp_usecs );
+    Frame.add_field( frame_number );
+    Frame.add_field( bounding_box );
+  }
+};
+
+} // ...track_oracle
+} // ...kwiver
+
+#endif


### PR DESCRIPTION
track_oracle plumbing to support KPF geometry I/O.

As a side effect, track_oracle/examples/track_reader_example can now convert back and forth between kw18 and kpf-geometry.

(With the exception of the timestamp_usecs, which hasn't yet been formally defined as KPF timestamp domain.)

All the changes are inside track_oracle except for the following commits:
5f945a1 ("Read support for KPF geometry files")
eb1bf7d ("Implement KPF EVAL packet")
daf1714 ("Minor cleanups of the KPF packet declaration")


