### PR TITLE
Refactor timestamp types for time and frame number.

### DIFF
--- a/arrows/core/detected_object_set_output_csv.cxx
+++ b/arrows/core/detected_object_set_output_csv.cxx
@@ -104,7 +104,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
 
   if (d->m_first)
   {
-    time_t rawtime;
+    std::time_t rawtime;
     struct tm * timeinfo;
 
     time ( &rawtime );

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -173,7 +173,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
 
   if (d->m_first)
   {
-    time_t rawtime;
+    std::time_t rawtime;
     struct tm * timeinfo;
 
     time ( &rawtime );

--- a/arrows/core/interpolate_track_spline.cxx
+++ b/arrows/core/interpolate_track_spline.cxx
@@ -47,12 +47,12 @@ public:
 namespace {
 
 // ----------------------------------------------------------------------------
-time_t
-lerp( time_t a, time_t b, double k )
+time_us_t
+lerp( time_us_t a, time_us_t b, double k )
 {
   auto const x = static_cast< double >( a );
   auto const y = static_cast< double >( b );
-  return static_cast< time_t >( ( ( 1.0 - k ) * x ) + ( k * y ) );
+  return static_cast< time_us_t >( ( ( 1.0 - k ) * x ) + ( k * y ) );
 }
 
 // ----------------------------------------------------------------------------
@@ -109,7 +109,7 @@ interpolate( track_sptr input_track )
   if ( !input_track ) return nullptr;
 
   // Extract states, for easier iteration over intervals to be filled
-  std::map< frame_id_t, std::pair< time_t, detected_object_sptr > > states;
+  std::map< frame_id_t, std::pair< time_us_t, detected_object_sptr > > states;
   for ( auto const& sp : *input_track )
   {
     auto const osp = std::dynamic_pointer_cast< object_track_state >( sp );
@@ -125,7 +125,7 @@ interpolate( track_sptr input_track )
   auto new_track = track::create( input_track->data() );
   new_track->set_id( input_track->id() );
 
-  auto append = [&new_track]( frame_id_t frame, time_t time,
+  auto append = [&new_track]( frame_id_t frame, time_us_t time,
                               detected_object_sptr detection ){
     new_track->append(
       std::make_shared< object_track_state >( frame, time, detection ) );

--- a/arrows/core/tests/test_interpolate_track_spline.cxx
+++ b/arrows/core/tests/test_interpolate_track_spline.cxx
@@ -59,7 +59,7 @@ TEST(interpolate_track_spline, create)
 
 namespace {
 
-constexpr static auto FRAME_RATE = time_t{ 3000 };
+constexpr static auto FRAME_RATE = kv::time_us_t{ 3000 };
 
 // ----------------------------------------------------------------------------
 void add_track_state( kv::track_sptr track, kv::frame_id_t frame,

--- a/arrows/core/video_input_filter.cxx
+++ b/arrows/core/video_input_filter.cxx
@@ -51,8 +51,8 @@ public:
   { }
 
   // Configuration values
-  vital::timestamp::frame_t c_start_at_frame;
-  vital::timestamp::frame_t c_stop_after_frame;
+  vital::frame_id_t c_start_at_frame;
+  vital::frame_id_t c_stop_after_frame;
   double c_frame_rate;
 
   // local state
@@ -92,11 +92,11 @@ video_input_filter
                      "If set to zero, start at the beginning of the video." );
 
   config->set_value( "stop_after_frame", d->c_stop_after_frame,
-                     "End the video after passing this frame number. " 
+                     "End the video after passing this frame number. "
                      "Set this value to 0 to disable filter.");
 
   config->set_value( "frame_rate", d->c_frame_rate, "Number of frames per second. "
-                     "If the video does not provide a valid time, use this rate " 
+                     "If the video does not provide a valid time, use this rate "
                      "to compute frame time.  Set 0 to disable.");
 
   vital::algo::video_input::
@@ -114,10 +114,10 @@ video_input_filter
   vital::config_block_sptr config = this->get_configuration();
   config->merge_config(in_config);
 
-  d->c_start_at_frame = config->get_value<vital::timestamp::frame_t>(
+  d->c_start_at_frame = config->get_value<vital::frame_id_t>(
     "start_at_frame", d->c_start_at_frame );
 
-  d->c_stop_after_frame = config->get_value<vital::timestamp::frame_t>(
+  d->c_stop_after_frame = config->get_value<vital::frame_id_t>(
     "stop_after_frame", d->c_stop_after_frame );
 
   // get frame time

--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -66,7 +66,7 @@ public:
   // local state
   std::vector < kwiver::vital::path_t > m_files;
   std::vector < kwiver::vital::path_t >::const_iterator m_current_file;
-  kwiver::vital::timestamp::frame_t m_frame_number;
+  kwiver::vital::frame_id_t m_frame_number;
   kwiver::vital::image_container_sptr m_image;
 
   // processing classes

--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -67,7 +67,7 @@ public:
   typedef std::pair < vital::path_t, vital::path_t > path_pair_t;
   std::vector < path_pair_t > d_img_md_files;
   std::vector < path_pair_t >::const_iterator d_current_files;
-  kwiver::vital::timestamp::frame_t d_frame_number;
+  kwiver::vital::frame_id_t d_frame_number;
 
   vital::metadata_sptr d_metadata;
 };

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -120,11 +120,11 @@ public:
   bool d_have_metadata;
 
   double pts_of_meta_ts;            // probably seconds
-  vital::timestamp::time_t meta_ts; // time in usec
+  vital::time_us_t meta_ts; // time in usec
 
   // used to create timestamp output
-  vital::timestamp::time_t d_frame_time; // usec
-  vital::timestamp::frame_t d_frame_number;
+  vital::time_us_t d_frame_time; // usec
+  vital::frame_id_t d_frame_number;
 
   std::string video_path; // name of video we opened
 
@@ -439,10 +439,10 @@ vidl_ffmpeg_video_input
   vital::config_block_sptr config = this->get_configuration();
   config->merge_config(in_config);
 
-  d->c_start_at_frame = config->get_value<vital::timestamp::frame_t>(
+  d->c_start_at_frame = config->get_value<vital::frame_id_t>(
     "start_at_frame", d->c_start_at_frame );
 
-  d->c_stop_after_frame = config->get_value<vital::timestamp::frame_t>(
+  d->c_stop_after_frame = config->get_value<vital::frame_id_t>(
     "stop_after_frame", d->c_stop_after_frame );
 
   kwiver::vital::tokenize( config->get_value<std::string>( "time_source", d->c_time_source ),
@@ -485,7 +485,7 @@ vidl_ffmpeg_video_input
   // validate start frame
   if (config->has_value("start_at_frame"))
   {
-    vital::timestamp::frame_t frame = config->get_value<vital::timestamp::frame_t>("start_at_frame");
+    vital::frame_id_t frame = config->get_value<vital::frame_id_t>("start_at_frame");
     //  zero indicates not set, otherwise must be 1 or greater
     if (frame < 0)
     {

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -117,6 +117,11 @@ Vital
    moved into vital/io, and the KLV conversion functions have moved into
    vital/klv.
 
+ * Refactor timestamp types for time and frame number. Standardized on
+   the base kwiver::vital types for frame_id and time. Renamed time_t
+   to time_us_t to provide some distance from std::time_t and make the
+   units apparent.
+
 Vital Bindings
 
  * Vital C and Python bindings have been updated with respect the refactoring

--- a/sprokit/processes/core/frame_list_process.cxx
+++ b/sprokit/processes/core/frame_list_process.cxx
@@ -90,14 +90,14 @@ public:
 
   // Configuration values
   std::string m_config_image_list_filename;
-  kwiver::vital::timestamp::time_t m_config_frame_time;
+  kwiver::vital::time_us_t m_config_frame_time;
   std::vector< std::string > m_config_path;
 
   // process local data
   std::vector < kwiver::vital::path_t > m_files;
   std::vector < kwiver::vital::path_t >::const_iterator m_current_file;
-  kwiver::vital::timestamp::frame_t m_frame_number;
-  kwiver::vital::timestamp::time_t m_frame_time;
+  kwiver::vital::frame_id_t m_frame_number;
+  kwiver::vital::time_us_t m_frame_time;
 
   // processing classes
   algo::image_io_sptr m_image_reader;

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -108,11 +108,11 @@ public:
   // Configuration values
   int m_config_error_mode; // error mode
   std::vector< std::string > m_config_path;
-  kwiver::vital::timestamp::time_t m_config_frame_time;
+  kwiver::vital::time_us_t m_config_frame_time;
 
   // local state
-  kwiver::vital::timestamp::frame_t m_frame_number;
-  kwiver::vital::timestamp::time_t m_frame_time;
+  kwiver::vital::frame_id_t m_frame_number;
+  kwiver::vital::time_us_t m_frame_time;
 
   // processing classes
   algo::image_io_sptr m_image_reader;

--- a/sprokit/processes/core/image_writer_process.cxx
+++ b/sprokit/processes/core/image_writer_process.cxx
@@ -83,7 +83,7 @@ public:
   std::string m_file_template;
 
   // Number for current image.
-  kwiver::vital::timestamp::frame_t m_frame_number;
+  kwiver::vital::frame_id_t m_frame_number;
 
   // processing classes
   algo::image_io_sptr m_image_writer;
@@ -145,7 +145,7 @@ void image_writer_process
     frame_time = grab_from_port_using_trait( timestamp );
     if (frame_time.has_valid_frame() )
     {
-      kwiver::vital::timestamp::frame_t next_frame;
+      kwiver::vital::frame_id_t next_frame;
       next_frame = frame_time.get_frame();
 
       if ( next_frame <= d->m_frame_number )

--- a/sprokit/processes/core/video_input_process.cxx
+++ b/sprokit/processes/core/video_input_process.cxx
@@ -73,16 +73,16 @@ public:
   ~priv();
 
   // Configuration values
-  std::string                             m_config_video_filename;
-  kwiver::vital::timestamp::time_t        m_config_frame_time;
+  std::string                           m_config_video_filename;
+  kwiver::vital::time_us_t              m_config_frame_time;
 
-  kwiver::vital::algo::video_input_sptr   m_video_reader;
+  kwiver::vital::algo::video_input_sptr m_video_reader;
   kwiver::vital::algorithm_capabilities m_video_traits;
 
-  kwiver::vital::timestamp::frame_t       m_frame_number;
-  kwiver::vital::timestamp::time_t        m_frame_time;
+  kwiver::vital::frame_id_t             m_frame_number;
+  kwiver::vital::time_us_t              m_frame_time;
 
-  kwiver::vital::metadata_vector          m_last_metadata;
+  kwiver::vital::metadata_vector        m_last_metadata;
 
 }; // end priv class
 
@@ -113,7 +113,7 @@ void video_input_process
 
   // Examine the configuration
   d->m_config_video_filename = config_value_using_trait( video_filename );
-  d->m_config_frame_time = static_cast<vital::timestamp::time_t>(
+  d->m_config_frame_time = static_cast<vital::time_us_t>(
                                config_value_using_trait( frame_time ) * 1e6); // in usec
 
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process

--- a/sprokit/processes/ocv/image_viewer_process.cxx
+++ b/sprokit/processes/ocv/image_viewer_process.cxx
@@ -109,7 +109,7 @@ public:
 
   // ------------------------------------------------------------------
   cv::Mat
-  annotate_image( cv::Mat cv_img, kwiver::vital::timestamp::frame_t frame)
+  annotate_image( cv::Mat cv_img, kwiver::vital::frame_id_t frame)
   {
     static const int font_face = cv::FONT_HERSHEY_SIMPLEX;
     static const double font_scale( 1.0 );

--- a/track_oracle/core/kwiver_io_helpers.cxx
+++ b/track_oracle/core/kwiver_io_helpers.cxx
@@ -191,7 +191,7 @@ kwiver_ts_string_read( const string& frame_str,
       return false;
     }
   }
-  t.set_time_usec( static_cast< vital::timestamp::time_t >( ts * 1.0e6) );
+  t.set_time_usec( static_cast< vital::time_us_t >( ts * 1.0e6) );
   return true;
 }
 

--- a/track_oracle/example/track_reader_example.cxx
+++ b/track_oracle/example/track_reader_example.cxx
@@ -232,7 +232,7 @@ int load_tracks( const string& track_fn, track_handle_list_type& tracks, const s
     frame_handle_list_type frames = track_oracle_core::get_frames( tracks[i] );
     frame_count += frames.size();
     vector< oracle_entry_handle_type > frame_handles( frames.size() );
-    for (auto j=0; j<frames.size(); ++j)
+    for (size_t j=0; j<frames.size(); ++j)
     {
       frame_handles[j] = frames[j].row;
     }

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -573,11 +573,11 @@ config_block_get_value_cast( config_block_value_t const& value )
   std::stringstream str;
   str << value;
 
-  timestamp::time_t t;
+  kwiver::vital::time_us_t t;
   str >> t;
   obj.set_time( t );
 
-  timestamp::frame_t f;
+  kwiver::vital::frame_id_t f;
   str >> f;
   obj.set_frame( f );
 

--- a/vital/types/object_track_set.h
+++ b/vital/types/object_track_set.h
@@ -59,7 +59,7 @@ public:
 
   /// Default constructor
   object_track_state( frame_id_t frame,
-                      time_t time,
+                      time_us_t time,
                       detected_object_sptr d = nullptr )
     : track_state( frame )
     , detection( d )
@@ -79,7 +79,7 @@ public:
     return std::make_shared< object_track_state >( *this );
   }
 
-  time_t time() const
+  time_us_t time() const
   {
     return time_;
   }
@@ -87,7 +87,7 @@ public:
   detected_object_sptr detection;
 
 private:
-  time_t time_;
+  time_us_t time_;
 };
 
 

--- a/vital/types/timestamp.cxx
+++ b/vital/types/timestamp.cxx
@@ -47,7 +47,7 @@ timestamp::timestamp()
 { }
 
 
-timestamp::timestamp( time_t t, frame_t f )
+timestamp::timestamp( time_us_t t, frame_id_t f )
   : m_valid_time( true ),
     m_valid_frame( true ),
     m_time( t ),
@@ -58,7 +58,7 @@ timestamp::timestamp( time_t t, frame_t f )
 
 // ------------------------------------------------------------------
 timestamp& timestamp
-::set_time_usec( time_t t )
+::set_time_usec( time_us_t t )
 {
   m_time = t;
   m_valid_time = true;
@@ -71,7 +71,7 @@ timestamp& timestamp
 timestamp& timestamp
 ::set_time_seconds( double t )
 {
-  m_time = static_cast< time_t >(t * 1e6);     // Convert to usec
+  m_time = static_cast< time_us_t >(t * 1e6);     // Convert to usec
   m_valid_time = true;
 
   return *this;
@@ -80,7 +80,7 @@ timestamp& timestamp
 
 // ------------------------------------------------------------------
 timestamp& timestamp
-::set_frame( frame_t f)
+::set_frame( frame_id_t f)
 {
   m_frame = f;
   m_valid_frame = true;

--- a/vital/types/timestamp.h
+++ b/vital/types/timestamp.h
@@ -36,6 +36,7 @@
 #include <istream>
 
 #include <vital/vital_export.h>
+#include <vital/vital_types.h>
 
 namespace kwiver {
 namespace vital {
@@ -63,9 +64,8 @@ namespace vital {
 class VITAL_EXPORT timestamp
 {
 public:
-  // -- TYPES --
-  typedef int64_t time_t; // in micro-seconds
-  typedef int64_t frame_t;
+  typedef kwiver::vital::frame_id_t frame_t;
+  typedef kwiver::vital::time_us_t  time_t;
 
   /**
    * \brief Default constructor.
@@ -80,10 +80,10 @@ public:
    *
    * Creates a valid timestamp with specified time and frame number.
    *
-   * @param t Time for timestamp
+   * @param t Time for timestamp in micro-seconds
    * @param f Frame number for timestamp
    */
-  explicit timestamp( time_t t, frame_t f);
+  explicit timestamp( time_us_t t, frame_id_t f);
 
   /**
    * \brief Is timestamp valid.
@@ -126,7 +126,7 @@ public:
    *
    * @return Frame time in micro-seconds
    */
-  time_t get_time_usec() const { return m_time; }
+  time_us_t get_time_usec() const { return m_time; }
 
 
   /**
@@ -150,7 +150,7 @@ public:
    *
    * @return Frame number.
    */
-  frame_t get_frame() const { return m_frame; }
+  frame_id_t get_frame() const { return m_frame; }
 
 
   /**
@@ -158,13 +158,13 @@ public:
    *
    * @param t Time for frame.
    */
-  timestamp& set_time_usec( time_t t );
+  timestamp& set_time_usec( time_us_t t );
 
 
   /**
    * \brief Set time portion of timestamp.
    *
-   * @param t Time for frame.
+   * @param t Time for frame in seconds.
    */
   timestamp& set_time_seconds( double t );
 
@@ -174,7 +174,7 @@ public:
    *
    * @param f Frame number
    */
-  timestamp& set_frame( frame_t f);
+  timestamp& set_frame( frame_id_t f);
 
 
   /**
@@ -219,8 +219,8 @@ private:
   bool m_valid_time;            ///< indicates valid time
   bool m_valid_frame;           ///< indicates valid frame number
 
-  time_t m_time;                ///< frame time in seconds
-  frame_t  m_frame;             ///< frame number
+  time_us_t m_time;             ///< frame time in seconds
+  frame_id_t  m_frame;          ///< frame number
 
   // index used to determine the time domain for this timestamp.
   int m_time_domain_index;

--- a/vital/types/timestamp_config.h
+++ b/vital/types/timestamp_config.h
@@ -62,11 +62,11 @@ config_block_get_value_cast( config_block_value_t const& value )
   std::stringstream str; // add string to stream
   str << value;
 
-  timestamp::time_t t;
+  time_us_t t;
   str >> t;
   obj.set_time_usec( t );
 
-  timestamp::frame_t f;
+  frame_id_t f;
   str >> f;
   obj.set_frame( f );
 

--- a/vital/vital_types.h
+++ b/vital/vital_types.h
@@ -58,6 +58,9 @@ typedef int64_t track_id_t;
 /// The type of a frame number
 typedef int64_t frame_id_t;
 
+// Time in micro-seconds
+typedef int64_t time_us_t;
+
 // -- concrete types --
 typedef double gsd_t;
 


### PR DESCRIPTION
- Standardized on the base kwiver::vital types for frame_id and time.
- Renamed time_t to time_us_t to provide some distance from std::time_t
and make the units apparent.
- Removed the type names from the timestamp class.