### PR TITLE
Fixed broken CSV detection reader

### DIFF
--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -75,7 +75,8 @@ public:
 
   bool get_input();
   void add_detection();
-
+  void read_all();
+  void parse_detection( const std::vector< std::string >& parsed_line);
 
   // -------------------------------------
   detected_object_set_input_csv* m_parent;
@@ -87,6 +88,9 @@ public:
   std::shared_ptr< kwiver::vital::data_stream_reader > m_stream_reader;
   std::vector< std::string > m_input_buffer;
   kwiver::vital::detected_object_set_sptr m_current_set;
+
+  std::map< std::string, kwiver::vital::detected_object_set_sptr > m_gt_sets;
+  std::vector< std::string > m_filenames;
   std::string m_image_name;
 };
 
@@ -129,6 +133,47 @@ check_configuration(vital::config_block_sptr config) const
 }
 
 
+void
+detected_object_set_input_csv::priv::
+read_all()
+{
+  std::string line;
+  kwiver::vital::data_stream_reader stream_reader( m_parent->stream() );
+  //Reset the groundtruth sets
+  m_gt_sets.clear();
+  
+  //Run through all the lines in the groundtruth file
+  while( stream_reader.getline( line ) )
+  {
+    if( line.substr(0,6) == "Image," || line.empty() ) //ignore header
+    {
+      continue;
+    }
+
+    line.erase( std::remove( line.begin(), line.end(), '[' ), line.end() );
+    line.erase( std::remove( line.begin(), line.end(), ']' ), line.end() );
+    line.erase( std::remove( line.begin(), line.end(), '\"' ), line.end() );
+    line.erase( std::remove( line.begin(), line.end(), ':' ), line.end() );
+    
+    //Parse the file on commas, not that whitespace is not stripped 
+    std::vector< std::string > parsed_line;
+    kwiver::vital::tokenize( line, parsed_line, ",", true );
+
+    // Test the minimum number of fields.
+    if ( parsed_line.size() < 7 )
+    {
+      std::cout << "Invalid line: " << line << std::endl;
+      continue;
+    }
+
+    //parsed_line.insert( parsed_line.begin() + 3, parsed_loc.begin(), parsed_loc.end() );
+    parse_detection( parsed_line );
+  }
+
+  std::sort( m_filenames.begin(), m_filenames.end() );
+}
+
+
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_csv::
@@ -137,18 +182,35 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
   if ( d->m_first )
   {
     d->m_first = false;
-
     if ( ! d->get_input() )
     {
       return false; // indicate end of file.
     }
-
+    //Setting up the map from file name to detection set
+    d->read_all();
     // allocate first detection set
     d->m_current_set = std::make_shared<kwiver::vital::detected_object_set>();
 
     // set current frame number from line in buffer
     d->m_frame_number = atoi( d->m_input_buffer[0].c_str() );
   } // end first
+
+  // External image name provided, use that
+  if( !image_name.empty() )
+  {
+    // return detection set at current index if there is one
+    if( d->m_gt_sets.find( image_name ) == d->m_gt_sets.end() )
+    {
+      // return empty set
+      set = std::make_shared< kwiver::vital::detected_object_set>();
+    }
+    else
+    {
+      // Return detections for this frame.
+      set = d->m_gt_sets[ image_name ];
+    }
+    return true;
+  }
 
   // test for end of stream
   if (this->at_eof())
@@ -167,7 +229,6 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     {
       // We are in the same frame, so add this detection to current set
       d->add_detection();
-
       // Get next input line
       valid_line = d->get_input();
     }
@@ -195,6 +256,8 @@ new_stream()
 {
   d->m_first = true;
   d->m_stream_reader = std::make_shared< kwiver::vital::data_stream_reader>( stream() );
+  //d->m_filenames.clear();
+  d->m_gt_sets.clear();
 }
 
 
@@ -234,6 +297,51 @@ get_input()
 
 
 // ------------------------------------------------------------------
+void
+detected_object_set_input_csv::priv::
+parse_detection( const std::vector< std::string >& parsed_line)
+{
+  kwiver::vital::detected_object_type_sptr dot;
+
+  // Create DOT object if classifiers are present
+  if ( parsed_line.size() > 7 )
+  {
+    dot = std::make_shared<kwiver::vital::detected_object_type>();
+    const size_t limit( parsed_line.size() );
+
+    for (size_t i = 7; i < limit; i += 2 )
+    {
+      double score = atof( parsed_line[i+1].c_str() );
+      dot->set_score( parsed_line[i], score );
+    }
+  } // end classes
+
+  const kwiver::vital::bounding_box_d bbox(
+    atof( parsed_line[2].c_str() ),
+    atof( parsed_line[3].c_str() ),
+    atof( parsed_line[4].c_str() ),
+    atof( parsed_line[5].c_str() ) );
+
+  const double confid( atof( parsed_line[6].c_str() ) );
+
+   //initializing the map
+   if( m_gt_sets.find( parsed_line[0] ) == m_gt_sets.end() )
+   {
+     // create a new detection set entry
+     m_gt_sets[ parsed_line[0] ] =
+       std::make_shared<kwiver::vital::detected_object_set>();
+
+     m_filenames.push_back( parsed_line[0] );
+   }
+
+   //adding a detection
+   m_gt_sets[ parsed_line[0] ]->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
+  //m_current_set->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
+
+  m_image_name = parsed_line[1];
+}
+
+
 void
 detected_object_set_input_csv::priv::
 add_detection()

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -75,13 +75,8 @@ public:
 
   bool get_input();
   void add_detection();
-<<<<<<< HEAD
-  void add_detection( const std::vector< std::string >& parsed_line);
-  void read_all();
-=======
   void read_all();
   void parse_detection( const std::vector< std::string >& parsed_line);
->>>>>>> 826f107... Improved the process of extracting detections per frame
 
   // -------------------------------------
   detected_object_set_input_csv* m_parent;
@@ -150,11 +145,7 @@ read_all()
   //Run through all the lines in the groundtruth file
   while( stream_reader.getline( line ) )
   {
-<<<<<<< HEAD
     if( line.substr(0,6) == "Image,") //ignore header
-=======
-    if( line.substr(0,6) == "Image," || line.empty() ) //ignore header
->>>>>>> 826f107... Improved the process of extracting detections per frame
     {
       continue;
     }
@@ -176,11 +167,7 @@ read_all()
     }
 
     //parsed_line.insert( parsed_line.begin() + 3, parsed_loc.begin(), parsed_loc.end() );
-<<<<<<< HEAD
-    parse_add( parsed_line );
-=======
     parse_detection( parsed_line );
->>>>>>> 826f107... Improved the process of extracting detections per frame
   }
 
   std::sort( m_filenames.begin(), m_filenames.end() );
@@ -199,17 +186,11 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     {
       return false; // indicate end of file.
     }
-<<<<<<< HEAD
-	
     //This is what creates the map from file name to object set
     //In the future maybe it should be computed if ever any 
     if ( !image_name.empty() ){
       d->read_all();
     }
-
-=======
-    d->read_all();
->>>>>>> 826f107... Improved the process of extracting detections per frame
     // allocate first detection set
     d->m_current_set = std::make_shared<kwiver::vital::detected_object_set>();
 
@@ -231,12 +212,9 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
       // Return detections for this frame.
       set = d->m_gt_sets[ image_name ];
     }
-<<<<<<< HEAD
 
-    //
+    //Setting the image name so it can be returned
     image_name = d->m_image_name;
-=======
->>>>>>> 826f107... Improved the process of extracting detections per frame
     return true;
   }
 
@@ -284,11 +262,7 @@ new_stream()
 {
   d->m_first = true;
   d->m_stream_reader = std::make_shared< kwiver::vital::data_stream_reader>( stream() );
-<<<<<<< HEAD
   d->m_filenames.clear();
-=======
-  //d->m_filenames.clear();
->>>>>>> 826f107... Improved the process of extracting detections per frame
   d->m_gt_sets.clear();
 }
 
@@ -331,9 +305,6 @@ get_input()
 // ------------------------------------------------------------------
 void
 detected_object_set_input_csv::priv::
-<<<<<<< HEAD
-add_detection( const std::vector< std::string >& parsed_line)
-=======
 parse_detection( const std::vector< std::string >& parsed_line)
 {
   kwiver::vital::detected_object_type_sptr dot;
@@ -371,7 +342,6 @@ parse_detection( const std::vector< std::string >& parsed_line)
 
    //adding a detection
    m_gt_sets[ parsed_line[0] ]->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
-  //m_current_set->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
 
   m_image_name = parsed_line[1];
 }
@@ -380,54 +350,6 @@ parse_detection( const std::vector< std::string >& parsed_line)
 void
 detected_object_set_input_csv::priv::
 add_detection()
->>>>>>> 826f107... Improved the process of extracting detections per frame
-{
-  kwiver::vital::detected_object_type_sptr dot;
-  //The first seven fields are required in any detection
-  const size_t num_required_fields( 7 );
-
-  // Create DOT object if classifiers are present
-  if ( parsed_line.size() > num_required_fields )
-  {
-    dot = std::make_shared<kwiver::vital::detected_object_type>();
-    const size_t limit( parsed_line.size() );
-
-    //The required fields may be followed by an arbitrary number of (class-name, score) pairs 
-    for (size_t i = num_required_fields; i < limit; i += 2 )
-    {
-      double score = atof( parsed_line[i+1].c_str() );
-      dot->set_score( parsed_line[i], score );
-    }
-  } // end classes
-
-  const kwiver::vital::bounding_box_d bbox(
-    atof( parsed_line[2].c_str() ),
-    atof( parsed_line[3].c_str() ),
-    atof( parsed_line[4].c_str() ),
-    atof( parsed_line[5].c_str() ) );
-
-  const double confid( atof( parsed_line[6].c_str() ) );
-
-  //initializing the map
-  if( m_gt_sets.find( parsed_line[0] ) == m_gt_sets.end() )
-  {
-    // create a new detection set entry
-    m_gt_sets[ parsed_line[0] ] =
-      std::make_shared<kwiver::vital::detected_object_set>();
-
-    m_filenames.push_back( parsed_line[0] );
-  }
-
-  //adding a detection
-  m_gt_sets[ parsed_line[0] ]->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
-
-  m_image_name = parsed_line[1];
-}
-
-
-void
-detected_object_set_input_csv::priv::
-add_detection(const std::vector< std::string >& parsed_line)
 {
   kwiver::vital::detected_object_type_sptr dot;
   //The first seven fields are required in any detection

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -75,8 +75,13 @@ public:
 
   bool get_input();
   void add_detection();
+<<<<<<< HEAD
   void add_detection( const std::vector< std::string >& parsed_line);
   void read_all();
+=======
+  void read_all();
+  void parse_detection( const std::vector< std::string >& parsed_line);
+>>>>>>> 826f107... Improved the process of extracting detections per frame
 
   // -------------------------------------
   detected_object_set_input_csv* m_parent;
@@ -145,7 +150,11 @@ read_all()
   //Run through all the lines in the groundtruth file
   while( stream_reader.getline( line ) )
   {
+<<<<<<< HEAD
     if( line.substr(0,6) == "Image,") //ignore header
+=======
+    if( line.substr(0,6) == "Image," || line.empty() ) //ignore header
+>>>>>>> 826f107... Improved the process of extracting detections per frame
     {
       continue;
     }
@@ -167,7 +176,11 @@ read_all()
     }
 
     //parsed_line.insert( parsed_line.begin() + 3, parsed_loc.begin(), parsed_loc.end() );
+<<<<<<< HEAD
     parse_add( parsed_line );
+=======
+    parse_detection( parsed_line );
+>>>>>>> 826f107... Improved the process of extracting detections per frame
   }
 
   std::sort( m_filenames.begin(), m_filenames.end() );
@@ -186,6 +199,7 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     {
       return false; // indicate end of file.
     }
+<<<<<<< HEAD
 	
     //This is what creates the map from file name to object set
     //In the future maybe it should be computed if ever any 
@@ -193,6 +207,9 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
       d->read_all();
     }
 
+=======
+    d->read_all();
+>>>>>>> 826f107... Improved the process of extracting detections per frame
     // allocate first detection set
     d->m_current_set = std::make_shared<kwiver::vital::detected_object_set>();
 
@@ -214,9 +231,12 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
       // Return detections for this frame.
       set = d->m_gt_sets[ image_name ];
     }
+<<<<<<< HEAD
 
     //
     image_name = d->m_image_name;
+=======
+>>>>>>> 826f107... Improved the process of extracting detections per frame
     return true;
   }
 
@@ -264,7 +284,11 @@ new_stream()
 {
   d->m_first = true;
   d->m_stream_reader = std::make_shared< kwiver::vital::data_stream_reader>( stream() );
+<<<<<<< HEAD
   d->m_filenames.clear();
+=======
+  //d->m_filenames.clear();
+>>>>>>> 826f107... Improved the process of extracting detections per frame
   d->m_gt_sets.clear();
 }
 
@@ -307,7 +331,56 @@ get_input()
 // ------------------------------------------------------------------
 void
 detected_object_set_input_csv::priv::
+<<<<<<< HEAD
 add_detection( const std::vector< std::string >& parsed_line)
+=======
+parse_detection( const std::vector< std::string >& parsed_line)
+{
+  kwiver::vital::detected_object_type_sptr dot;
+
+  // Create DOT object if classifiers are present
+  if ( parsed_line.size() > 7 )
+  {
+    dot = std::make_shared<kwiver::vital::detected_object_type>();
+    const size_t limit( parsed_line.size() );
+
+    for (size_t i = 7; i < limit; i += 2 )
+    {
+      double score = atof( parsed_line[i+1].c_str() );
+      dot->set_score( parsed_line[i], score );
+    }
+  } // end classes
+
+  const kwiver::vital::bounding_box_d bbox(
+    atof( parsed_line[2].c_str() ),
+    atof( parsed_line[3].c_str() ),
+    atof( parsed_line[4].c_str() ),
+    atof( parsed_line[5].c_str() ) );
+
+  const double confid( atof( parsed_line[6].c_str() ) );
+
+   //initializing the map
+   if( m_gt_sets.find( parsed_line[0] ) == m_gt_sets.end() )
+   {
+     // create a new detection set entry
+     m_gt_sets[ parsed_line[0] ] =
+       std::make_shared<kwiver::vital::detected_object_set>();
+
+     m_filenames.push_back( parsed_line[0] );
+   }
+
+   //adding a detection
+   m_gt_sets[ parsed_line[0] ]->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
+  //m_current_set->add( std::make_shared<kwiver::vital::detected_object>( bbox, confid, dot ) );
+
+  m_image_name = parsed_line[1];
+}
+
+
+void
+detected_object_set_input_csv::priv::
+add_detection()
+>>>>>>> 826f107... Improved the process of extracting detections per frame
 {
   kwiver::vital::detected_object_type_sptr dot;
   //The first seven fields are required in any detection

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -162,7 +162,7 @@ read_all()
     // Test the minimum number of fields.
     if ( parsed_line.size() < 7 )
     {
-      LOG_WARN( m_logger, "Invalid line, too few fields: " << line );// logger() as the first arguement results in build errors
+      LOG_WARN( logger(), "Invalid line, too few fields: " << line );// logger() as the first arguement results in build errors
       continue;
     }
 

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -162,7 +162,7 @@ read_all()
     // Test the minimum number of fields.
     if ( parsed_line.size() < 7 )
     {
-      LOG_WARN( logger(), "Invalid line, too few fields: " << line );// logger() as the first arguement results in build errors
+      LOG_WARN( m_parent->logger(), "Invalid line, too few fields: " << line );
       continue;
     }
 

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -186,8 +186,13 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     {
       return false; // indicate end of file.
     }
-    //Setting up the map from file name to detection set
-    d->read_all();
+	
+    //This is what creates the map from file name to object set
+    //In the future maybe it should be computed if ever any 
+    if ( !image_name.empty() ){
+      d->read_all();
+    }
+
     // allocate first detection set
     d->m_current_set = std::make_shared<kwiver::vital::detected_object_set>();
 


### PR DESCRIPTION
In cases where a CSV file of detections was not sorted by image, the reader would fail to correctly match the detections to the appropriate images. I fixed this in a similar fashion to how Matt D. did it for HABCAM inputs, by pre-computing a map from image names to a set of detections.  