### PR TITLE
Disallow python symlinks on windows

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -144,7 +144,7 @@ function (kwiver_add_python_module path     modpath    module)
   set(pypkg_install_path "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}")
 
   # copy and configure the source file into the binary directory
-  if (KWIVER_SYMLINK_PYTHON)
+  if (KWIVER_SYMLINK_PYTHON AND NOT WIN32)
     kwiver_symlink_file("python${python_arch}-${safe_modpath}-${module}"
       "${pyfile_src}"
       "${pyfile_dst}"


### PR DESCRIPTION
cmake -E create_symlink doesn't really work on Windows. Ordinarily, we
could default to just turning KWIVER_SYMLINK_PYTHON off, and all would
be well. But this doesn't work for viame, which doesn't run through the
normal kwiver configuration.