### PR TITLE
Fix the fletch_DIR used by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - cmake -DCMAKE_C_COMPILER=$C_COMPILER
           -DCMAKE_CXX_COMPILER=$CXX_COMPILER
           -DCMAKE_INSTALL_PREFIX=$HOME/install
-          -Dfletch_DIR=/opt/kitware/fletch
+          -Dfletch_DIR=/opt/kitware/fletch/share/cmake/
           -DKWIVER_ENABLE_ARROWS=ON
           -DKWIVER_ENABLE_CERES=ON
           -DKWIVER_ENABLE_C_BINDINGS=ON


### PR DESCRIPTION
The MR is a response to a change in fletch which relocated its config file to a more sensible location.