### PR TITLE
Insert plugin search paths relative to the executable

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -170,6 +170,12 @@ Sprokit
    in the pipeline. If a python process is found, an exception is
    thrown.
 
+Tools
+
+ * Added built-in plugin search paths to the plugin_explorer and dump_klv
+   tools.  These search paths are relative to the executable location so
+   plugins are can be found in installations without an environment variable.
+
 Unit Tests
 
  * KWIVER is in the process of transitioning to Google Test as its primary

--- a/vital/tools/dump_klv.cxx
+++ b/vital/tools/dump_klv.cxx
@@ -38,6 +38,7 @@
 #include <vital/config/config_block.h>
 #include <vital/config/config_block_io.h>
 #include <vital/exceptions.h>
+#include <vital/util/get_paths.h>
 
 #include <vital/algo/video_input.h>
 
@@ -121,6 +122,8 @@ int main( int argc, char** argv )
   arg.DeleteRemainingArguments(newArgc, &newArgv);
 
   // register the algorithm implementations
+  std::string rel_plugin_path = kwiver::vital::get_executable_path() + "/../lib/modules";
+  kwiver::vital::plugin_manager::instance().add_search_path(rel_plugin_path);
   kwiver::vital::plugin_manager::instance().load_all_plugins();
   kwiver::vital::algo::video_input_sptr video_reader;
   kwiver::vital::config_block_sptr config = default_config();

--- a/vital/tools/explorer_context_priv.h
+++ b/vital/tools/explorer_context_priv.h
@@ -57,6 +57,7 @@ public:
   bool opt_scheduler;
   bool opt_summary;
   bool opt_attrs;
+  bool opt_skip_relative;
 
   std::ostream* m_out_stream;
 
@@ -98,6 +99,7 @@ public:
     opt_all = false;
     opt_summary = false;
     opt_attrs = false;
+    opt_skip_relative = false;
 
     opt_attr_filter = false;
     opt_fact_filt = false;

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@
 #include <vital/plugin_loader/plugin_factory.h>
 #include <vital/config/config_block.h>
 #include <vital/util/demangle.h>
+#include <vital/util/get_paths.h>
 #include <vital/util/wrap_text_block.h>
 #include <vital/logger/logger.h>
 #include <vital/algo/algorithm_factory.h>
@@ -581,6 +582,9 @@ main( int argc, char* argv[] )
   G_context.m_args.AddArgument( "--load",    argT::SPACE_ARGUMENT, &G_context.opt_load_module,
                                 "Load only specified plugin file for inspection. No other plugins are loaded." );
 
+  G_context.m_args.AddArgument( "--skip-relative", argT::NO_ARGUMENT, &G_context.opt_skip_relative,
+                                "Skip built-in plugin paths that are relative to the executable location");
+
   G_context.m_args.AddArgument( "--fmt",     argT::SPACE_ARGUMENT, &G_context.formatting_type,
                                 "Generate display using alternative format, such as 'rst' or 'pipe'" );
 
@@ -717,6 +721,11 @@ main( int argc, char* argv[] )
 
   // ========
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
+  if (!G_context.opt_skip_relative)
+  {
+    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/modules");
+    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/sprokit");
+  }
 
   char** newArgv = 0;
   int newArgc = 0;


### PR DESCRIPTION
In the case of plugin_explorer these paths are added by default for
convenience, but there is an option to disable these paths.

This change is very useful when the tools are installed so environment variable are not needed to run them.