### PR TITLE
Remove usage of snprintf and other style changes

### DIFF
--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -38,6 +38,7 @@
 #include <vital/logger/logger.h>
 #include <vital/exceptions/io.h>
 #include <vital/types/feature_track_set.h>
+#include <vital/util/string.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -53,7 +54,6 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
-#include <stdio.h> // using C99 interface to support older compilers
 #include <deque>
 
 using namespace kwiver::vital;
@@ -70,10 +70,6 @@ typedef std::vector< std::pair< cv::Point, cv::Point > > line_vec_t;
 
 /// Helper typedef for storing past frame id offsets
 typedef std::vector< frame_id_t > fid_offset_vec_t;
-
-#if VITAL_SYSTEM_WIN_API
-#define snprintf _snprintf
-#endif
 
 /// Private implementation class
 class draw_tracks::priv
@@ -119,7 +115,7 @@ public:
 /// Constructor
 draw_tracks
 ::draw_tracks()
-: d_( new priv )
+: d( new priv )
 {
 }
 
@@ -138,37 +134,37 @@ draw_tracks
 {
   vital::config_block_sptr config = vital::algo::draw_tracks::get_configuration();
 
-  config->set_value( "draw_track_ids", d_->draw_track_ids,
+  config->set_value( "draw_track_ids", d->draw_track_ids,
                      "Draw track ids next to each feature point." );
-  config->set_value( "draw_untracked_features", d_->draw_untracked_features,
+  config->set_value( "draw_untracked_features", d->draw_untracked_features,
                      "Draw untracked feature points in error_color." );
-  config->set_value( "draw_match_lines", d_->draw_match_lines,
+  config->set_value( "draw_match_lines", d->draw_match_lines,
                      "Draw lines between tracked features on the current frame "
                      "to any past frames." );
-  config->set_value( "draw_shift_lines", d_->draw_shift_lines,
+  config->set_value( "draw_shift_lines", d->draw_shift_lines,
                      "Draw lines showing the movement of the feature in the image "
                      "plane from the last frame to the current one drawn on every "
                      "single image individually." );
-  config->set_value( "draw_comparison_lines", d_->draw_comparison_lines,
+  config->set_value( "draw_comparison_lines", d->draw_comparison_lines,
                      "If more than 1 track set is input to this class, should we "
                      "draw comparison lines between tracks with the same ids in "
                      "both input sets?" );
-  config->set_value( "swap_comparison_set", d_->swap_comparison_set,
+  config->set_value( "swap_comparison_set", d->swap_comparison_set,
                      "If we are using a comparison track set, swap it and the input "
                      "track set, so that the comparison set becomes the main set "
                      "being displayed." );
-  config->set_value( "write_images_to_disk", d_->write_images_to_disk,
+  config->set_value( "write_images_to_disk", d->write_images_to_disk,
                      "Should images be written out to disk?" );
-  config->set_value( "pattern", d_->pattern,
+  config->set_value( "pattern", d->pattern,
                      "The output pattern for writing images to disk." );
 
   std::stringstream ss;
-  if ( !d_->past_frames_to_show.empty() )
+  if ( !d->past_frames_to_show.empty() )
   {
-    ss << d_->past_frames_to_show[0];
-    for(unsigned i=1; i < d_->past_frames_to_show.size(); ++i)
+    ss << d->past_frames_to_show[0];
+    for(unsigned i=1; i < d->past_frames_to_show.size(); ++i)
     {
-      ss << ", " << d_->past_frames_to_show[i];
+      ss << ", " << d->past_frames_to_show[i];
     }
   }
   config->set_value( "past_frames_to_show", ss.str(),
@@ -193,12 +189,12 @@ draw_tracks
   std::string past_frames_str = config->get_value<std::string>( "past_frames_to_show" );
 
   std::stringstream ss( past_frames_str );
-  d_->past_frames_to_show.clear();
+  d->past_frames_to_show.clear();
 
   unsigned next_int;
   while( ss >> next_int )
   {
-    d_->past_frames_to_show.push_back( next_int );
+    d->past_frames_to_show.push_back( next_int );
 
     if( ss.peek() == ',' )
     {
@@ -206,18 +202,18 @@ draw_tracks
     }
   }
 
-  d_->draw_track_ids = config->get_value<bool>( "draw_track_ids" );
-  d_->draw_untracked_features = config->get_value<bool>( "draw_untracked_features" );
-  d_->draw_match_lines = config->get_value<bool>( "draw_match_lines" );
-  d_->draw_shift_lines = config->get_value<bool>( "draw_shift_lines" );
-  d_->draw_comparison_lines = config->get_value<bool>( "draw_comparison_lines" );
-  d_->swap_comparison_set = config->get_value<bool>( "swap_comparison_set" );
-  d_->write_images_to_disk = config->get_value<bool>( "write_images_to_disk" );
-  d_->pattern = config->get_value<std::string>( "pattern" );
+  d->draw_track_ids = config->get_value<bool>( "draw_track_ids" );
+  d->draw_untracked_features = config->get_value<bool>( "draw_untracked_features" );
+  d->draw_match_lines = config->get_value<bool>( "draw_match_lines" );
+  d->draw_shift_lines = config->get_value<bool>( "draw_shift_lines" );
+  d->draw_comparison_lines = config->get_value<bool>( "draw_comparison_lines" );
+  d->swap_comparison_set = config->get_value<bool>( "swap_comparison_set" );
+  d->write_images_to_disk = config->get_value<bool>( "write_images_to_disk" );
+  d->pattern = config->get_value<std::string>( "pattern" );
 
-  if( !d_->past_frames_to_show.empty() )
+  if( !d->past_frames_to_show.empty() )
   {
-    d_->buffer.resize( *std::max_element( d_->past_frames_to_show.begin(), d_->past_frames_to_show.end()) );
+    d->buffer.resize( *std::max_element( d->past_frames_to_show.begin(), d->past_frames_to_show.end()) );
   }
 }
 
@@ -328,7 +324,7 @@ draw_tracks
   track_set_sptr display_set = input_display_set;
   track_set_sptr comparison_set = input_comparison_set;
 
-  if( d_->swap_comparison_set )
+  if( d->swap_comparison_set )
   {
     std::swap( display_set, comparison_set );
   }
@@ -347,13 +343,13 @@ draw_tracks
   cv::Mat output_image;
 
   // The total number of past frames we are showing
-  const unsigned past_frames = static_cast<unsigned>( d_->past_frames_to_show.size() );
+  const unsigned past_frames = static_cast<unsigned>( d->past_frames_to_show.size() );
 
   // The total number of output frames to display
   const unsigned display_frames = past_frames + 1;
 
   // Generate output images
-  frame_id_t fid = d_->cur_frame_id;
+  frame_id_t fid = d->cur_frame_id;
 
   // Colors to use
   const cv::Scalar default_color( 255, 0, 0 );
@@ -367,7 +363,7 @@ draw_tracks
   for( image_container_sptr ctr_sptr : image_data )
   {
     // Should the current frame be written to disk?
-    bool write_image_to_disk = d_->write_images_to_disk;
+    bool write_image_to_disk = d->write_images_to_disk;
 
     // Clone a copy of the current image (so we don't modify the original input).
     cv::Mat img = ocv::image_container::vital_to_ocv( ctr_sptr->get_image() ).clone();
@@ -424,13 +420,13 @@ draw_tracks
       }
 
       // Generate and store match lines for later use
-      if( d_->draw_match_lines )
+      if( d->draw_match_lines )
       {
-        generate_match_lines( trk, fid, d_->past_frames_to_show, pt_adj, lines );
+        generate_match_lines( trk, fid, d->past_frames_to_show, pt_adj, lines );
       }
 
       // Generate comparison lines
-      if( d_->draw_comparison_lines && comparison_set_provided )
+      if( d->draw_comparison_lines && comparison_set_provided )
       {
         track_sptr comparison_trk = comparison_set->get_track( trk->id() );
 
@@ -456,7 +452,7 @@ draw_tracks
       }
 
       // Generate and draw shift lines on the video
-      if( d_->draw_shift_lines && trk->size() > 1 && fid > 0 )
+      if( d->draw_shift_lines && trk->size() > 1 && fid > 0 )
       {
         track::history_const_itr itr = trk->find( fid-1 );
 
@@ -471,12 +467,12 @@ draw_tracks
         }
       }
 
-      if( d_->draw_track_ids && trk->size() > 1 )
+      if( d->draw_track_ids && trk->size() > 1 )
       {
         cv::putText( img, tid_str, loc + txt_offset, cv::FONT_HERSHEY_COMPLEX_SMALL, 0.5, color );
       }
 
-      if( d_->draw_untracked_features || trk->size() > 1 )
+      if( d->draw_untracked_features || trk->size() > 1 )
       {
         cv::circle( img, loc, 1, color, 3 );
       }
@@ -494,23 +490,16 @@ draw_tracks
     // was a %f, for example. An alternative could be to append a 5
     // digit frame number to the base file name and not use format
     // specifiers.
-    std::string ofn;
-    size_t max_len = d_->pattern.size() + 4096;
-    ofn.resize( max_len );
-    int num_bytes = snprintf( &ofn[0], max_len, d_->pattern.c_str(), fid );
-    if (num_bytes < 0) // format conversion error
+    std::string ofn = kwiver::vital::string_format( d->pattern, fid );
+    if ( ofn.empty() )
     {
-      LOG_WARN( logger(), "Could not format output file name: \"" <<  d_->pattern
+      LOG_WARN( logger(), "Could not format output file name: \"" <<  d->pattern
                 << "\". Disabling writing to disk." );
 
       // The safest thing is to disable writing since we have no idea
       // what the file name looks like after a format conversion
       // error.
       write_image_to_disk = false;
-    }
-    else if (static_cast< unsigned >(num_bytes) < max_len)
-    {
-      ofn.resize( num_bytes );
     }
 
     output_image = cv::Mat( img.rows, display_frames*img.cols, img.type(), cv::Scalar(0) );
@@ -519,10 +508,10 @@ draw_tracks
     {
       cv::Mat region( output_image, cv::Rect( i*img.cols, 0, img.cols, img.rows ) );
 
-      if( ((signed) d_->buffer.size() >= d_->past_frames_to_show[i]) &&
-          (d_->past_frames_to_show[i] != 0) )
+      if( ((signed) d->buffer.size() >= d->past_frames_to_show[i]) &&
+          (d->past_frames_to_show[i] != 0) )
       {
-        d_->buffer[ d_->buffer.size()-d_->past_frames_to_show[i] ].copyTo( region );
+        d->buffer[ d->buffer.size()-d->past_frames_to_show[i] ].copyTo( region );
       }
     }
 
@@ -553,10 +542,10 @@ draw_tracks
 
     // Store last image with all features and shift lines already drawn on it
     // add new element to buffer
-    if( d_->buffer.size() > 0 )
+    if( d->buffer.size() > 0 )
     {
-      d_->buffer.push_back( img );
-      d_->buffer.pop_front();
+      d->buffer.push_back( img );
+      d->buffer.pop_front();
     }
 
     // Increase frame id counter
@@ -564,7 +553,7 @@ draw_tracks
   }
 
   // Store latest states
-  d_->cur_frame_id = fid;
+  d->cur_frame_id = fid;
 
   // Return the last generated image
   return image_container_sptr( new ocv::image_container( output_image ) );

--- a/arrows/ocv/draw_tracks.h
+++ b/arrows/ocv/draw_tracks.h
@@ -86,7 +86,7 @@ private:
 
   /// private implementation class
   class priv;
-  const std::unique_ptr<priv> d_;
+  const std::unique_ptr<priv> d;
 };
 
 } // end namespace ocv


### PR DESCRIPTION
The usage for snprintf was awkward. Replaced with vital util to format directly to std::string.