### PR TITLE
Modify embedded pipeline to allow config update before running.

### DIFF
--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -157,6 +157,9 @@ embedded_pipeline
   m_priv->m_pipeline = builder.pipeline();
   m_priv->m_pipe_config = builder.config();
 
+  // Call framework method to allow config updates.
+  update_config(  m_priv->m_pipe_config );
+
   if ( ! m_priv->m_pipeline)
   {
     throw std::runtime_error( "Unable to bake pipeline" );
@@ -374,6 +377,14 @@ embedded_pipeline
 }
 
 
+// ----------------------------------------------------------------------------
+void
+embedded_pipeline::
+update_config( kwiver::vital::config_block_sptr config )
+{
+}
+
+
 // ==================================================================
 bool
 embedded_pipeline::priv::
@@ -412,6 +423,5 @@ connect_output_adapter()
   }
   return false;
 }
-
 
 } // end namespace kwiver

--- a/sprokit/processes/adapters/embedded_pipeline.h
+++ b/sprokit/processes/adapters/embedded_pipeline.h
@@ -344,6 +344,23 @@ protected:
    */
   virtual bool connect_output_adapter();
 
+  /**
+   * @brief Update pipeline config.
+   *
+   * This method provides the ability for a derived class to inspect
+   * and update the pipeline config before it is used to create the
+   * pipeline. Additional config entries can be added or existing ones
+   * modified to suit a specific application.
+   *
+   * The default implementation does not modify the config in any way.
+   *
+   * @param[in,out] config Configuration to update.
+   */
+  virtual void update_config( kwiver::vital::config_block_sptr config );
+
+  /**
+   * Reference to logger.
+   */
   kwiver::vital::logger_handle_t m_logger;
 
 private:

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -1384,6 +1384,7 @@ SCOPED_INSTRUMENTATION(reconfigure);
     SPROKIT_PIPELINE_NO_EXPORT void add_property ( const property_t& prop );
 };
 
+
 // ----------------------------------------------------------------------------
 template <typename T>
 T
@@ -1393,6 +1394,8 @@ process
   return kwiver::vital::config_block_get_value_cast<T>(config_value_raw(key));
 }
 
+
+// ----------------------------------------------------------------------------
 template <typename T>
 T
 process
@@ -1401,6 +1404,8 @@ process
   return grab_datum_from_port(port)->get_datum<T>();
 }
 
+
+// ----------------------------------------------------------------------------
 template <typename T>
 T
 process
@@ -1414,6 +1419,8 @@ process
   return grab_from_port_as<T>(port);
 }
 
+
+// ----------------------------------------------------------------------------
 template <typename T>
 void
 process


### PR DESCRIPTION
In order to support inspecting, verifying and modifying the pipeline
config after the config has been ingested but before the pipeline has
been built, a method is added to allow derived classes to access the
config at the correct point in the execution.

This is useful in cases where the pipeline description must be read from
a file, but it must also meet specific requirements imposed by the
application. A derived class can implement the update_config() method
and verify that the requirements have been met, or add required entries
to the config before building the pipeline.