### PR TITLE
cleanup arrows

### DIFF
--- a/arrows/burnout/burnout_track_descriptors.h
+++ b/arrows/burnout/burnout_track_descriptors.h
@@ -33,8 +33,6 @@
 
 #include <arrows/burnout/kwiver_algo_burnout_export.h>
 
-#include <vital/vital_config.h>
-
 #include <vital/algo/compute_track_descriptors.h>
 
 namespace kwiver {

--- a/arrows/ceres/bundle_adjust.h
+++ b/arrows/ceres/bundle_adjust.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CERES_BUNDLE_ADJUST_H_
 #define KWIVER_ARROWS_CERES_BUNDLE_ADJUST_H_
 
-#include <vital/vital_config.h>
 #include <arrows/ceres/kwiver_algo_ceres_export.h>
 
 #include <vital/algo/bundle_adjust.h>

--- a/arrows/ceres/camera_smoothness.h
+++ b/arrows/ceres/camera_smoothness.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_CERES_CAMERA_SMOOTHNESS_H_
 #define KWIVER_ARROWS_CERES_CAMERA_SMOOTHNESS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ceres/kwiver_algo_ceres_export.h>
 
 #include <arrows/ceres/types.h>

--- a/arrows/ceres/optimize_cameras.h
+++ b/arrows/ceres/optimize_cameras.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CERES_OPTIMIZE_CAMERAS_H_
 #define KWIVER_ARROWS_CERES_OPTIMIZE_CAMERAS_H_
 
-#include <vital/vital_config.h>
 #include <arrows/ceres/kwiver_algo_ceres_export.h>
 
 #include <vital/algo/optimize_cameras.h>

--- a/arrows/ceres/reprojection_error.cxx
+++ b/arrows/ceres/reprojection_error.cxx
@@ -36,8 +36,6 @@
 
 #include "reprojection_error.h"
 
-#include <vital/vital_config.h>
-
 #include <arrows/ceres/lens_distortion.h>
 #include <arrows/ceres/types.h>
 
@@ -254,4 +252,3 @@ create_cost_func(LensDistortionType ldt, double x, double y)
 } // end namespace ceres
 } // end namespace arrows
 } // end namespace kwiver
-

--- a/arrows/core/class_probablity_filter.h
+++ b/arrows/core/class_probablity_filter.h
@@ -31,12 +31,9 @@
 #ifndef KWIVER_ARROWS_CLASS_PROBABLITY_FILTER_H_
 #define KWIVER_ARROWS_CLASS_PROBABLITY_FILTER_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <vital/algo/algorithm.h>
 #include <vital/algo/detected_object_filter.h>
-#include <vital/types/image_container.h>
 
 #include <utility>
 #include <set>
@@ -66,12 +63,10 @@ class KWIVER_ALGO_CORE_EXPORT class_probablity_filter
   : public vital::algorithm_impl<class_probablity_filter, vital::algo::detected_object_filter>
 {
 public:
-
   class_probablity_filter();
   virtual ~class_probablity_filter() = default;
 
   virtual vital::config_block_sptr get_configuration() const;
-
   virtual void set_configuration(vital::config_block_sptr config);
   virtual bool check_configuration(vital::config_block_sptr config) const;
 

--- a/arrows/core/close_loops_bad_frames_only.h
+++ b/arrows/core/close_loops_bad_frames_only.h
@@ -36,10 +36,8 @@
 #ifndef KWIVER_ARROWS_CORE_CLOSE_LOOPS_BAD_FRAMES_ONLY_H_
 #define KWIVER_ARROWS_CORE_CLOSE_LOOPS_BAD_FRAMES_ONLY_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <vital/algo/algorithm.h>
 #include <vital/types/image_container.h>
 #include <vital/types/feature_track_set.h>
 

--- a/arrows/core/close_loops_exhaustive.h
+++ b/arrows/core/close_loops_exhaustive.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS__CLOSE_LOOPS_EXHAUSTIVE_H_
 #define KWIVER_ARROWS__CLOSE_LOOPS_EXHAUSTIVE_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/algorithm.h>
@@ -45,8 +44,6 @@
 
 #include <vital/algo/close_loops.h>
 #include <vital/config/config_block.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/close_loops_keyframe.h
+++ b/arrows/core/close_loops_keyframe.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_CLOSE_LOOPS_KEYFRAME_H_
 #define KWIVER_ARROWS_CLOSE_LOOPS_KEYFRAME_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/close_loops.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/close_loops_multi_method.h
+++ b/arrows/core/close_loops_multi_method.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CORE_CLOSE_LOOPS_MULTI_METHOD_H_
 #define KWIVER_ARROWS_CORE_CLOSE_LOOPS_MULTI_METHOD_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/algorithm.h>

--- a/arrows/core/compute_ref_homography_core.h
+++ b/arrows/core/compute_ref_homography_core.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CORE_COMPUTE_REF_HOMOGRAPHY_CORE_H_
 #define KWIVER_ARROWS_CORE_COMPUTE_REF_HOMOGRAPHY_CORE_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/algorithm.h>
@@ -45,12 +44,9 @@
 #include <vital/types/image_container.h>
 #include <vital/types/feature_track_set.h>
 
-#include <memory>
-
 namespace kwiver {
 namespace arrows {
 namespace core {
-
 
 /// Default impl class for mapping each image to some reference image.
 /**

--- a/arrows/core/convert_image_bypass.h
+++ b/arrows/core/convert_image_bypass.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CORE_CONVERT_IMAGE_BYPASS_H_
 #define KWIVER_ARROWS_CORE_CONVERT_IMAGE_BYPASS_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/convert_image.h>

--- a/arrows/core/detected_object_set_input_csv.h
+++ b/arrows/core/detected_object_set_input_csv.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_CORE_DETECTED_OBJECT_SET_INPUT_CSV_H
 #define KWIVER_ARROWS_CORE_DETECTED_OBJECT_SET_INPUT_CSV_H
 
-
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/detected_object_set_input.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/detected_object_set_input_kw18.h
+++ b/arrows/core/detected_object_set_input_kw18.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_CORE_DETECTED_OBJECT_SET_INPUT_KW18_H
 #define KWIVER_ARROWS_CORE_DETECTED_OBJECT_SET_INPUT_KW18_H
 
-
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/detected_object_set_input.h>

--- a/arrows/core/detected_object_set_output_csv.h
+++ b/arrows/core/detected_object_set_output_csv.h
@@ -36,12 +36,10 @@
 #ifndef KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_CSV_H
 #define KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_CSV_H
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/detected_object_set_output.h>
 
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/detected_object_set_output_kw18.h
+++ b/arrows/core/detected_object_set_output_kw18.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_KW18_H
 #define KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_KW18_H
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/detected_object_set_output.h>

--- a/arrows/core/estimate_canonical_transform.h
+++ b/arrows/core/estimate_canonical_transform.h
@@ -31,12 +31,9 @@
 #ifndef KWIVER_ARROWS__ESTIMATE_CANONICAL_TRANSFORM_H_
 #define KWIVER_ARROWS__ESTIMATE_CANONICAL_TRANSFORM_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/estimate_canonical_transform.h>
-
-#include <memory>
 
 /**
  * \file

--- a/arrows/core/feature_descriptor_io.h
+++ b/arrows/core/feature_descriptor_io.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_CORE_FEATURE_DESCRIPTOR_IO_H_
 #define KWIVER_ARROWS_CORE_FEATURE_DESCRIPTOR_IO_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/feature_descriptor_io.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/filter_features_magnitude.h
+++ b/arrows/core/filter_features_magnitude.h
@@ -31,12 +31,9 @@
 #ifndef KWIVER_ARROWS_CORE_FILTER_FEATURES_MAGNITUDE_H_
 #define KWIVER_ARROWS_CORE_FILTER_FEATURES_MAGNITUDE_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/filter_features.h>
-
-#include <memory>
 
 /**
  * \file

--- a/arrows/core/filter_features_scale.h
+++ b/arrows/core/filter_features_scale.h
@@ -28,20 +28,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef KWIVER_ARROWS_CORE_FILTER_FEATURES_SCALE_H_
-#define KWIVER_ARROWS_CORE_FILTER_FEATURES_SCALE_H_
-
-#include <vital/vital_config.h>
-#include <arrows/core/kwiver_algo_core_export.h>
-
-#include <vital/algo/filter_features.h>
-
-#include <memory>
-
 /**
  * \file
  * \brief Header defining the filter_features_scale algorithm
  */
+
+#ifndef KWIVER_ARROWS_CORE_FILTER_FEATURES_SCALE_H_
+#define KWIVER_ARROWS_CORE_FILTER_FEATURES_SCALE_H_
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/algo/filter_features.h>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/filter_tracks.h
+++ b/arrows/core/filter_tracks.h
@@ -31,12 +31,9 @@
 #ifndef KWIVER_ARROWS_CORE_FILTER_TRACKS_H_
 #define KWIVER_ARROWS_CORE_FILTER_TRACKS_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/filter_tracks.h>
-
-#include <memory>
 
 /**
  * \file

--- a/arrows/core/formulate_query_core.h
+++ b/arrows/core/formulate_query_core.h
@@ -36,8 +36,6 @@
 #ifndef ARROWS_PLUGINS_CORE_FORMULATE_QUERY_CORE_H_
 #define ARROWS_PLUGINS_CORE_FORMULATE_QUERY_CORE_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/algorithm.h>
@@ -45,7 +43,6 @@
 
 #include <vital/algo/image_io.h>
 #include <vital/algo/compute_track_descriptors.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/hierarchical_bundle_adjust.h
+++ b/arrows/core/hierarchical_bundle_adjust.h
@@ -36,14 +36,11 @@
 #ifndef KWIVER_ARROWS_CORE_HIERARCHICAL_BUNDLE_ADJUST_H_
 #define KWIVER_ARROWS_CORE_HIERARCHICAL_BUNDLE_ADJUST_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/algorithm.h>
 #include <vital/algo/bundle_adjust.h>
 #include <vital/config/config_block.h>
-
-#include <memory>
 
 
 namespace kwiver {

--- a/arrows/core/initialize_cameras_landmarks.h
+++ b/arrows/core/initialize_cameras_landmarks.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_CORE_INITIALIZE_CAMERAS_LANDMARKS_H_
 #define KWIVER_ARROWS_CORE_INITIALIZE_CAMERAS_LANDMARKS_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/initialize_cameras_landmarks.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/match_features_fundamental_matrix.h
+++ b/arrows/core/match_features_fundamental_matrix.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS__MATCH_FEATURES_FUNDMENTAL_MATRIX_H_
 #define KWIVER_ARROWS__MATCH_FEATURES_FUNDMENTAL_MATRIX_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/filter_features.h>
@@ -44,8 +43,6 @@
 #include <vital/algo/estimate_fundamental_matrix.h>
 #include <vital/algo/match_features.h>
 #include <vital/config/config_block.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/match_features_homography.h
+++ b/arrows/core/match_features_homography.h
@@ -36,7 +36,6 @@
 #ifndef KWIVER_ARROWS_CORE_MATCH_FEATURES_HOMOGRAPHY_H_
 #define KWIVER_ARROWS_CORE_MATCH_FEATURES_HOMOGRAPHY_H_
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/filter_features.h>
@@ -45,7 +44,6 @@
 #include <vital/algo/match_features.h>
 #include <vital/config/config_block.h>
 
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/track_descriptor_set_output_csv.h
+++ b/arrows/core/track_descriptor_set_output_csv.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_TRACK_DESCRIPTOR_SET_OUTPUT_CSV_H
 #define KWIVER_ARROWS_TRACK_DESCRIPTOR_SET_OUTPUT_CSV_H
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/track_descriptor_set_output.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/track_features_core.h
+++ b/arrows/core/track_features_core.h
@@ -37,15 +37,11 @@
 #define ARROWS_PLUGINS_CORE_TRACK_FEATURES_CORE_H_
 
 
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/track_features.h>
 #include <vital/types/image_container.h>
 #include <vital/types/feature_track_set.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/core/track_set_impl.h
+++ b/arrows/core/track_set_impl.h
@@ -39,20 +39,13 @@
 
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <vital/vital_config.h>
-#include <vital/vital_types.h>
 #include <vital/types/track_set.h>
 
 #include <map>
-#include <memory>
-#include <set>
-#include <vector>
-
 
 namespace kwiver {
 namespace arrows {
 namespace core {
-
 
 /// A custom track set implementation that provides fast indexing by frame id
 /**

--- a/arrows/core/triangulate_landmarks.h
+++ b/arrows/core/triangulate_landmarks.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_CORE_TRIANGULATE_LANDMARKS_H_
 #define KWIVER_ARROWS_CORE_TRIANGULATE_LANDMARKS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/triangulate_landmarks.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/darknet/darknet_custom_resize.h
+++ b/arrows/darknet/darknet_custom_resize.h
@@ -34,8 +34,6 @@
 
 #include <arrows/darknet/kwiver_algo_darknet_export.h>
 
-#include <vital/vital_config.h>
-
 #include <opencv2/core/core.hpp>
 
 #include <vital/algo/image_object_detector.h>

--- a/arrows/darknet/darknet_detector.h
+++ b/arrows/darknet/darknet_detector.h
@@ -34,8 +34,6 @@
 
 #include <arrows/darknet/kwiver_algo_darknet_export.h>
 
-#include <vital/vital_config.h>
-
 #include <vital/algo/image_object_detector.h>
 
 namespace kwiver {

--- a/arrows/darknet/darknet_trainer.h
+++ b/arrows/darknet/darknet_trainer.h
@@ -34,8 +34,6 @@
 
 #include <arrows/darknet/kwiver_algo_darknet_export.h>
 
-#include <vital/vital_config.h>
-
 #include <vital/algo/train_detector.h>
 
 namespace kwiver {

--- a/arrows/kpf/detected_object_set_input_kpf.h
+++ b/arrows/kpf/detected_object_set_input_kpf.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_KPF_DETECTED_OBJECT_SET_INPUT_KPF_H
 #define KWIVER_ARROWS_KPF_DETECTED_OBJECT_SET_INPUT_KPF_H
 
-
-#include <vital/vital_config.h>
 #include <arrows/kpf/kwiver_algo_kpf_export.h>
 
 #include <vital/algo/detected_object_set_input.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/kpf/detected_object_set_output_kpf.h
+++ b/arrows/kpf/detected_object_set_output_kpf.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_KPF_H
 #define KWIVER_ARROWS_DETECTED_OBJECT_SET_OUTPUT_KPF_H
 
-#include <vital/vital_config.h>
 #include <arrows/kpf/kwiver_algo_kpf_export.h>
 
 #include <vital/algo/detected_object_set_output.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/analyze_tracks.h
+++ b/arrows/ocv/analyze_tracks.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_ANALYZE_TRACKS_H_
 #define KWIVER_ARROWS_OCV_ANALYZE_TRACKS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/analyze_tracks.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/detect_features.h
+++ b/arrows/ocv/detect_features.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_OCV_DETECT_FEATURES_H_
 #define KWIVER_ARROWS_OCV_DETECT_FEATURES_H_
 
-
-#include <vital/vital_config.h>
 #include <vital/algo/detect_features.h>
 
 #include <arrows/ocv/kwiver_algo_ocv_export.h>

--- a/arrows/ocv/detect_features_AGAST.h
+++ b/arrows/ocv/detect_features_AGAST.h
@@ -39,13 +39,10 @@
 // Only available in OpenCV 3.x
 #ifdef KWIVER_HAS_OPENCV_VER_3
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/detect_features_FAST.h
+++ b/arrows/ocv/detect_features_FAST.h
@@ -36,17 +36,13 @@
 #ifndef KWIVER_ARROWS_DETECT_FEATURES_FAST_H_
 #define KWIVER_ARROWS_DETECT_FEATURES_FAST_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {
 namespace ocv{
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_FAST
   : public vital::algorithm_impl<detect_features_FAST,

--- a/arrows/ocv/detect_features_GFTT.h
+++ b/arrows/ocv/detect_features_GFTT.h
@@ -36,18 +36,14 @@
 #ifndef KWIVER_ARROWS_DETECT_FEATURES_GFTT_H_
 #define KWIVER_ARROWS_DETECT_FEATURES_GFTT_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {
 namespace ocv {
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_GFTT
   : public vital::algorithm_impl< detect_features_GFTT,

--- a/arrows/ocv/detect_features_MSD.h
+++ b/arrows/ocv/detect_features_MSD.h
@@ -40,13 +40,10 @@
 #include <opencv2/opencv_modules.hpp>
 #ifdef HAVE_OPENCV_XFEATURES2D
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/detect_features_MSER.h
+++ b/arrows/ocv/detect_features_MSER.h
@@ -36,18 +36,14 @@
 #ifndef KWIVER_ARROWS_DETECT_FEATURES_MSER_H_
 #define KWIVER_ARROWS_DETECT_FEATURES_MSER_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {
 namespace ocv{
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_MSER
   : public vital::algorithm_impl< detect_features_MSER,

--- a/arrows/ocv/detect_features_simple_blob.h
+++ b/arrows/ocv/detect_features_simple_blob.h
@@ -36,18 +36,14 @@
 #ifndef KWIVER_ARROWS_DETECT_FEATURES_SIMPLE_BLOB_H_
 #define KWIVER_ARROWS_DETECT_FEATURES_SIMPLE_BLOB_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {
 namespace ocv {
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_simple_blob
   : public vital::algorithm_impl< detect_features_simple_blob,

--- a/arrows/ocv/draw_detected_object_set.h
+++ b/arrows/ocv/draw_detected_object_set.h
@@ -36,13 +36,9 @@
 #ifndef ARROWS_OCV_DRAW_DETECTED_OBJECT_SET_H
 #define ARROWS_OCV_DRAW_DETECTED_OBJECT_SET_H
 
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/draw_detected_object_set.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -35,16 +35,6 @@
 
 #include "draw_tracks.h"
 
-#include <set>
-#include <fstream>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
-#include <stdio.h> // using C99 interface to support older compilers
-#include <deque>
-
-#include <vital/vital_config.h>
 #include <vital/logger/logger.h>
 #include <vital/exceptions/io.h>
 #include <vital/types/feature_track_set.h>
@@ -56,6 +46,15 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
+
+#include <set>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+#include <stdio.h> // using C99 interface to support older compilers
+#include <deque>
 
 using namespace kwiver::vital;
 

--- a/arrows/ocv/draw_tracks.h
+++ b/arrows/ocv/draw_tracks.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_DRAW_TRACKS_H_
 #define KWIVER_ARROWS_OCV_DRAW_TRACKS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/draw_tracks.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/estimate_fundamental_matrix.h
+++ b/arrows/ocv/estimate_fundamental_matrix.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_ESTIMATE_FUNDAMENTAL_MATRIX_H_
 #define KWIVER_ARROWS_OCV_ESTIMATE_FUNDAMENTAL_MATRIX_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/estimate_fundamental_matrix.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/estimate_homography.h
+++ b/arrows/ocv/estimate_homography.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_ESTIMATE_HOMOGRAPHY_H_
 #define KWIVER_ARROWS_OCV_ESTIMATE_HOMOGRAPHY_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/estimate_homography.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/extract_descriptors.h
+++ b/arrows/ocv/extract_descriptors.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_OCV_EXTRACT_DESCRIPTORS_H_
 #define KWIVER_ARROWS_OCV_EXTRACT_DESCRIPTORS_H_
 
-
-#include <vital/vital_config.h>
 #include <vital/algo/extract_descriptors.h>
 
 #include <arrows/ocv/kwiver_algo_ocv_export.h>

--- a/arrows/ocv/extract_descriptors_BRIEF.h
+++ b/arrows/ocv/extract_descriptors_BRIEF.h
@@ -39,13 +39,11 @@
 #include <opencv2/opencv_modules.hpp>
 #if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
 
-#include <memory>
-#include <string>
-
 #include <vital/algo/extract_descriptors.h>
-#include <vital/vital_config.h>
 
 #include <arrows/ocv/extract_descriptors.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/feature_detect_extract_BRISK.h
+++ b/arrows/ocv/feature_detect_extract_BRISK.h
@@ -36,19 +36,15 @@
 #ifndef KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_BRISK_H_
 #define KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_BRISK_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/extract_descriptors.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
+#include <string>
+
 namespace kwiver {
 namespace arrows {
 namespace ocv {
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_BRISK
   : public vital::algorithm_impl< detect_features_BRISK,

--- a/arrows/ocv/feature_detect_extract_ORB.h
+++ b/arrows/ocv/feature_detect_extract_ORB.h
@@ -36,14 +36,11 @@
 #ifndef KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_ORB_H_
 #define KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_ORB_H_
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/extract_descriptors.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/feature_detect_extract_SIFT.h
+++ b/arrows/ocv/feature_detect_extract_SIFT.h
@@ -39,19 +39,15 @@
 #include <opencv2/opencv_modules.hpp>
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/extract_descriptors.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
+#include <string>
+
 namespace kwiver {
 namespace arrows {
 namespace ocv {
-
 
 class KWIVER_ALGO_OCV_EXPORT detect_features_SIFT
   : public vital::algorithm_impl< detect_features_SIFT,

--- a/arrows/ocv/feature_detect_extract_SURF.h
+++ b/arrows/ocv/feature_detect_extract_SURF.h
@@ -39,14 +39,11 @@
 #include <opencv2/opencv_modules.hpp>
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
-#include <memory>
-#include <string>
-
-#include <vital/vital_config.h>
-
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/extract_descriptors.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
+
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/image_io.h
+++ b/arrows/ocv/image_io.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_OCV_IMAGE_IO_H_
 #define KWIVER_ARROWS_OCV_IMAGE_IO_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/image_io.h>

--- a/arrows/ocv/match_features.h
+++ b/arrows/ocv/match_features.h
@@ -36,14 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_MATCH_FEATURES_H_
 #define KWIVER_ARROWS_OCV_MATCH_FEATURES_H_
 
-#include <memory>
-
-#include <vital/vital_config.h>
 #include <vital/algo/match_features.h>
 
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
-
-#include <memory>
 
 #include <opencv2/features2d/features2d.hpp>
 

--- a/arrows/ocv/refine_detections_write_to_disk.h
+++ b/arrows/ocv/refine_detections_write_to_disk.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_REFINE_DETECTIONS_WRITE_TO_DISK_H_
 #define KWIVER_ARROWS_OCV_REFINE_DETECTIONS_WRITE_TO_DISK_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/refine_detections.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/ocv/split_image.h
+++ b/arrows/ocv/split_image.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
 #define KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/algo/split_image.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {
@@ -51,7 +47,7 @@ namespace ocv {
 /// A class for writing out image chips around detections, useful as a debugging process
 /// for ensuring that the refine detections process is running on desired ROIs.
 class KWIVER_ALGO_OCV_EXPORT split_image
-: public vital::algorithm_impl<split_image, vital::algo::split_image>
+  : public vital::algorithm_impl<split_image, vital::algo::split_image>
 {
 public:
 

--- a/arrows/ocv/split_image.h
+++ b/arrows/ocv/split_image.h
@@ -57,6 +57,9 @@ public:
   /// Destructor
   virtual ~split_image();
 
+  virtual void set_configuration( kwiver::vital::config_block_sptr ) { }
+  virtual bool check_configuration( kwiver::vital::config_block_sptr config) const { return true; }
+
   /// Split image
   virtual std::vector< kwiver::vital::image_container_sptr >
   split(kwiver::vital::image_container_sptr img) const;

--- a/arrows/proj/geo_conv.h
+++ b/arrows/proj/geo_conv.h
@@ -49,7 +49,8 @@ namespace arrows {
 namespace proj {
 
 /// PROJ implementation of geo_conversion functor
-class KWIVER_ALGO_PROJ_EXPORT geo_conversion : public vital::geo_conversion
+class KWIVER_ALGO_PROJ_EXPORT geo_conversion
+  : public vital::geo_conversion
 {
 public:
   geo_conversion() {}

--- a/arrows/viscl/convert_image.h
+++ b/arrows/viscl/convert_image.h
@@ -31,8 +31,6 @@
 #ifndef KWIVER_ARROWS_VISCL_CONVERT_IMAGE_H_
 #define KWIVER_ARROWS_VISCL_CONVERT_IMAGE_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/viscl/kwiver_algo_viscl_export.h>
 
 #include <vital/algo/convert_image.h>

--- a/arrows/viscl/detect_features.h
+++ b/arrows/viscl/detect_features.h
@@ -31,13 +31,9 @@
 #ifndef KWIVER_ARROWS_VISCL_DETECT_FEATURES_H_
 #define KWIVER_ARROWS_VISCL_DETECT_FEATURES_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/viscl/kwiver_algo_viscl_export.h>
 
 #include <vital/algo/detect_features.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/viscl/extract_descriptors.h
+++ b/arrows/viscl/extract_descriptors.h
@@ -31,14 +31,9 @@
 #ifndef KWIVER_ARROWS_VISCL_EXTRACT_DESCRIPTORS_H_
 #define KWIVER_ARROWS_VISCL_EXTRACT_DESCRIPTORS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/viscl/kwiver_algo_viscl_export.h>
 
 #include <vital/algo/extract_descriptors.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/viscl/match_features.h
+++ b/arrows/viscl/match_features.h
@@ -31,14 +31,9 @@
 #ifndef KWIVER_ARROWS_VISCL_MATCH_FEATURES_H_
 #define KWIVER_ARROWS_VISCL_MATCH_FEATURES_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/viscl/kwiver_algo_viscl_export.h>
 
 #include <vital/algo/match_features.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/bundle_adjust.h
+++ b/arrows/vxl/bundle_adjust.h
@@ -36,14 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_BUNDLE_ADJUST_H_
 #define KWIVER_ARROWS_VXL_BUNDLE_ADJUST_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/bundle_adjust.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/camera_map.h
+++ b/arrows/vxl/camera_map.h
@@ -36,9 +36,6 @@
 #ifndef KWIVER_ARROWS_VXL_CAMERA_MAP_H_
 #define KWIVER_ARROWS_VXL_CAMERA_MAP_H_
 
-
-#include <map>
-
 #include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
@@ -46,6 +43,7 @@
 
 #include <vpgl/vpgl_perspective_camera.h>
 
+#include <map>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/close_loops_homography_guided.h
+++ b/arrows/vxl/close_loops_homography_guided.h
@@ -37,16 +37,12 @@
 #ifndef KWIVER_ARROWS_VXL_CLOSE_LOOPS_HOMOGRAPHY_GUIDED_H_
 #define KWIVER_ARROWS_VXL_CLOSE_LOOPS_HOMOGRAPHY_GUIDED_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/types/image_container.h>
 #include <vital/types/feature_track_set.h>
 
 #include <vital/algo/close_loops.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/compute_homography_overlap.h
+++ b/arrows/vxl/compute_homography_overlap.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_COMPUTE_HOMOGRAPHY_OVERLAP_H_
 #define KWIVER_ARROWS_VXL_COMPUTE_HOMOGRAPHY_OVERLAP_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vnl/vnl_double_3x3.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/estimate_canonical_transform.h
+++ b/arrows/vxl/estimate_canonical_transform.h
@@ -31,12 +31,9 @@
 #ifndef KWIVER_ARROWS_VXL_ESTIMATE_CANONICAL_TRANSFORM_H_
 #define KWIVER_ARROWS_VXL_ESTIMATE_CANONICAL_TRANSFORM_H_
 
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/estimate_canonical_transform.h>
-
-#include <memory>
 
 /**
  * \file

--- a/arrows/vxl/estimate_essential_matrix.h
+++ b/arrows/vxl/estimate_essential_matrix.h
@@ -36,16 +36,11 @@
 #ifndef KWIVER_ARROWS_VXL_ESTIMATE_ESSENTIAL_MATRIX_H_
 #define KWIVER_ARROWS_VXL_ESTIMATE_ESSENTIAL_MATRIX_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/types/camera_intrinsics.h>
 
 #include <vital/algo/estimate_essential_matrix.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/estimate_fundamental_matrix.h
+++ b/arrows/vxl/estimate_fundamental_matrix.h
@@ -36,14 +36,11 @@
 #ifndef KWIVER_ARROWS_VXL_ESTIMATE_FUNDAMENTAL_MATRIX_H_
 #define KWIVER_ARROWS_VXL_ESTIMATE_FUNDAMENTAL_MATRIX_H_
 
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/types/camera_intrinsics.h>
 
 #include <vital/algo/estimate_fundamental_matrix.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/estimate_homography.h
+++ b/arrows/vxl/estimate_homography.h
@@ -36,12 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_ESTIMATE_HOMOGRAPHY_H_
 #define KWIVER_ARROWS_VXL_ESTIMATE_HOMOGRAPHY_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/estimate_homography.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/estimate_similarity_transform.h
+++ b/arrows/vxl/estimate_similarity_transform.h
@@ -36,13 +36,10 @@
 #ifndef KWIVER_ARROWS_VXL_ESTIMATE_SIMILARITY_TRANSFORM_H_
 #define KWIVER_ARROWS_VXL_ESTIMATE_SIMILARITY_TRANSFORM_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/estimate_similarity_transform.h>
 #include <vital/types/vector.h>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/image_io.h
+++ b/arrows/vxl/image_io.h
@@ -36,13 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_IMAGE_IO_H_
 #define KWIVER_ARROWS_VXL_IMAGE_IO_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/image_io.h>
-
-#include <memory>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/match_features_constrained.h
+++ b/arrows/vxl/match_features_constrained.h
@@ -36,14 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_MATCH_FEATURES_CONSTRAINED_H_
 #define KWIVER_ARROWS_VXL_MATCH_FEATURES_CONSTRAINED_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/match_features.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/optimize_cameras.h
+++ b/arrows/vxl/optimize_cameras.h
@@ -36,15 +36,12 @@
 #ifndef KWIVER_ARROWS_VXL_OPTIMIZE_CAMERAS_H_
 #define KWIVER_ARROWS_VXL_OPTIMIZE_CAMERAS_H_
 
-
-#include <string>
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/algorithm.h>
 #include <vital/algo/optimize_cameras.h>
 
+#include <string>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/vxl/split_image.h
+++ b/arrows/vxl/split_image.h
@@ -56,6 +56,9 @@ public:
   /// Destructor
   virtual ~split_image();
 
+  virtual void set_configuration( kwiver::vital::config_block_sptr ) { }
+  virtual bool check_configuration( kwiver::vital::config_block_sptr config) const { return true; }
+
   /// Split image
   virtual std::vector< kwiver::vital::image_container_sptr >
   split(kwiver::vital::image_container_sptr img) const;

--- a/arrows/vxl/split_image.h
+++ b/arrows/vxl/split_image.h
@@ -36,8 +36,6 @@
 #ifndef KWIVER_ARROWS_VXL_SPLIT_IMAGE_H_
 #define KWIVER_ARROWS_VXL_SPLIT_IMAGE_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/split_image.h>

--- a/arrows/vxl/triangulate_landmarks.h
+++ b/arrows/vxl/triangulate_landmarks.h
@@ -36,14 +36,9 @@
 #ifndef KWIVER_ARROWS_VXL_TRIANGULATE_LANDMARKS_H_
 #define KWIVER_ARROWS_VXL_TRIANGULATE_LANDMARKS_H_
 
-
-#include <vital/vital_config.h>
 #include <arrows/vxl/kwiver_algo_vxl_export.h>
 
 #include <vital/algo/triangulate_landmarks.h>
-
-#include <memory>
-
 
 namespace kwiver {
 namespace arrows {

--- a/vital/algo/split_image.cxx
+++ b/vital/algo/split_image.cxx
@@ -44,23 +44,4 @@ split_image
   attach_logger( "split_image" );
 }
 
-
-/// Set this algorithm's properties via a config block
-void
-split_image
-::set_configuration(kwiver::vital::config_block_sptr config)
-{
-  (void) config;
-}
-
-/// Check that the algorithm's current configuration is valid
-bool
-split_image
-::check_configuration(kwiver::vital::config_block_sptr config) const
-{
-  (void) config;
-  return true;
-}
-
-
 } } } // end namespace

--- a/vital/algo/split_image.h
+++ b/vital/algo/split_image.h
@@ -50,11 +50,6 @@ public:
   /// Return the name of this algorithm
   static std::string static_type_name() { return "split_image"; }
 
-  /// Set this algorithm's properties via a config block
-  virtual void set_configuration(kwiver::vital::config_block_sptr config);
-  /// Check that the algorithm's currently configuration is valid
-  virtual bool check_configuration(kwiver::vital::config_block_sptr config) const;
-
   /// Split image
   virtual std::vector< kwiver::vital::image_container_sptr >
     split(kwiver::vital::image_container_sptr img) const = 0;


### PR DESCRIPTION
Removing unneeded include files and adjusting some whitespace.

Move {set,check}_config methods from base class to leaf classes. Leaf classes should explicitly state what they are doing with the config rather than relying on the do-nothing behaviour of the base class.