### PR TITLE
"Fix" interpolate_track_spline algorithm

### DIFF
--- a/arrows/core/interpolate_track_spline.cxx
+++ b/arrows/core/interpolate_track_spline.cxx
@@ -47,13 +47,24 @@ public:
 namespace {
 
 // ----------------------------------------------------------------------------
-vector_2d lerp(vector_2d const& a, vector_2d const& b, double k)
+time_t
+lerp( time_t a, time_t b, double k )
+{
+  auto const x = static_cast< double >( a );
+  auto const y = static_cast< double >( b );
+  return static_cast< time_t >( ( ( 1.0 - k ) * x ) + ( k * y ) );
+}
+
+// ----------------------------------------------------------------------------
+vector_2d
+lerp( vector_2d const& a, vector_2d const& b, double k )
 {
   return ( ( 1.0 - k ) * a ) + ( k * b );
 }
 
 // ----------------------------------------------------------------------------
-bounding_box_d lerp(bounding_box_d const& a, bounding_box_d const& b, double k)
+bounding_box_d
+lerp( bounding_box_d const& a, bounding_box_d const& b, double k )
 {
   auto const& ul = lerp( a.upper_left(), b.upper_left(), k );
   auto const& lr = lerp( a.lower_right(), b.lower_right(), k );
@@ -98,7 +109,7 @@ interpolate( track_sptr input_track )
   if ( !input_track ) return nullptr;
 
   // Extract states, for easier iteration over intervals to be filled
-  std::map< frame_id_t, detected_object_sptr > states;
+  std::map< frame_id_t, std::pair< time_t, detected_object_sptr > > states;
   for ( auto const& sp : *input_track )
   {
     auto const osp = std::dynamic_pointer_cast< object_track_state >( sp );
@@ -107,42 +118,47 @@ interpolate( track_sptr input_track )
     auto const detection = osp->detection;
     if ( !detection ) continue;
 
-    states.emplace( osp->frame(), detection );
+    states.emplace( osp->frame(), std::make_pair( osp->time(), detection ) );
   }
 
   // Create result track
   auto new_track = track::create( input_track->data() );
   new_track->set_id( input_track->id() );
 
-  auto append = [&new_track]( frame_id_t frame,
+  auto append = [&new_track]( frame_id_t frame, time_t time,
                               detected_object_sptr detection ){
     new_track->append(
-      std::make_shared< object_track_state >( frame, detection ) );
+      std::make_shared< object_track_state >( frame, time, detection ) );
   };
 
   // Iterate over intervals to be filled
   for ( auto i = states.begin(), n = states.begin();; i = n )
   {
-    append( i->first, i->second );
+    append( i->first, i->second.first, i->second.second );
     if ( ( ++n ) == states.end() ) break;
 
     // Get end points of interval
-    auto const& f0 = i->first;
-    auto const& f1 = n->first;
-    auto const tk = 1.0 / static_cast< double >( f1 - f0 );
+    auto const f0 = i->first;
+    auto const f1 = n->first;
+    auto const xk = 1.0 / static_cast< double >( f1 - f0 );
+
+    auto const& p0 = i->second.second->bounding_box();
+    auto const& p1 = n->second.second->bounding_box();
+    auto const c0 = i->second.second->confidence();
+    auto const c1 = n->second.second->confidence();
 
     // Iterate over frame numbers in interval
     for ( auto fn = f0 + 1; fn < f1; ++fn )
     {
-      auto const t = static_cast< double >( fn - f0 ) * tk;
-      auto const& bbox = lerp( i->second->bounding_box(),
-                               n->second->bounding_box(), t );
-      auto const c = ( pow( t, 2.0 ) * i->second->confidence() ) +
-                     ( pow( 1.0 - t, 2.0 ) * n->second->confidence() );
+      auto const x = static_cast< double >( fn - f0 ) * xk;
+      auto const tn = lerp( i->second.first, n->second.first, x );
+
+      auto const& bbox = lerp( p0, p1, x );
+      auto const c = ( pow( x, 2.0 ) * c0 ) + ( pow( 1.0 - x, 2.0 ) * c1 );
 
       auto const d = std::make_shared< detected_object >( bbox, c );
       new_track->append(
-        std::make_shared< object_track_state >( fn, d ) );
+        std::make_shared< object_track_state >( fn, tn, d ) );
     }
   }
 

--- a/arrows/core/tests/test_interpolate_track_spline.cxx
+++ b/arrows/core/tests/test_interpolate_track_spline.cxx
@@ -59,13 +59,16 @@ TEST(interpolate_track_spline, create)
 
 namespace {
 
+constexpr static auto FRAME_RATE = time_t{ 3000 };
+
 // ----------------------------------------------------------------------------
 void add_track_state( kv::track_sptr track, kv::frame_id_t frame,
                       kv::bounding_box_d bbox, double confidence )
 {
+  auto const time = frame * FRAME_RATE;
   auto d = std::make_shared< kv::detected_object >( bbox, confidence );
   track->append(
-    std::make_shared< kv::object_track_state >( frame, d ) );
+    std::make_shared< kv::object_track_state >( frame, time, d ) );
 }
 
 // ----------------------------------------------------------------------------
@@ -82,6 +85,7 @@ void check_track_state( kv::track_sptr track, kv::frame_id_t frame,
 
   EXPECT_EQ( track, state->track() );
   EXPECT_EQ( frame, state->frame() );
+  EXPECT_EQ( frame * FRAME_RATE, state->time() );
 
   ASSERT_NE( nullptr, state->detection );
 


### PR DESCRIPTION
Refactor `interpolate_track_spline` to address the addition of a time value (by @KyleFromKitware) to object track states since the algorithm was created.