### PR TITLE
Support for Python 2 and 3

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -198,7 +198,7 @@ function (kwiver_create_python_init    modpath)
   file(WRITE "${init_template}"      "${copyright_header}\n\n")
 
   foreach (module IN LISTS ARGN)
-    file(APPEND "${init_template}"      "from ${module} import *\n")
+    file(APPEND "${init_template}"      "from .${module} import *\n")
   endforeach ()
 
   kwiver_add_python_module("${init_template}"

--- a/sprokit/conf/sprokit-macro-python.cmake
+++ b/sprokit/conf/sprokit-macro-python.cmake
@@ -184,9 +184,12 @@ function (sprokit_create_python_init    modpath)
   file(WRITE "${init_template}"
     "${copyright_header}\n\n")
 
+  file(APPEND "${init_template}"
+    "from __future__ import absolute_import\n\n")
+
   foreach (module IN LISTS ARGN)
     file(APPEND "${init_template}"
-      "from ${module} import *\n")
+      "from .${module} import *\n")
   endforeach ()
 
   sprokit_add_python_module("${init_template}"

--- a/vital/bindings/python/vital/util/VitalPIL.py
+++ b/vital/bindings/python/vital/util/VitalPIL.py
@@ -35,6 +35,7 @@ Helper functions for dealing with PIL
 """
 
 from vital.types import Image
+import six
 
 def _pil_image_to_bytes(p_img):
     """
@@ -180,8 +181,12 @@ def get_pil_image(img):
         raise RuntimeError("Unsupported image format.")
 
     # get buffer from image
-    img_pixels = buffer(bytearray(img))
+    if six.PY2:
+        img_pixels = buffer(bytearray(img))
+    else:
+        img_pixels = memoryview(bytearray(img)).tobytes()
 
-    return _pil_image_from_bytes(mode, (img.width(), img.height()),
-                                 img_pixels, "raw", mode,
-                                 img.h_step() * img.pixel_num_bytes(), 1)
+    pil_img = _pil_image_from_bytes(mode, (img.width(), img.height()),
+                                    img_pixels, "raw", mode,
+                                    img.h_step() * img.pixel_num_bytes(), 1)
+    return pil_img


### PR DESCRIPTION
This PR fixes issues that prevented KWIVER from being used with python3. 

After applying this patch all python tests pass except for 4:

```
The following tests FAILED:
	364 - test-python-export_-simple_pipeline (SEGFAULT)
	371 - test-python-pymodules-load (Failed)
	373 - test-python-pymodules-extra_modules (Failed)
	374 - test-python-pymodules-pythonpath (Failed)
```

@hughed2 Are these tests known to fail in python2 as well? or is there still a bit more work to be done?  