### PR TITLE
Cleanup logger usage in arrows.

### DIFF
--- a/arrows/ceres/optimize_cameras.cxx
+++ b/arrows/ceres/optimize_cameras.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,19 +46,18 @@ namespace arrows {
 namespace ceres {
 
 
-/// Private implementation class
+// Private implementation class
 class optimize_cameras::priv
   : public solver_options,
     public camera_options
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
   : camera_options(),
     verbose(false),
     loss_function_type(TRIVIAL_LOSS),
-    loss_function_scale(1.0),
-    m_logger( vital::get_logger( "arrows.ceres.optimize_cameras" ))
+    loss_function_scale(1.0)
   {
   }
 
@@ -66,47 +65,38 @@ public:
   : camera_options(other),
     verbose(other.verbose),
     loss_function_type(other.loss_function_type),
-    loss_function_scale(other.loss_function_scale),
-    m_logger( vital::get_logger( "arrows.ceres.optimize_cameras" ))
+    loss_function_scale(other.loss_function_scale)
   {
   }
 
-  /// verbose output
+  // verbose output
   bool verbose;
-  /// the robust loss function type to use
+  // the robust loss function type to use
   LossFunctionType loss_function_type;
-  /// the scale of the loss function
+  // the scale of the loss function
   double loss_function_scale;
-
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 optimize_cameras
 ::optimize_cameras()
 : d_(new priv)
 {
+  attach_logger( "arrows.ceres.optimize_cameras" );
 }
 
 
-/// Copy Constructor
-optimize_cameras
-::optimize_cameras(const optimize_cameras& other)
-: d_(new priv(*other.d_))
-{
-}
-
-
-/// Destructor
+// Destructor
 optimize_cameras
 ::~optimize_cameras()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 config_block_sptr
 optimize_cameras
 ::get_configuration() const
@@ -132,7 +122,8 @@ optimize_cameras
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 optimize_cameras
 ::set_configuration(config_block_sptr in_config)
@@ -162,7 +153,8 @@ optimize_cameras
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's currently configuration is valid
 bool
 optimize_cameras
 ::check_configuration(config_block_sptr config) const
@@ -170,14 +162,15 @@ optimize_cameras
   std::string msg;
   if( !d_->options.IsValid(&msg) )
   {
-    LOG_ERROR( d_->m_logger, msg);
+    LOG_ERROR( logger(), msg);
     return false;
   }
   return true;
 }
 
 
-/// Optimize camera parameters given sets of landmarks and feature tracks
+// ----------------------------------------------------------------------------
+// Optimize camera parameters given sets of landmarks and feature tracks
 void
 optimize_cameras
 ::optimize(vital::camera_map_sptr & cameras,
@@ -307,7 +300,7 @@ optimize_cameras
   ::ceres::Solve(d_->options, &problem, &summary);
   if( d_->verbose )
   {
-    LOG_DEBUG(d_->m_logger, "Ceres Full Report:\n" << summary.FullReport());
+    LOG_DEBUG(logger(), "Ceres Full Report:\n" << summary.FullReport());
   }
 
   // Update the cameras with the optimized values
@@ -317,7 +310,8 @@ optimize_cameras
 }
 
 
-/// Optimize a single camera given corresponding features and landmarks
+// ----------------------------------------------------------------------------
+// Optimize a single camera given corresponding features and landmarks
 void
 optimize_cameras
 ::optimize(vital::camera_sptr& camera,
@@ -390,7 +384,7 @@ optimize_cameras
   ::ceres::Solve(d_->options, &problem, &summary);
   if( d_->verbose )
   {
-    LOG_DEBUG(d_->m_logger, "Ceres Full Report:\n" << summary.FullReport());
+    LOG_DEBUG(logger(), "Ceres Full Report:\n" << summary.FullReport());
   }
 
   // update the cameras from optimized parameters

--- a/arrows/ceres/optimize_cameras.h
+++ b/arrows/ceres/optimize_cameras.h
@@ -57,9 +57,6 @@ public:
   /// Destructor
   virtual ~optimize_cameras();
 
-  /// Copy Constructor
-  optimize_cameras(const optimize_cameras& other);
-
   /// Get this algorithm's \link vital::config_block configuration block \endlink
   virtual vital::config_block_sptr get_configuration() const;
   /// Set this algorithm's properties via a config block

--- a/arrows/core/close_loops_exhaustive.cxx
+++ b/arrows/core/close_loops_exhaustive.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,9 +57,8 @@ class close_loops_exhaustive::priv
 public:
   /// Constructor
   priv()
-    : match_req(100),
-      num_look_back(-1),
-      m_logger( vital::get_logger( "arrows.core.close_loops_exhaustive" ))
+    : match_req(100)
+    , num_look_back(-1)
   {
   }
 
@@ -71,9 +70,6 @@ public:
 
   /// The feature matching algorithm to use
   vital::algo::match_features_sptr matcher;
-
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
@@ -83,6 +79,7 @@ close_loops_exhaustive
 ::close_loops_exhaustive()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.close_loops_exhaustive" );
 }
 
 
@@ -207,9 +204,9 @@ close_loops_exhaustive
       }
     }
 
-    LOG_INFO(d_->m_logger, "Matching frame " << frame_number << " to " << f
-                           << " has "<< num_matched << " matches and "
-                           << num_linked << " joined tracks");
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to " << f
+                       << " has "<< num_matched << " matches and "
+                       << num_linked << " joined tracks");
   }
 
   return input;

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,8 +61,7 @@ public:
     : match_req(100),
       search_bandwidth(10),
       min_keyframe_misses(5),
-      stop_after_match(false),
-      m_logger( vital::get_logger( "arrows.core.close_loops_keyframe" ))
+      stop_after_match(false)
   {
   }
 
@@ -89,9 +88,6 @@ public:
 
   /// The feature matching algorithm to use
   vital::algo::match_features_sptr matcher;
-
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
@@ -101,6 +97,7 @@ close_loops_keyframe
 ::close_loops_keyframe()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.close_loops_keyframe" );
 }
 
 
@@ -306,10 +303,10 @@ close_loops_keyframe
       ++kitr;
       frame_name = "keyframe ";
     }
-    LOG_INFO(d_->m_logger, "Matching frame " << frame_number << " to "
-                           << frame_name << f
-                           << " has "<< num_matched << " matches and "
-                           << num_linked << " joined tracks");
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to "
+                        << frame_name << f
+                        << " has "<< num_matched << " matches and "
+                        << num_linked << " joined tracks");
   }
   // divide by number of matched frames to get the average
   d_->frame_matches[frame_number] /=
@@ -336,9 +333,9 @@ close_loops_keyframe
         }
       }
     }
-    LOG_INFO(d_->m_logger, "Matching frame " << frame_number << " to keyframe "<< *kitr
-                           << " has "<< num_matched << " matches and "
-                           << num_linked << " joined tracks");
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *kitr
+                       << " has "<< num_matched << " matches and "
+                       << num_linked << " joined tracks");
     if( num_matched > max_keyframe_matched )
     {
       max_keyframe_matched = num_matched;
@@ -359,8 +356,8 @@ close_loops_keyframe
   if (max_keyframe_matched < d_->match_req)
   {
     d_->keyframe_misses.push_back(frame_number);
-    LOG_DEBUG(d_->m_logger, "Frame " << frame_number << " added to keyframe misses. "
-                            << "Count: "<<d_->keyframe_misses.size());
+    LOG_DEBUG(logger(), "Frame " << frame_number << " added to keyframe misses. "
+                         << "Count: "<<d_->keyframe_misses.size());
   }
 
   // If we've seen enough keyframe misses and the first miss has passed outside
@@ -385,7 +382,7 @@ close_loops_keyframe
     if( max_matches > static_cast<unsigned int>(d_->match_req) )
     {
       // create the new keyframe and clear the list of misses
-      LOG_INFO(d_->m_logger, "creating new keyframe on frame " << max_id);
+      LOG_INFO(logger(), "creating new keyframe on frame " << max_id);
       d_->keyframes.push_back(max_id);
       d_->keyframe_misses.clear();
     }

--- a/arrows/core/compute_ref_homography_core.cxx
+++ b/arrows/core/compute_ref_homography_core.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,6 @@
 #include <memory>
 
 #include <vital/algo/estimate_homography.h>
-#include <vital/logger/logger.h>
 
 #include <Eigen/LU>
 
@@ -388,7 +387,7 @@ compute_ref_homography_core
 ::estimate( frame_id_t frame_number,
             feature_track_set_sptr tracks ) const
 {
-  LOG_DEBUG( d_->m_logger,
+  LOG_DEBUG( logger(),
              "Starting ref homography estimation for frame " << frame_number );
 
   // Get active tracks for the current frame
@@ -423,7 +422,7 @@ compute_ref_homography_core
       new_tracks.push_back( trk );
     }
   }
-  LOG_DEBUG( d_->m_logger,
+  LOG_DEBUG( logger(),
              active_tracks.size() << " tracks on current frame (" <<
              (active_tracks.size() - new_tracks.size()) << " active, " <<
              new_tracks.size() << " new)" );
@@ -447,7 +446,7 @@ compute_ref_homography_core
       earliest_ref = ti.ref_id;
     }
   }
-  LOG_DEBUG( d_->m_logger,
+  LOG_DEBUG( logger(),
              "Earliest Ref: " << earliest_ref );
 
   // Add new tracks to buffer.
@@ -506,7 +505,7 @@ compute_ref_homography_core
       }
     }
   }
-  LOG_DEBUG( d_->m_logger,
+  LOG_DEBUG( logger(),
              "Using " << pts_ref.size() << " points for estimation" );
 
   // Compute homography if possible
@@ -518,7 +517,7 @@ compute_ref_homography_core
 
   if( bad_homog )
   {
-    LOG_DEBUG( d_->m_logger, "estimation FAILED" );
+    LOG_DEBUG( logger(), "estimation FAILED" );
     // Start of new shot. Both frames the same and identity transform.
     output = f2f_homography_sptr( new f2f_homography( frame_number ) );
     d_->frames_since_reset = 0;
@@ -526,7 +525,7 @@ compute_ref_homography_core
   }
   else
   {
-    LOG_DEBUG( d_->m_logger, "estimation SUCCEEDED" );
+    LOG_DEBUG( logger(), "estimation SUCCEEDED" );
     // extend current shot
     h = h->normalize();
     output = f2f_homography_sptr( new f2f_homography( h, frame_number, earliest_ref ) );
@@ -585,9 +584,9 @@ compute_ref_homography_core
     }
   }
 
-  if ( IS_DEBUG_ENABLED( d_->m_logger ) &&  ti_reset_count )
+  if ( IS_DEBUG_ENABLED( logger() ) &&  ti_reset_count )
   {
-    LOG_DEBUG( d_->m_logger,
+    LOG_DEBUG( logger(),
                "Resetting " << ti_reset_count <<
                " tracks to reference frame: " << frame_number );
   }

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
-#include <vital/logger/logger.h>
 #include <vital/exceptions.h>
 
 #include <sstream>
@@ -64,7 +63,6 @@ class detected_object_set_input_csv::priv
 public:
   priv( detected_object_set_input_csv* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_input_csv" ) )
     , m_first( true )
     , m_frame_number( 0 )
     , m_delim( "," )
@@ -79,7 +77,6 @@ public:
 
   // -------------------------------------
   detected_object_set_input_csv* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
   int m_frame_number;
   std::string m_delim;
@@ -96,6 +93,7 @@ detected_object_set_input_csv::
 detected_object_set_input_csv()
   : d( new detected_object_set_input_csv::priv( this ) )
 {
+  attach_logger( "arrows.core.detected_object_set_input_csv" );
 }
 
 

--- a/arrows/core/detected_object_set_input_kw18.cxx
+++ b/arrows/core/detected_object_set_input_kw18.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
-#include <vital/logger/logger.h>
 #include <vital/exceptions.h>
 
 #include <map>
@@ -77,7 +76,6 @@ class detected_object_set_input_kw18::priv
 public:
   priv( detected_object_set_input_kw18* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_input_kw18" ) )
     , m_first( true )
   { }
 
@@ -86,7 +84,6 @@ public:
   void read_all();
 
   detected_object_set_input_kw18* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
 
   int m_current_idx;
@@ -103,6 +100,7 @@ detected_object_set_input_kw18::
 detected_object_set_input_kw18()
   : d( new detected_object_set_input_kw18::priv( this ) )
 {
+  attach_logger( "arrows.core.detected_object_set_input_kw18" );
 }
 
 

--- a/arrows/core/detected_object_set_output_csv.cxx
+++ b/arrows/core/detected_object_set_output_csv.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,6 @@ class detected_object_set_output_csv::priv
 public:
   priv( detected_object_set_output_csv* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_output_csv" ) )
     , m_first( true )
     , m_frame_number( 1 )
     , m_delim( "," )
@@ -57,7 +56,6 @@ public:
   ~priv() { }
 
   detected_object_set_output_csv* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
   int m_frame_number;
   std::string m_delim;
@@ -69,6 +67,7 @@ detected_object_set_output_csv::
 detected_object_set_output_csv()
   : d( new detected_object_set_output_csv::priv( this ) )
 {
+  attach_logger( "arrows.core.detected_object_set_output_csv" );
 }
 
 

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -68,7 +68,6 @@ class detected_object_set_output_kw18::priv
 public:
   priv( detected_object_set_output_kw18* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_output_kw18" ) )
     , m_first( true )
     , m_frame_number( 1 )
     , m_write_tot( false )
@@ -79,7 +78,6 @@ public:
   void read_all();
 
   detected_object_set_output_kw18* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
   int m_frame_number;
   bool m_write_tot;
@@ -94,6 +92,7 @@ detected_object_set_output_kw18::
 detected_object_set_output_kw18()
   : d( new detected_object_set_output_kw18::priv( this ) )
 {
+  attach_logger( "arrows.core.detected_object_set_output_kw18" );
 }
 
 

--- a/arrows/core/estimate_canonical_transform.cxx
+++ b/arrows/core/estimate_canonical_transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,6 @@
 
 #include "estimate_canonical_transform.h"
 
-#include <vital/logger/logger.h>
-
 #include <algorithm>
 
 using namespace kwiver::vital;
@@ -53,33 +51,32 @@ public:
   /// Constructor
   priv()
     : estimate_scale(true),
-      height_percentile(0.05),
-      m_logger( vital::get_logger( "arrows.core.estimate_canonical_transform" ))
+      height_percentile(0.05)
   {
   }
 
   priv(const priv& other)
     : estimate_scale(other.estimate_scale),
-      height_percentile(other.height_percentile),
-      m_logger( vital::get_logger( "arrows.core.estimate_canonical_transform" ))
+      height_percentile(other.height_percentile)
   {
   }
 
   bool estimate_scale;
   double height_percentile;
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 estimate_canonical_transform
 ::estimate_canonical_transform()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.estimate_canonical_transform" );
 }
 
 
-/// Copy Constructor
+// Copy Constructor
 estimate_canonical_transform
 ::estimate_canonical_transform(const estimate_canonical_transform& other)
 : d_(new priv(*other.d_))
@@ -87,14 +84,15 @@ estimate_canonical_transform
 }
 
 
-/// Destructor
+// Destructor
 estimate_canonical_transform
 ::~estimate_canonical_transform()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 estimate_canonical_transform
 ::get_configuration() const
@@ -117,7 +115,8 @@ estimate_canonical_transform
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 estimate_canonical_transform
 ::set_configuration(vital::config_block_sptr config)
@@ -127,7 +126,8 @@ estimate_canonical_transform
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_canonical_transform
 ::check_configuration(vital::config_block_sptr config) const
@@ -136,7 +136,8 @@ estimate_canonical_transform
 }
 
 
-/// Estimate a canonical similarity transform for cameras and points
+// ----------------------------------------------------------------------------
+// Estimate a canonical similarity transform for cameras and points
 kwiver::vital::similarity_d
 estimate_canonical_transform
 ::estimate_transform(kwiver::vital::camera_map_sptr const cameras,

--- a/arrows/core/feature_descriptor_io.cxx
+++ b/arrows/core/feature_descriptor_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 
 #include <fstream>
 
-#include <vital/logger/logger.h>
 #include <vital/exceptions.h>
 #include <cereal/archives/portable_binary.hpp>
 
@@ -49,41 +48,39 @@ namespace arrows {
 namespace core {
 
 
-/// Private implementation class
+// Private implementation class
 class feature_descriptor_io::priv
 {
 public:
   /// Constructor
   priv()
-  : write_float_features(false),
-    m_logger( vital::get_logger( "arrows.vxl.feature_descriptor_io" ) )
+  : write_float_features(false)
   {
   }
 
   bool write_float_features;
-
-  vital::logger_handle_t m_logger;
 };
 
 
 
-/// Constructor
+// Constructor
 feature_descriptor_io
 ::feature_descriptor_io()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.feature_descriptor_io" );
 }
 
 
-/// Destructor
+// Destructor
 feature_descriptor_io
 ::~feature_descriptor_io()
 {
 }
 
 
-
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 feature_descriptor_io
 ::get_configuration() const
@@ -99,7 +96,8 @@ feature_descriptor_io
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 feature_descriptor_io
 ::set_configuration(vital::config_block_sptr in_config)
@@ -114,7 +112,8 @@ feature_descriptor_io
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's currently configuration is valid
 bool
 feature_descriptor_io
 ::check_configuration(vital::config_block_sptr config) const
@@ -147,6 +146,7 @@ save_features(Archive & ar, std::vector<feature_sptr> const& features)
 }
 
 
+// ----------------------------------------------------------------------------
 // Helper function to unserialized a vector of N features of known type
 template <typename Archive, typename T>
 vital::feature_set_sptr
@@ -164,6 +164,7 @@ read_features(Archive & ar, size_t num_feat)
 }
 
 
+// ----------------------------------------------------------------------------
 // Helper function to serialized a vector of descriptors of known type
 template <typename Archive, typename T>
 void
@@ -202,6 +203,7 @@ save_descriptors(Archive & ar, std::vector<descriptor_sptr> const& descriptors)
 }
 
 
+// ----------------------------------------------------------------------------
 // Helper function to unserialized a vector of N descriptors of known type
 template <typename Archive, typename T>
 vital::descriptor_set_sptr
@@ -239,14 +241,15 @@ read_descriptors(Archive & ar, size_t num_desc)
 }
 
 
-
-
+// ----------------------------------------------------------------------------
 // compute base 2 log of integers at compile time
 constexpr size_t log2(size_t n)
 {
   return ( (n<2) ? 0 : 1+log2(n/2));
 }
 
+
+// ----------------------------------------------------------------------------
 // compute a unique byte code for built-in types
 template <typename T>
 struct type_traits
@@ -257,6 +260,8 @@ struct type_traits
     log2(sizeof(T)));
 };
 
+
+// ----------------------------------------------------------------------------
 uint8_t code_from_typeid(std::type_info const& tid)
 {
 #define CODE_TYPE(T) \
@@ -282,7 +287,9 @@ uint8_t code_from_typeid(std::type_info const& tid)
 
 }
 
-/// Implementation specific load functionality.
+
+// ----------------------------------------------------------------------------
+// Implementation specific load functionality.
 void
 feature_descriptor_io
 ::load_(std::string const& filename,
@@ -374,8 +381,8 @@ feature_descriptor_io
 }
 
 
-
-/// Implementation specific save functionality.
+// ----------------------------------------------------------------------------
+// Implementation specific save functionality.
 void
 feature_descriptor_io
 ::save_(std::string const& filename,
@@ -385,7 +392,7 @@ feature_descriptor_io
   if( !(feat && feat->size() > 0) &&
       !(desc && desc->size() > 0) )
   {
-    LOG_WARN(d_->m_logger, "Not writing file, no features or descriptors");
+    LOG_WARN(logger(), "Not writing file, no features or descriptors");
     return;
   }
 

--- a/arrows/core/filter_features_magnitude.cxx
+++ b/arrows/core/filter_features_magnitude.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
  */
 #include "filter_features_magnitude.h"
 
-#include <vital/logger/logger.h>
-
 #include <algorithm>
 
 using namespace kwiver::vital;
@@ -60,8 +58,7 @@ public:
   /// Constructor
   priv()
     : top_fraction(0.2),
-      min_features(100),
-      m_logger( vital::get_logger( "arrows.core.filter_features_magnitude" ))
+      min_features(100)
   {
   }
 
@@ -116,22 +113,26 @@ public:
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 filter_features_magnitude
 ::filter_features_magnitude()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.filter_features_magnitude" );
+  d_->m_logger = logger();
 }
 
 
-/// Destructor
+// Destructor
 filter_features_magnitude
 ::~filter_features_magnitude()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 filter_features_magnitude
 ::get_configuration() const
@@ -150,7 +151,8 @@ filter_features_magnitude
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 filter_features_magnitude
 ::set_configuration(vital::config_block_sptr config)
@@ -160,7 +162,8 @@ filter_features_magnitude
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 filter_features_magnitude
 ::check_configuration(vital::config_block_sptr config) const
@@ -168,7 +171,7 @@ filter_features_magnitude
   double top_fraction = config->get_value<double>("top_fraction", d_->top_fraction);
   if( top_fraction <= 0.0 || top_fraction > 1.0 )
   {
-    LOG_ERROR( d_->m_logger,
+    LOG_ERROR( logger(),
              "top_fraction parameter is " << top_fraction << ", needs to be in (0.0, 1.0].");
     return false;
   }
@@ -176,7 +179,8 @@ filter_features_magnitude
 }
 
 
-/// Filter feature set
+// ----------------------------------------------------------------------------
+// Filter feature set
 vital::feature_set_sptr
 filter_features_magnitude
 ::filter(vital::feature_set_sptr feat, std::vector<unsigned int> &indices) const

--- a/arrows/core/filter_features_scale.cxx
+++ b/arrows/core/filter_features_scale.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,8 +34,6 @@
  */
 #include "filter_features_scale.h"
 
-#include <vital/logger/logger.h>
-
 #include <algorithm>
 
 using namespace kwiver::vital;
@@ -54,19 +52,21 @@ struct feature_at_index_is_greater
   }
 };
 
-/// Private implementation class
+
+// Private implementation class
 class filter_features_scale::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
     : top_fraction(0.2),
       min_features(100),
-      max_features(1000),
-      m_logger( vital::get_logger( "arrows.core.filter_features_scale" ))
+      max_features(1000)
   {
   }
 
+
+// ----------------------------------------------------------------------------
   feature_set_sptr
   filter(feature_set_sptr feat, std::vector<unsigned int> &ind) const
   {
@@ -126,22 +126,26 @@ public:
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 filter_features_scale
 ::filter_features_scale()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.filter_features_scale" );
+  d_->m_logger = logger();
 }
 
 
-/// Destructor
+// Destructor
 filter_features_scale
 ::~filter_features_scale()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 filter_features_scale
 ::get_configuration() const
@@ -163,7 +167,8 @@ filter_features_scale
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 filter_features_scale
 ::set_configuration(vital::config_block_sptr config)
@@ -174,7 +179,7 @@ filter_features_scale
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 filter_features_scale
 ::check_configuration(vital::config_block_sptr config) const
@@ -182,7 +187,7 @@ filter_features_scale
   double top_fraction = config->get_value<double>("top_fraction", d_->top_fraction);
   if( top_fraction <= 0.0 || top_fraction > 1.0 )
   {
-    LOG_ERROR( d_->m_logger,
+    LOG_ERROR( logger(),
              "top_fraction parameter is " << top_fraction << ", needs to be in (0.0, 1.0].");
     return false;
   }
@@ -193,7 +198,7 @@ filter_features_scale
     config->get_value<unsigned int>("max_features", d_->max_features);
   if( max_features > 0 && max_features < min_features )
   {
-    LOG_ERROR( d_->m_logger, "max_features (" << max_features
+    LOG_ERROR( logger(), "max_features (" << max_features
                              << ") must be zero or greater than min_features ("
                              << min_features << ")" );
     return false;
@@ -202,7 +207,8 @@ filter_features_scale
 }
 
 
-/// Filter feature set
+// ----------------------------------------------------------------------------
+// Filter feature set
 vital::feature_set_sptr
 filter_features_scale
 ::filter(vital::feature_set_sptr feat, std::vector<unsigned int> &indices) const

--- a/arrows/core/filter_tracks.cxx
+++ b/arrows/core/filter_tracks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,6 @@
 #include <arrows/core/filter_tracks.h>
 #include <arrows/core/match_matrix.h>
 
-#include <vital/logger/logger.h>
-
 #include <algorithm>
 
 using namespace kwiver::vital;
@@ -52,34 +50,35 @@ class filter_tracks::priv
 public:
   /// Constructor
   priv()
-    : min_track_length(3),
-      min_mm_importance(1.0),
-      m_logger( vital::get_logger( "arrows.core.filter_tracks" ))
+    : min_track_length(3)
+    , min_mm_importance(1.0)
   {
   }
 
   unsigned int min_track_length;
   double min_mm_importance;
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 filter_tracks
 ::filter_tracks()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.filter_tracks" );
 }
 
 
-/// Destructor
+// Destructor
 filter_tracks
 ::~filter_tracks()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
   vital::config_block_sptr
 filter_tracks
 ::get_configuration() const
@@ -100,7 +99,8 @@ filter_tracks
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 filter_tracks
 ::set_configuration(vital::config_block_sptr config)
@@ -112,7 +112,8 @@ filter_tracks
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 filter_tracks
 ::check_configuration(vital::config_block_sptr config) const
@@ -121,7 +122,7 @@ filter_tracks
                                                        d_->min_mm_importance);
   if( min_mm_importance < 0.0 )
   {
-    LOG_ERROR( d_->m_logger,
+    LOG_ERROR( logger(),
                "min_mm_importance parameter is " << min_mm_importance
                << ", must be non-negative.");
     return false;
@@ -130,7 +131,8 @@ filter_tracks
 }
 
 
-/// Filter feature set
+// ----------------------------------------------------------------------------
+// Filter feature set
 vital::track_set_sptr
 filter_tracks
 ::filter(vital::track_set_sptr tracks) const

--- a/arrows/core/hierarchical_bundle_adjust.cxx
+++ b/arrows/core/hierarchical_bundle_adjust.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ namespace core {
 namespace // anonymous
 {
 
-/// subsample a every Nth camera
+// subsample a every Nth camera
 /**
  * Subsamples are chosen based on camera order index instead of frame nubmer,
  * as cameras given may not be in sequential order.
@@ -95,7 +95,9 @@ subsample_cameras(camera_map::map_camera_t const& cameras, unsigned n)
   return subsample;
 }
 
-/// Integer interpolation -- used with indices, so can assume positive
+
+// ----------------------------------------------------------------------------
+// Integer interpolation -- used with indices, so can assume positive
 frame_id_t
 int_interp(frame_id_t a, frame_id_t b, double p)
 {
@@ -106,7 +108,8 @@ int_interp(frame_id_t a, frame_id_t b, double p)
 } // end anonymous namespace
 
 
-/// private implementation / data container for hierarchical_bundle_adjust
+// ============================================================================
+// private implementation / data container for hierarchical_bundle_adjust
 class hierarchical_bundle_adjust::priv
 {
 public:
@@ -114,7 +117,6 @@ public:
     : initial_sub_sample(1)
     , interpolation_rate(0)
     , rmse_reporting_enabled(false)
-    , m_logger( vital::get_logger( "arrows.core.hierarchical_bundle_adjust" ))
   {
   }
 
@@ -127,26 +129,28 @@ public:
   vital::algo::bundle_adjust_sptr sba;
   vital::algo::optimize_cameras_sptr camera_optimizer;
   vital::algo::triangulate_landmarks_sptr lm_triangulator;
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 hierarchical_bundle_adjust
 ::hierarchical_bundle_adjust()
   : d_(new priv)
-{ }
+{
+  attach_logger( "arrows.core.hierarchical_bundle_adjust" );
+}
 
 
-/// Destructor
+// Destructor
 hierarchical_bundle_adjust
 ::~hierarchical_bundle_adjust() noexcept
 {
 }
 
 
-/// Get this algorithm's \link kwiver::vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link kwiver::vital::config_block configuration block \endlink
   vital::config_block_sptr
 hierarchical_bundle_adjust
 ::get_configuration() const
@@ -181,7 +185,8 @@ hierarchical_bundle_adjust
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 hierarchical_bundle_adjust
 ::set_configuration(vital::config_block_sptr config)
@@ -202,7 +207,8 @@ hierarchical_bundle_adjust
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 hierarchical_bundle_adjust
 ::check_configuration(vital::config_block_sptr config) const
@@ -210,7 +216,7 @@ hierarchical_bundle_adjust
   bool valid = true;
 
 #define HSBA_CHECK_FAIL(msg) \
-  LOG_DEBUG(d_->m_logger, "Config Check Fail: " << msg); \
+  LOG_DEBUG(logger(), "Config Check Fail: " << msg);      \
   valid = false
 
   // using long to allow negatives and maintain numerical capacity of
@@ -235,7 +241,7 @@ hierarchical_bundle_adjust
 
   if (config->get_value<std::string>("camera_optimizer:type", "") == "")
   {
-    LOG_DEBUG(d_->m_logger, "HSBA per-iteration camera optimization disabled");
+    LOG_DEBUG(logger(), "HSBA per-iteration camera optimization disabled");
   }
   else if (!vital::algo::optimize_cameras::check_nested_algo_configuration("camera_optimizer", config))
   {
@@ -244,11 +250,11 @@ hierarchical_bundle_adjust
 
   if (config->get_value<std::string>("lm_triangulator:type", "") == "")
   {
-    LOG_DEBUG(d_->m_logger, "HSBA per-iteration LM Triangulation disabled");
+    LOG_DEBUG(logger(), "HSBA per-iteration LM Triangulation disabled");
   }
   else if (!vital::algo::triangulate_landmarks::check_nested_algo_configuration("lm_triangulator", config))
   {
-    LOG_DEBUG(d_->m_logger, "lm_triangulator type: \""
+    LOG_DEBUG(logger(), "lm_triangulator type: \""
                             << config->get_value<std::string>("lm_triangulator:type") << "\"");
     HSBA_CHECK_FAIL("lm_triangulator configuration invalid.");
   }
@@ -262,7 +268,8 @@ hierarchical_bundle_adjust
 }
 
 
-/// Optimize the camera and landmark parameters given a set of feature tracks
+// ----------------------------------------------------------------------------
+// Optimize the camera and landmark parameters given a set of feature tracks
 /**
  * Making naive assuptions:
  *  - cameras we are given are in sequence (no previous sub-sampling and no frame gaps)
@@ -280,7 +287,7 @@ hierarchical_bundle_adjust
   using namespace std;
 
   //frame_id_t orig_max_frame = cameras->cameras().rbegin()->first;
-  LOG_INFO(d_->m_logger, cameras->size() << " cameras provided");
+  LOG_INFO(logger(), cameras->size() << " cameras provided");
   size_t num_orig_cams = tracks->all_frame_ids().size();
 
   // If interpolation rate is 0, then that means that all intermediate frames
@@ -291,7 +298,7 @@ hierarchical_bundle_adjust
   {
     ir = std::numeric_limits<frame_id_t>::max();
   }
-  LOG_DEBUG(d_->m_logger, "Interpolation rate: " << ir);
+  LOG_DEBUG(logger(), "Interpolation rate: " << ir);
 
   // Sub-sample cameras
   // Always adding the last camera (if not already in there) to the sub-
@@ -303,7 +310,7 @@ hierarchical_bundle_adjust
   acm = subsample_cameras(input_cams, ssr);
   acm[input_cams.rbegin()->first] = input_cams.rbegin()->second;
   camera_map_sptr active_cam_map(new simple_camera_map(acm));
-  LOG_INFO(d_->m_logger, "Subsampled cameras: " << active_cam_map->size());
+  LOG_INFO(logger(), "Subsampled cameras: " << active_cam_map->size());
 
   // need to have at least 2 cameras
   if (active_cam_map->size() < 2)
@@ -314,7 +321,7 @@ hierarchical_bundle_adjust
   bool done = false;
   do
   {
-    LOG_INFO(d_->m_logger, "Optimizing " << active_cam_map->size() << " active cameras");
+    LOG_INFO(logger(), "Optimizing " << active_cam_map->size() << " active cameras");
     // updated active_cam_map and landmarks
     { // scope block
       kwiver::vital::scoped_cpu_timer t( "inner-SBA iteration" );
@@ -324,15 +331,15 @@ hierarchical_bundle_adjust
     double rmse = kwiver::arrows::reprojection_rmse(active_cam_map->cameras(),
                                     landmarks->landmarks(),
                                     tracks->tracks());
-    LOG_DEBUG(d_->m_logger, "current RMSE: " << rmse);
+    LOG_DEBUG(logger(), "current RMSE: " << rmse);
 
     // If we've just completed SBA with all original frames in the new map,
     // then we're done.
-    LOG_DEBUG(d_->m_logger, "completion check: " << active_cam_map->size()
+    LOG_DEBUG(logger(), "completion check: " << active_cam_map->size()
                             << " >= " << num_orig_cams );
     if (active_cam_map->size() >= num_orig_cams)
     {
-      LOG_INFO(d_->m_logger, "complete");
+      LOG_INFO(logger(), "complete");
       done = true;
     }
 
@@ -395,7 +402,7 @@ hierarchical_bundle_adjust
       }
       if(interped_cams.empty())
       {
-        LOG_INFO(d_->m_logger, "No new cameras interpolated, done.");
+        LOG_INFO(logger(), "No new cameras interpolated, done.");
         break;
       }
       camera_map_sptr interped_cams_p(new simple_camera_map(interped_cams));
@@ -403,14 +410,14 @@ hierarchical_bundle_adjust
       // Optimize new camers
       if (d_->camera_optimizer)
       {
-        LOG_INFO(d_->m_logger, "Optimizing new interpolated cameras ("
-                               << interped_cams.size() << " cams)");
+        LOG_INFO(logger(), "Optimizing new interpolated cameras ("
+                            << interped_cams.size() << " cams)");
         if (d_->rmse_reporting_enabled)
         {
-          LOG_DEBUG(d_->m_logger, "pre-optimization RMSE : "
-                                  << reprojection_rmse(interped_cams_p->cameras(),
-                                    landmarks->landmarks(),
-                                                       tracks->tracks()));
+          LOG_DEBUG(logger(), "pre-optimization RMSE : "
+                              << reprojection_rmse(interped_cams_p->cameras(),
+                                                   landmarks->landmarks(),
+                                                   tracks->tracks()));
         }
 
         { // scope block
@@ -420,10 +427,10 @@ hierarchical_bundle_adjust
 
         if (d_->rmse_reporting_enabled)
         {
-          LOG_DEBUG(d_->m_logger, "post-optimization RMSE : "
-                                  << reprojection_rmse(interped_cams_p->cameras(),
-                                    landmarks->landmarks(),
-                                                       tracks->tracks()));
+          LOG_DEBUG(logger(), "post-optimization RMSE : "
+                              << reprojection_rmse(interped_cams_p->cameras(),
+                                                   landmarks->landmarks(),
+                                                   tracks->tracks()));
         }
       }
       // adding optimized interpolated cameras to the map of existing cameras
@@ -435,22 +442,22 @@ hierarchical_bundle_adjust
       active_cam_map = camera_map_sptr(new simple_camera_map(ac_map));
       if (d_->rmse_reporting_enabled)
       {
-          LOG_DEBUG(d_->m_logger, "combined map RMSE : "
-                                  << reprojection_rmse(active_cam_map->cameras(),
-                                  landmarks->landmarks(),
-                                                       tracks->tracks()));
+        LOG_DEBUG(logger(), "combined map RMSE : "
+                            << reprojection_rmse(active_cam_map->cameras(),
+                                                 landmarks->landmarks(),
+                                                 tracks->tracks()));
       }
 
       // LM triangulation
       if (d_->lm_triangulator)
       {
-        LOG_INFO(d_->m_logger, "Triangulating landmarks after interpolating cameras");
+        LOG_INFO(logger(), "Triangulating landmarks after interpolating cameras");
         if (d_->rmse_reporting_enabled)
         {
-          LOG_DEBUG(d_->m_logger, "pre-triangulation RMSE : "
-                                  << reprojection_rmse(active_cam_map->cameras(),
-                                    landmarks->landmarks(),
-                                                       tracks->tracks()));
+          LOG_DEBUG(logger(), "pre-triangulation RMSE : "
+                              << reprojection_rmse(active_cam_map->cameras(),
+                                                   landmarks->landmarks(),
+                                                   tracks->tracks()));
         }
 
         { // scoped block
@@ -460,10 +467,10 @@ hierarchical_bundle_adjust
 
         if (d_->rmse_reporting_enabled)
         {
-          LOG_DEBUG(d_->m_logger, "post-triangulation RMSE : "
-                                  << reprojection_rmse(active_cam_map->cameras(),
-                                    landmarks->landmarks(),
-                                                       tracks->tracks()));
+          LOG_DEBUG(logger(), "post-triangulation RMSE : "
+                              << reprojection_rmse(active_cam_map->cameras(),
+                                                   landmarks->landmarks(),
+                                                   tracks->tracks()));
         }
       }
 

--- a/arrows/core/initialize_cameras_landmarks.cxx
+++ b/arrows/core/initialize_cameras_landmarks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@
 using namespace kwiver::vital;
 
 namespace {
-/// detect bad tracks
+// detect bad tracks
 std::set<track_id_t>
 detect_bad_tracks(const camera_map::map_camera_t& cams,
                   const landmark_map::map_landmark_t& lms,
@@ -79,7 +79,7 @@ detect_bad_tracks(const camera_map::map_camera_t& cams,
   return to_remove;
 }
 
-/// remove landmarks with IDs in the set
+// remove landmarks with IDs in the set
 void
 remove_landmarks(const std::set<track_id_t>& to_remove,
                  landmark_map::map_landmark_t& lms)
@@ -91,7 +91,7 @@ remove_landmarks(const std::set<track_id_t>& to_remove,
 }
 
 
-/// remove landmarks with IDs in the set
+// remove landmarks with IDs in the set
 void
 remove_tracks(const std::set<track_id_t>& to_remove,
               std::vector<track_sptr>& trks)
@@ -116,11 +116,11 @@ namespace arrows {
 namespace core {
 
 
-/// Private implementation class
+// Private implementation class
 class initialize_cameras_landmarks::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
   : verbose(false),
     continue_processing(true),
@@ -137,34 +137,33 @@ public:
     camera_optimizer(),
     // use the core triangulation as the default, users can change it
     lm_triangulator(new core::triangulate_landmarks()),
-    bundle_adjuster(),
-    m_logger( vital::get_logger( "arrows.core.initialize_cameras_landmarks" ))
+    bundle_adjuster()
   {
   }
 
-  /// Destructor
+  // Destructor
   ~priv()
   {
   }
 
-  /// Construct and initialized camera for \a frame
+  // Construct and initialized camera for \a frame
   camera_sptr init_camera(frame_id_t frame, frame_id_t last_frame,
                           const camera_map::map_camera_t& cams,
                           const std::vector<track_sptr>& trks,
                           const landmark_map::map_landmark_t& lms) const;
 
-  /// Re-triangulate all landmarks for provided tracks
+  // Re-triangulate all landmarks for provided tracks
   void retriangulate(landmark_map::map_landmark_t& lms,
                      const camera_map::map_camera_t& cams,
                      const std::vector<track_sptr>& trks,
                      const std::set<landmark_id_t>& new_lm_ids) const;
 
-  /// Estimate the translation scale using a 2d-3d correspondence
+  // Estimate the translation scale using a 2d-3d correspondence
   double estimate_t_scale(const vector_3d& KRp,
                           const vector_3d& Kt,
                           const vector_2d& pt2d) const;
 
-  /// Pass through this callback to another callback but cache the return value
+  // Pass through this callback to another callback but cache the return value
   bool pass_through_callback(callback_t cb,
                              camera_map_sptr cams,
                              landmark_map_sptr lms);
@@ -184,12 +183,13 @@ public:
   vital::algo::optimize_cameras_sptr camera_optimizer;
   vital::algo::triangulate_landmarks_sptr lm_triangulator;
   vital::algo::bundle_adjust_sptr bundle_adjuster;
-  /// Logger handle
+  // Logger handle
   vital::logger_handle_t m_logger;
 };
 
 
-/// Construct and initialized camera for \a frame
+// ----------------------------------------------------------------------------
+// Construct and initialized camera for \a frame
 camera_sptr
 initialize_cameras_landmarks::priv
 ::init_camera(frame_id_t frame, frame_id_t last_frame,
@@ -306,7 +306,8 @@ initialize_cameras_landmarks::priv
 }
 
 
-/// Re-triangulate all landmarks for provided tracks
+// ----------------------------------------------------------------------------
+// Re-triangulate all landmarks for provided tracks
 void
 initialize_cameras_landmarks::priv
 ::retriangulate(landmark_map::map_landmark_t& lms,
@@ -357,7 +358,7 @@ initialize_cameras_landmarks::priv
 }
 
 
-/// Estimate the translation scale using a 2d-3d correspondence
+// Estimate the translation scale using a 2d-3d correspondence
 double
 initialize_cameras_landmarks::priv
 ::estimate_t_scale(const vector_3d& KRp,
@@ -376,7 +377,7 @@ initialize_cameras_landmarks::priv
 }
 
 
-/// Pass through this callback to another callback but cache the return value
+// Pass through this callback to another callback but cache the return value
 bool
 initialize_cameras_landmarks::priv
 ::pass_through_callback(callback_t cb,
@@ -388,22 +389,25 @@ initialize_cameras_landmarks::priv
 }
 
 
-/// Constructor
+// Constructor
 initialize_cameras_landmarks
 ::initialize_cameras_landmarks()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.initialize_cameras_landmarks" );
+  d_->m_logger = logger();
 }
 
 
-/// Destructor
+// Destructor
 initialize_cameras_landmarks
 ::~initialize_cameras_landmarks()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 initialize_cameras_landmarks
 ::get_configuration() const
@@ -490,7 +494,8 @@ initialize_cameras_landmarks
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 initialize_cameras_landmarks
 ::set_configuration(vital::config_block_sptr config)
@@ -565,7 +570,8 @@ initialize_cameras_landmarks
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's currently configuration is valid
 bool
 initialize_cameras_landmarks
 ::check_configuration(vital::config_block_sptr config) const
@@ -589,10 +595,9 @@ initialize_cameras_landmarks
              ::check_nested_algo_configuration("lm_triangulator", config);
 }
 
-namespace
-{
+namespace {
 
-/// Extract valid cameras and cameras to initialize.
+// Extract valid cameras and cameras to initialize.
 /**
  * If \a cameras is NULL then return empty cam_map and frame_ids unchanged.
  * If not NULL, return frame_ids containing IDs of all NULL cameras and
@@ -632,7 +637,8 @@ void extract_cameras(const camera_map_sptr& cameras,
 }
 
 
-/// Extract valid landmarks and landmarks to initialize.
+// ----------------------------------------------------------------------------
+// Extract valid landmarks and landmarks to initialize.
 /**
  * If \a landmarks is NULL then return empty lm_map and track_ids unchanged.
  * If not NULL, return track_ids containing IDs of all NULL landmark and
@@ -672,7 +678,8 @@ void extract_landmarks(const landmark_map_sptr& landmarks,
 }
 
 
-/// Find the closest frame number with an existing camera
+// ----------------------------------------------------------------------------
+// Find the closest frame number with an existing camera
 frame_id_t
 find_closest_camera(const frame_id_t& frame,
                     const camera_map::map_camera_t& cams)
@@ -697,7 +704,7 @@ find_closest_camera(const frame_id_t& frame,
 }
 
 
-/// Find the subset of new_frames within dist frames of a camera in cams
+// Find the subset of new_frames within dist frames of a camera in cams
 std::set<frame_id_t>
 find_nearby_new_frames(const std::set<frame_id_t>& new_frames,
                        const camera_map::map_camera_t& cams,
@@ -720,7 +727,8 @@ find_nearby_new_frames(const std::set<frame_id_t>& new_frames,
 }
 
 
-/// find the best pair of camera indices to start with
+// ----------------------------------------------------------------------------
+// find the best pair of camera indices to start with
 void
 find_best_initial_pair(const Eigen::SparseMatrix<unsigned int>& mm,
                        int& i, int& j,
@@ -772,6 +780,7 @@ find_best_initial_pair(const Eigen::SparseMatrix<unsigned int>& mm,
 }
 
 
+// ----------------------------------------------------------------------------
 // find the frame in the set \p new_frame_ids that sees the most
 // landmarks in \p lms in the track set \p tracks.
 frame_id_t
@@ -829,6 +838,7 @@ next_best_frame(const track_set_sptr tracks,
 }
 
 
+// ----------------------------------------------------------------------------
 double
 estimate_gsd(const frame_id_t frame,
              std::vector<track_sptr> const& tracks,
@@ -880,7 +890,8 @@ estimate_gsd(const frame_id_t frame,
 } // end anonymous namespace
 
 
-/// Initialize the camera and landmark parameters given a set of tracks
+// ----------------------------------------------------------------------------
+// Initialize the camera and landmark parameters given a set of tracks
 void
 initialize_cameras_landmarks
 ::initialize(camera_map_sptr& cameras,
@@ -947,8 +958,8 @@ initialize_cameras_landmarks
   Eigen::SparseMatrix<unsigned int> mm = match_matrix(tracks, mm_frames);
   int init_i=0,init_j=0;
   find_best_initial_pair(mm, init_i, init_j, d_->m_logger);
-  LOG_INFO(d_->m_logger, "Initializing with frames "<< mm_frames[init_i]
-                         << " and " << mm_frames[init_j]);
+  LOG_INFO(logger(), "Initializing with frames "<< mm_frames[init_i]
+                     << " and " << mm_frames[init_j]);
 
   if(cams.empty())
   {
@@ -1003,7 +1014,7 @@ initialize_cameras_landmarks
     frame_id_t other_frame = find_closest_camera(f, cams);
     if(d_->verbose)
     {
-      LOG_DEBUG(d_->m_logger, "frame "<< f <<" uses reference "<< other_frame);
+      LOG_DEBUG(logger(), "frame "<< f <<" uses reference "<< other_frame);
     }
 
     // get the subset of tracks that have features on frame f
@@ -1029,9 +1040,9 @@ initialize_cameras_landmarks
       double gsd_prev = estimate_gsd(other_frame, trks, flms);
       double gsd_next = estimate_gsd(f, trks, flms);
       scale_change = gsd_prev / gsd_next;
-      LOG_DEBUG(d_->m_logger, "GSD estimates: "<<gsd_prev<<", "
-                              <<gsd_next<<" ratio "
-                              <<scale_change);
+      LOG_DEBUG(logger(), "GSD estimates: " << gsd_prev << ", "
+                               << gsd_next << " ratio "
+                              << scale_change);
       // small scale changes are less likely to be zoom, so share intrinsics
       if (scale_change < 1.0 + d_->zoom_scale_thresh &&
           1.0/scale_change < 1.0 + d_->zoom_scale_thresh)
@@ -1060,7 +1071,7 @@ initialize_cameras_landmarks
       auto K = std::make_shared<simple_camera_intrinsics>(*cam->intrinsics());
       K->set_focal_length(K->get_focal_length() * scale_change);
       cams[f] = std::make_shared<simple_camera>(cam->center(), cam->rotation(), K);
-      LOG_DEBUG(d_->m_logger, "Constructing new intrinsics");
+      LOG_DEBUG(logger(), "Constructing new intrinsics");
     }
 
     // optionally optimize the new camera
@@ -1086,26 +1097,26 @@ initialize_cameras_landmarks
       std::vector<double> rpe = kwiver::arrows::reprojection_errors(new_cam_map, lms, trks);
       if( rpe.empty() )
       {
-        LOG_DEBUG(d_->m_logger, "no landmark projections for new camera");
+        LOG_DEBUG(logger(), "no landmark projections for new camera");
       }
       else
       {
         std::sort(rpe.begin(), rpe.end());
-        LOG_DEBUG(d_->m_logger, "new camera reprojections - median: "
+        LOG_DEBUG(logger(), "new camera reprojections - median: "
                                 << rpe[rpe.size()/2] << " max: " << rpe.back());
       }
     }
 
     if( d_->bundle_adjuster && cams.size() >= num_cams_for_next_ba )
     {
-      LOG_INFO(d_->m_logger, "Running Global Bundle Adjustment on "
+      LOG_INFO(logger(), "Running Global Bundle Adjustment on "
                               << cams.size() << " cameras and "
                               << lms.size() << " landmarks");
       num_cams_for_next_ba = static_cast<size_t>(std::ceil(d_->global_ba_rate * num_cams_for_next_ba));
       camera_map_sptr ba_cams(new simple_camera_map(cams));
       landmark_map_sptr ba_lms(new simple_landmark_map(lms));
       double init_rmse = kwiver::arrows::reprojection_rmse(cams, lms, trks);
-      LOG_INFO(d_->m_logger, "initial reprojection RMSE: " << init_rmse);
+      LOG_INFO(logger(), "initial reprojection RMSE: " << init_rmse);
 
       d_->bundle_adjuster->optimize(ba_cams, ba_lms, tracks, metadata);
       cams = ba_cams->cameras();
@@ -1117,17 +1128,17 @@ initialize_cameras_landmarks
       // detect tracks/landmarks with large error and remove them
       std::set<track_id_t> to_remove = detect_bad_tracks(cams, lms, trks,
                                                          d_->interim_reproj_thresh);
-      LOG_INFO(d_->m_logger, "removing "<<to_remove.size()
-                             << "/" << lms.size()
-                             << " landmarks with RMSE > "
-                             << d_->interim_reproj_thresh);
+      LOG_INFO(logger(), "removing "<<to_remove.size()
+                         << "/" << lms.size()
+                         << " landmarks with RMSE > "
+                         << d_->interim_reproj_thresh);
       remove_landmarks(to_remove, lms);
       std::vector<track_sptr> all_trks = tracks->tracks();
       remove_tracks(to_remove, all_trks);
       tracks = std::make_shared<feature_track_set>(all_trks);
       double final_rmse = kwiver::arrows::reprojection_rmse(cams, lms, trks);
-      LOG_INFO(d_->m_logger, "final reprojection RMSE: " << final_rmse);
-      LOG_DEBUG(d_->m_logger, "updated focal length "
+      LOG_INFO(logger(), "final reprojection RMSE: " << final_rmse);
+      LOG_DEBUG(logger(), "updated focal length "
                               << cams.begin()->second->intrinsics()->focal_length());
 
       if( !tried_necker_reverse && d_->reverse_ba_error_ratio > 0 )
@@ -1138,23 +1149,23 @@ initialize_cameras_landmarks
         necker_reverse(ba_cams2, ba_lms2);
         d_->lm_triangulator->triangulate(ba_cams2, tracks, ba_lms2);
         init_rmse = kwiver::arrows::reprojection_rmse(ba_cams2->cameras(), ba_lms2->landmarks(), trks);
-        LOG_DEBUG(d_->m_logger, "Necker reversed initial reprojection RMSE: " << init_rmse);
+        LOG_DEBUG(logger(), "Necker reversed initial reprojection RMSE: " << init_rmse);
         if( init_rmse < final_rmse * d_->reverse_ba_error_ratio )
         {
           // Only try a Necker reversal once when we have enough data to
           // support it. We will either decide to reverse or not.
           // Either way we should not have to try this again.
           tried_necker_reverse = true;
-          LOG_INFO(d_->m_logger, "Running Necker reversed bundle adjustment for comparison");
+          LOG_INFO(logger(), "Running Necker reversed bundle adjustment for comparison");
           d_->bundle_adjuster->optimize(ba_cams2, ba_lms2, tracks, metadata);
           map_cam_t cams2 = ba_cams2->cameras();
           map_landmark_t lms2 = ba_lms2->landmarks();
           double final_rmse2 = kwiver::arrows::reprojection_rmse(cams2, lms2, trks);
-          LOG_DEBUG(d_->m_logger, "Necker reversed final reprojection RMSE: " << final_rmse2);
+          LOG_DEBUG(logger(), "Necker reversed final reprojection RMSE: " << final_rmse2);
 
           if(final_rmse2 < final_rmse)
           {
-            LOG_INFO(d_->m_logger, "Necker reversed solution is better");
+            LOG_INFO(logger(), "Necker reversed solution is better");
             cams = ba_cams2->cameras();
             lms = ba_lms2->landmarks();
           }
@@ -1167,9 +1178,9 @@ initialize_cameras_landmarks
       camera_map_sptr ba_cams(new simple_camera_map(cams));
       landmark_map_sptr ba_lms(new simple_landmark_map(lms));
       double curr_rmse = kwiver::arrows::reprojection_rmse(cams, lms, trks);
-      LOG_INFO(d_->m_logger, "current reprojection RMSE: " << curr_rmse);
+      LOG_INFO(logger(), "current reprojection RMSE: " << curr_rmse);
 
-      LOG_DEBUG(d_->m_logger, "frame "<<f<<" - num landmarks = "<< lms.size());
+      LOG_DEBUG(logger(), "frame "<<f<<" - num landmarks = "<< lms.size());
     }
     if( this->m_callback )
     {
@@ -1181,19 +1192,19 @@ initialize_cameras_landmarks
   // Run a final bundle adjustment
   if( d_->bundle_adjuster && d_->continue_processing )
   {
-    LOG_INFO(d_->m_logger, "Running final bundle adjustment");
+    LOG_INFO(logger(), "Running final bundle adjustment");
     camera_map_sptr ba_cams(new simple_camera_map(cams));
     landmark_map_sptr ba_lms(new simple_landmark_map(lms));
     double init_rmse = kwiver::arrows::reprojection_rmse(cams, lms, trks);
-    LOG_DEBUG(d_->m_logger, "initial reprojection RMSE: " << init_rmse);
+    LOG_DEBUG(logger(), "initial reprojection RMSE: " << init_rmse);
 
     d_->bundle_adjuster->optimize(ba_cams, ba_lms, tracks, metadata);
     map_cam_t cams1 = ba_cams->cameras();
     map_landmark_t lms1 = ba_lms->landmarks();
     double final_rmse1 = kwiver::arrows::reprojection_rmse(cams1, lms1, trks);
-    LOG_DEBUG(d_->m_logger, "final reprojection RMSE: " << final_rmse1);
+    LOG_DEBUG(logger(), "final reprojection RMSE: " << final_rmse1);
     double final_med_err = kwiver::arrows::reprojection_median_error(cams1, lms1, trks);
-    LOG_DEBUG(d_->m_logger, "final reprojection Median Error: " << final_med_err);
+    LOG_DEBUG(logger(), "final reprojection Median Error: " << final_med_err);
     cams = ba_cams->cameras();
     lms = ba_lms->landmarks();
 
@@ -1202,10 +1213,10 @@ initialize_cameras_landmarks
     const double outlier_thresh = final_med_err * d_->final_reproj_thresh;
     std::set<track_id_t> to_remove = detect_bad_tracks(cams, lms, trks,
                                                        outlier_thresh);
-    LOG_INFO(d_->m_logger, "removing "<<to_remove.size()
-                           << "/" << lms.size()
-                           << " landmarks with RMSE > "
-                           << outlier_thresh);
+    LOG_INFO(logger(), "removing " << to_remove.size()
+                       << "/" << lms.size()
+                       << " landmarks with RMSE > "
+                       << outlier_thresh);
     remove_landmarks(to_remove, lms);
   }
   cameras = camera_map_sptr(new simple_camera_map(cams));
@@ -1213,7 +1224,8 @@ initialize_cameras_landmarks
 }
 
 
-/// Set a callback function to report intermediate progress
+// ----------------------------------------------------------------------------
+// Set a callback function to report intermediate progress
 void
 initialize_cameras_landmarks
 ::set_callback(callback_t cb)

--- a/arrows/core/match_features_fundamental_matrix.cxx
+++ b/arrows/core/match_features_fundamental_matrix.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,16 +49,15 @@ namespace arrows {
 namespace core
 {
 
-/// Private implementation class
+// Private implementation class
 class match_features_fundamental_matrix::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
   : inlier_scale(10.0),
     min_required_inlier_count(0),
-    min_required_inlier_percent(0.0),
-    m_logger( vital::get_logger( "arrows.core.match_features_fundamental_matrix" ))
+    min_required_inlier_percent(0.0)
   {
   }
 
@@ -71,33 +70,36 @@ public:
   // min inlier percent required to make any matches
   double min_required_inlier_percent;
 
-  /// The feature matching algorithm to use
+  // The feature matching algorithm to use
   vital::algo::match_features_sptr matcher_;
 
-  /// The fundamental matrix estimation algorithm to use
+  // The fundamental matrix estimation algorithm to use
   vital::algo::estimate_fundamental_matrix_sptr f_estimator_;
 
-  /// Logger handle
+  // Logger handle
   vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 match_features_fundamental_matrix
 ::match_features_fundamental_matrix()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.match_features_fundamental_matrix" );
 }
 
 
-/// Destructor
+// Destructor
 match_features_fundamental_matrix
 ::~match_features_fundamental_matrix()
 {
 }
 
 
-/// Get this alg's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this alg's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 match_features_fundamental_matrix
 ::get_configuration() const
@@ -124,6 +126,7 @@ match_features_fundamental_matrix
 }
 
 
+// ----------------------------------------------------------------------------
 void
 match_features_fundamental_matrix
 ::set_configuration(vital::config_block_sptr in_config)
@@ -144,6 +147,8 @@ match_features_fundamental_matrix
   d_->min_required_inlier_percent = config->get_value<double>("min_required_inlier_percent");
 }
 
+
+// ----------------------------------------------------------------------------
 bool
 match_features_fundamental_matrix
 ::check_configuration(vital::config_block_sptr config) const
@@ -167,7 +172,8 @@ match_features_fundamental_matrix
 }
 
 
-/// Match one set of features and corresponding descriptors to another
+// ----------------------------------------------------------------------------
+// Match one set of features and corresponding descriptors to another
 match_set_sptr
 match_features_fundamental_matrix
 ::match(feature_set_sptr feat1, descriptor_set_sptr desc1,
@@ -186,7 +192,7 @@ match_features_fundamental_matrix
   fundamental_matrix_sptr F = d_->f_estimator_->estimate(feat1, feat2, init_matches,
                                                      inliers, d_->inlier_scale);
   int inlier_count = static_cast<int>(std::count(inliers.begin(), inliers.end(), true));
-  LOG_INFO(d_->m_logger, "inlier ratio: " << inlier_count << "/" << inliers.size());
+  LOG_INFO(logger(), "inlier ratio: " << inlier_count << "/" << inliers.size());
 
   // verify matching criteria are met
   if( !inlier_count || inlier_count < d_->min_required_inlier_count ||

--- a/arrows/core/match_features_homography.cxx
+++ b/arrows/core/match_features_homography.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,16 +47,15 @@ namespace kwiver {
 namespace arrows {
 namespace core {
 
-/// Private implementation class
+// Private implementation class
 class match_features_homography::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
   : inlier_scale(1.0),
     min_required_inlier_count(0),
-    min_required_inlier_percent(0.0),
-    m_logger( vital::get_logger( "arrows.core.match_features_homography" ))
+    min_required_inlier_percent(0.0)
   {
   }
 
@@ -68,27 +67,28 @@ public:
 
   // min inlier percent required to make any matches
   double min_required_inlier_percent;
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 match_features_homography
 ::match_features_homography()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.match_features_homography" );
 }
 
 
-/// Destructor
+// Destructor
 match_features_homography
 ::~match_features_homography()
 {
 }
 
 
-/// Get this alg's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this alg's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 match_features_homography
 ::get_configuration() const
@@ -121,6 +121,7 @@ match_features_homography
 }
 
 
+// ----------------------------------------------------------------------------
 void
 match_features_homography
 ::set_configuration(vital::config_block_sptr in_config)
@@ -146,6 +147,8 @@ match_features_homography
   d_->min_required_inlier_percent = config->get_value<double>("min_required_inlier_percent");
 }
 
+
+// ----------------------------------------------------------------------------
 bool
 match_features_homography
 ::check_configuration(vital::config_block_sptr config) const
@@ -175,8 +178,9 @@ match_features_homography
 }
 
 
+// ----------------------------------------------------------------------------
 namespace {
-/// Compute the average feature scale
+// Compute the average feature scale
 double
 average_feature_scale(feature_set_sptr features)
 {
@@ -197,7 +201,7 @@ average_feature_scale(feature_set_sptr features)
 }
 
 
-/// Compute the minimum feature scale
+// Compute the minimum feature scale
 double
 min_feature_scale(feature_set_sptr features)
 {
@@ -216,7 +220,7 @@ min_feature_scale(feature_set_sptr features)
 }
 
 
-/// Match one set of features and corresponding descriptors to another
+// Match one set of features and corresponding descriptors to another
 match_set_sptr
 match_features_homography
 ::match(feature_set_sptr feat1, descriptor_set_sptr desc1,
@@ -253,7 +257,7 @@ match_features_homography
                                min_feature_scale(feat2) );
 
   double scale_ratio = avg_scale / min_scale;
-  LOG_DEBUG( d_->m_logger, "Filtered scale ratio: " << scale_ratio );
+  LOG_DEBUG( logger(), "Filtered scale ratio: " << scale_ratio );
 
 
   // compute the initial matches
@@ -268,7 +272,7 @@ match_features_homography
   // count the number of inliers
   int inlier_count = static_cast<int>(std::count(inliers.begin(),
                                                  inliers.end(), true));
-  LOG_INFO(d_->m_logger, "inlier ratio: " <<
+  LOG_INFO(logger(), "inlier ratio: " <<
                          inlier_count << "/" << inliers.size());
 
   // verify matching criteria are met

--- a/arrows/core/track_descriptor_set_output_csv.cxx
+++ b/arrows/core/track_descriptor_set_output_csv.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,6 @@ class track_descriptor_set_output_csv::priv
 public:
   priv( track_descriptor_set_output_csv* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "track_descriptor_set_output_csv" ) )
     , m_first( true )
     , m_frame_number( 1 )
     , m_delim( "," )
@@ -57,7 +56,6 @@ public:
   ~priv() { }
 
   track_descriptor_set_output_csv* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
   int m_frame_number;
   std::string m_delim;
@@ -69,6 +67,7 @@ track_descriptor_set_output_csv::
 track_descriptor_set_output_csv()
   : d( new track_descriptor_set_output_csv::priv( this ) )
 {
+  attach_logger( "arrows.core.track_descriptor_set_output_csv" );
 }
 
 

--- a/arrows/core/triangulate_landmarks.cxx
+++ b/arrows/core/triangulate_landmarks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,47 +37,42 @@
 
 #include <set>
 
-#include <vital/logger/logger.h>
-
 #include <arrows/core/triangulate.h>
 
 namespace kwiver {
 namespace arrows {
 namespace core {
 
-/// Private implementation class
+// Private implementation class
 class triangulate_landmarks::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
-    : homogeneous(false),
-      m_logger( vital::get_logger( "arrows.core.triangulate_landmarks" ))
+    : homogeneous(false)
   {
   }
 
   priv(const priv& other)
-    : homogeneous(other.homogeneous),
-      m_logger( vital::get_logger( "arrows.core.triangulate_landmarks" ))
+    : homogeneous(other.homogeneous)
   {
   }
 
-  /// use the homogeneous method for triangulation
+  // use the homogeneous method for triangulation
   bool homogeneous;
-  /// logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// Constructor
 triangulate_landmarks
 ::triangulate_landmarks()
 : d_(new priv)
 {
+  attach_logger( "arrows.core.triangulate_landmarks" );
 }
 
 
-/// Copy Constructor
+// Copy Constructor
 triangulate_landmarks
 ::triangulate_landmarks(const triangulate_landmarks& other)
 : d_(new priv(*other.d_))
@@ -85,14 +80,14 @@ triangulate_landmarks
 }
 
 
-/// Destructor
+// Destructor
 triangulate_landmarks
 ::~triangulate_landmarks()
 {
 }
 
 
-/// Get this alg's \link vital::config_block configuration block \endlink
+// Get this alg's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 triangulate_landmarks
 ::get_configuration() const
@@ -111,7 +106,7 @@ triangulate_landmarks
 }
 
 
-/// Set this algorithm's properties via a config block
+// Set this algorithm's properties via a config block
 void
 triangulate_landmarks
 ::set_configuration(vital::config_block_sptr in_config)
@@ -126,7 +121,7 @@ triangulate_landmarks
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// Check that the algorithm's currently configuration is valid
 bool
 triangulate_landmarks
 ::check_configuration(vital::config_block_sptr config) const
@@ -135,7 +130,7 @@ triangulate_landmarks
 }
 
 
-/// Triangulate the landmark locations given sets of cameras and tracks
+// Triangulate the landmark locations given sets of cameras and tracks
 void
 triangulate_landmarks
 ::triangulate(vital::camera_map_sptr cameras,
@@ -255,7 +250,7 @@ triangulate_landmarks
   }
   if( !failed_landmarks.empty() )
   {
-    LOG_WARN( d_->m_logger,
+    LOG_WARN( logger(),
               "failed to triangulate " << failed_landmarks.size()
               << " of " << lms.size() << " landmarks");
   }

--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,6 @@
 #include "darknet_custom_resize.h"
 
 // kwiver includes
-#include <vital/logger/logger.h>
 #include <vital/util/cpu_timer.h>
 
 #include <arrows/ocv/image_container.h>
@@ -48,7 +47,7 @@
 // Since we need to wrap darknet.h in an extern C
 // We need to include CUDA/CUDNN before darknet does
 // so C++ gets a hold of them first
-// We may want to wrap all the declarations in darknet.h in 
+// We may want to wrap all the declarations in darknet.h in
 // an extern C rather than have to do it here.
 
 #ifdef DARKNET_USE_GPU
@@ -127,9 +126,11 @@ darknet_detector::
 darknet_detector()
   : d( new priv() )
 {
+  attach_logger( "arrows.darknet.darknet_detector" );
+  d->m_logger = logger();
+
   // set darknet global GPU index
   gpu_index = d->m_gpu_index;
-  d->m_logger = logger();
 }
 
 

--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -31,7 +31,6 @@
 #include "darknet_trainer.h"
 #include "darknet_custom_resize.h"
 
-#include <vital/logger/logger.h>
 #include <vital/util/cpu_timer.h>
 
 #include <arrows/ocv/image_container.h>

--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,6 @@
 #include "vital_kpf_adapters.h"
 
 #include <vital/util/data_stream_reader.h>
-#include <vital/logger/logger.h>
 #include <vital/exceptions.h>
 
 #include <map>
@@ -59,7 +58,6 @@ class detected_object_set_input_kpf::priv
 public:
   priv( detected_object_set_input_kpf* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_input_kpf" ) )
     , m_first( true )
   { }
 
@@ -68,7 +66,6 @@ public:
   void read_all();
 
   detected_object_set_input_kpf* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   bool m_first;
 
   int m_current_idx;
@@ -85,6 +82,7 @@ detected_object_set_input_kpf::
 detected_object_set_input_kpf()
   : d( new detected_object_set_input_kpf::priv( this ) )
 {
+  attach_logger( "arrows.kpf.detected_object_set_input_kpf" );
 }
 
 

--- a/arrows/kpf/detected_object_set_output_kpf.cxx
+++ b/arrows/kpf/detected_object_set_output_kpf.cxx
@@ -61,7 +61,6 @@ class detected_object_set_output_kpf::priv
 public:
   priv( detected_object_set_output_kpf* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "detected_object_set_output_kpf" ) )
     , m_frame_number( 1 )
   {}
 
@@ -70,7 +69,6 @@ public:
   void read_all();
 
   detected_object_set_output_kpf* m_parent;
-  kwiver::vital::logger_handle_t m_logger;
   int m_frame_number;
 };
 
@@ -80,6 +78,7 @@ detected_object_set_output_kpf::
 detected_object_set_output_kpf()
   : d( new detected_object_set_output_kpf::priv( this ) )
 {
+  attach_logger( "arrows.kpf.detected_object_set_output_kpf" );
 }
 
 

--- a/arrows/kpf/yaml/kpf_bounce_buffer.cxx
+++ b/arrows/kpf/yaml/kpf_bounce_buffer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@
 #include <arrows/kpf/yaml/kpf_parse_utils.h>
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.bounce_buffer" ) );
 
 using std::string;
 using std::pair;

--- a/arrows/kpf/yaml/kpf_canonical_types.cxx
+++ b/arrows/kpf/yaml/kpf_canonical_types.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 #include <arrows/kpf/yaml/kpf_packet.h>
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.kpf_canonical_types" ) );
 
 using std::string;
 
@@ -63,4 +63,3 @@ kv_t
 } // ...kpf
 } // ...vital
 } // ...kwiver
-

--- a/arrows/kpf/yaml/kpf_packet.cxx
+++ b/arrows/kpf/yaml/kpf_packet.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,6 @@
 
 #include "kpf_packet.h"
 #include <arrows/kpf/yaml/kpf_canonical_types.h>
-
-#include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
 
 #include <stdexcept>
 #include <sstream>
@@ -287,4 +284,3 @@ operator<<( std::ostream& os, const packet_t& p )
 } // ...kpf
 } // ...vital
 } // ...kwiver
-

--- a/arrows/kpf/yaml/kpf_parse_utils.cxx
+++ b/arrows/kpf/yaml/kpf_parse_utils.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,7 @@
 #include <map>
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.kpf_parse_utils" ) );
 
 using std::string;
 using std::map;

--- a/arrows/kpf/yaml/kpf_reader.cxx
+++ b/arrows/kpf/yaml/kpf_reader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,6 @@
 #include <stdexcept>
 #include <algorithm>
 
-#include <vital/logger/logger.h>
 #include <arrows/kpf/yaml/kpf_canonical_io_adapter.h>
 
 using std::istream;
@@ -51,8 +50,6 @@ using std::string;
 using std::vector;
 using std::pair;
 using std::make_pair;
-
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
 
 namespace kwiver {
 namespace vital {

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@
 #include <vital/util/tokenize.h>
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.kpf_yaml_parser" ) );
 
 
 using std::istream;

--- a/arrows/kpf/yaml/kpf_yaml_schemas.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_schemas.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 #include "kpf_yaml_schemas.h"
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.kpf_yaml_schemas" ) );
 
 using std::vector;
 using std::string;

--- a/arrows/kpf/yaml/kpf_yaml_writer.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_writer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 #include <arrows/kpf/yaml/kpf_yaml_schemas.h>
 
 #include <vital/logger/logger.h>
-static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
+static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( "arrows.kpf.kpf_yaml_writer" ) );
 
 #include <ios>
 

--- a/arrows/matlab/matlab_detection_output.cxx
+++ b/arrows/matlab/matlab_detection_output.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 #include "matlab_engine.h"
 #include "matlab_util.h"
 
-#include <vital/logger/logger.h>
 #include <kwiversys/SystemTools.hxx>
 
 #include <string>
@@ -52,7 +51,6 @@ class matlab_detection_output::priv
 public:
   priv( matlab_detection_output* parent)
     : m_parent( parent )
-    , m_logger( kwiver::vital::get_logger( "matlab_detection_output" ) )
     , m_first( true )
   { }
 
@@ -77,6 +75,7 @@ public:
 
     return m_matlab_engine.get();
   }
+
 
   // ------------------------------------------------------------------
   void check_result()
@@ -157,6 +156,8 @@ matlab_detection_output::
 matlab_detection_output()
   : d( new matlab_detection_output::priv( this ) )
 {
+  attach_logger( "arrows.matlab.matlab_detection_output" );
+  d->m_logger = logger;
 }
 
 

--- a/arrows/matlab/matlab_engine.cxx
+++ b/arrows/matlab/matlab_engine.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,7 @@ namespace matlab {
 // ------------------------------------------------------------------
 matlab_engine::
 matlab_engine()
-  : m_logger( kwiver::vital::get_logger( "vital.matlab_engine" ) )
+  : m_logger( kwiver::vital::get_logger( "arrows.matlab.matlab_engine" ) )
   , m_engine_handle( 0 )
   , m_output_buffer( 0 )
 {

--- a/arrows/matlab/matlab_image_filter.cxx
+++ b/arrows/matlab/matlab_image_filter.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 #include "matlab_engine.h"
 #include "matlab_util.h"
 
-#include <vital/logger/logger.h>
 #include <kwiversys/SystemTools.hxx>
 
 #include <arrows/ocv/image_container.h>
@@ -89,8 +88,7 @@ class matlab_image_filter::priv
 public:
   // -- CONSTRUCTORS --
   priv()
-    : m_logger( kwiver::vital::get_logger( "vital.matlab_image_filter" ) )
-    , m_first( true )
+    : m_first( true )
   {}
 
   ~priv()
@@ -195,7 +193,10 @@ private:
 matlab_image_filter::
 matlab_image_filter()
   : d( new priv )
-{ }
+{
+  attach_logger( "arrows.matlab.matlab_image_filter" );
+  d->m_logger = logger();
+}
 
 
  matlab_image_filter::

--- a/arrows/matlab/matlab_image_object_detector.cxx
+++ b/arrows/matlab/matlab_image_object_detector.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,6 @@
 #include "matlab_engine.h"
 #include "matlab_util.h"
 
-#include <vital/logger/logger.h>
 #include <kwiversys/SystemTools.hxx>
 
 #include <arrows/ocv/image_container.h>
@@ -96,8 +95,7 @@ class matlab_image_object_detector::priv
 public:
   // -- CONSTRUCTORS --
   priv()
-    : m_logger( kwiver::vital::get_logger( "vital.matlab_image_object_detector" ) )
-    , m_first( true )
+    : m_first( true )
   {}
 
   ~priv()
@@ -202,7 +200,10 @@ private:
 matlab_image_object_detector::
 matlab_image_object_detector()
   : d( new priv )
-{ }
+{
+  attach_logger( "arrows.matlab.matlab_image_object_detector" );
+  d->m_logger = logger();
+}
 
 
  matlab_image_object_detector::

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -35,7 +35,6 @@
 
 #include "draw_tracks.h"
 
-#include <vital/logger/logger.h>
 #include <vital/exceptions/io.h>
 #include <vital/types/feature_track_set.h>
 #include <vital/util/string.h>

--- a/arrows/ocv/estimate_fundamental_matrix.cxx
+++ b/arrows/ocv/estimate_fundamental_matrix.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,43 +41,41 @@
 
 namespace kwiver {
 namespace arrows {
+namespace ocv {
 
-namespace ocv
-{
-
-/// Private implementation class
+// Private implementation class
 class estimate_fundamental_matrix::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
-    : confidence_threshold(0.99),
-      m_logger( vital::get_logger( "arrows.ocv.estimate_fundamental_matrix" ))
+    : confidence_threshold(0.99)
   {
   }
 
   double confidence_threshold;
-
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 estimate_fundamental_matrix
 ::estimate_fundamental_matrix()
 : d_(new priv)
 {
+  attach_logger( "arrows.ocv.estimate_fundamental_matrix" );
 }
 
 
-/// Destructor
+// Destructor
 estimate_fundamental_matrix
 ::~estimate_fundamental_matrix()
 {
 }
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 estimate_fundamental_matrix
 ::get_configuration() const
@@ -93,7 +91,8 @@ estimate_fundamental_matrix
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 estimate_fundamental_matrix
 ::set_configuration(vital::config_block_sptr config)
@@ -102,7 +101,8 @@ estimate_fundamental_matrix
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_fundamental_matrix
 ::check_configuration(vital::config_block_sptr config) const
@@ -110,7 +110,7 @@ estimate_fundamental_matrix
   double confidence_threshold = config->get_value<double>("confidence_threshold", d_->confidence_threshold);
   if( confidence_threshold <= 0.0 || confidence_threshold > 1.0 )
   {
-    LOG_ERROR(d_->m_logger, "confidence_threshold parameter is "
+    LOG_ERROR(logger(), "confidence_threshold parameter is "
                             << confidence_threshold
                             << ", needs to be in (0.0, 1.0].");
     return false;
@@ -120,7 +120,8 @@ estimate_fundamental_matrix
 }
 
 
-/// Estimate a fundamental matrix from corresponding points
+// ----------------------------------------------------------------------------
+// Estimate a fundamental matrix from corresponding points
 vital::fundamental_matrix_sptr
 estimate_fundamental_matrix
 ::estimate(const std::vector<vital::vector_2d>& pts1,
@@ -130,7 +131,7 @@ estimate_fundamental_matrix
 {
   if (pts1.size() < 8 || pts2.size() < 8)
   {
-    LOG_ERROR(d_->m_logger, "Not enough points to estimate a fundamental matrix");
+    LOG_ERROR(logger(), "Not enough points to estimate a fundamental matrix");
     return vital::fundamental_matrix_sptr();
   }
 

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -43,7 +43,6 @@
 #include <deque>
 
 #include <vital/vital_config.h>
-#include <vital/logger/logger.h>
 #include <vital/exceptions/io.h>
 
 #include <kwiversys/SystemTools.hxx>

--- a/arrows/vxl/bundle_adjust.cxx
+++ b/arrows/vxl/bundle_adjust.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,8 +64,7 @@ public:
     normalize_data(true),
     max_iterations(1000),
     x_tolerance(1e-8),
-    g_tolerance(1e-8),
-    m_logger( vital::get_logger( "arrows.vxl.bundle_adjust" ))
+    g_tolerance(1e-8)
   {
   }
 
@@ -81,8 +80,6 @@ public:
   unsigned max_iterations;
   double x_tolerance;
   double g_tolerance;
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
@@ -91,6 +88,7 @@ bundle_adjust
 ::bundle_adjust()
 : d_(new priv)
 {
+  attach_logger( "arrows.vxl.bundle_adjust" );
 }
 
 
@@ -206,26 +204,26 @@ bundle_adjust
   }
   if( metadata && metadata->size() > 0 )
   {
-    LOG_WARN( d_->m_logger, "metadata is provided but will be ignored "
+    LOG_WARN( logger(), "metadata is provided but will be ignored "
                             "by this algorithm");
   }
   typedef vxl::camera_map::map_vcam_t map_vcam_t;
   typedef vital::landmark_map::map_landmark_t map_landmark_t;
 
-#define SBA_TIMED(msg, code)                                      \
+#define SBA_TIMED(msg, code)                                            \
   do                                                                    \
   {                                                                     \
     kwiver::vital::cpu_timer t;                                         \
     if (d_->verbose)                                                    \
     {                                                                   \
       t.start();                                                        \
-      LOG_DEBUG(d_->m_logger, msg << " ... ");                          \
+      LOG_DEBUG(logger(), msg << " ... ");                              \
     }                                                                   \
     code                                                                \
     if (d_->verbose)                                                    \
     {                                                                   \
       t.stop();                                                         \
-      LOG_DEBUG(d_->m_logger, " --> " << t.elapsed() << "s CPU");       \
+      LOG_DEBUG(logger(), " --> " << t.elapsed() << "s CPU");           \
     }                                                                   \
   } while(false)
 

--- a/arrows/vxl/close_loops_homography_guided.cxx
+++ b/arrows/vxl/close_loops_homography_guided.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -125,8 +125,7 @@ public:
   : enabled_( true ),
     max_checkpoint_frames_( 10000 ),
     checkpoint_percent_overlap_( 0.70 ),
-    homography_filename_( "" ),
-    m_logger( vital::get_logger( "arrows.vxl.close_loops_homography_guided" ))
+    homography_filename_( "" )
   {
   }
 
@@ -154,15 +153,15 @@ public:
 
   /// The feature matching algorithm to use
   vital::algo::match_features_sptr matcher_;
-  /// Logger handle
-  vital::logger_handle_t m_logger;
 };
 
 
+// ----------------------------------------------------------------------------
 close_loops_homography_guided
 ::close_loops_homography_guided()
 : d_( new priv() )
 {
+  attach_logger( "arrows.vxl.close_loops_homography_guided" );
 }
 
 
@@ -172,6 +171,7 @@ close_loops_homography_guided
 }
 
 
+// ----------------------------------------------------------------------------
 vital::config_block_sptr
 close_loops_homography_guided
 ::get_configuration() const
@@ -353,7 +353,7 @@ close_loops_homography_guided
     if( mset->size() > 0 ) // If matches are good
     {
       // Logging
-      LOG_INFO(d_->m_logger, "Stitching frames " << prior_frame << " and " << frame_number);
+      LOG_INFO(logger(), "Stitching frames " << prior_frame << " and " << frame_number);
 
       // Get all tracks on the past frame
       std::vector< track_sptr > prior_trks = input->active_tracks( prior_frame );

--- a/arrows/vxl/estimate_canonical_transform.cxx
+++ b/arrows/vxl/estimate_canonical_transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,6 @@
 
 #include "estimate_canonical_transform.h"
 
-#include <vital/logger/logger.h>
-
 #include <algorithm>
 
 #include <vnl/vnl_double_3.h>
@@ -53,12 +51,13 @@ namespace kwiver {
 namespace arrows {
 namespace vxl {
 
-/// Private implementation class
+
+// Private implementation class
 class estimate_canonical_transform::priv
 {
 public:
   enum rrel_method_types {RANSAC, LMS, IRLS};
-  /// Constructor
+  // Constructor
   priv()
     : estimate_scale(true),
       trace_level(0),
@@ -68,12 +67,12 @@ public:
       prior_inlier_scale(0.1),
       irls_max_iterations(15),
       irls_iterations_for_scale(2),
-      irls_conv_tolerance(1e-4),
-      m_logger( vital::get_logger( "arrows.vxl.estimate_canonical_transform" ))
+      irls_conv_tolerance(1e-4)
   {
   }
 
-  /// Helper function to estimate a ground plane from the data points
+  // ----------------------------------------------------------------------------
+  // Helper function to estimate a ground plane from the data points
   vector_4d estimate_plane(std::vector<vector_3d> const& points) const
   {
     std::vector< vnl_vector<double> > vnl_points;
@@ -174,28 +173,33 @@ public:
   int irls_iterations_for_scale;
   // The convergence tolerance for IRLS
   double irls_conv_tolerance;
+
   // Logger handle
   vital::logger_handle_t m_logger;
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 estimate_canonical_transform
 ::estimate_canonical_transform()
 : d_(new priv)
 {
+  attach_logger( "arrows.vxl.estimate_canonical_transform" );
+  d_->m_logger = logger();
 }
 
 
-/// Destructor
+// Destructor
 estimate_canonical_transform
 ::~estimate_canonical_transform()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
-  vital::config_block_sptr
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
+vital::config_block_sptr
 estimate_canonical_transform
 ::get_configuration() const
 {
@@ -241,7 +245,8 @@ estimate_canonical_transform
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 estimate_canonical_transform
 ::set_configuration(vital::config_block_sptr config)
@@ -259,7 +264,8 @@ estimate_canonical_transform
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_canonical_transform
 ::check_configuration(vital::config_block_sptr config) const
@@ -268,7 +274,8 @@ estimate_canonical_transform
 }
 
 
-/// Estimate a canonical similarity transform for cameras and points
+// ----------------------------------------------------------------------------
+// Estimate a canonical similarity transform for cameras and points
 kwiver::vital::similarity_d
 estimate_canonical_transform
 ::estimate_transform(kwiver::vital::camera_map_sptr const cameras,

--- a/arrows/vxl/image_io.cxx
+++ b/arrows/vxl/image_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,6 @@
 
 #include "image_io.h"
 
-#include <vital/logger/logger.h>
 #include <vital/io/eigen_io.h>
 #include <vital/types/vector.h>
 #include <vital/exceptions/image.h>
@@ -55,7 +54,7 @@ namespace vxl {
 namespace
 {
 
-/// Helper function to convert images based on configuration
+// Helper function to convert images based on configuration
 template <typename inP, typename outP>
 void
 convert_image_helper(const vil_image_view<inP>& src,
@@ -94,7 +93,7 @@ convert_image_helper(const vil_image_view<inP>& src,
 }
 
 
-/// Helper function to convert images based on configuration - specialized for byte output
+// Helper function to convert images based on configuration - specialized for byte output
 template <typename inP>
 void
 convert_image_helper(const vil_image_view<inP>& src,
@@ -119,7 +118,7 @@ convert_image_helper(const vil_image_view<inP>& src,
 }
 
 
-/// Helper function to convert images based on configuration - specialization for bool
+// Helper function to convert images based on configuration - specialization for bool
 template <typename outP>
 void
 convert_image_helper(const vil_image_view<bool>& src,
@@ -140,7 +139,7 @@ convert_image_helper(const vil_image_view<bool>& src,
 }
 
 
-/// Helper function to convert images based on configuration - resolve specialization ambiguity
+// Helper function to convert images based on configuration - resolve specialization ambiguity
 void
 convert_image_helper(const vil_image_view<bool>& src,
                      vil_image_view<vxl_byte>& dest,
@@ -151,7 +150,7 @@ convert_image_helper(const vil_image_view<bool>& src,
 }
 
 
-/// Helper function to convert images based on configuration - specialization for bool/bool
+// Helper function to convert images based on configuration - specialization for bool/bool
 void
 convert_image_helper(const vil_image_view<bool>& src,
                      vil_image_view<bool>& dest,
@@ -167,17 +166,16 @@ convert_image_helper(const vil_image_view<bool>& src,
 
 
 
-/// Private implementation class
+// Private implementation class
 class image_io::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
   : force_byte(false),
     auto_stretch(false),
     manual_stretch(false),
-    intensity_range(0, 255),
-    m_logger( vital::get_logger( "arrows.vxl.image_io" ) )
+    intensity_range(0, 255)
   {
   }
 
@@ -196,29 +194,28 @@ public:
   bool auto_stretch;
   bool manual_stretch;
   vector_2d intensity_range;
-
-  vital::logger_handle_t m_logger;
 };
 
 
-
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 image_io
 ::image_io()
 : d_(new priv)
 {
+  attach_logger( "arrows.vxl.image_io" );
 }
 
 
-/// Destructor
+// Destructor
 image_io
 ::~image_io()
 {
 }
 
 
-
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 image_io
 ::get_configuration() const
@@ -257,7 +254,8 @@ image_io
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 image_io
 ::set_configuration(vital::config_block_sptr in_config)
@@ -278,7 +276,8 @@ image_io
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's currently configuration is valid
 bool
 image_io
 ::check_configuration(vital::config_block_sptr config) const
@@ -289,7 +288,7 @@ image_io
                                                   d_->manual_stretch);
   if( auto_stretch && manual_stretch)
   {
-    LOG_ERROR( d_->m_logger, "can not enable both manual and auto stretching");
+    LOG_ERROR( logger(), "can not enable both manual and auto stretching");
     return false;
   }
   if( manual_stretch )
@@ -298,7 +297,7 @@ image_io
                                         d_->intensity_range.transpose());
     if( range[0] >= range[1] )
     {
-      LOG_ERROR( d_->m_logger, "stretching range minimum not less than maximum"
+      LOG_ERROR( logger(), "stretching range minimum not less than maximum"
                 <<" ("<<range[0]<<", "<<range[1]<<")");
       return false;
     }
@@ -307,12 +306,13 @@ image_io
 }
 
 
-/// Load image image from the file
+// ----------------------------------------------------------------------------
+// Load image image from the file
 image_container_sptr
 image_io
 ::load_(const std::string& filename) const
 {
-  LOG_DEBUG( d_->m_logger, "Loading image from file: " << filename );
+  LOG_DEBUG( logger(), "Loading image from file: " << filename );
 
   vil_image_resource_sptr img_rsc = vil_load_image_resource(filename.c_str());
 
@@ -362,7 +362,7 @@ image_io
     }
     else if( d_->manual_stretch )
     {
-      LOG_ERROR( d_->m_logger, "Unable to manually stretch pixel type: "
+      LOG_ERROR( logger(), "Unable to manually stretch pixel type: "
                 << img_rsc->pixel_format());
       throw vital::image_type_mismatch_exception("kwiver::arrows::vxl::image_io::load_()");
     }
@@ -377,7 +377,8 @@ image_io
 }
 
 
-/// Save image image to a file
+// ----------------------------------------------------------------------------
+// Save image image to a file
 void
 image_io
 ::save_(const std::string& filename,
@@ -435,7 +436,7 @@ image_io
     }
     else if( d_->manual_stretch )
     {
-      LOG_ERROR( d_->m_logger, "Unable to manually stretch pixel type: "
+      LOG_ERROR( logger(), "Unable to manually stretch pixel type: "
                 << view->pixel_format());
       throw vital::image_type_mismatch_exception("kwiver::arrows::vxl::image_io::save_()");
     }

--- a/arrows/vxl/match_features_constrained.cxx
+++ b/arrows/vxl/match_features_constrained.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,8 +41,6 @@
 #include <vital/types/descriptor_set.h>
 #include <vital/types/match_set.h>
 
-#include <vital/logger/logger.h>
-
 #include <rsdl/rsdl_kd_tree.h>
 #include <vnl/vnl_vector_fixed.h>
 
@@ -54,20 +52,20 @@ namespace kwiver {
 namespace arrows {
 namespace vxl {
 
-/// Private implementation class
+// Private implementation class
 class match_features_constrained::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv() :
     scale_thresh(2.0),
     angle_thresh(-1.0),
-    radius_thresh(200.0),
-    m_logger( vital::get_logger( "arrows.vxl.match_features_constrained" ) )
+    radius_thresh(200.0)
   {
   }
 
-  /// Compute the minimum angle between two angles in degrees
+  // ----------------------------------------------------------------------------
+  // Compute the minimum angle between two angles in degrees
   inline static
   double angle_dist(double a1, double a2)
   {
@@ -156,22 +154,26 @@ public:
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 match_features_constrained
 ::match_features_constrained()
 : d_(new priv)
 {
+  attach_logger( "arrows.vxl.match_features_constrained" );
+  d_->m_logger = logger();
 }
 
 
-/// Destructor
+// Destructor
 match_features_constrained
 ::~match_features_constrained()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 match_features_constrained
 ::get_configuration() const
@@ -195,7 +197,8 @@ match_features_constrained
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 match_features_constrained
 ::set_configuration(vital::config_block_sptr config)
@@ -206,7 +209,8 @@ match_features_constrained
 }
 
 
-/// Check that the algorithm's configuration vital::config_block is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's configuration vital::config_block is valid
 bool
 match_features_constrained
 ::check_configuration(vital::config_block_sptr config) const
@@ -214,13 +218,13 @@ match_features_constrained
   double radius_thresh = config->get_value<double>("radius_thresh", d_->radius_thresh);
   if (radius_thresh <= 0.0)
   {
-    LOG_ERROR( d_->m_logger, "radius_thresh should be > 0.0, is " << radius_thresh);
+    LOG_ERROR( logger(), "radius_thresh should be > 0.0, is " << radius_thresh);
     return false;
   }
   double scale_thresh = config->get_value<double>("scale_thresh", d_->scale_thresh);
   if (scale_thresh < 1.0 && scale_thresh >= 0.0)
   {
-    LOG_ERROR( d_->m_logger, "scale_thresh should be >= 1.0 (or < 0.0 to disable), is "
+    LOG_ERROR( logger(), "scale_thresh should be >= 1.0 (or < 0.0 to disable), is "
                                << scale_thresh);
     return false;
   }
@@ -229,7 +233,8 @@ match_features_constrained
 }
 
 
-/// Match one set of features and corresponding descriptors to another
+// ----------------------------------------------------------------------------
+// Match one set of features and corresponding descriptors to another
 vital::match_set_sptr
 match_features_constrained
 ::match(vital::feature_set_sptr feat1, vital::descriptor_set_sptr desc1,

--- a/arrows/vxl/triangulate_landmarks.cxx
+++ b/arrows/vxl/triangulate_landmarks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,38 +48,38 @@ namespace kwiver {
 namespace arrows {
 namespace vxl {
 
-/// Private implementation class
+// Private implementation class
 class triangulate_landmarks::priv
 {
 public:
-  /// Constructor
+  // Constructor
   priv()
-  : m_logger( vital::get_logger( "arrows.vxl.triangulate_landmarks" ))
   {
   }
 
-  /// parameters - none yet
-  /// Logger handle
-  vital::logger_handle_t m_logger;
+  // parameters - none yet
 };
 
 
-/// Constructor
+// ----------------------------------------------------------------------------
+// Constructor
 triangulate_landmarks
 ::triangulate_landmarks()
 : d_(new priv)
 {
+  attach_logger( "arrows.vxl.triangulate_landmarks" );
 }
 
 
-/// Destructor
+// Destructor
 triangulate_landmarks
 ::~triangulate_landmarks()
 {
 }
 
 
-/// Get this algorithm's \link vital::config_block configuration block \endlink
+// ----------------------------------------------------------------------------
+// Get this algorithm's \link vital::config_block configuration block \endlink
 vital::config_block_sptr
 triangulate_landmarks
 ::get_configuration() const
@@ -90,7 +90,8 @@ triangulate_landmarks
 }
 
 
-/// Set this algorithm's properties via a config block
+// ----------------------------------------------------------------------------
+// Set this algorithm's properties via a config block
 void
 triangulate_landmarks
 ::set_configuration(vital::config_block_sptr in_config)
@@ -98,7 +99,8 @@ triangulate_landmarks
 }
 
 
-/// Check that the algorithm's currently configuration is valid
+// ----------------------------------------------------------------------------
+// Check that the algorithm's currently configuration is valid
 bool
 triangulate_landmarks
 ::check_configuration(vital::config_block_sptr config) const
@@ -107,7 +109,8 @@ triangulate_landmarks
 }
 
 
-/// Triangulate the landmark locations given sets of cameras and feature tracks
+// ----------------------------------------------------------------------------
+// Triangulate the landmark locations given sets of cameras and feature tracks
 void
 triangulate_landmarks
 ::triangulate(vital::camera_map_sptr cameras,
@@ -203,7 +206,7 @@ triangulate_landmarks
   }
   if( !failed_landmarks.empty() )
   {
-    LOG_ERROR(d_->m_logger, "failed to triangulate " << failed_landmarks.size()
+    LOG_ERROR(logger(), "failed to triangulate " << failed_landmarks.size()
                             << " of " << lms.size() << " landmarks");
   }
   landmarks = landmark_map_sptr(new simple_landmark_map(triangulated_lms));


### PR DESCRIPTION
Remove duplicate logger allocations and pointers. Use the logger API
that is part of vital::algorithm instead.

Remove unneeded includes for logger.h.

Normalized logger names.