### PR TITLE
Replace boost LCM with a local implementation.

### DIFF
--- a/sprokit/src/processes/clusters/registration.cxx
+++ b/sprokit/src/processes/clusters/registration.cxx
@@ -57,7 +57,7 @@
 using namespace sprokit;
 
 static std::string const default_include_dirs = std::string(DEFAULT_CLUSTER_PATHS);
-static envvar_name_t const sprokit_include_envvar = envvar_name_t("SPROKIT_CLUSTER_PATH");
+static std::string const sprokit_include_envvar = std::string("SPROKIT_CLUSTER_PATH");
 static std::string const cluster_suffix = std::string(".cluster");
 static const std::string path_separator( 1, PATH_SEPARATOR_CHAR );
 

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -110,9 +110,7 @@ target_link_libraries(sprokit_pipeline
                       vital_logger
                       ${Boost_CHRONO_LIBRARY}
                       ${Boost_SYSTEM_LIBRARY}
-  PRIVATE             ${Boost_FILESYSTEM_LIBRARY}
-                      ${Boost_DATE_TIME_LIBRARY}
-                      ${Boost_THREAD_LIBRARY}
+  PRIVATE             ${Boost_THREAD_LIBRARY}
                       ${CMAKE_DL_LIBS}
                       ${CMAKE_THREAD_LIBS_INIT}
                       vital_vpm kwiversys

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -67,6 +67,9 @@ namespace {
 /**
  * @brief Greatest common denominator
  *
+ * gcd algorithm ref:
+ * Knuth, Donald. "Art of Computer Programming", Volume 2, Third edition, pp. 337
+ *
  * @param a First number
  * @param b Second number
  *
@@ -76,14 +79,14 @@ template <typename T>
 T
 gcd( T a, T b )
 {
-  for ( ; ; )
+  while (b != 0)
   {
-    if ( a == 0 ) { return b; }
-    b %= a;
+    T r = a % b;
+    a = b;
+    b = r;
+  } // end while
 
-    if ( b == 0 ) { return a; }
-    a %= b;
-  } // end for
+  return a;
 }
 
 

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -37,11 +37,10 @@
 
 #include <vital/logger/logger.h>
 #include <vital/config/config_block.h>
+#include <vital/util/string.h>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/graph/directed_graph.hpp>
 #include <boost/graph/topological_sort.hpp>
-#include <boost/integer/common_factor_rt.hpp>
 
 #include <functional>
 #include <map>
@@ -61,8 +60,52 @@
  * \brief Implementation of the base class for \link sprokit::pipeline pipelines\endlink.
  */
 
-namespace sprokit
+namespace sprokit {
+
+namespace {
+
+/**
+ * @brief Greatest common denominator
+ *
+ * @param a First number
+ * @param b Second number
+ *
+ * @return GCD
+ */
+template <typename T>
+T
+gcd( T a, T b )
 {
+  for ( ; ; )
+  {
+    if ( a == 0 ) { return b; }
+    b %= a;
+
+    if ( b == 0 ) { return a; }
+    a %= b;
+  } // end for
+}
+
+
+/**
+ * @brief Find least common multiple of two values
+ *
+ * @param a First value
+ * @param b Second value
+ *
+ * @return Least common multiple.
+ */
+template <typename T>
+T
+lcm( T a, T b )
+{
+  T temp = gcd( a, b );
+
+  return temp ? ( a / temp * b ) : 0;
+}
+
+} // end namespace
+
 
 class pipeline::priv
 {
@@ -1245,8 +1288,8 @@ pipeline::priv
     return type_deferred;
   }
 
-  bool const up_flow_dep = boost::starts_with(up_type, process::type_flow_dependent);
-  bool const down_flow_dep = boost::starts_with(down_type, process::type_flow_dependent);
+  bool const up_flow_dep = kwiver::vital::starts_with(up_type, process::type_flow_dependent);
+  bool const down_flow_dep = kwiver::vital::starts_with(down_type, process::type_flow_dependent);
 
   if (up_flow_dep || down_flow_dep)
   {
@@ -1355,7 +1398,7 @@ pipeline::priv
         process::port_info_t const info = proc->input_port_info(downstream_port);
         process::port_type_t const& type = info->type;
 
-        bool const flow_dep = boost::starts_with(type, process::type_flow_dependent);
+        bool const flow_dep = kwiver::vital::starts_with(type, process::type_flow_dependent);
 
         if (!flow_dep)
         {
@@ -1383,7 +1426,7 @@ pipeline::priv
         process::port_info_t const info = proc->output_port_info(upstream_port);
         process::port_type_t const& type = info->type;
 
-        bool const flow_dep = boost::starts_with(type, process::type_flow_dependent);
+        bool const flow_dep = kwiver::vital::starts_with(type, process::type_flow_dependent);
 
         if (!flow_dep)
         {
@@ -2197,7 +2240,7 @@ pipeline::priv
     process::port_frequency_t const& freq = proc_freq.second;
     process::frequency_component_t const denom = freq.denominator();
 
-    freq_gcd = boost::integer::lcm(freq_gcd, denom);
+    freq_gcd = lcm(freq_gcd, denom);
   }
 
   for (process_frequency_map_t::value_type const& proc_freq : freq_map)

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -35,15 +35,13 @@
 #include "stamp.h"
 
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/util/string.h>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/assign/ptr_map_inserter.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/optional.hpp>
-#include <boost/make_shared.hpp>
 
 #include <map>
 #include <utility>
@@ -816,7 +814,7 @@ process
   }
 
   bool const is_data_dependent = (old_type == type_data_dependent);
-  bool const is_flow_dependent = boost::starts_with(old_type, type_flow_dependent);
+  bool const is_flow_dependent = kwiver::vital::starts_with(old_type, type_flow_dependent);
   bool const is_any = (old_type == type_any);
 
   if (!is_data_dependent && !is_flow_dependent && !is_any)
@@ -890,7 +888,7 @@ process
   }
 
   bool const is_data_dependent = (old_type == type_data_dependent);
-  bool const is_flow_dependent = boost::starts_with(old_type, type_flow_dependent);
+  bool const is_flow_dependent = kwiver::vital::starts_with(old_type, type_flow_dependent);
   bool const is_any = (old_type == type_any);
 
   if (!is_data_dependent && !is_flow_dependent && !is_any)
@@ -2238,7 +2236,7 @@ process::priv::tag_t
 process::priv
 ::port_flow_tag_name(port_type_t const& port_type) const
 {
-  if (boost::starts_with(port_type, type_flow_dependent))
+  if (kwiver::vital::starts_with(port_type, type_flow_dependent))
   {
     return port_type.substr(type_flow_dependent.size());
   }

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,16 +42,14 @@
 
 #include <sprokit/pipeline/scheduler.h>
 
-#include <boost/make_shared.hpp>
-
 #include <functional>
 #include <memory>
 
 namespace sprokit {
 
 // returns: scheduler_t - shared_ptr<scheduler>
-  typedef std::function< scheduler_t( pipeline_t const& pipe,
-                                      kwiver::vital::config_block_sptr const& config ) > scheduler_factory_func_t;
+typedef std::function< scheduler_t( pipeline_t const& pipe,
+        kwiver::vital::config_block_sptr const& config ) > scheduler_factory_func_t;
 
 // ------------------------------------------------------------------
 /**

--- a/sprokit/src/sprokit/pipeline/utils.cxx
+++ b/sprokit/src/sprokit/pipeline/utils.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,6 @@
  */
 
 #include "utils.h"
-
-#include <vital/logger/logger.h>
 
 #ifdef HAVE_PTHREAD_NAMING
 #define NAME_THREAD_USING_PTHREAD
@@ -70,7 +68,7 @@
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)
-#include <boost/scoped_array.hpp>
+
 #include <windows.h>
 
 #else
@@ -105,6 +103,7 @@ static bool name_thread_pthread(thread_name_t const& name);
 static bool name_thread_win32(thread_name_t const& name);
 #endif
 
+// ----------------------------------------------------------------------------
 bool
 name_thread(thread_name_t const& name)
 {
@@ -141,45 +140,8 @@ name_thread(thread_name_t const& name)
   return ret;
 }
 
-envvar_value_t
-get_envvar(envvar_name_t const& name)
-{
-  kwiver::vital::logger_handle_t m_logger(kwiver::vital::get_logger("sprokit.pipeline_utilities"));
 
-  envvar_value_t value;
-
-#if defined(_WIN32) || defined(_WIN64)
-  char const* const name_cstr = name.c_str();
-
-  DWORD sz = GetEnvironmentVariable(name_cstr, NULL, 0);
-
-  if (sz)
-  {
-    typedef boost::scoped_array<char> raw_envvar_value_t;
-    raw_envvar_value_t const envvalue(new char[sz]);
-
-    sz = GetEnvironmentVariable(name_cstr, envvalue.get(), sz);
-
-    value = envvalue.get();
-  }
-
-  // Check return code
-  if ( 0 == sz)
-  {
-    LOG_ERROR( m_logger, "Error reading environment");
-  }
-#else
-  char const* const envvalue = getenv(name.c_str());
-
-  if (envvalue)
-  {
-    value = envvalue;
-  }
-#endif
-
-  return value;
-}
-
+// ----------------------------------------------------------------------------
 #ifdef NAME_THREAD_USING_PRCTL
 bool
 name_thread_prctl(thread_name_t const& name)
@@ -190,6 +152,8 @@ name_thread_prctl(thread_name_t const& name)
 }
 #endif
 
+
+// ----------------------------------------------------------------------------
 #ifdef NAME_THREAD_USING_SETPROCTITLE
 bool
 name_thread_setproctitle(thread_name_t const& name)
@@ -198,6 +162,8 @@ name_thread_setproctitle(thread_name_t const& name)
 }
 #endif
 
+
+// ----------------------------------------------------------------------------
 #ifdef NAME_THREAD_USING_PTHREAD
 bool
 name_thread_pthread(thread_name_t const& name)
@@ -222,6 +188,8 @@ name_thread_pthread(thread_name_t const& name)
 }
 #endif
 
+
+// ----------------------------------------------------------------------------
 #ifdef NAME_THREAD_USING_WIN32
 static void set_thread_name(DWORD thread_id, LPCSTR name);
 
@@ -246,6 +214,8 @@ typedef struct tagTHREADNAME_INFO
 } THREADNAME_INFO;
 #pragma pack(pop)
 
+
+// ----------------------------------------------------------------------------
 void
 set_thread_name(DWORD thread_id, LPCSTR name)
 {

--- a/sprokit/src/sprokit/pipeline/utils.h
+++ b/sprokit/src/sprokit/pipeline/utils.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,32 +28,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SPROKIT_PIPELINE_UTILS_H
-#define SPROKIT_PIPELINE_UTILS_H
-
-#include <sprokit/pipeline/sprokit_pipeline_export.h>
-
-#include <boost/optional.hpp>
-
-#include <string>
-#include <typeinfo>
-
 /**
  * \file utils.h
  *
  * \brief Common utilities when dealing with pipelines.
  */
 
-namespace sprokit
-{
+#ifndef SPROKIT_PIPELINE_UTILS_H
+#define SPROKIT_PIPELINE_UTILS_H
+
+#include <sprokit/pipeline/sprokit_pipeline_export.h>
+
+#include <string>
+#include <typeinfo>
+
+namespace sprokit {
 
 /// The type for the name of a thread.
 typedef std::string thread_name_t;
-
-/// The type for an environment variable name.
-typedef std::string envvar_name_t;
-/// The type of an environment variable value.
-typedef boost::optional<std::string> envvar_value_t;
 
 /**
  * \brief Name the thread that the function was called from.
@@ -70,16 +62,6 @@ typedef boost::optional<std::string> envvar_value_t;
  * \returns True if the name was successfully set, false otherwise.
  */
 SPROKIT_PIPELINE_EXPORT bool name_thread(thread_name_t const& name);
-
-/**
- * \brief Retrieve the value of an environment variable.
- *
- * \param name The variable to retrieve from the environement.
- *
- * \returns The value of the environment variable, \c NULL if it was not set.
- */
-SPROKIT_PIPELINE_EXPORT envvar_value_t get_envvar(envvar_name_t const& name);
-
 
 } // end namespace
 

--- a/sprokit/tests/sprokit/test/test_test.cxx
+++ b/sprokit/tests/sprokit/test/test_test.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2013 by Kitware, Inc.
+ * Copyright 2012-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -100,7 +100,7 @@ IMPLEMENT_TEST(unexpected_exception)
 TEST_PROPERTY(ENVIRONMENT, TEST_ENVVAR=test_value)
 IMPLEMENT_TEST(environment)
 {
-  sprokit::envvar_name_t const envvar = "TEST_ENVVAR";
+  const std::string envvar = "TEST_ENVVAR";
 
   std::string envvalue;
   kwiversys::SystemTools::GetEnv( envvar, envvalue );

--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -93,7 +93,7 @@ join( const std::vector<std::string>& elements, const std::string& str_separator
  * forward iteration. The result is a unique vector of strings that preserves
  * the forwards order.
  *
- * @param items Vector of strings to modify inplace
+ * @param[in,out] items Vector of strings to modify inplace
  */
 VITAL_UTIL_EXPORT void
 erase_duplicates(std::vector<std::string>& items);


### PR DESCRIPTION
Remove other boost constructs.
Cleanup environment access code. Removed get_envvar() function since it has been replaced with kwiversys function.