### PR TITLE
Move python libraries install location

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -66,8 +66,7 @@ endmacro ()
 function (kwiver_add_python_library    name    modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
 
-  set(library_subdir "/${kwiver_python_subdir}")
-  set(library_subdir_suffix "/${python_sitename}/${modpath}")
+  set(library_subdir "/${kwiver_python_subdir}/${python_sitename}/${modpath}")
   set(component runtime)
 
   set(no_export ON)

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -54,8 +54,7 @@ define_property(GLOBAL PROPERTY kwiver_python_modules
 function (sprokit_add_python_library    name    modpath)
   _kwiver_create_safe_modpath("${modpath}" safe_modpath)
 
-  set(library_subdir "/${kwiver_python_subdir}")
-  set(library_subdir_suffix "/${python_sitename}/${modpath}")
+  set(library_subdir "/${kwiver_python_subdir}/${python_sitename}/${modpath}")
   set(component runtime)
 
   set(no_export ON)

--- a/sprokit/processes/bindings/python/kwiver/kwiver_process.py
+++ b/sprokit/processes/bindings/python/kwiver/kwiver_process.py
@@ -159,8 +159,8 @@ class KwiverProcess(process.PythonProcess):
                             datum.Datum.get_descriptor_set,
                             datum.new_descriptor_set)
         self.add_type_trait("detected_object_set", "kwiver:detected_object_set",
-                            datum.Datum.get_detected_object,
-                            datum.new_detected_object)
+                            datum.Datum.get_detected_object_set,
+                            datum.new_detected_object_set)
         self.add_type_trait("track_set", "kwiver:track_set",
                             datum.Datum.get_track_set,
                             datum.new_track_set)

--- a/sprokit/processes/python/ApplyDescriptor.py
+++ b/sprokit/processes/python/ApplyDescriptor.py
@@ -29,6 +29,7 @@
 from __future__ import print_function
 from sprokit.pipeline import process
 from kwiver.kwiver_process import KwiverProcess
+from vital.util.VitalPIL import from_pil, get_pil_image
 
 apply_descriptor_test_mode = False
 try:
@@ -111,11 +112,11 @@ class ApplyDescriptor(KwiverProcess):
         # smqtk.
         if not apply_descriptor_test_mode:
             # Get image from conatiner
-            in_img = in_img_c.get_image()
+            in_img = in_img_c.image()
 
 
             # convert generic image to PIL image
-            pil_image = in_img.get_pil_image()
+            pil_image = get_pil_image(in_img)
             pix = np.array(pil_image)
 
             # get image in acceptable format

--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -2,154 +2,154 @@ project(vital_python_types)
 
 include_directories(${PYBIND11_INCLUDE_DIR})
 
-sprokit_add_python_library(bounding_box
+kwiver_add_python_library(bounding_box
   vital/types
   bounding_box.cxx)
 target_link_libraries(python-vital.types-bounding_box
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(camera
+kwiver_add_python_library(camera
   vital/types
   camera.cxx)
 target_link_libraries(python-vital.types-camera
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(camera_intrinsics
+kwiver_add_python_library(camera_intrinsics
   vital/types
   camera_intrinsics.cxx)
 target_link_libraries(python-vital.types-camera_intrinsics
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(camera_map
+kwiver_add_python_library(camera_map
   vital/types
   camera_map.cxx)
 target_link_libraries(python-vital.types-camera_map
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(color
+kwiver_add_python_library(color
   vital/types
   color.cxx)
 target_link_libraries(python-vital.types-color
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(covariance
+kwiver_add_python_library(covariance
   vital/types
   covariance.cxx)
 target_link_libraries(python-vital.types-covariance
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(descriptor
+kwiver_add_python_library(descriptor
   vital/types
   descriptor.cxx)
 target_link_libraries(python-vital.types-descriptor
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(descriptor_set
+kwiver_add_python_library(descriptor_set
   vital/types
   descriptor_set.cxx)
 target_link_libraries(python-vital.types-descriptor_set
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(detected_object
+kwiver_add_python_library(detected_object
   vital/types
   detected_object.cxx)
 target_link_libraries(python-vital.types-detected_object
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(detected_object_set
+kwiver_add_python_library(detected_object_set
   vital/types
   detected_object_set.cxx)
 target_link_libraries(python-vital.types-detected_object_set
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(detected_object_type
+kwiver_add_python_library(detected_object_type
   vital/types
   detected_object_type.cxx)
 target_link_libraries(python-vital.types-detected_object_type
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(eigen
+kwiver_add_python_library(eigen
   vital/types
   eigen.cxx)
 target_link_libraries(python-vital.types-eigen
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(feature
+kwiver_add_python_library(feature
   vital/types
   feature.cxx)
 target_link_libraries(python-vital.types-feature
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(homography
+kwiver_add_python_library(homography
   vital/types
   homography.cxx)
 target_link_libraries(python-vital.types-homography
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(image
+kwiver_add_python_library(image
   vital/types
   image.cxx)
 target_link_libraries(python-vital.types-image
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(image_container
+kwiver_add_python_library(image_container
   vital/types
   image_container.cxx)
 target_link_libraries(python-vital.types-image_container
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(landmark
+kwiver_add_python_library(landmark
   vital/types
   landmark.cxx)
 target_link_libraries(python-vital.types-landmark
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(rotation
+kwiver_add_python_library(rotation
   vital/types
   rotation.cxx)
 target_link_libraries(python-vital.types-rotation
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(similarity
+kwiver_add_python_library(similarity
   vital/types
   similarity.cxx)
 target_link_libraries(python-vital.types-similarity
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(track
+kwiver_add_python_library(track
   vital/types
   track.cxx)
 target_link_libraries(python-vital.types-track
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(track_set
+kwiver_add_python_library(track_set
   vital/types
   track_set.cxx)
 target_link_libraries(python-vital.types-track_set
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_add_python_library(object_track_set
+kwiver_add_python_library(object_track_set
   vital/types
   object_track_set.cxx)
 target_link_libraries(python-vital.types-object_track_set


### PR DESCRIPTION
Python binding libraries build at ${library_subdir}${library_subdir_suffix}. However, they install to ${library_subdir}. Previously, all libraries would install to lib/python#.#, rather then the module subdirectories. Putting the full path in ${library_subdir} insures they install to the correct location.

Also, pointing the vital bindings to the kwiver rather than the sprokit functions.