### PR TITLE
Fix build when KPF is not enabled

### DIFF
--- a/track_oracle/example/CMakeLists.txt
+++ b/track_oracle/example/CMakeLists.txt
@@ -26,9 +26,14 @@ target_link_libraries( track_reader_example
  track_oracle
  data_terms
  track_oracle_file_formats
- kpf_utils
  ${Boost_SYSTEM_LIBRARY}
 )
+
+if( KWIVER_ENABLE_KPF )
+  target_link_libraries( track_reader_example
+    kpf_utils
+  )
+endif()
 
 #
 # example track writer

--- a/track_oracle/example/track_reader_example.cxx
+++ b/track_oracle/example/track_reader_example.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2012-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2012-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -27,7 +27,9 @@
 #include <track_oracle/file_formats/file_format_schema.h>
 #include <track_oracle/file_formats/file_format_manager.h>
 #include <track_oracle/file_formats/file_format_base.h>
+#if KWIVER_ENABLE_KPF
 #include <track_oracle/file_formats/kpf_utils/kpf_utils.h>
+#endif
 #include <track_oracle/utils/tokenizers.h>
 #include <track_oracle/data_terms/data_terms.h>
 
@@ -55,8 +57,12 @@ int main( int argc, char *argv[] )
   vul_arg< string > kwiver_arg( "-kwiver", "write out as kwiver to this file" );
   vul_arg< string > kw18_arg( "-kw18", "write out as kw18 to this file" );
   vul_arg< string > csv_arg( "-csv", "write out as csv to this file" );
+#if KWIVER_ENABLE_KPF
   vul_arg< string > kpf_g_arg( "-kpf-g", "write out as KPF geometry to this file" );
   vul_arg< bool > kpf_any_arg( "-kpf-any", "read file as unstructured yaml" );
+#else
+  auto kpf_any_arg = [](){ return false; };
+#endif
   vul_arg< string > csv_v1_arg( "-csv-v1", "write out as old-style csv to this file" );
   vul_arg< string > kwxml_ts_arg( "-kwxml_ts", "if writing kwxml, set default track style to this", "trackObjectKitware" );
   vul_arg< string > tag_arg( "-tag", "if writing kwiver, test tags by setting track-level 'test' flag to this" );
@@ -146,11 +152,13 @@ int main( int argc, char *argv[] )
         LOG_ERROR( main_logger, "Could not write CSV to '" << csv_arg() << "'" );
       }
     }
+#if KWIVER_ENABLE_KPF
     if ( kpf_g_arg.set() )
     {
       bool okay = file_format_manager::get_format( TF_KPF_GEOM )->write( kpf_g_arg(), tracks );
       LOG_INFO( main_logger, "Wrote KPF geometry to " << kpf_g_arg() << " success: " << okay );
     }
+#endif
   }
   return rc;
 }
@@ -185,11 +193,13 @@ trim( string s )
 
 int load_tracks( const string& track_fn, track_handle_list_type& tracks, const string& unique_key, bool kpf_any )
 {
+#if KWIVER_ENABLE_KPF
   if (kpf_any)
   {
     tracks = kpf_utils::read_unstructured_yaml( track_fn );
   }
   else
+#endif
   {
     if (! file_format_manager::read( track_fn, tracks ))
     {


### PR DESCRIPTION
Disable portions of `track_reader_example` that require KPF when KPF is not enabled. This fixes build errors that would otherwise occur if KPF is not enabled.