### PR TITLE
Shorten pythread_per_process_scheduler name

### DIFF
--- a/sprokit/src/bindings/python/schedulers/CMakeLists.txt
+++ b/sprokit/src/bindings/python/schedulers/CMakeLists.txt
@@ -5,4 +5,4 @@ sprokit_create_python_plugin_init(sprokit/schedulers)
 
 sprokit_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/pythread_per_process_scheduler.py
   sprokit/schedulers
-  pythread_per_process_scheduler)
+  pythread_per_process)


### PR DESCRIPTION
This is to avoid the Windows 248 character limit on filenames.