### PR TITLE
Fix ocv image test

### DIFF
--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -179,7 +179,9 @@ run_ocv_conversion_tests( cv::Mat const& img )
       {
         for( int i = 0; i < img.cols; ++i )
         {
-          ASSERT_EQ( img.ptr<T>( j )[ num_c * i + c ], vimg.at<T>( i, j, c ) );
+          auto img_pix = img.ptr<T>( j )[ num_c * i + c ];
+          auto vimg_pix = vimg.at<T>( i, j, c );
+          ASSERT_EQ( img_pix, vimg_pix  );
         }
       }
     }


### PR DESCRIPTION
On certain versions of gcc, we get template errors on test_image.cxx:182. Using temp variables moves the templates out of the ASSERT_EQ call and fixes the error.