### PR TITLE
Make sure context file name is fully expanded.

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -202,3 +202,8 @@ Sprokit
    directory and file name that represent the location of the pipeline
    definition and can be used to supply needed directory for
    relativepath.
+
+Vital
+
+ * Fixed problem #503 where relativepath modifier in a config entry
+   would not supply the correct directory. See MR #504.

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -21,6 +21,7 @@ set( sources
   image_object_detector_process.cxx
   image_writer_process.cxx
   matcher_process.cxx
+  print_config_process.cxx
   read_descriptor_process.cxx
   refine_detections_process.cxx
   split_image_process.cxx
@@ -46,6 +47,7 @@ set( private_headers
   image_object_detector_process.h
   image_writer_process.h
   matcher_process.h
+  print_config_process.h
   read_descriptor_process.h
   refine_detections_process.h
   split_image_process.h

--- a/sprokit/processes/core/print_config_process.cxx
+++ b/sprokit/processes/core/print_config_process.cxx
@@ -1,0 +1,143 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "print_config_process.h"
+
+#include <sprokit/processes/kwiver_type_traits.h>
+
+namespace kwiver {
+
+//----------------------------------------------------------------
+// Private implementation class
+class print_config_process::priv
+{
+public:
+  priv();
+  ~priv();
+
+  std::set< sprokit::process::port_t > m_active_ports;
+
+}; // end priv class
+
+
+// ==================================================================
+print_config_process::
+print_config_process( kwiver::vital::config_block_sptr const& config )
+  : process( config ),
+    d( new print_config_process::priv )
+{
+}
+
+
+print_config_process::
+~print_config_process()
+{
+}
+
+
+// ------------------------------------------------------------------
+void
+print_config_process::
+_configure()
+{
+  scoped_configure_instrumentation();
+
+  vital::config_block_sptr my_config = get_config();
+  my_config->print( std::cout );
+}
+
+
+// ------------------------------------------------------------------
+sprokit::process::port_info_t
+print_config_process::
+_input_port_info(port_t const& port)
+{
+  // If we have not created the port, then make a new one.
+  if ( d->m_active_ports.count( port ) == 0 )
+  {
+    port_flags_t p_flags;
+
+    LOG_TRACE( logger(), "Creating input port: \"" << port << "\" on process \"" << name() << "\"" );
+
+    // create a new port
+    declare_input_port( port, // port name
+                        type_any, // port data type expected
+                        p_flags,
+                        port_description_t("Input for " + port)
+      );
+
+    // Add to our list of existing ports
+    d->m_active_ports.insert( port );
+  }
+
+  return process::_input_port_info(port);
+}
+
+
+// ------------------------------------------------------------------
+void
+print_config_process::
+_step()
+{
+  // Take a peek at the first port to see if it is the end of data
+  // marker.  If so, push end marker into our output interface queue.
+  // The assumption is that if the first port is at end, then they all
+  // are.
+  auto edat = this->peek_at_port( *d->m_active_ports.begin() );
+  if ( edat.datum->type() == sprokit::datum::complete )
+  {
+    LOG_DEBUG( logger(), "End of data detected." );
+
+    mark_process_as_complete();
+
+    return;
+  }
+
+  // The grab call is blocking, so it will wait until data is there.
+  for( auto const p : d->m_active_ports )
+  {
+    auto dtm = this->grab_datum_from_port( p );
+  } // end foreach
+}
+
+
+// ================================================================
+print_config_process::priv
+::priv()
+{
+}
+
+
+print_config_process::priv
+::~priv()
+{
+}
+
+} // end namespace kwiver

--- a/sprokit/processes/core/print_config_process.h
+++ b/sprokit/processes/core/print_config_process.h
@@ -1,0 +1,71 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ARROWS_PROCESSES_PRINT_CONFIG_PROCESS_H
+#define ARROWS_PROCESSES_PRINT_CONFIG_PROCESS_H
+
+#include <sprokit/pipeline/process.h>
+
+#include "kwiver_processes_export.h"
+
+#include <vital/config/config_block.h>
+
+namespace kwiver {
+
+// ----------------------------------------------------------------
+/**
+ * @brief Image object detector process.
+ *
+ */
+class KWIVER_PROCESSES_NO_EXPORT print_config_process
+  : public sprokit::process
+{
+public:
+  print_config_process( kwiver::vital::config_block_sptr const& config );
+  virtual ~print_config_process();
+
+
+protected:
+  virtual void _configure();
+  virtual void _step();
+
+  // This is used to intercept connections and make ports JIT
+  virtual sprokit::process::port_info_t _input_port_info(port_t const& port);
+
+private:
+  class priv;
+  const std::unique_ptr<priv> d;
+}; // end class object_detector_process
+
+
+
+} // end namespace
+
+#endif // ARROWS_PROCESSES_PRINT_CONFIG_PROCESS_H

--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -49,6 +49,7 @@
 #include "image_object_detector_process.h"
 #include "image_writer_process.h"
 #include "matcher_process.h"
+#include "print_config_process.h"
 #include "read_descriptor_process.h"
 #include "refine_detections_process.h"
 #include "split_image_process.h"
@@ -270,6 +271,19 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                     "Writes track descriptor sets to an output file. All descriptors are written to the same file." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    ;
+
+
+  fact = vpm.ADD_PROCESS( kwiver::print_config_process );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "print_config" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                    "Print process configuration.\n\n"
+                    "This process is a debugging aide and performs no other function in a pipeline. "
+                    "The supplied configuration is printed when it is presented to the process. "
+                    "All ports connections to the process are accepted and the supplied data is taken from the port and "
+                    "discarded. This process produces no outputs and has no output ports.")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
     ;
 

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -72,7 +72,7 @@ public:
     : m_fstream( file_name ) // open file stream
     , m_stream( &m_fstream )
     , m_reader( m_fstream ) // assign stream to reader
-    , m_filename( std::make_shared< std::string >(file_name) )
+    , m_filename( std::make_shared< std::string >( kwiversys::SystemTools::GetRealPath(file_name) ) )
   {
     if ( ! m_stream )
     {
@@ -84,7 +84,7 @@ public:
   include_context( std::istream& str, const std::string& file_name )
     : m_stream( &str ) // open file stream
     , m_reader( *m_stream ) // assign stream to reader
-    , m_filename( std::make_shared< std::string >(file_name) )
+    , m_filename( std::make_shared< std::string >( kwiversys::SystemTools::GetRealPath(file_name) ) )
   {
   }
 
@@ -419,7 +419,7 @@ get_next_token()
     if ( ! m_priv->m_absorb_eol )
     {
       auto t = std::make_shared< token > ( TK_EOL, "" );
-      t->set_location( m_priv->current_loc() );
+      t->set_location( current_location() );
       return t;
     }
   } // end of EOL handling
@@ -504,7 +504,7 @@ get_next_token()
       std::string text( m_priv->m_cur_char, m_priv->m_input_line.end() );
       m_priv->trim_string( text );
       t = std::make_shared< token > ( TK_ASSIGN, text );
-      t->set_location( m_priv->current_loc() );
+      t->set_location( current_location() );
 
       m_priv->flush_line();
       return t;
@@ -513,7 +513,7 @@ get_next_token()
     if ( ':' == c )  // old style config line
     {
       t = std::make_shared< token > ( TK_COLON, ":" );
-      t->set_location( m_priv->current_loc() );
+      t->set_location( current_location() );
       return t;
     }
 
@@ -531,7 +531,7 @@ get_next_token()
     // At this point,just pass all single characters
     // as tokens.  Let the parser decide what to do.
     t = std::make_shared< token > ( c );
-    t->set_location( m_priv->current_loc() );
+    t->set_location( current_location() );
     return t;
   }   // end while
 

--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -127,7 +127,8 @@ right_trim( std::string& s )
  * @brief Removes whitespace from both ends of a string.
  *
  * @param[in,out] s String to be trimmed in place
- */inline void
+ */
+inline void
 string_trim( std::string& s )
 {
   right_trim(s);


### PR DESCRIPTION
The file name used to establish the include context is now fully expanded
into a real file name, with actual path and all that. Previously
an file name without directory could come from the pipeline loader and
be used as the include context file name.

Fix for problem #503 