### PR TITLE
Force pybind11 to use the PyGILState_* API to prevent deadlocks

### DIFF
--- a/sprokit/src/bindings/python/modules/registration.cxx
+++ b/sprokit/src/bindings/python/modules/registration.cxx
@@ -40,6 +40,7 @@
 #endif
 
 #include <sprokit/pipeline/utils.h>
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 #include <sprokit/python/util/python.h>
@@ -78,6 +79,9 @@ class scoped_save_thread
       PyEval_SaveThread();
     }
 };
+
+
+static sprokit::python::pyoptions options;
 
 
 // ==================================================================

--- a/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/config.cxx
@@ -33,6 +33,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
 
+#include <sprokit/python/util/pyoptions.h>
+
 #include <sstream>
 
 /**
@@ -74,6 +76,9 @@ static void config_setitem( kwiver::vital::config_block_sptr          self,
                             object const&                             value );
 static void config_delitem( kwiver::vital::config_block_sptr          self,
                             kwiver::vital::config_block_key_t const&  key );
+
+
+static sprokit::python::pyoptions options;
 
 
 PYBIND11_MODULE(config, m)

--- a/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
@@ -41,6 +41,7 @@
 
 #include <sprokit/pipeline/datum.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_gil.h>
 
 // Type conversions
@@ -84,6 +85,9 @@ static sprokit::datum_t datum_from_capsule( PyObject* cap );
 template<class T> T datum_get_object(sprokit::datum &);
 
 char const* sprokit_datum_PyCapsule_name() { return  "sprokit::datum"; }
+
+
+static sprokit::python::pyoptions options;
 
 
 PYBIND11_MODULE(datum, m)

--- a/sprokit/src/bindings/python/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/edge.cxx
@@ -32,6 +32,7 @@
 #include <sprokit/pipeline/edge.h>
 #include <sprokit/pipeline/stamp.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_gil.h>
 
 #include <pybind11/stl_bind.h>
@@ -49,6 +50,8 @@ using namespace pybind11;
 static void push_datum(sprokit::edge& self, wrap_edge_datum const& datum); 
 static wrap_edge_datum get_datum(sprokit::edge& self);
 static wrap_edge_datum peek_datum(sprokit::edge& self, pybind11::size_t const& idx);
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(edge, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/modules.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/modules.cxx
@@ -32,6 +32,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <sprokit/python/util/pyoptions.h>
+
 /**
  * \file modules.cxx
  *
@@ -48,6 +50,8 @@ void load_known_modules()
 {
   kwiver::vital::plugin_manager::instance().load_all_plugins();
 }
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(modules, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/pipeline.cxx
@@ -30,6 +30,7 @@
 
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/process_cluster.h>
+#include <sprokit/python/util/pyoptions.h>
 
 #if WIN32
 #pragma warning (push)
@@ -53,6 +54,8 @@ using namespace pybind11;
 static std::shared_ptr<wrap_process_cluster> cluster_by_name(sprokit::pipeline& self, sprokit::process::name_t const& name);
 static std::vector<wrap_port_addr> connections_from_addr(sprokit::pipeline& self, sprokit::process::name_t const& name, sprokit::process::port_t const& port);
 static std::vector<wrap_port_addr> receivers_for_port(sprokit::pipeline& self, sprokit::process::name_t const& name, sprokit::process::port_t const& port); 
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(pipeline,m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -32,6 +32,7 @@
 typedef std::set<std::string> string_set; // This has to be done first thing, or the macro breaks
 PYBIND11_MAKE_OPAQUE(string_set)
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_exceptions.h>
 
 #include <pybind11/stl_bind.h>
@@ -154,6 +155,8 @@ void push_value_to_port(sprokit::process &self, sprokit::process::port_t const& 
 void push_datum_to_port(sprokit::process &self, sprokit::process::port_t const& port, sprokit::datum const& dat);
 
 std::string config_value(sprokit::process &self, kwiver::vital::config_block_key_t const& key);
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(process, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_cluster.cxx
@@ -32,6 +32,7 @@
 #include <sprokit/pipeline/process.h>
 #include <sprokit/pipeline/process_cluster.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 
@@ -48,6 +49,8 @@
 using namespace pybind11;
 
 static object cluster_from_process(sprokit::process_t const& process);
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(process_cluster, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -39,6 +39,7 @@
 #include <sprokit/pipeline/process_factory.h>
 #include <sprokit/pipeline/process_registry_exception.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 
@@ -127,6 +128,9 @@ create_object(kwiver::vital::config_block_sptr const& config)
 
   SPROKIT_PYTHON_GIL_SCOPED_ACQUIRE_END
 }
+
+
+static sprokit::python::pyoptions options;
 
 
 // ==================================================================

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler.cxx
@@ -31,6 +31,7 @@
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/scheduler.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_exceptions.h>
 #include <sprokit/python/util/python_gil.h>
 
@@ -72,6 +73,8 @@ class scheduler_trampoline
     void _resume() override;
     void _stop() override;
 };
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(scheduler, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -39,6 +39,7 @@
 #include <sprokit/pipeline/scheduler_factory.h>
 #include <sprokit/pipeline/scheduler_registry_exception.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/python_gil.h>
 #include <sprokit/python/util/python_exceptions.h>
 
@@ -109,6 +110,9 @@ create_object(sprokit::pipeline_t const& pipe, kwiver::vital::config_block_sptr 
 
   SPROKIT_PYTHON_GIL_SCOPED_ACQUIRE_END
 }
+
+
+static sprokit::python::pyoptions options;
 
 
 //==================================================================

--- a/sprokit/src/bindings/python/sprokit/pipeline/stamp.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/stamp.cxx
@@ -32,6 +32,8 @@
 
 #include "python_wrappers.cxx"
 
+#include <sprokit/python/util/pyoptions.h>
+
 /**
  * \file stamp.cxx
  *
@@ -39,6 +41,8 @@
  */
 
 using namespace pybind11;
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(stamp, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/utils.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/utils.cxx
@@ -33,6 +33,8 @@
 
 #include <sprokit/pipeline/utils.h>
 
+#include <sprokit/python/util/pyoptions.h>
+
 /**
  * \file utils.cxx
  *
@@ -40,6 +42,8 @@
  */
 
 using namespace pybind11;
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(utils, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline/version.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/version.cxx
@@ -34,6 +34,8 @@
 
 #include <sprokit/version.h>
 
+#include <sprokit/python/util/pyoptions.h>
+
 
 /**
  * \file version.cxx
@@ -77,6 +79,8 @@ std::string const compile::git_dirty = SPROKIT_GIT_DIRTY;
 class runtime
 {
 };
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(version, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline_util/bake.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline_util/bake.cxx
@@ -35,6 +35,7 @@
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/process_factory.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/pystream.h>
 #include <sprokit/python/util/python_gil.h>
 
@@ -60,6 +61,8 @@ static sprokit::pipeline_t bake_pipe_file(std::string const& path);
 static sprokit::pipeline_t bake_pipe(object stream);
 static sprokit::cluster_info_t bake_cluster_file(std::string const& path);
 static sprokit::cluster_info_t bake_cluster(object stream);
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(bake, m)
 {

--- a/sprokit/src/bindings/python/sprokit/pipeline_util/load.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline_util/load.cxx
@@ -35,6 +35,7 @@
 
 #include <sprokit/pipeline/process.h>
 
+#include <sprokit/python/util/pyoptions.h>
 #include <sprokit/python/util/pystream.h>
 #include <sprokit/python/util/python_gil.h>
 
@@ -78,6 +79,8 @@ static sprokit::cluster_blocks load_cluster_file(std::string const& path);
 static sprokit::cluster_blocks load_cluster(object const& stream);
 static std::vector<wrap_port_addr> get_targets(sprokit::cluster_input_t const& self);
 static void set_targets(sprokit::cluster_input_t &self, std::vector<wrap_port_addr> const& wrap_targets);
+
+static sprokit::python::pyoptions options;
 
 PYBIND11_MODULE(load, m)
 {

--- a/sprokit/src/sprokit/python/util/CMakeLists.txt
+++ b/sprokit/src/sprokit/python/util/CMakeLists.txt
@@ -4,6 +4,7 @@ set(python_util_srcs
   python_exceptions.cxx)
 
 set(python_util_headers
+  pyoptions.h
   python_exceptions.h
   python_gil.h
   python.h)

--- a/sprokit/src/sprokit/python/util/pyoptions.h
+++ b/sprokit/src/sprokit/python/util/pyoptions.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2013 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,42 +28,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sprokit/pipeline/pipeline.h>
-
-#include <sprokit/pipeline_util/export_dot.h>
-#include <sprokit/pipeline_util/export_dot_exception.h>
-
-#include <sprokit/python/util/pyoptions.h>
-#include <sprokit/python/util/pystream.h>
-#include <sprokit/python/util/python_gil.h>
+#ifndef SPROKIT_PYTHON_UTIL_PYOPTIONS_H
+#define SPROKIT_PYTHON_UTIL_PYOPTIONS_H
 
 #include <pybind11/pybind11.h>
 
-#include <string>
+namespace sprokit {
+namespace python {
 
-/**
- * \file export.cxx
- *
- * \brief Python bindings for exporting functions.
- */
-
-using namespace pybind11;
-
-void export_dot(object const& stream, sprokit::pipeline_t const pipe, std::string const& graph_name);
-
-static sprokit::python::pyoptions options;
-
-PYBIND11_MODULE(export_, m)
+// NOTE: This has to be in the header because pybind11 is header-only, so each
+// shared library gets its own copy of the pybind11::options singleton. DO NOT
+// EXPORT THIS CLASS!
+class pyoptions
+  : public pybind11::options
 {
-  m.def("export_dot", &export_dot, call_guard<gil_scoped_release>()
-    , arg("stream"), arg("pipeline"), arg("name")
-    , "Writes the pipeline to the stream in dot format.");
+  public:
+    pyoptions()
+    {
+      enable_use_gilstate();
+    }
+};
+
+}
 }
 
-void
-export_dot(object const& stream, sprokit::pipeline_t const pipe, std::string const& graph_name)
-{
-  sprokit::python::pyostream ostr(stream);
-
-  return sprokit::export_dot(ostr, pipe, graph_name);
-}
+#endif // SPROKIT_PYTHON_UTIL_PYOPTIONS_H


### PR DESCRIPTION
Note: this depends on Kitware/fletch#326.