### PR TITLE
Time include fix

### DIFF
--- a/arrows/core/detected_object_set_output_csv.cxx
+++ b/arrows/core/detected_object_set_output_csv.cxx
@@ -35,7 +35,7 @@
 
 #include "detected_object_set_output_csv.h"
 
-#include <time.h>
+#include <ctime>
 
 
 namespace kwiver {

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -35,7 +35,7 @@
 #include <memory>
 #include <vector>
 #include <fstream>
-#include <time.h>
+#include <ctime>
 
 #if ( __GNUC__ == 4 && __GNUC_MINOR__ < 5 && !defined(__clang__) )
   #include <cstdatomic>


### PR DESCRIPTION
MSVC 2015 does not  see std::time_t as a part of std when only including time.h
Boost 1.65.1 might be confusing msvc for some reason...

This fixes it