### PR TITLE
Downgrade log message for missing directory in path.

### DIFF
--- a/sprokit/src/processes/clusters/registration.cxx
+++ b/sprokit/src/processes/clusters/registration.cxx
@@ -93,7 +93,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     LOG_DEBUG( logger, "Loading clusters from directory: " << include_dir );
     if ( ! kwiversys::SystemTools::FileExists( include_dir) )
     {
-      LOG_WARN( logger, "Path not found loading clusters: " << include_dir );
+      LOG_DEBUG( logger, "Path not found loading clusters: " << include_dir );
       continue;
     }
 


### PR DESCRIPTION
This message caused customers much confusion since it looks like
a real problem. It is downgraded to be more compatible with other
path search approaches such as bash which does not complain when
a non-existent directory is in the path.