### PR TITLE
Respect PYTHON_VERSION_MAJOR and fix potential windows issues

### DIFF
--- a/CMake/kwiver-setup-python.cmake
+++ b/CMake/kwiver-setup-python.cmake
@@ -85,7 +85,16 @@ endfunction()
 ###
 # Python major version user option
 #
-set(KWIVER_PYTHON_MAJOR_VERSION "2" CACHE STRING "Python version to use: 3 or 2")
+
+# Respect the PYTHON_VERSION_MAJOR version if it is set
+if (PYTHON_VERSION_MAJOR)
+  set(DEFAULT_PYTHON_MAJOR ${PYTHON_VERSION_MAJOR})
+else()
+  set(DEFAULT_PYTHON_MAJOR "2")
+endif()
+
+
+set(KWIVER_PYTHON_MAJOR_VERSION "${DEFAULT_PYTHON_MAJOR}" CACHE STRING "Python version to use: 3 or 2")
 set_property(CACHE KWIVER_PYTHON_MAJOR_VERSION PROPERTY STRINGS "3" "2")
 
 
@@ -138,10 +147,7 @@ include_directories(SYSTEM ${PYTHON_INCLUDE_DIR})
 # Get canonical directory for python site packages (relative to install
 # location).  It varys from system to system.
 #
-_pycmd(python_site_packages "\
-from distutils import sysconfig
-print(sysconfig.get_python_lib(prefix=''))
-")
+_pycmd(python_site_packages "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
 message(STATUS "python_site_packages = ${python_site_packages}")
 # Current usage determines most of the path in alternate ways.
 # All we need to supply is the '*-packages' directory name.
@@ -155,12 +161,11 @@ get_filename_component(python_sitename ${python_site_packages} NAME)
 # Use the executable to find the major/minor version.
 # If you want to change this, then change the executable.
 #
-_pycmd(PYTHON_VERSION "\
-import sys
-print(sys.version[0:3])
-")
+_pycmd(PYTHON_VERSION "import sys; print(sys.version[0:3])")
 # assert that the right python version was found
 if(NOT PYTHON_VERSION MATCHES "^${KWIVER_PYTHON_MAJOR_VERSION}.*")
+  message(STATUS "KWIVER_PYTHON_MAJOR_VERSION = ${KWIVER_PYTHON_MAJOR_VERSION}")
+  message(STATUS "PYTHON_VERSION = ${PYTHON_VERSION}")
   message(FATAL_ERROR "Requested python \"${KWIVER_PYTHON_MAJOR_VERSION}\" but got \"${PYTHON_VERSION}\"")
 endif()
 
@@ -173,10 +178,7 @@ endif()
 #
 if (KWIVER_PYTHON_MAJOR_VERSION STREQUAL "3")
   # In python 3, we can determine what the ABI flags are
-  _pycmd(_python_abi_flags "\
-from distutils import sysconfig
-print(sysconfig.get_config_var('ABIFLAGS'))
-")
+  _pycmd(_python_abi_flags "from distutils import sysconfig; print(sysconfig.get_config_var('ABIFLAGS'))")
 else()
   # Not sure if ABI flags are easilly found (or are even used in python2)
   set(_python_abi_flags, "")


### PR DESCRIPTION
Due to this thread https://github.com/caffe2/caffe2/issues/1982 I realized there may be an issue with my `_pycmd` command on windows. Just in case there is I modified the places where it was being used to use one-liner commands instead of the multi-line commands. 

I also added logic so `KWIVER_PYTHON_MAJOR_VERSION` respects the variable `PYTHON_VERSION_MAJOR` if a program passes it on on the command line via `-D` (like the VIAME super build)