### PR TITLE
Use list append instead of set for proper list spacing

### DIFF
--- a/CMake/utils/kwiver-utils-configuration.cmake
+++ b/CMake/utils/kwiver-utils-configuration.cmake
@@ -43,8 +43,7 @@ function(kwiver_configure_file name source dest)
 
   set(gen_command_args)
   foreach(arg IN LISTS mcf_UNPARSED_ARGUMENTS)
-    set(gen_command_args
-      ${gen_command_args}
+    list(APPEND gen_command_args
       "-D${arg}=\"${${arg}}\""
       )
   endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ get_property(kwiver_libs GLOBAL PROPERTY kwiver_libraries)
 string(REPLACE ";" " " kwiver_libs "${kwiver_libs}")
 
 # setup general paths to includes and libs for packages we use/provide
-set( KWIVER_INCLUDE_DIRS "${EIGEN3_INCLUDE_DIR}")
+list(APPEND KWIVER_INCLUDE_DIRS "${EIGEN3_INCLUDE_DIR}")
 set( KWIVER_LIBRARY_DIRS "")
 
 if ( NOT fletch_ENABLED_Boost)


### PR DESCRIPTION
Kwiver uses a macro to add arguments to the config file. When those arguments are lists, like KWIVER_INCLUDE_DIRS, they get messed up if they are built using the set command. Switching to using the list(APPEND ...) structure fixes the issue. Aside from that list(APPEND is generally better anyway since it's faster than set(VAL ${VAL} ${NEWVAL}).