### PR TITLE
Refactor algorithm registration

### DIFF
--- a/arrows/core/class_probablity_filter.h
+++ b/arrows/core/class_probablity_filter.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,19 @@ class KWIVER_ALGO_CORE_EXPORT class_probablity_filter
   : public vital::algorithm_impl<class_probablity_filter, vital::algo::detected_object_filter>
 {
 public:
+  static constexpr char const* name = "class_probablity_filter";
+
+  static constexpr char const* description =
+    "Filters detections based on class probability.\n\n"
+    "This algorithm filters out items that are less than the threshold."
+    " The following steps are applied to each input detected object set.\n\n"
+    "1) Select all class names with scores greater than threshold.\n\n"
+    "2) Create a new detected_object_type object with all selected class"
+    " names from step 1. The class name can be selected individually"
+    " or with the keep_all_classes option.\n\n"
+    "3) The input detection_set is cloned and the detected_object_type"
+    " from step 2 is attached.";
+
   class_probablity_filter();
   virtual ~class_probablity_filter() = default;
 

--- a/arrows/core/close_loops_bad_frames_only.h
+++ b/arrows/core/close_loops_bad_frames_only.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,6 +60,13 @@ class KWIVER_ALGO_CORE_EXPORT close_loops_bad_frames_only
   : public vital::algorithm_impl<close_loops_bad_frames_only, vital::algo::close_loops>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "bad_frames_only";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Attempts short-term loop closure based on percentage"
+    " of feature points tracked.";
 
   /// Default Constructor
   close_loops_bad_frames_only();

--- a/arrows/core/close_loops_exhaustive.h
+++ b/arrows/core/close_loops_exhaustive.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,13 @@ class KWIVER_ALGO_CORE_EXPORT close_loops_exhaustive
   : public vital::algorithm_impl<close_loops_exhaustive, vital::algo::close_loops>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "exhaustive";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Exhaustive matching of all frame pairs,"
+    " or all frames within a moving window.";
 
   /// Default Constructor
   close_loops_exhaustive();

--- a/arrows/core/close_loops_keyframe.h
+++ b/arrows/core/close_loops_keyframe.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,12 @@ class KWIVER_ALGO_CORE_EXPORT close_loops_keyframe
   : public vital::algorithm_impl<close_loops_keyframe, vital::algo::close_loops>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "keyframe";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Establishes keyframes matches to all keyframes.";
 
   /// Default Constructor
   close_loops_keyframe();

--- a/arrows/core/close_loops_multi_method.h
+++ b/arrows/core/close_loops_multi_method.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,6 +60,12 @@ class KWIVER_ALGO_CORE_EXPORT close_loops_multi_method
   : public vital::algorithm_impl<close_loops_multi_method, vital::algo::close_loops>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "multi_method";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Iteratively run multiple loop closure algorithms.";
 
   /// Default Constructor
   close_loops_multi_method();

--- a/arrows/core/compute_ref_homography_core.h
+++ b/arrows/core/compute_ref_homography_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,12 @@ class KWIVER_ALGO_CORE_EXPORT compute_ref_homography_core
   : public vital::algorithm_impl<compute_ref_homography_core, vital::algo::compute_ref_homography>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Default online sequential-frame reference homography estimator.";
 
   /// Default Constructor
   compute_ref_homography_core();

--- a/arrows/core/convert_image_bypass.h
+++ b/arrows/core/convert_image_bypass.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,13 @@ class KWIVER_ALGO_CORE_EXPORT convert_image_bypass
   : public vital::algorithm_impl<convert_image_bypass, vital::algo::convert_image>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "bypass";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Performs no conversion and returns the given image container.";
+
    /// Default Constructor
   convert_image_bypass();
 

--- a/arrows/core/detected_object_set_input_csv.h
+++ b/arrows/core/detected_object_set_input_csv.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,21 @@ class KWIVER_ALGO_CORE_EXPORT detected_object_set_input_csv
   : public vital::algorithm_impl<detected_object_set_input_csv, vital::algo::detected_object_set_input>
 {
 public:
+  static constexpr char const* name = "csv";
+
+  // NOTE: Keep description in sync with detected_object_set_output_csv
+  static constexpr char const* description =
+    "Detected object set reader using CSV format.\n\n"
+    " - 1: frame number\n"
+    " - 2: file name\n"
+    " - 3: TL-x\n"
+    " - 4: TL-y\n"
+    " - 5: BR-x\n"
+    " - 6: BR-y\n"
+    " - 7: confidence\n"
+    " - 8,9: class-name, score"
+    " (this pair may be omitted or may repeat any number of times)\n";
+
   detected_object_set_input_csv();
   virtual ~detected_object_set_input_csv();
 

--- a/arrows/core/detected_object_set_input_kw18.h
+++ b/arrows/core/detected_object_set_input_kw18.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,25 @@ class KWIVER_ALGO_CORE_EXPORT detected_object_set_input_kw18
   : public vital::algorithm_impl<detected_object_set_input_kw18, vital::algo::detected_object_set_input>
 {
 public:
+  static constexpr char const* name = "kw18";
+
+  // NOTE: Keep description in sync with detected_object_set_output_kw18
+  static constexpr char const* description =
+    "Detected object set reader using kw18 format.\n\n"
+    "  - Column(s) 1: Track-id\n"
+    "  - Column(s) 2: Track-length (number of detections)\n"
+    "  - Column(s) 3: Frame-number (-1 if not available)\n"
+    "  - Column(s) 4-5: Tracking-plane-loc(x,y) (could be same as World-loc)\n"
+    "  - Column(s) 6-7: Velocity(x,y)\n"
+    "  - Column(s) 8-9: Image-loc(x,y)\n"
+    "  - Column(s) 10-13: Img-bbox(TL_x,TL_y,BR_x,BR_y)"
+    " (location of top-left & bottom-right vertices)\n"
+    "  - Column(s) 14: Area\n"
+    "  - Column(s) 15-17: World-loc(x,y,z)"
+    " (longitude, latitude, 0 - when available)\n"
+    "  - Column(s) 18: Timesetamp (-1 if not available)\n"
+    "  - Column(s) 19: Track-confidence (-1 if not available)\n";
+
   detected_object_set_input_kw18();
   virtual ~detected_object_set_input_kw18();
 

--- a/arrows/core/detected_object_set_output_csv.h
+++ b/arrows/core/detected_object_set_output_csv.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,21 @@ class KWIVER_ALGO_CORE_EXPORT detected_object_set_output_csv
   : public vital::algorithm_impl<detected_object_set_output_csv, vital::algo::detected_object_set_output>
 {
 public:
+  static constexpr char const* name = "csv";
+
+  // NOTE: Keep description in sync with detected_object_set_input_csv
+  static constexpr char const* description =
+    "Detected object set writer using CSV format.\n\n"
+    " - 1: frame number\n"
+    " - 2: file name\n"
+    " - 3: TL-x\n"
+    " - 4: TL-y\n"
+    " - 5: BR-x\n"
+    " - 6: BR-y\n"
+    " - 7: confidence\n"
+    " - 8,9: class-name, score"
+    " (this pair may be omitted or may repeat any number of times)\n";
+
   detected_object_set_output_csv();
   virtual ~detected_object_set_output_csv();
 

--- a/arrows/core/detected_object_set_output_kw18.h
+++ b/arrows/core/detected_object_set_output_kw18.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,25 @@ class KWIVER_ALGO_CORE_EXPORT detected_object_set_output_kw18
   : public vital::algorithm_impl<detected_object_set_output_kw18, vital::algo::detected_object_set_output>
 {
 public:
+  static constexpr char const* name = "kw18";
+
+  // NOTE: Keep description in sync with detected_object_set_input_kw18
+  static constexpr char const* description =
+    "Detected object set writer using kw18 format.\n\n"
+    "  - Column(s) 1: Track-id\n"
+    "  - Column(s) 2: Track-length (number of detections)\n"
+    "  - Column(s) 3: Frame-number (-1 if not available)\n"
+    "  - Column(s) 4-5: Tracking-plane-loc(x,y) (could be same as World-loc)\n"
+    "  - Column(s) 6-7: Velocity(x,y)\n"
+    "  - Column(s) 8-9: Image-loc(x,y)\n"
+    "  - Column(s) 10-13: Img-bbox(TL_x,TL_y,BR_x,BR_y)"
+    " (location of top-left & bottom-right vertices)\n"
+    "  - Column(s) 14: Area\n"
+    "  - Column(s) 15-17: World-loc(x,y,z)"
+    " (longitude, latitude, 0 - when available)\n"
+    "  - Column(s) 18: Timesetamp (-1 if not available)\n"
+    "  - Column(s) 19: Track-confidence (-1 if not available)\n";
+
   detected_object_set_output_kw18();
   virtual ~detected_object_set_output_kw18();
 

--- a/arrows/core/dynamic_config_none.h
+++ b/arrows/core/dynamic_config_none.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,15 @@ class KWIVER_ALGO_CORE_EXPORT dynamic_config_none
   : public vital::algorithm_impl<dynamic_config_none, vital::algo::dynamic_configuration>
 {
 public:
-  /// default constructor
+  /// Name of the algorithm
+  static constexpr char const* name = "none";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Null implementation of dynamic_configuration.\n\n"
+    "This algorithm always returns an empty configuration block.";
+
+  /// Default constructor
   dynamic_config_none();
 
   virtual void set_configuration( kwiver::vital::config_block_sptr config );

--- a/arrows/core/estimate_canonical_transform.h
+++ b/arrows/core/estimate_canonical_transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,14 @@ class KWIVER_ALGO_CORE_EXPORT estimate_canonical_transform
                                  vital::algo::estimate_canonical_transform>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core_pca";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Uses PCA to estimate a canonical similarity transform"
+    " that aligns the best fit plane to Z=0";
+
   /// Constructor
   estimate_canonical_transform();
 

--- a/arrows/core/example_detector.h
+++ b/arrows/core/example_detector.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,11 @@ class KWIVER_ALGO_CORE_EXPORT example_detector
         : public vital::algorithm_impl<example_detector, vital::algo::image_object_detector>
 {
 public:
+  static constexpr char const* name = "example_detector";
+
+  static constexpr char const* description =
+    "Simple example detector that just creates a user-specified bounding box.";
+
   example_detector();
   virtual ~example_detector();
 

--- a/arrows/core/feature_descriptor_io.h
+++ b/arrows/core/feature_descriptor_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,14 @@ class KWIVER_ALGO_CORE_EXPORT feature_descriptor_io
                                  vital::algo::feature_descriptor_io>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Read and write features and descriptor"
+    " to binary files using Cereal serialization.";
+
   /// Constructor
   feature_descriptor_io();
 

--- a/arrows/core/filter_features_magnitude.h
+++ b/arrows/core/filter_features_magnitude.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,14 @@ class KWIVER_ALGO_CORE_EXPORT filter_features_magnitude
   : public vital::algorithm_impl<filter_features_magnitude, vital::algo::filter_features>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "magnitude";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Filter features using a threshold"
+    " on the magnitude of the detector response function.";
+
   /// Constructor
   filter_features_magnitude();
 

--- a/arrows/core/filter_features_scale.h
+++ b/arrows/core/filter_features_scale.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,13 @@ class KWIVER_ALGO_CORE_EXPORT filter_features_scale
   : public vital::algorithm_impl<filter_features_scale, vital::algo::filter_features>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "scale";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Filter features using a threshold on the scale of the detected features.";
+
   /// Constructor
   filter_features_scale();
 

--- a/arrows/core/filter_tracks.h
+++ b/arrows/core/filter_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,13 @@ class KWIVER_ALGO_CORE_EXPORT filter_tracks
   : public vital::algorithm_impl<filter_tracks, vital::algo::filter_tracks>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Filter tracks by track length or matrix matrix importance.";
+
   /// Constructor
   filter_tracks();
 

--- a/arrows/core/formulate_query_core.h
+++ b/arrows/core/formulate_query_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,6 +53,12 @@ class KWIVER_ALGO_CORE_EXPORT formulate_query_core
   : public vital::algorithm_impl<formulate_query_core, vital::algo::formulate_query>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Formulate descriptors for later queries.";
 
   /// Default Constructor
   formulate_query_core();

--- a/arrows/core/hierarchical_bundle_adjust.h
+++ b/arrows/core/hierarchical_bundle_adjust.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,13 @@ class KWIVER_ALGO_CORE_EXPORT hierarchical_bundle_adjust
   : public vital::algorithm_impl<hierarchical_bundle_adjust, vital::algo::bundle_adjust>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "hierarchical";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Run a bundle adjustment algorithm in a temporally hierarchical fashion"
+    " (useful for video)";
 
   /// Constructor
   hierarchical_bundle_adjust();

--- a/arrows/core/initialize_cameras_landmarks.h
+++ b/arrows/core/initialize_cameras_landmarks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,14 @@ class KWIVER_ALGO_CORE_EXPORT initialize_cameras_landmarks
                               vital::algo::initialize_cameras_landmarks>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Run SfM to iteratively estimate new cameras and landmarks"
+    " using feature tracks.";
+
   /// Constructor
   initialize_cameras_landmarks();
 

--- a/arrows/core/match_features_fundamental_matrix.h
+++ b/arrows/core/match_features_fundamental_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,14 @@ class KWIVER_ALGO_CORE_EXPORT match_features_fundamental_matrix
   : public vital::algorithm_impl<match_features_fundamental_matrix, vital::algo::match_features>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "fundamental_matrix_guided";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Use an estimated fundamental matrix as a geometric filter"
+    " to remove outlier matches.";
+
   /// Default Constructor
   match_features_fundamental_matrix();
 

--- a/arrows/core/match_features_homography.h
+++ b/arrows/core/match_features_homography.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,6 +77,14 @@ class KWIVER_ALGO_CORE_EXPORT match_features_homography
   : public vital::algorithm_impl<match_features_homography, vital::algo::match_features>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "homography_guided";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Use an estimated homography as a geometric filter"
+    " to remove outlier matches.";
+
   /// Default Constructor
   match_features_homography();
 

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,373 +43,97 @@
 #include <arrows/core/close_loops_multi_method.h>
 #include <arrows/core/compute_ref_homography_core.h>
 #include <arrows/core/convert_image_bypass.h>
+#include <arrows/core/detected_object_set_input_csv.h>
+#include <arrows/core/detected_object_set_input_kw18.h>
+#include <arrows/core/detected_object_set_output_csv.h>
+#include <arrows/core/detected_object_set_output_kw18.h>
+#include <arrows/core/dynamic_config_none.h>
 #include <arrows/core/estimate_canonical_transform.h>
+#include <arrows/core/example_detector.h>
 #include <arrows/core/feature_descriptor_io.h>
 #include <arrows/core/filter_features_magnitude.h>
-#include <arrows/core/formulate_query_core.h>
 #include <arrows/core/filter_features_scale.h>
 #include <arrows/core/filter_tracks.h>
+#include <arrows/core/formulate_query_core.h>
 #include <arrows/core/hierarchical_bundle_adjust.h>
 #include <arrows/core/initialize_cameras_landmarks.h>
 #include <arrows/core/match_features_fundamental_matrix.h>
 #include <arrows/core/match_features_homography.h>
+#include <arrows/core/track_descriptor_set_output_csv.h>
 #include <arrows/core/track_features_core.h>
 #include <arrows/core/triangulate_landmarks.h>
 #include <arrows/core/video_input_filter.h>
 #include <arrows/core/video_input_image_list.h>
 #include <arrows/core/video_input_pos.h>
 #include <arrows/core/video_input_split.h>
-#include <arrows/core/detected_object_set_input_kw18.h>
-#include <arrows/core/detected_object_set_output_kw18.h>
-#include <arrows/core/detected_object_set_input_csv.h>
-#include <arrows/core/detected_object_set_output_csv.h>
-#include <arrows/core/example_detector.h>
-#include <arrows/core/track_descriptor_set_output_csv.h>
-#include <arrows/core/dynamic_config_none.h>
-
 
 namespace kwiver {
 namespace arrows {
 namespace core {
 
+namespace {
+
+static auto const module_name         = std::string{ "arrows.core" };
+static auto const module_version      = std::string{ "1.0" };
+static auto const module_organization = std::string{ "Kitware Inc." };
+
+// ----------------------------------------------------------------------------
+template <typename algorithm_t>
+void register_algorithm( kwiver::vital::plugin_loader& vpm )
+{
+  using kvpf = kwiver::vital::plugin_factory;
+
+  auto fact = vpm.ADD_ALGORITHM( algorithm_t::name, algorithm_t );
+  fact->add_attribute( kvpf::PLUGIN_DESCRIPTION,  algorithm_t::description )
+       .add_attribute( kvpf::PLUGIN_MODULE_NAME,  module_name )
+       .add_attribute( kvpf::PLUGIN_VERSION,      module_version )
+       .add_attribute( kvpf::PLUGIN_ORGANIZATION, module_organization )
+       ;
+}
+
+}
+
+// ----------------------------------------------------------------------------
 extern "C"
 KWIVER_ALGO_CORE_PLUGIN_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  static auto const module_name = std::string( "arrows.core" );
   if (vpm.is_module_loaded( module_name ) )
   {
     return;
   }
 
-  // add factory                  implementation-name       type-to-create
-  auto fact = vpm.ADD_ALGORITHM( "bad_frames_only", kwiver::arrows::core::close_loops_bad_frames_only );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                    "Attempts short-term loop closure based on percentage of feature."
-                    "points tracked.")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "exhaustive", kwiver::arrows::core::close_loops_exhaustive );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                    "Exhaustive matching of all frame pairs, or all frames within a moving window." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "keyframe", kwiver::arrows::core::close_loops_keyframe );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Establishes keyframes matches to all keyframes.")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "multi_method", kwiver::arrows::core::close_loops_multi_method );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Iteratively run multiple loop closure algorithms." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::compute_ref_homography_core );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Default online sequential-frame reference homography estimator." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "bypass", kwiver::arrows::core::convert_image_bypass );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Performs no conversion and returns the given image container." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core_pca", kwiver::arrows::core::estimate_canonical_transform );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Uses PCA to estimate a canonical similarity transform that aligns the best fit plane to Z=0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::feature_descriptor_io );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Read and write features and descriptor to binary files using Cereal serialization." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "magnitude", kwiver::arrows::core::filter_features_magnitude );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Filter features using a threshold on the magnitude of the detector response function." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "scale", kwiver::arrows::core::filter_features_scale );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Filter features using a threshold on the scale of the detected features." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::filter_tracks );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Filter tracks by track length or matrix matrix importance." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "hierarchical", kwiver::arrows::core::hierarchical_bundle_adjust );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Run a bundle adjustment algorithm in a temporally hierarchical fashion (useful for video)" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::initialize_cameras_landmarks );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Run SfM to iteratively estimate new cameras and landmarks using feature tracks." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "fundamental_matrix_guided", kwiver::arrows::core::match_features_fundamental_matrix );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Use an estimated fundamental matrix as a geometric filter to remove outlier matches." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "homography_guided", kwiver::arrows::core::match_features_homography );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Use an estimated homography as a geometric filter to remove outlier matches." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::track_features_core );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Track features from frame to frame using feature detection, matching, and loop closure." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::triangulate_landmarks );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Triangulate landmarks from tracks and cameras using a simple least squares solver." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "core", kwiver::arrows::core::formulate_query_core );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Formulate descriptors for later queries." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "filter", kwiver::arrows::core::video_input_filter );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "A video input that calls another video input and filters the output on "
-                       "frame range and other parameters." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "image_list", kwiver::arrows::core::video_input_image_list );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Read a list of images from a list of file names and presents them in the same way "
-                       "as reading a video.  The actual algorithm to read an image is specified in the "
-                       "\"image_reader\" config block.  Read an image list as a video stream." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "pos", kwiver::arrows::core::video_input_pos );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Read video metadata in AFRL POS format. "
-                       "The algorithm takes configuration for a directory full of images "
-                       "and an associated directory name for the metadata files. These "
-                       "metadata files have the same base name as the image files. "
-                       "Each metadata file is associated with the image file." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "split", kwiver::arrows::core::video_input_split );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Coordinate two video readers. One reader supplies the image/data stream. "
-                       "The other reader supplies the metadata stream." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "none", kwiver::arrows::core::dynamic_config_none );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Null implementation of dynamic_configuration.\n\n"
-                       "This algorithm always returns an empty configuration block.")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "kw18", kwiver::arrows::core::detected_object_set_input_kw18 );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Detected object set reader using kw18 format.\n\n"
-                       "  - Column(s) 1: Track-id\n"
-                       "  - Column(s) 2: Track-length (# of detections)\n"
-                       "  - Column(s) 3: Frame-number (-1 if not available)\n"
-                       "  - Column(s) 4-5: Tracking-plane-loc(x,y) (Could be same as World-loc)\n"
-                       "  - Column(s) 6-7: Velocity(x,y)\n"
-                       "  - Column(s) 8-9: Image-loc(x,y)\n"
-                       "  - Column(s) 10-13: Img-bbox(TL_x,TL_y,BR_x,BR_y) (location of top-left & bottom-right vertices)\n"
-                       "  - Column(s) 14: Area\n"
-                       "  - Column(s) 15-17: World-loc(x,y,z) (longitude, latitude, 0 - when available)\n"
-                       "  - Column(s) 18: Timesetamp(-1 if not available)\n"
-                       "  - Column(s) 19: Track-confidence(-1_when_not_available)\n")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "kw18", kwiver::arrows::core::detected_object_set_output_kw18 );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Detected object set writer using kw18 format.\n\n"
-                       "  - Column(s) 1: Track-id\n"
-                       "  - Column(s) 2: Track-length (# of detections)\n"
-                       "  - Column(s) 3: Frame-number (-1 if not available)\n"
-                       "  - Column(s) 4-5: Tracking-plane-loc(x,y) (Could be same as World-loc)\n"
-                       "  - Column(s) 6-7: Velocity(x,y)\n"
-                       "  - Column(s) 8-9: Image-loc(x,y)\n"
-                       "  - Column(s) 10-13: Img-bbox(TL_x,TL_y,BR_x,BR_y) (location of top-left & bottom-right vertices)\n"
-                       "  - Column(s) 14: Area\n"
-                       "  - Column(s) 15-17: World-loc(x,y,z) (longitude, latitude, 0 - when available)\n"
-                       "  - Column(s) 18: Timesetamp(-1 if not available)\n"
-                       "  - Column(s) 19: Track-confidence(-1_when_not_available)\n")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "csv", kwiver::arrows::core::detected_object_set_input_csv );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Detected object set reader using CSV format.\n\n"
-                       " - 1: frame number\n"
-                       " - 2: file name\n"
-                       " - 3: TL-x\n"
-                       " - 4: TL-y\n"
-                       " - 5: BR-x\n"
-                       " - 6: BR-y\n"
-                       " - 7: confidence\n"
-                       " - 8,9  : class-name,  score  (this pair may be omitted or may repeat any number of times)\n")
-
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "csv", kwiver::arrows::core::detected_object_set_output_csv );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Detected object set reader using CSV format.\n\n"
-                       " - 1: frame number\n"
-                       " - 2: file name\n"
-                       " - 3: TL-x\n"
-                       " - 4: TL-y\n"
-                       " - 5: BR-x\n"
-                       " - 6: BR-y\n"
-                       " - 7: confidence\n"
-                       " - 8,9  : class-name,  score  (this pair may be omitted or may repeat any number of times)\n")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-  fact = vpm.ADD_ALGORITHM( "csv", kwiver::arrows::core::track_descriptor_set_output_csv );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Track descriptor csv writer\n")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "class_probablity_filter", kwiver::arrows::core::class_probablity_filter );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Filters detections based on class probability.\n\n"
-                       "This algorithm filters out items that are less than the threshold. "
-                       "The following steps are applied to each input detected object set.\n\n"
-                       "1) Select all class names with scores greater than threshold.\n\n"
-                       "2) Create a new detected_object_type object with all selected class "
-                       "names from step 1. The class name can be selected individually "
-                       "or with the keep_all_classes option.\n\n"
-                       "3) The input detection_set is cloned and the detected_object_type "
-                       "from step 2 is attached." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    ;
-
-
-  fact = vpm.ADD_ALGORITHM( "example_detector", kwiver::arrows::core::example_detector );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Simple example detector, just creates user-specified "
-                       "bounding box" )
-          .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-          .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-          .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-          ;
-
+  register_algorithm< class_probablity_filter >( vpm );
+  register_algorithm< close_loops_bad_frames_only >( vpm );
+  register_algorithm< close_loops_exhaustive >( vpm );
+  register_algorithm< close_loops_keyframe >( vpm );
+  register_algorithm< close_loops_multi_method >( vpm );
+  register_algorithm< compute_ref_homography_core >( vpm );
+  register_algorithm< convert_image_bypass >( vpm );
+  register_algorithm< detected_object_set_input_csv >( vpm );
+  register_algorithm< detected_object_set_input_kw18 >( vpm );
+  register_algorithm< detected_object_set_output_csv >( vpm );
+  register_algorithm< detected_object_set_output_kw18 >( vpm );
+  register_algorithm< dynamic_config_none >( vpm );
+  register_algorithm< estimate_canonical_transform >( vpm );
+  register_algorithm< example_detector >( vpm );
+  register_algorithm< feature_descriptor_io >( vpm );
+  register_algorithm< filter_features_magnitude >( vpm );
+  register_algorithm< filter_features_scale >( vpm );
+  register_algorithm< filter_tracks >( vpm );
+  register_algorithm< formulate_query_core >( vpm );
+  register_algorithm< hierarchical_bundle_adjust >( vpm );
+  register_algorithm< initialize_cameras_landmarks >( vpm );
+  register_algorithm< match_features_fundamental_matrix >( vpm );
+  register_algorithm< match_features_homography >( vpm );
+  register_algorithm< track_descriptor_set_output_csv >( vpm );
+  register_algorithm< track_features_core >( vpm );
+  register_algorithm< triangulate_landmarks >( vpm );
+  register_algorithm< video_input_filter >( vpm );
+  register_algorithm< video_input_image_list >( vpm );
+  register_algorithm< video_input_pos >( vpm );
+  register_algorithm< video_input_split >( vpm );
 
   vpm.mark_module_as_loaded( module_name );
 }

--- a/arrows/core/track_descriptor_set_output_csv.h
+++ b/arrows/core/track_descriptor_set_output_csv.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,11 @@ class KWIVER_ALGO_CORE_EXPORT track_descriptor_set_output_csv
       vital::algo::track_descriptor_set_output>
 {
 public:
+  static constexpr char const* name = "csv";
+
+  static constexpr char const* description =
+    "Track descriptor csv writer\n";
+
   track_descriptor_set_output_csv();
   virtual ~track_descriptor_set_output_csv();
 

--- a/arrows/core/track_features_core.h
+++ b/arrows/core/track_features_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,13 @@ class KWIVER_ALGO_CORE_EXPORT track_features_core
   : public vital::algorithm_impl<track_features_core, vital::algo::track_features>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Track features from frame to frame"
+    " using feature detection, matching, and loop closure.";
 
   /// Default Constructor
   track_features_core();

--- a/arrows/core/triangulate_landmarks.h
+++ b/arrows/core/triangulate_landmarks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,14 @@ class KWIVER_ALGO_CORE_EXPORT triangulate_landmarks
                               vital::algo::triangulate_landmarks>
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "core";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Triangulate landmarks from tracks and cameras"
+    " using a simple least squares solver.";
+
   /// Constructor
   triangulate_landmarks();
 

--- a/arrows/core/video_input_filter.h
+++ b/arrows/core/video_input_filter.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,14 @@ class KWIVER_ALGO_CORE_EXPORT video_input_filter
   : public vital::algorithm_impl < video_input_filter, vital::algo::video_input >
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "filter";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "A video input that calls another video input"
+    " and filters the output on frame range and other parameters.";
+
   /// Constructor
   video_input_filter();
   virtual ~video_input_filter();

--- a/arrows/core/video_input_image_list.h
+++ b/arrows/core/video_input_image_list.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,6 +54,17 @@ class KWIVER_ALGO_CORE_EXPORT video_input_image_list
   : public vital::algorithm_impl < video_input_image_list, vital::algo::video_input >
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "image_list";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Read a list of images from a list of file names"
+    " and presents them in the same way as reading a video."
+    " The actual algorithm to read an image is specified"
+    " in the \"image_reader\" config block."
+    " Read an image list as a video stream.";
+
   /// Constructor
   video_input_image_list();
   virtual ~video_input_image_list();

--- a/arrows/core/video_input_pos.h
+++ b/arrows/core/video_input_pos.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,18 @@ class KWIVER_ALGO_CORE_EXPORT video_input_pos
   : public vital::algorithm_impl < video_input_pos, vital::algo::video_input >
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "pos";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Read video metadata in AFRL POS format."
+    " The algorithm takes configuration for a directory full of images"
+    " and an associated directory name for the metadata files."
+    " These metadata files have the same base name as the image files."
+    " Each metadata file is associated with the image file"
+    " of the same base name.";
+
   /// Constructor
   video_input_pos();
   virtual ~video_input_pos();

--- a/arrows/core/video_input_split.h
+++ b/arrows/core/video_input_split.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,15 @@ class KWIVER_ALGO_CORE_EXPORT video_input_split
   : public vital::algorithm_impl < video_input_split, vital::algo::video_input >
 {
 public:
+  /// Name of the algorithm
+  static constexpr char const* name = "split";
+
+  /// Description of the algorithm
+  static constexpr char const* description =
+    "Coordinate two video readers."
+    " One reader supplies the image/data stream."
+    " The other reader supplies the metadata stream.";
+
   /// Constructor
   video_input_split();
   virtual ~video_input_split();


### PR DESCRIPTION
Move algorithm names and descriptions to the algorithm headers, rather than the registration source file, so that they exist closer to the thing they are describing. Refactor registration to use this information and to avoid redundant code.

I'm pretty sure I didn't mess up any of the algorithm names in the process of moving things around, but I did tweak some of the descriptions. Now would be a good time to review the algorithm descriptions for overall quality, as this is a good chance to make improvements.