### PR TITLE
Update tokenize call to use TokenizeTrimEmpty symbol.

### DIFF
--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -210,7 +210,7 @@ get_input()
   }
 
   m_input_buffer.clear();
-  kwiver::vital::tokenize( line, m_input_buffer, m_delim, false );
+  kwiver::vital::tokenize( line, m_input_buffer, m_delim, kwiver::vital::TokenizeNoTrimEmpty );
 
   // Test the minimum number of fields.
   if ( m_input_buffer.size() < 7 )

--- a/arrows/core/detected_object_set_input_kw18.cxx
+++ b/arrows/core/detected_object_set_input_kw18.cxx
@@ -193,7 +193,7 @@ read_all()
   while ( stream_reader.getline( line ) )
   {
     std::vector< std::string > col;
-    kwiver::vital::tokenize( line, col, " ", true );
+    kwiver::vital::tokenize( line, col, " ", kwiver::vital::TokenizeTrimEmpty );
 
     if ( ( col.size() < 18 ) || ( col.size() > 20 ) )
     {

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -120,8 +120,8 @@ set_configuration( vital::config_block_sptr config_in )
   d->m_tot_field1_ids = config->get_value<std::string>( "tot_field1_ids" , d->m_tot_field1_ids );
   d->m_tot_field2_ids = config->get_value<std::string>( "tot_field2_ids" , d->m_tot_field2_ids );
 
-  vital::tokenize( d->m_tot_field1_ids, d->m_parsed_tot_ids1, ",;", true );
-  vital::tokenize( d->m_tot_field2_ids, d->m_parsed_tot_ids2, ",;", true );
+  vital::tokenize( d->m_tot_field1_ids, d->m_parsed_tot_ids1, ",;", kwiver::vital::TokenizeTrimEmpty );
+  vital::tokenize( d->m_tot_field2_ids, d->m_parsed_tot_ids2, ",;", kwiver::vital::TokenizeTrimEmpty );
 }
 
 

--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -131,7 +131,7 @@ video_input_image_list
 
   // Extract string and create vector of directories
   std::string path = config->get_value<std::string>( "path", "" );
-  kwiver::vital::tokenize( path, d->c_search_path, ":", true );
+  kwiver::vital::tokenize( path, d->c_search_path, ":", kwiver::vital::TokenizeTrimEmpty );
   d->c_search_path.push_back( "." ); // add current directory
 
   // Setup actual reader algorithm

--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -41,7 +41,6 @@
 
 #include "vital_kpf_adapters.h"
 
-#include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/logger/logger.h>
 #include <vital/exceptions.h>
@@ -164,7 +163,7 @@ read_all()
 {
   m_detected_sets.clear();
 
-  
+
 
   KPF::kpf_yaml_parser_t parser(m_parent->stream());
   KPF::kpf_reader_t reader(parser);
@@ -198,7 +197,7 @@ read_all()
     box_adapter.get(bbox);
     kwiver::vital::detected_object_sptr det(new kwiver::vital::detected_object(bbox, confidence, types));
     det->set_detector_name(detector_name);
-    
+
     frame_detections = m_detected_sets[frame_number];
     if (frame_detections.get() == nullptr)
     {

--- a/arrows/kpf/detected_object_set_output_kpf.cxx
+++ b/arrows/kpf/detected_object_set_output_kpf.cxx
@@ -30,8 +30,6 @@
 
 #include "detected_object_set_output_kpf.h"
 
-#include <vital/util/tokenize.h>
-
 #include <arrows/kpf/yaml/kpf_canonical_io_adapter.h>
 #include <arrows/kpf/yaml/kpf_yaml_writer.h>
 
@@ -88,7 +86,7 @@ detected_object_set_output_kpf()
 detected_object_set_output_kpf::
 ~detected_object_set_output_kpf()
 {
-  
+
 }
 
 

--- a/arrows/kpf/yaml/CMakeLists.txt
+++ b/arrows/kpf/yaml/CMakeLists.txt
@@ -72,4 +72,3 @@ kwiver_install_headers(
 if (KWIVER_ENABLE_TESTS)
    add_subdirectory( tests )
 endif()
-

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -155,7 +155,7 @@ bool
 parse_geom( KPF::packet_t& p, const string& s )
 {
   vector< string > tokens;
-  ::kwiver::vital::tokenize( s, tokens, " ", true );
+  ::kwiver::vital::tokenize( s, tokens, " ", kwiver::vital::TokenizeTrimEmpty );
   if ( tokens.size() != 4 )
   {
     LOG_ERROR( main_logger, "YAML parser: geometry: Expected four tokens from '"
@@ -609,4 +609,3 @@ kpf_yaml_parser_t
 } // ...kpf
 } // ...vital
 } // ...kwiver
-

--- a/arrows/ocv/draw_detected_object_set.cxx
+++ b/arrows/ocv/draw_detected_object_set.cxx
@@ -293,7 +293,7 @@ process_config()
   // e.g. person/3.5/0 0 255;
   {
     std::vector< std::string > cspec;
-    kwiver::vital::tokenize( m_tmp_custom, cspec, ";", true );
+    kwiver::vital::tokenize( m_tmp_custom, cspec, ";", kwiver::vital::TokenizeTrimEmpty );
 
     for( auto cs : cspec )
     {
@@ -350,7 +350,7 @@ process_config()
   } // end local scope
 
   // Parse selected class_names
-  kwiver::vital::tokenize( m_tmp_class_select, m_select_classes, ";", true );
+  kwiver::vital::tokenize( m_tmp_class_select, m_select_classes, ";", kwiver::vital::TokenizeTrimEmpty );
 }
 
 }; // end priv class

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -437,7 +437,7 @@ vidl_ffmpeg_video_input
     "stop_after_frame", d->c_stop_after_frame );
 
   kwiver::vital::tokenize( config->get_value<std::string>( "time_source", d->c_time_source ),
-            d->c_time_source_list, " ,", true );
+            d->c_time_source_list, " ,", kwiver::vital::TokenizeTrimEmpty );
 }
 
 
@@ -452,7 +452,7 @@ vidl_ffmpeg_video_input
   bool valid_src( true );
   std::vector< std::string > time_source;
   kwiver::vital::tokenize( config->get_value<std::string>( "time_source", d->c_time_source ),
-            time_source, " ,", true );
+            time_source, " ,", kwiver::vital::TokenizeTrimEmpty );
 
   for( auto source : time_source )
   {

--- a/sprokit/processes/core/frame_list_process.cxx
+++ b/sprokit/processes/core/frame_list_process.cxx
@@ -134,7 +134,7 @@ void frame_list_process
   d->m_config_frame_time          = config_value_using_trait( frame_time ) * 1e6; // in usec
 
   std::string path = config_value_using_trait( path );
-  kwiver::vital::tokenize( path, d->m_config_path, ":", true );
+  kwiver::vital::tokenize( path, d->m_config_path, ":", kwiver::vital::TokenizeTrimEmpty );
   d->m_config_path.push_back( "." ); // add current directory
 
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -149,7 +149,7 @@ void image_file_reader_process
   std::string path = config_value_using_trait( path );
   d->m_config_frame_time = config_value_using_trait( frame_time ) * 1e6; // in usec
 
-  kwiver::vital::tokenize( path, d->m_config_path, ":", true );
+  kwiver::vital::tokenize( path, d->m_config_path, ":", kwiver::vital::TokenizeTrimEmpty );
   d->m_config_path.push_back( "." ); // add current directory
 
   d->m_config_error_mode = priv::mode_converter().from_string( mode );

--- a/sprokit/src/processes/clusters/registration.cxx
+++ b/sprokit/src/processes/clusters/registration.cxx
@@ -85,7 +85,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   // Build include directories.
   kwiversys::SystemTools::GetPath( include_dirs, sprokit_include_envvar.c_str() );
-  kwiver::vital::tokenize( default_include_dirs, include_dirs, path_separator, true );
+  kwiver::vital::tokenize( default_include_dirs, include_dirs, path_separator, kwiver::vital::TokenizeTrimEmpty );
 
   for ( const kwiver::vital::path_t& include_dir : include_dirs)
   {

--- a/vital/util/tokenize.h
+++ b/vital/util/tokenize.h
@@ -41,8 +41,8 @@
 namespace kwiver {
 namespace vital {
 
-
 enum {
+  TokenizeNoTrimEmpty = 0,
   TokenizeTrimEmpty = 1
 };
 


### PR DESCRIPTION
Using a specific self documenting symbol makes the call more understandable
than using the raw boolean. An enum was chosen over a define to make the
scoping specific.