### PR TITLE
Update Google Test release note

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -178,10 +178,10 @@ Tools
 
 Unit Tests
 
- * KWIVER is in the process of transitioning to Google Test as its primary
-   testing framework.  This means that Google Test is now a hard dependency
-   when KWIVER_ENABLE_TESTS is ON.  (Recent versions of Fletch include Google
-   Test.)  The Sprokit tests will continue to use their own framework.
+ * KWIVER now uses Google Test as its primary testing framework.  This means
+   that Google Test is now a hard dependency when KWIVER_ENABLE_TESTS is ON.
+   (Recent versions of Fletch include Google Test.)  The Sprokit tests will
+   continue to use their own framework.
 
 
 Fixes since v1.1.0


### PR DESCRIPTION
The main effort porting to Google Test finished some time ago, but updating the initial "work in progress" release note was overlooked. Update it now to reflect the "completed" status of the effort.