### PR TITLE
Add support for KPF v4 in arrows/kpf, track_oracle

### DIFF
--- a/arrows/kpf/yaml/kpf_canonical_types.h
+++ b/arrows/kpf/yaml/kpf_canonical_types.h
@@ -148,16 +148,14 @@ struct KPF_YAML_EXPORT activity_t
     std::vector< scoped< timestamp_range_t > > actor_timespan;
   };
 
-  std::string activity_label;
+  cset_t activity_labels;
   scoped< id_t > activity_id;
   std::vector< scoped< timestamp_range_t > > timespan;
   std::vector< actor_t > actors;
   std::vector< kv_t > attributes;
-  std::vector< scoped< conf_t > > confidences;
   std::vector< scoped< eval_t > > evals;
 
   activity_t():
-    activity_label( "invalid" ),
     activity_id( id_t(), -1 )
     {}
 

--- a/arrows/kpf/yaml/kpf_packet.cxx
+++ b/arrows/kpf/yaml/kpf_packet.cxx
@@ -247,8 +247,12 @@ operator<<( std::ostream& os, const packet_t& p )
   case packet_style::ACT:
     {
       const canonical::activity_t& act = p.activity;
-      os << act.activity_label
-         << " id " << act.activity_id.t.d << "/" << act.activity_id.domain
+      os << " what [ ";
+      for (auto t: act.activity_labels.d)
+      {
+        os << t.first << ": " << t.second << ", ";
+      }
+      os << " ] id " << act.activity_id.t.d << "/" << act.activity_id.domain
          << " [ ";
       for (auto t: act.timespan )
       {

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -81,6 +81,29 @@ kpf_v3_check( const YAML::Node& n )
 }
 
 bool
+cset_helper_parser( const string& context, const YAML::Node& n, KPFC::cset_t& cset )
+{
+  if ( ! n.IsMap() )
+  {
+    LOG_ERROR( main_logger, "YAML parser: " << context << ": not a map?" );
+    return false;
+  }
+  try
+  {
+    for (auto i=n.begin(); i != n.end(); ++i)
+    {
+      cset.d.insert( make_pair( i->first.as<string>(), i->second.as<double>() ));
+    }
+  }
+  catch (const std::invalid_argument& e )
+  {
+    LOG_ERROR( main_logger, "YAML parser: " << context << ": error converting to double: " << e.what() );
+    return false;
+  }
+  return true;
+}
+
+bool
 parse_poly( KPF::packet_t& p, const YAML::Node& n )
 {
   if (! n.IsSequence())
@@ -124,25 +147,8 @@ parse_poly( KPF::packet_t& p, const YAML::Node& n )
 bool
 parse_cset( KPF::packet_t& p, const YAML::Node& n )
 {
-  if ( ! n.IsMap() )
-  {
-    LOG_ERROR( main_logger, "YAML parser: cset: not a map?" );
-    return false;
-  }
   p.cset = new KPFC::cset_t();
-  try
-  {
-    for (auto i=n.begin(); i != n.end(); ++i)
-    {
-      p.cset->d.insert( make_pair( i->first.as<string>(), i->second.as<double>() ));
-    }
-  }
-  catch (const std::invalid_argument& e )
-  {
-    LOG_ERROR( main_logger, "YAML parser: cse: error converting to double: " << e.what() );
-    return false;
-  }
-  return true;
+  return cset_helper_parser( "cset", n, *(p.cset) );
 }
 
 bool
@@ -387,7 +393,10 @@ parse_activity( const YAML::Node& n, KPF::packet_buffer_t& local_packet_buffer )
     if ( h.style == KPF::packet_style::ACT)
     {
       act.activity_id.domain = h.domain;
-      act.activity_label = i->second.as<string>();
+      if (! cset_helper_parser( "activity-label cset", i->second, act.activity_labels ))
+      {
+        return false;
+      }
     }
   }
   if ( act.activity_id.domain == -1 )
@@ -432,12 +441,6 @@ parse_activity( const YAML::Node& n, KPF::packet_buffer_t& local_packet_buffer )
         KPF::packet_t p(h);
         if ( ! parse_packet( i, p )) return false;
         act.evals.push_back ( {p.eval, p.header.domain} );
-      }
-      else if (h.style == KPF::packet_style::CONF)
-      {
-        KPF::packet_t p(h);
-        if ( ! parse_packet( i, p )) return false;
-        act.confidences.push_back ( {p.conf, p.header.domain} );
       }
       else if (h.style == KPF::packet_style::ACT)
       {

--- a/arrows/kpf/yaml/kpf_yaml_schemas.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_schemas.cxx
@@ -69,7 +69,7 @@ required_packets( KPF::schema_style schema )
   case KPF::schema_style::TYPES:
     return {
       KPF::validation_data( KPF::packet_style::ID ),
-      KPF::validation_data( KPF::packet_style::KV, "obj_type" )
+      KPF::validation_data( KPF::packet_style::CSET )
     };
 
   case KPF::schema_style::REGIONS:

--- a/arrows/kpf/yaml/kpf_yaml_writer.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_writer.cxx
@@ -184,7 +184,12 @@ operator<<( record_yaml_writer& w, const writer< canonical::activity_t >& io )
   const canonical::activity_t& act = io.activity;
 
   w.oss << "act" << io.domain << ": ";
-  w.oss << act.activity_label << ", ";
+  w.oss << "{ ";
+  for (auto p:act.activity_labels.d)
+  {
+    w.oss << p.first << ": " << p.second << ", ";
+  }
+  w.oss << "}, ";
 
   w.oss << "id" << act.activity_id.domain << ": " << act.activity_id.t.d << ", ";
 
@@ -198,11 +203,6 @@ operator<<( record_yaml_writer& w, const writer< canonical::activity_t >& io )
   for (auto k: act.attributes )
   {
     w << writer<canonical::kv_t>( k );
-  }
-
-  for (auto c: act.confidences )
-  {
-    w << writer< canonical::conf_t>( c );
   }
 
   for (auto e: act.evals )

--- a/examples/cpp/kpf/kpf_example_activity.cxx
+++ b/examples/cpp/kpf/kpf_example_activity.cxx
@@ -142,7 +142,17 @@ struct user_act_adapter_t: public KPF::kpf_act_adapter< user_activity_t >
         }
         // load the activity ID, name, and start and stop frames
         u.id = a.activity_id.t.d;
-        u.name = a.activity_label;
+
+
+        // there should only be one name in the activity labels map,
+        const KPF::canonical::cset_t& al = a.activity_labels;
+        if ((al.d.size() != 1))
+        {
+          throw logic_error( "KPF activity label not a single value" );
+        }
+        u.name = al.d.begin()->first;
+        u.confidence = al.d.begin()->second;
+
         u.start = a.timespan[0].t.start;
         u.stop = a.timespan[0].t.stop;
         // load in our actor IDs
@@ -158,29 +168,18 @@ struct user_act_adapter_t: public KPF::kpf_act_adapter< user_activity_t >
             u.source = kv.val;
           }
         }
-        // look for our confidence in confidence packets
-        for (const auto& c: a.confidences)
-        {
-          if (c.domain == DETECTOR_DOMAIN)
-          {
-            u.confidence = c.t.d;
-          }
-        }
       },
 
       // converts a user_activity "a" into a canonical activity and returns it
       []( const user_activity_t& u ) {
         KPF::canonical::activity_t a;
         // set the name, ID, and domain
-        a.activity_label = u.name;
+        a.activity_labels.d[ u.name ] = u.confidence;
         a.activity_id.t.d = u.id;
         a.activity_id.domain = DETECTOR_DOMAIN;
 
         // set our source as a key/value pair
         a.attributes.push_back( KPF::canonical::kv_t( "source", u.source ));
-
-        // set our confidence
-        a.confidences.push_back( {KPF::canonical::conf_t( u.confidence ), DETECTOR_DOMAIN });
 
         // set the start / stop time (as frame numbers)
         KPF::canonical::scoped< KPF::canonical::timestamp_range_t > tsr;
@@ -272,7 +271,7 @@ int main()
 
   {
     stringstream shuffle;
-    shuffle << "- { act: { timespan: [{ tsr0: [1001 , 1010],  }], conf17: 0.3, actors: [{ id15: 15, timespan: [{ tsr0: [1001 , 1010],  }], }], act17: walking, id17: 100, source: SHUFFLE }}";
+    shuffle << "- { act: { timespan: [{ tsr0: [1001 , 1010],  }], conf17: 0.3, actors: [{ id15: 15, timespan: [{ tsr0: [1001 , 1010],  }], }], act17: {walking: 1.0} , id17: 100, source: SHUFFLE }}";
 
     std::cout << "\nAbout to convert a shuffled V3 activity:\n" << shuffle.str() << "\n";
     vector< user_activity_t> shuffle_acts = read_activities_from_stream( shuffle );

--- a/track_oracle/core/kwiver_io_base.txx
+++ b/track_oracle/core/kwiver_io_base.txx
@@ -118,7 +118,6 @@ struct output_handler< false, vector<T> >
   {
     for (size_t i=0; i<vals.size(); ++i)
     {
-      //      os << vals[i] << " ";
       output_handler< class_has_kwiver_write<T>::value, T>::write( os, vals[i] );
       os << " ";
     }
@@ -140,7 +139,6 @@ ostream& operator<<( ostream& os, const vector< T >& vals )
 {
   for (size_t i=0; i<vals.size(); ++i)
   {
-    //    os << vals[i] << " ";
     output_handler< class_has_kwiver_write<T>::value, T>::write( os, vals[i] );
   }
   return os;

--- a/track_oracle/core/kwiver_io_base.txx
+++ b/track_oracle/core/kwiver_io_base.txx
@@ -118,7 +118,9 @@ struct output_handler< false, vector<T> >
   {
     for (size_t i=0; i<vals.size(); ++i)
     {
-      os << vals[i] << " ";
+      //      os << vals[i] << " ";
+      output_handler< class_has_kwiver_write<T>::value, T>::write( os, vals[i] );
+      os << " ";
     }
     return os;
   }
@@ -160,8 +162,8 @@ ostream&
 kwiver_io_base<DATA_TERM_T>
 ::to_stream( ostream& os, const Type& val ) const
 {
-  os << val;
-  //output_handler< class_has_kwiver_write<Type>::value, Type>::write( os, val );
+  //os << val;
+  output_handler< class_has_kwiver_write<Type>::value, Type>::write( os, val );
   return os;
 }
 

--- a/track_oracle/core/kwiver_io_helpers.cxx
+++ b/track_oracle/core/kwiver_io_helpers.cxx
@@ -214,5 +214,35 @@ ostream& kwiver_write( ostream& os, const vital::timestamp& ts )
   return os;
 }
 
+bool kwiver_read( const std::string& s, kpf_cset_type& cset )
+{
+  return false;
+}
+
+ostream& kwiver_write( std::ostream& os, const kpf_cset_type& cset )
+{
+  return os;
+}
+
+bool kwiver_read( const std::string& s, kpf_cset_sys_type& cset )
+{
+  return false;
+}
+
+ostream& kwiver_write( std::ostream& os, const kpf_cset_sys_type& cset )
+{
+  return os;
+}
+
+bool kwiver_read( const std::string& s, kpf_cset_s2i_type& cset )
+{
+  return false;
+}
+
+ostream& kwiver_write( std::ostream& os, const kpf_cset_s2i_type& cset )
+{
+  return os;
+}
+
 } // ...track_oracle
 } // ...kwiver

--- a/track_oracle/core/kwiver_io_helpers.h
+++ b/track_oracle/core/kwiver_io_helpers.h
@@ -9,6 +9,7 @@
 
 #include <vital/vital_config.h>
 #include <track_oracle/core/track_oracle_export.h>
+#include <track_oracle/core/track_oracle_api_types.h>
 
 #include <iostream>
 #include <vector>
@@ -42,6 +43,13 @@ TRACK_ORACLE_EXPORT bool kwiver_ts_string_read( const std::string& frame_str,
                                                 vital::timestamp& t );
 TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, vital::timestamp& ts );
 TRACK_ORACLE_EXPORT std::ostream& kwiver_write( std::ostream& os, const vital::timestamp& ts );
+
+TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, kpf_cset_type& cset );
+TRACK_ORACLE_EXPORT std::ostream&  kwiver_write( std::ostream& os, const kpf_cset_type& cset );
+TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, kpf_cset_sys_type& cset );
+TRACK_ORACLE_EXPORT std::ostream&  kwiver_write( std::ostream& os, const kpf_cset_sys_type& cset );
+TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, kpf_cset_s2i_type& cset );
+TRACK_ORACLE_EXPORT std::ostream&  kwiver_write( std::ostream& os, const kpf_cset_s2i_type& cset );
 
 //
 // default, unimplemented output routine for TMP

--- a/track_oracle/core/track_field_output_specializations.cxx
+++ b/track_oracle/core/track_field_output_specializations.cxx
@@ -18,6 +18,7 @@ using std::runtime_error;
 using std::set;
 using std::string;
 using std::vector;
+using std::map;
 
 namespace kwiver {
 namespace track_oracle {
@@ -190,6 +191,14 @@ ostream& operator<<( ostream& os,
   {
     os << " (no row set)";
   }
+  return os;
+}
+
+template< >
+ostream& operator<<( ostream& os,
+                     const track_field< map< string, double > >& f )
+{
+  os << " (" << f.field_handle << ") " << f.name;
   return os;
 }
 

--- a/track_oracle/core/track_field_output_specializations.h
+++ b/track_oracle/core/track_field_output_specializations.h
@@ -59,6 +59,11 @@ TRACK_ORACLE_EXPORT std::ostream&
 operator<<( std::ostream& os,
             const track_field< std::set< std::string> >& f );
 
+template< >
+TRACK_ORACLE_EXPORT std::ostream&
+operator<<( std::ostream& os,
+            const track_field< std::map< std::string, double > >& f );
+
 } // ...track_oracle
 } // ...kwiver
 

--- a/track_oracle/core/track_oracle_api_types.h
+++ b/track_oracle/core/track_oracle_api_types.h
@@ -120,6 +120,14 @@ typedef std::vector< size_t > csv_header_index_type;
 typedef std::map< field_handle_type, csv_header_index_type > csv_handler_map_type;
 typedef std::map< field_handle_type, csv_header_index_type >::const_iterator csv_handler_map_cit;
 
+///
+/// typedefs for the KPF cset map types
+///
+
+typedef std::map< std::string, double > kpf_cset_type;
+typedef std::map< std::string, size_t > kpf_cset_s2i_type;
+typedef std::map< size_t, double > kpf_cset_sys_type;
+
 namespace dt {
 
 struct TRACK_ORACLE_EXPORT context

--- a/track_oracle/core/track_oracle_instances_old_style.cxx
+++ b/track_oracle/core/track_oracle_instances_old_style.cxx
@@ -94,6 +94,10 @@ TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(std::vector< double >);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(std::vector< std::vector< double > >);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(std::vector< std::string >);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(std::set< std::string >);
+TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(kwiver::track_oracle::kpf_cset_type);
+TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(kwiver::track_oracle::kpf_cset_sys_type);
+TRACK_ORACLE_INSTANTIATE_OLD_STYLE_SPECIAL_OUTPUT(kwiver::track_oracle::kpf_cset_s2i_type);
+
 
 #ifdef WIN32
 TRACK_ORACLE_INSTANCES(std::pair<unsigned MACRO_COMMA unsigned >);

--- a/track_oracle/data_terms/data_term_instances.cxx
+++ b/track_oracle/data_terms/data_term_instances.cxx
@@ -50,7 +50,6 @@ TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::event_ty
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::event_probability );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::source_track_ids );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::actor_track_rows );
-TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::kpf_activity_label );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::kpf_activity_domain );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::kpf_activity_start );
 TRACK_ORACLE_INSTANTIATE_DATA_TERM( ::kwiver::track_oracle::dt::events::kpf_activity_stop );

--- a/track_oracle/data_terms/data_terms.cxx
+++ b/track_oracle/data_terms/data_terms.cxx
@@ -375,7 +375,6 @@ namespace events {
   DEF_DT( event_probability );
   DEF_DT( source_track_ids );
   DEF_DT( actor_track_rows );
-  DEF_DT( kpf_activity_label );
   DEF_DT( kpf_activity_domain );
   DEF_DT( kpf_activity_start );
   DEF_DT( kpf_activity_stop );

--- a/track_oracle/data_terms/data_terms.h
+++ b/track_oracle/data_terms/data_terms.h
@@ -105,7 +105,7 @@ namespace events {
   DECL_DT( event_probability, double, "event probability" );
   DECL_DT_RW_STR( source_track_ids, std::vector<unsigned>, "Track IDs contributing to the event" );
   DECL_DT_RW_STR( actor_track_rows, track_handle_list_type, "Track handles participating in the event" );
-  DECL_DT( kpf_activity_label, std::string, "KPF activity string" );
+
   DECL_DT( kpf_activity_domain, int, "KPF activity domain" );
   DECL_DT( kpf_activity_start, unsigned, "KPF activity start (frame number)" );
   DECL_DT( kpf_activity_stop, unsigned, "KPF activity stop (frame number)" );

--- a/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
+++ b/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
@@ -300,20 +300,20 @@ kpf_utils::add_to_row( kwiver::logging_map_type& log_map,
         {
           element_descriptor s2i_e( s2i_name,
                                     "KPF cset string-to-index helper",
-                                    typeid( map<string, size_t> ).name(),
+                                    typeid( kpf_cset_s2i_type ).name(),
                                     element_descriptor::SYSTEM );
-          s2i_f = track_oracle_core::create_element< map<string, size_t > >( s2i_e );
+          s2i_f = track_oracle_core::create_element< kpf_cset_s2i_type >( s2i_e );
         }
 
         element_descriptor e( oss.str(),
                               "KPF ad-hoc cset",
-                              typeid( map< size_t, double> ).name(),
+                              typeid( kpf_cset_sys_type ).name(),
                               element_descriptor::ADHOC );
-        f = track_oracle_core::create_element< map< size_t, double > >( e );
+        f = track_oracle_core::create_element< kpf_cset_sys_type >( e );
       }
 
       // iterate over the string / double pairs in the KPF packet, inserting
-      auto s2i_map = track_oracle_core::get_field< map< string, size_t > >( SYSTEM_ROW_HANDLE, s2i_f );
+      auto s2i_map = track_oracle_core::get_field< kpf_cset_s2i_type >( SYSTEM_ROW_HANDLE, s2i_f );
 
       map< size_t, double > payload;
       for (auto i: p.cset->d )
@@ -335,8 +335,8 @@ kpf_utils::add_to_row( kwiver::logging_map_type& log_map,
       }
 
       // store the s2i_map and payload back
-      track_oracle_core::get_field< map< string, size_t > >( SYSTEM_ROW_HANDLE, s2i_f ) = s2i_map;
-      track_oracle_core::get_field< map< size_t, double > >( row, f ) = payload;
+      track_oracle_core::get_field< kpf_cset_s2i_type >( SYSTEM_ROW_HANDLE, s2i_f ) = s2i_map;
+      track_oracle_core::get_field< kpf_cset_sys_type >( row, f ) = payload;
     }
     break;
   case KPF::packet_style::KV:
@@ -455,8 +455,8 @@ kpf_utils::optional_fields_to_packets( kpf_utils::optional_field_state& ofs,
         bool all_okay = true;
         if ( s2i_fh != INVALID_FIELD_HANDLE)
         {
-          const auto& s2i_map = track_oracle_core::get< map<string, size_t> >( SYSTEM_ROW_HANDLE, s2i_fh );
-          const auto& payload = track_oracle_core::get< map<size_t, double> >( row, fh );
+          const auto& s2i_map = track_oracle_core::get< kpf_cset_s2i_type >( SYSTEM_ROW_HANDLE, s2i_fh );
+          const auto& payload = track_oracle_core::get< kpf_cset_sys_type >( row, fh );
           if ( ! (s2i_map.first && payload.first ))
           {
             LOG_ERROR( main_logger, "KPF converting " << p.header

--- a/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
+++ b/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
@@ -286,30 +286,23 @@ kpf_utils::add_to_row( kwiver::logging_map_type& log_map,
       ostringstream oss;
       oss << KPF::style2str( p.header.style ) << "_" << p.header.domain;
       field_handle_type f = track_oracle_core::lookup_by_name( oss.str() );
-      field_handle_type s2i_f = INVALID_FIELD_HANDLE;
       if ( f == INVALID_FIELD_HANDLE )
       {
-        // create the string-to-index field as well
-        string s2i_name = oss.str()+"_s2i";
-        s2i_f = track_oracle_core::lookup_by_name( s2i_name );
-        if (s2i_f != INVALID_FIELD_HANDLE)
-        {
-          LOG_ERROR( main_logger, "Logic error: " << s2i_name << " exists but " << oss.str() << " does not?" );
-        }
-        else
-        {
-          element_descriptor s2i_e( s2i_name,
-                                    "KPF cset string-to-index helper",
-                                    typeid( kpf_cset_s2i_type ).name(),
-                                    element_descriptor::SYSTEM );
-          s2i_f = track_oracle_core::create_element< kpf_cset_s2i_type >( s2i_e );
-        }
-
         element_descriptor e( oss.str(),
                               "KPF ad-hoc cset",
                               typeid( kpf_cset_sys_type ).name(),
                               element_descriptor::ADHOC );
         f = track_oracle_core::create_element< kpf_cset_sys_type >( e );
+      }
+      string s2i_name = oss.str()+"_s2i";
+      field_handle_type s2i_f = track_oracle_core::lookup_by_name( s2i_name );
+      if (s2i_f == INVALID_FIELD_HANDLE)
+      {
+        element_descriptor s2i_e( s2i_name,
+                                  "KPF cset string-to-index helper",
+                                  typeid( kpf_cset_s2i_type ).name(),
+                                  element_descriptor::SYSTEM );
+        s2i_f = track_oracle_core::create_element< kpf_cset_s2i_type >( s2i_e );
       }
 
       // iterate over the string / double pairs in the KPF packet, inserting

--- a/track_oracle/file_formats/track_filter_kpf_activity/kpf_cset_instances.cxx
+++ b/track_oracle/file_formats/track_filter_kpf_activity/kpf_cset_instances.cxx
@@ -1,0 +1,39 @@
+/*ckwg +29
+ * Copyright 2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <track_oracle/core/track_oracle_api_types.h>
+#include <track_oracle/core/track_field_instantiation.h>
+
+#include <vital/vital_config.h>
+#include <track_oracle/core/track_oracle_export.h>
+#define TRACK_FIELD_EXPORT TRACK_ORACLE_EXPORT
+
+TRACK_FIELD_INSTANCES_GENERAL( kwiver::track_oracle::kpf_cset_type );
+

--- a/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.cxx
+++ b/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.cxx
@@ -261,7 +261,7 @@ track_filter_kpf_activity
 
       track_handle_type k = act_schema.create();
 
-      act_schema.activity_label() = kpf_act.activity_label;
+      act_schema.activity_labels() = kpf_act.activity_labels.d;
       act_schema.activity_id() = kpf_act.activity_id.t.d;
       act_schema.activity_domain() = kpf_activity_domain;
       act_schema.actors() = actor_tracks;
@@ -299,15 +299,8 @@ track_filter_kpf_activity
       }
 
       //
-      // set confidences & evaluations
+      // set evaluations
       //
-      for (auto const& c: kpf_act.confidences)
-      {
-        KPF::packet_t p (KPF::packet_header_t( KPF::packet_style::CONF , c.domain));
-        p.conf = c.t;
-        kpf_utils::add_to_row( wmsgs, k.row, p );
-      }
-
       for (auto const& e: kpf_act.evals)
       {
         KPF::packet_t p (KPF::packet_header_t( KPF::packet_style::EVAL , e.domain));
@@ -381,7 +374,7 @@ track_filter_kpf_activity
       // gather the fields
 
       auto id_p = k.activity_id.get( t.row );
-      auto label_p = k.activity_label.get( t.row );
+      auto label_p = k.activity_labels.get( t.row );
       auto actor_p = k.actors.get( t.row );
       auto domain_p = k.activity_domain.get( t.row );
       auto ts_start_p = k.activity_start.get( t.row );
@@ -389,7 +382,7 @@ track_filter_kpf_activity
 
       size_t pre_check_size = wmsgs.n_msgs();
       if ( ! id_p.first )       wmsgs.add_msg( "No activity id" );
-      if ( ! label_p.first )    wmsgs.add_msg( "No activity label" );
+      if ( ! label_p.first )    wmsgs.add_msg( "No activity labels" );
       if ( ! actor_p.first )    wmsgs.add_msg( "No actors" );
       if ( ! domain_p.first )   wmsgs.add_msg( "No domain" );
       if ( ! ts_start_p.first ) wmsgs.add_msg( "No activity start frame" );
@@ -401,7 +394,7 @@ track_filter_kpf_activity
 
       // copy in the top-level data
       KPFC::activity_t a;
-      a.activity_label = label_p.second;
+      a.activity_labels.d = label_p.second;
       a.activity_id.t.d = id_p.second;
       a.activity_id.domain = domain_p.second;
 
@@ -449,10 +442,6 @@ track_filter_kpf_activity
         if (p.header.style == KPF::packet_style::KV)
         {
           a.attributes.push_back( p.kv );
-        }
-        else if (p.header.style == KPF::packet_style::CONF)
-        {
-          a.confidences.push_back( {p.conf, p.header.domain} );
         }
         else if (p.header.style == KPF::packet_style::EVAL)
         {

--- a/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.h
+++ b/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.h
@@ -63,16 +63,16 @@ struct TRACK_FILTER_KPF_ACTIVITY_EXPORT track_filter_kpf_activity:
 {
 
   track_field< dt::events::event_id > activity_id;
-  track_field< dt::events::kpf_activity_label > activity_label;
+  track_field< kpf_cset_type >& activity_labels;
   track_field< dt::events::kpf_activity_domain > activity_domain;
   track_field< dt::events::actor_track_rows > actors;
   track_field< dt::events::kpf_activity_start > activity_start;
   track_field< dt::events::kpf_activity_stop > activity_stop;
 
-  track_filter_kpf_activity()
+  track_filter_kpf_activity():
+    activity_labels( Track.add_field< kpf_cset_type >( "kpf_activity_labels" ))
   {
     Track.add_field( activity_id );
-    Track.add_field( activity_label );
     Track.add_field( activity_domain );
     Track.add_field( actors );
     Track.add_field( activity_start );


### PR DESCRIPTION
KPF v4 replaces single activity names with maps of (name, double) in the activity and types schemas, i.e.

old (v3):

act: { act2: **walking**, id2: 1, ...
types: { id1: 18, **obj_type: Person**, ...

new (v4):

act: { act2: **{walking: 1.0 }**, id2: 1, ...
types: { id1: 18, **cset3: { Person: 1.0 }**, ...

This allows the same structure to be used for both ground-truth and computed results, i.e. ground-truth will have a map with a single entry with confidence 1.0, while the computed results may look like

act: { act2: **{walking: 0.4, running: 0.3, juggling, 0.1 }** ...

The types map is a cset with a different domain (3 vs 2), because DIVA object types (3) are a different domain than DIVA activity types (2).

