### PR TITLE
Use PyBytes_AsString instead of PyString_AsString to support Python 3

### DIFF
--- a/sprokit/processes/bindings/c/vital_type_converters.cxx
+++ b/sprokit/processes/bindings/c/vital_type_converters.cxx
@@ -437,7 +437,7 @@ vital_string_vector_to_datum( PyObject *list )
   for( size_t i = 0; i < num_elem; ++i )
   {
     PyObject* item = PyList_GetItem( list, i );
-    vect_sptr->push_back( std::string( PyString_AsString( item ) ) );
+    vect_sptr->push_back( std::string( PyBytes_AsString( item ) ) );
   }
 
   PyObject* cap = put_in_datum_capsule( vect_sptr );


### PR DESCRIPTION
This change is needed to build sprokit against Python 3.  Apparently the PyString_* methods were replaced by PyBytes_* in Python 3, but PyBytes_* was also added to Python 2.7 for compatibility.