### PR TITLE
Add method to get current video input time stamp

### DIFF
--- a/arrows/core/tests/test_video_input_filter.cxx
+++ b/arrows/core/tests/test_video_input_filter.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -125,6 +125,9 @@ TEST_F(video_input_filter, read_list)
     ++num_frames;
     EXPECT_EQ( num_frames, ts.get_frame() )
       << "Frame numbers should be sequential";
+
+    EXPECT_EQ( ts.get_time_usec(), vif.frame_timestamp().get_time_usec() );
+    EXPECT_EQ( ts.get_frame(), vif.frame_timestamp().get_frame() );
   }
   EXPECT_EQ( 5, num_frames );
 }

--- a/arrows/core/tests/test_video_input_image_list.cxx
+++ b/arrows/core/tests/test_video_input_image_list.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,6 +108,9 @@ TEST_F(video_input_image_list, read_list)
     ++num_frames;
     EXPECT_EQ( num_frames, ts.get_frame() )
       << "Frame numbers should be sequential";
+
+    EXPECT_EQ( ts.get_time_usec(), viil.frame_timestamp().get_time_usec() );
+    EXPECT_EQ( ts.get_frame(), viil.frame_timestamp().get_frame() );
   }
   EXPECT_EQ( 5, num_frames );
 }

--- a/arrows/core/tests/test_video_input_pos.cxx
+++ b/arrows/core/tests/test_video_input_pos.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -101,6 +101,9 @@ TEST_F(video_input_pos, read_list)
     ++num_frames;
     EXPECT_EQ( num_frames, ts.get_frame() )
       << "Frame numbers should be sequential";
+
+    EXPECT_EQ( ts.get_time_usec(), vip.frame_timestamp().get_time_usec() );
+    EXPECT_EQ( ts.get_frame(), vip.frame_timestamp().get_frame() );
   }
   EXPECT_EQ( 5, num_frames );
 }

--- a/arrows/core/tests/test_video_input_split.cxx
+++ b/arrows/core/tests/test_video_input_split.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -123,6 +123,9 @@ TEST_F(video_input_split, read_list)
     ++num_frames;
     EXPECT_EQ( num_frames, ts.get_frame() )
       << "Frame numbers should be sequential";
+
+    EXPECT_EQ( ts.get_time_usec(), vis.frame_timestamp().get_time_usec() );
+    EXPECT_EQ( ts.get_frame(), vis.frame_timestamp().get_frame() );
   }
   EXPECT_EQ( 5, num_frames );
 }

--- a/arrows/core/video_input_filter.cxx
+++ b/arrows/core/video_input_filter.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -245,6 +245,29 @@ video_input_filter
   }
 
   return status;
+}
+
+
+// ------------------------------------------------------------------
+kwiver::vital::timestamp
+video_input_filter
+::frame_timestamp() const
+{
+  // Check for at end of data
+  if( d->d_at_eov )
+  {
+    return {};
+  }
+
+  auto ts = d->d_video_input->frame_timestamp();
+
+  // set the frame time base on rate if missing
+  if( d->c_frame_rate > 0 && ts.has_valid_frame() && !ts.has_valid_time() )
+  {
+    ts.set_time_seconds( ts.get_frame() / d->c_frame_rate );
+  }
+
+  return ts;
 }
 
 

--- a/arrows/core/video_input_filter.h
+++ b/arrows/core/video_input_filter.h
@@ -80,6 +80,7 @@ public:
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 );
 
+  virtual kwiver::vital::timestamp frame_timestamp() const;
   virtual kwiver::vital::image_container_sptr frame_image();
   virtual kwiver::vital::metadata_vector frame_metadata();
 

--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -276,9 +276,6 @@ video_input_image_list
   // clear the last loaded image
   d->m_image = nullptr;
 
-  // Return timestamp
-  ts = kwiver::vital::timestamp();
-
   // If this is the first call to next_frame() then
   // do not increment the file iteration.
   // next_frame() must be called once before accessing the first frame.
@@ -288,9 +285,29 @@ video_input_image_list
   }
 
   ++d->m_frame_number;
-  ts.set_frame( d->m_frame_number );
+
+  // Return timestamp
+  ts = this->frame_timestamp();
 
   return ! this->end_of_video();
+}
+
+
+// ------------------------------------------------------------------
+kwiver::vital::timestamp
+video_input_image_list
+::frame_timestamp() const
+{
+  if ( this->end_of_video() )
+  {
+    return {};
+  }
+
+  kwiver::vital::timestamp ts;
+
+  ts.set_frame( d->m_frame_number );
+
+  return ts;
 }
 
 

--- a/arrows/core/video_input_image_list.h
+++ b/arrows/core/video_input_image_list.h
@@ -95,6 +95,7 @@ public:
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 );
 
+  virtual kwiver::vital::timestamp frame_timestamp() const;
   virtual kwiver::vital::image_container_sptr frame_image();
   virtual kwiver::vital::metadata_vector frame_metadata();
 

--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -248,14 +248,34 @@ video_input_pos
     d->d_metadata = vital::read_pos_file( d->d_current_files->second );
   }
 
+  // Return timestamp
+  ts = this->frame_timestamp();
+
   // Include the path to the image
   if ( d->d_metadata )
   {
+    d->d_metadata->set_timestamp( ts );
     d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME,
                                            d->d_current_files->first ) );
   }
 
-  // Return timestamp
+  return true;
+}
+
+
+// ------------------------------------------------------------------
+kwiver::vital::timestamp
+video_input_pos
+::frame_timestamp() const
+{
+  // Check for at end of video
+  if ( this->end_of_video() )
+  {
+    return {};
+  }
+
+  kwiver::vital::timestamp ts;
+
   ts.set_frame( d->d_frame_number );
   if ( d->d_metadata )
   {
@@ -266,10 +286,9 @@ video_input_pos
       // or subtract off first frame time to get time relative to start
       ts.set_time_seconds( gps_sec );
     }
-    d->d_metadata->set_timestamp( ts );
   }
 
-  return true;
+  return ts;
 }
 
 

--- a/arrows/core/video_input_pos.h
+++ b/arrows/core/video_input_pos.h
@@ -95,6 +95,7 @@ public:
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 );
 
+  virtual kwiver::vital::timestamp frame_timestamp() const;
   virtual kwiver::vital::image_container_sptr frame_image();
   virtual kwiver::vital::metadata_vector frame_metadata();
 

--- a/arrows/core/video_input_split.h
+++ b/arrows/core/video_input_split.h
@@ -80,6 +80,7 @@ public:
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 );
 
+  virtual kwiver::vital::timestamp frame_timestamp() const;
   virtual kwiver::vital::image_container_sptr frame_image();
   virtual kwiver::vital::metadata_vector frame_metadata();
 

--- a/arrows/core/video_input_split.h
+++ b/arrows/core/video_input_split.h
@@ -85,6 +85,10 @@ public:
   virtual kwiver::vital::metadata_vector frame_metadata();
 
 private:
+  kwiver::vital::timestamp merge_timestamps(
+    kwiver::vital::timestamp const& image_ts,
+    kwiver::vital::timestamp const& metadata_ts ) const;
+
   /// private implementation class
   class priv;
   const std::unique_ptr<priv> d;

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -647,9 +647,28 @@ vidl_ffmpeg_video_input
   d->d_frame_time = d->meta_ts + pts_diff;
   d->d_frame_number = d->d_video_stream.frame_number();
 
+  ts = this->frame_timestamp();
+
+  // ---- process metadata ---
+  d->metadata_collection.clear(); // erase old metadata packets
+
+  return true;
+}
+
+
+// ------------------------------------------------------------------
+kwiver::vital::timestamp
+vidl_ffmpeg_video_input
+::frame_timestamp() const
+{
+  if (d->d_at_eov)
+  {
+    return {};
+  }
+
   // We don't always have all components of a timestamp, so start with
   // an invalid TS and add the data we have.
-  ts.set_invalid();
+  kwiver::vital::timestamp ts;
   ts.set_frame( d->d_frame_number );
 
   if ( d->d_have_frame_time )
@@ -657,10 +676,7 @@ vidl_ffmpeg_video_input
     ts.set_time_usec( d->d_frame_time );
   }
 
-  // ---- process metadata ---
-  d->metadata_collection.clear(); // erase old metadata packets
-
-  return true;
+  return ts;
 }
 
 

--- a/arrows/vxl/vidl_ffmpeg_video_input.h
+++ b/arrows/vxl/vidl_ffmpeg_video_input.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,6 +78,7 @@ public:
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 );
 
+  virtual kwiver::vital::timestamp frame_timestamp() const;
   virtual kwiver::vital::image_container_sptr frame_image();
   virtual kwiver::vital::metadata_vector frame_metadata();
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -122,6 +122,8 @@ Vital
    to time_us_t to provide some distance from std::time_t and make the
    units apparent.
 
+ * Added frame_time() method to video_input to access the current time stamp.
+
 Vital Bindings
 
  * Vital C and Python bindings have been updated with respect the refactoring

--- a/vital/algo/video_input.h
+++ b/vital/algo/video_input.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -235,6 +235,21 @@ public:
    */
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 ) = 0;
+
+
+  /**
+   * \brief Obtain the time stamp of the current frame.
+   *
+   * This method returns the time stamp of the current frame, if any, or an
+   * invalid time stamp. The returned time stamp shall have the same value
+   * as was set by the most recent call to \c next_frame().
+   *
+   * This method is idempotent. Calling it multiple times without
+   * calling next_frame() will return the same time stamp.
+   *
+   * \return The time stamp of the current frame.
+   */
+  virtual kwiver::vital::timestamp frame_timestamp( ) const = 0;
 
 
   /**


### PR DESCRIPTION
Add new method `frame_timestamp` to `video_input` interface to retrieve the current time stamp (i.e. the one that was produced by the most recent call to `next_frame`). This is useful for consumers that need to reference the time stamp more than once, especially if storing it themselves is inconvenient.