### PR TITLE
fix rgb bgr test fail

### DIFF
--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -283,7 +283,7 @@ detect( vital::image_container_sptr image_data ) const
 {
   kwiver::vital::scoped_cpu_timer t( "Time to Detect Objects" );
 
-  cv::Mat cv_image = kwiver::arrows::ocv::image_container::vital_to_ocv( image_data->get_image(), kwiver::arrows::ocv::image_container::BGR );
+  cv::Mat cv_image = kwiver::arrows::ocv::image_container::vital_to_ocv( image_data->get_image(), kwiver::arrows::ocv::image_container::BGR_COLOR );
 
   cv::Mat cv_resized_image;
 

--- a/arrows/ocv/detect_features.cxx
+++ b/arrows/ocv/detect_features.cxx
@@ -52,7 +52,7 @@ vital::feature_set_sptr
 detect_features
 ::detect(vital::image_container_sptr image_data, vital::image_container_sptr mask) const
 {
-  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::BGR );
+  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::BGR_COLOR );
   cv::Mat cv_mask;
   std::vector<cv::KeyPoint> keypoints;
 
@@ -79,7 +79,7 @@ detect_features
                    s.first_pixel(),
                    s.width(),  s.height(), 1 /*depth*/,
                    s.w_step(), s.h_step(), s.d_step(), s.pixel_traits());
-    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::BGR);
+    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::BGR_COLOR);
   }
 
   detector->detect(cv_img, keypoints, cv_mask);

--- a/arrows/ocv/detect_features.cxx
+++ b/arrows/ocv/detect_features.cxx
@@ -52,7 +52,7 @@ vital::feature_set_sptr
 detect_features
 ::detect(vital::image_container_sptr image_data, vital::image_container_sptr mask) const
 {
-  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image());
+  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::BGR );
   cv::Mat cv_mask;
   std::vector<cv::KeyPoint> keypoints;
 
@@ -79,7 +79,7 @@ detect_features
                    s.first_pixel(),
                    s.width(),  s.height(), 1 /*depth*/,
                    s.w_step(), s.h_step(), s.d_step(), s.pixel_traits());
-    cv_mask = ocv::image_container::vital_to_ocv(i);
+    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::BGR);
   }
 
   detector->detect(cv_img, keypoints, cv_mask);

--- a/arrows/ocv/draw_detected_object_set.cxx
+++ b/arrows/ocv/draw_detected_object_set.cxx
@@ -220,7 +220,7 @@ public:
   vital::image_container_sptr draw_detections( vital::image_container_sptr      image_data,
                                                vital::detected_object_set_sptr  in_set ) const
   {
-    cv::Mat image = image_container_to_ocv_matrix( *image_data, arrows::ocv::image_container::BGR ).clone();
+    cv::Mat image = image_container_to_ocv_matrix( *image_data, arrows::ocv::image_container::BGR_COLOR ).clone();
 
     // process the detection set
     auto ie =  in_set->cend();
@@ -261,7 +261,7 @@ public:
       }
     } // end foreach
 
-    return vital::image_container_sptr( new arrows::ocv::image_container( image, arrows::ocv::image_container::BGR ) );
+    return vital::image_container_sptr( new arrows::ocv::image_container( image, arrows::ocv::image_container::BGR_COLOR ) );
   } // end draw_detections
 
 

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -365,7 +365,7 @@ draw_tracks
     bool write_image_to_disk = d->write_images_to_disk;
 
     // Clone a copy of the current image (so we don't modify the original input).
-    cv::Mat img = ocv::image_container::vital_to_ocv( ctr_sptr->get_image() ).clone();
+    cv::Mat img = ocv::image_container::vital_to_ocv( ctr_sptr->get_image(), ocv::image_container::BGR ).clone();
 
     // Convert to 3 channel image if not one already
     if( img.channels() == 1 )
@@ -555,7 +555,7 @@ draw_tracks
   d->cur_frame_id = fid;
 
   // Return the last generated image
-  return image_container_sptr( new ocv::image_container( output_image ) );
+  return image_container_sptr( new ocv::image_container( output_image, ocv::image_container::BGR) );
 }
 
 } // end namespace ocv

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -365,7 +365,7 @@ draw_tracks
     bool write_image_to_disk = d->write_images_to_disk;
 
     // Clone a copy of the current image (so we don't modify the original input).
-    cv::Mat img = ocv::image_container::vital_to_ocv( ctr_sptr->get_image(), ocv::image_container::BGR ).clone();
+    cv::Mat img = ocv::image_container::vital_to_ocv( ctr_sptr->get_image(), ocv::image_container::BGR_COLOR ).clone();
 
     // Convert to 3 channel image if not one already
     if( img.channels() == 1 )
@@ -555,7 +555,7 @@ draw_tracks
   d->cur_frame_id = fid;
 
   // Return the last generated image
-  return image_container_sptr( new ocv::image_container( output_image, ocv::image_container::BGR) );
+  return image_container_sptr( new ocv::image_container( output_image, ocv::image_container::BGR_COLOR) );
 }
 
 } // end namespace ocv

--- a/arrows/ocv/extract_descriptors.cxx
+++ b/arrows/ocv/extract_descriptors.cxx
@@ -56,7 +56,7 @@ extract_descriptors
   {
     return descriptor_set_sptr();
   }
-  cv::Mat img = image_container_to_ocv_matrix(*image_data, ocv::image_container::BGR);
+  cv::Mat img = image_container_to_ocv_matrix(*image_data, ocv::image_container::BGR_COLOR);
   std::vector<cv::KeyPoint> kpts = features_to_ocv_keypoints(*features);
 
   cv::Mat desc;

--- a/arrows/ocv/hough_circle_detector.cxx
+++ b/arrows/ocv/hough_circle_detector.cxx
@@ -157,7 +157,7 @@ detect( vital::image_container_sptr image_data) const
 {
   auto detected_set = std::make_shared< kwiver::vital::detected_object_set>();
 
-  cv::Mat src = kwiver::arrows::ocv::image_container::vital_to_ocv( image_data->get_image() );
+  cv::Mat src = kwiver::arrows::ocv::image_container::vital_to_ocv( image_data->get_image(), kwiver::arrows::ocv::image_container::BGR );
   cv::Mat src_gray;
 
   // Convert it to gray

--- a/arrows/ocv/hough_circle_detector.cxx
+++ b/arrows/ocv/hough_circle_detector.cxx
@@ -157,7 +157,9 @@ detect( vital::image_container_sptr image_data) const
 {
   auto detected_set = std::make_shared< kwiver::vital::detected_object_set>();
 
-  cv::Mat src = kwiver::arrows::ocv::image_container::vital_to_ocv( image_data->get_image(), kwiver::arrows::ocv::image_container::BGR );
+  using namespace kwiver::arrows::ocv;
+  cv::Mat src = image_container::vital_to_ocv( image_data->get_image(), 
+                                               image_container::BGR_COLOR );
   cv::Mat src_gray;
 
   // Convert it to gray

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -51,7 +51,7 @@ image_container
 {
   //Handle BGR(A) case, others just copy the memory, the assumption is
   //RGB images
-  if(cm == BGR && (data_.channels() == 3 || data_.channels() == 4 ))
+  if(cm == BGR_COLOR && (data_.channels() == 3 || data_.channels() == 4 ))
   {
     switch(d.depth())
     {
@@ -70,7 +70,9 @@ image_container
       case CV_16S:
       case CV_32S:
       case CV_64F:
-        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+      default:
+        VITAL_THROW( image_type_mismatch_exception,
+                     "Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
     }
   }
 }
@@ -90,7 +92,7 @@ image_container
   }
   else
   {
-    this->data_ = vital_to_ocv(image_cont.get_image(), RGB);
+    this->data_ = vital_to_ocv(image_cont.get_image(), RGB_COLOR);
   }
 }
 
@@ -154,7 +156,8 @@ image_container
     case CV_64F:
       return pixel_traits_t(vital::image_pixel_traits::FLOAT, 8);
     default:
-      VITAL_THROW( image_type_mismatch_exception,"kwiver::arrows::ocv::image_container::ocv_to_vital(int)");
+      VITAL_THROW( image_type_mismatch_exception,
+                   "kwiver::arrows::ocv::image_container::ocv_to_vital(int)");
   }
 }
 
@@ -197,7 +200,7 @@ image_container
       out.addref();
     }
     // TODO use MatAllocator to share memory with image_memory
-    if( cm == RGB || cm == OTHER_COLOR_MODE || out.channels() < 3 || out.channels() > 4 )
+    if( cm != BGR_COLOR || out.channels() < 3 || out.channels() > 4 )
     {
       //Want output as something other than an BGR(A) image
       return out;
@@ -219,7 +222,9 @@ image_container
         case CV_16S:
         case CV_32S:
         case CV_64F:
-          VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+        default:
+          VITAL_THROW( image_type_mismatch_exception,
+                       "Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
       }
     }
   }
@@ -228,10 +233,10 @@ image_container
   cv::Mat out(static_cast<int>(img.height()), static_cast<int>(img.width()),
               CV_MAKETYPE(cv_type, static_cast<int>(img.depth())));
   // wrap the new image as a VITAL image (always a shallow copy)
-  image new_img = ocv_to_vital(out, RGB);
+  image new_img = ocv_to_vital(out, RGB_COLOR);
   new_img.copy_from(img);
 
-  if( cm == RGB || cm == OTHER_COLOR_MODE || out.channels() < 3 || out.channels() > 4 )
+  if( cm != BGR_COLOR || out.channels() < 3 || out.channels() > 4 )
   {
       //Want output as something other than an BGR(A) image
       return out;
@@ -253,7 +258,9 @@ image_container
       case CV_16S:
       case CV_32S:
       case CV_64F:
-        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+      default:
+        VITAL_THROW( image_type_mismatch_exception,
+                     "Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
     }
   }
   return out;
@@ -311,7 +318,8 @@ image_container
     default:
       break;
   }
-  VITAL_THROW( image_type_mismatch_exception,"kwiver::arrows::ocv::image_container::vital_to_ocv(pixel_traits_t)");
+  VITAL_THROW( image_type_mismatch_exception,
+               "kwiver::arrows::ocv::image_container::vital_to_ocv(pixel_traits_t)");
 }
 
 
@@ -321,10 +329,11 @@ cv::Mat
 image_container_to_ocv_matrix(const vital::image_container& img, image_container::ColorMode cm)
 {
   cv::Mat result;
-  if( const ocv::image_container* c =
-          dynamic_cast<const ocv::image_container*>(&img) )
+  if(const ocv::image_container* c =
+          dynamic_cast<const ocv::image_container*>(&img))
   {
-    if(cm == image_container::RGB || cm == image_container::OTHER_COLOR_MODE || result.channels()<3 || result.channels() > 4)
+    if(cm != image_container::BGR_COLOR || 
+      result.channels() < 3 || result.channels() > 4)
     {
       //Want something other than a BGR(A) image
       return c->get_Mat();
@@ -335,7 +344,7 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
   {
     return ocv::image_container::vital_to_ocv(img.get_image(), cm);
   }
-  if(cm == image_container::BGR && (result.channels()==3 || result.channels() == 4) )
+  if(cm == image_container::BGR_COLOR && (result.channels() == 3 || result.channels() == 4) )
   {
     //Want a BGR(A) image, and there is the correct number of channels for it to be a BGR(A) image
     switch(result.depth())
@@ -349,7 +358,9 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
       case CV_16S:
       case CV_32S:
       case CV_64F:
-        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+      default:
+        VITAL_THROW( image_type_mismatch_exception,
+                     "Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
     }
   }
   return result;

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -51,6 +51,7 @@ image_container
 {
   if(cm != RGB)
   {
+    CV_Assert( d.depth() == CV_8U || d.depth() == CV_16U || d.depth() == CV_32F );
     if ( data_.channels() == 3 )
     {
       cv::Mat new_color;
@@ -85,7 +86,7 @@ image_container
   }
   else
   {
-    this->data_ = vital_to_ocv(image_cont.get_image());
+    this->data_ = vital_to_ocv(image_cont.get_image(), RGB);
   }
 }
 
@@ -103,7 +104,7 @@ image_container
 /// Convert an OpenCV cv::Mat to a VITAL image
 image
 image_container
-::ocv_to_vital(const cv::Mat& img)
+::ocv_to_vital(const cv::Mat& img, ColorMode cm)
 {
   // if the cv::Mat has reference counted memory then wrap it to keep a
   // counted reference too it.  If it doesn't own its memory, then the
@@ -196,8 +197,9 @@ image_container
     {
       return out;
     }
-    else
+    else if( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F )
     {
+      CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
       cv::Mat bgr;
       if ( out.channels() == 3 )
       {
@@ -209,20 +211,25 @@ image_container
       }
       return bgr;
     }
+    else
+    {
+      //TODO: fix conversion when other cv types
+      CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
+    }
   }
 
   // allocated a new cv::Mat
   cv::Mat out(static_cast<int>(img.height()), static_cast<int>(img.width()),
               CV_MAKETYPE(cv_type, static_cast<int>(img.depth())));
   // wrap the new image as a VITAL image (always a shallow copy)
-  image new_img = ocv_to_vital(out);
+  image new_img = ocv_to_vital(out, RGB);
   new_img.copy_from(img);
 
   if(cm == RGB || out.channels() == 1 )
   {
       return out;
   }
-  else
+  else if( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F )
   {
     cv::Mat bgr;
     if ( out.channels() == 3 )
@@ -235,6 +242,11 @@ image_container
       cv::cvtColor(out, bgr, CV_RGBA2BGRA);
       return bgr;
     }
+  }
+  else
+  {
+    //TODO: fix conversion when other cv types
+    CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
   }
   return out;
 }
@@ -316,6 +328,7 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
   }
   if(cm == image_container::BGR)
   {
+    CV_Assert( result.depth() == CV_8U || result.depth() == CV_16U || result.depth() == CV_32F );
     if ( result.channels() == 3 )
     {
       cv::cvtColor(result, result, CV_RGB2BGR);

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -49,24 +49,26 @@ image_container
 ::image_container(const cv::Mat& d, ColorMode cm)
   : data_(d)
 {
-  if(cm != RGB)
+  if(cm != RGB && data_.channels() != 1)
   {
-    CV_Assert( d.depth() == CV_8U || d.depth() == CV_16U || d.depth() == CV_32F );
-    if ( data_.channels() == 3 )
+    switch(d.depth())
     {
-      cv::Mat new_color;
-      new_color.create( d.rows, d.cols, d.type() );
+      case CV_8U:
+      case CV_16U:
+      case CV_32F:
+      {
+        cv::Mat new_color;
+        new_color.create( d.rows, d.cols, d.type() );
 
-      cv::cvtColor(data_, new_color, CV_BGR2RGB);
-      data_ = new_color;
-    }
-    else if ( data_.channels() == 4 )
-    {
-      cv::Mat new_color;
-      new_color.create( d.rows, d.cols, d.type() );
-
-      cv::cvtColor(data_, new_color, CV_BGRA2RGBA);
-      data_ = new_color;
+        cv::cvtColor(data_, new_color, (data_.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        data_ = new_color;
+        break;
+      }
+      case CV_8S:
+      case CV_16S:
+      case CV_32S:
+      case CV_64F:
+        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
     }
   }
 }
@@ -197,24 +199,24 @@ image_container
     {
       return out;
     }
-    else if( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F )
-    {
-      CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
-      cv::Mat bgr;
-      if ( out.channels() == 3 )
-      {
-        cv::cvtColor(out, bgr, CV_RGB2BGR);
-      }
-      else if ( out.channels() == 4 )
-      {
-        cv::cvtColor(out, bgr, CV_RGBA2BGRA);
-      }
-      return bgr;
-    }
     else
     {
-      //TODO: fix conversion when other cv types
-      CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
+      switch(out.depth())
+      {
+        case CV_8U:
+        case CV_16U:
+        case CV_32F:
+        {
+          cv::Mat bgr;
+          cv::cvtColor(out, bgr, (out.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+          return bgr;
+        }
+        case CV_8S:
+        case CV_16S:
+        case CV_32S:
+        case CV_64F:
+          VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+      }
     }
   }
 
@@ -229,24 +231,24 @@ image_container
   {
       return out;
   }
-  else if( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F )
-  {
-    cv::Mat bgr;
-    if ( out.channels() == 3 )
-    {
-      cv::cvtColor(out, bgr, CV_RGB2BGR);
-      return bgr;
-    }
-    if ( out.channels() == 4 )
-    {
-      cv::cvtColor(out, bgr, CV_RGBA2BGRA);
-      return bgr;
-    }
-  }
   else
   {
-    //TODO: fix conversion when other cv types
-    CV_Assert( out.depth() == CV_8U || out.depth() == CV_16U || out.depth() == CV_32F );
+    switch(out.depth())
+    {
+      case CV_8U:
+      case CV_16U:
+      case CV_32F:
+      {
+        cv::Mat bgr;
+        cv::cvtColor(out, bgr, (out.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        return bgr;
+      }
+      case CV_8S:
+      case CV_16S:
+      case CV_32S:
+      case CV_64F:
+        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
+    }
   }
   return out;
 }
@@ -326,16 +328,20 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
   {
     return ocv::image_container::vital_to_ocv(img.get_image(), cm);
   }
-  if(cm == image_container::BGR)
+  if(cm == image_container::BGR && result.channels() != 1 )
   {
-    CV_Assert( result.depth() == CV_8U || result.depth() == CV_16U || result.depth() == CV_32F );
-    if ( result.channels() == 3 )
+    switch(result.depth())
     {
-      cv::cvtColor(result, result, CV_RGB2BGR);
-    }
-    else if ( result.channels() == 4 )
-    {
-      cv::cvtColor(result, result, CV_RGBA2BGRA);
+      case CV_8U:
+      case CV_16U:
+      case CV_32F:
+        cv::cvtColor(result, result, (result.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        break;
+      case CV_8S:
+      case CV_16S:
+      case CV_32S:
+      case CV_64F:
+        VITAL_THROW( image_type_mismatch_exception,"Only CV_8U, CV_16U, and CV_32F are supported for BGR and RGB conversion");
     }
   }
   return result;

--- a/arrows/ocv/image_container.h
+++ b/arrows/ocv/image_container.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ class KWIVER_ALGO_OCV_EXPORT image_container
 {
 public:
 
-  enum ColorMode{RGB,BGR};
+  enum ColorMode{RGB,BGR,OTHER_COLOR_MODE};
 
   /// Constructor - from a cv::Mat
   explicit image_container(const cv::Mat& d, ColorMode cm);

--- a/arrows/ocv/image_container.h
+++ b/arrows/ocv/image_container.h
@@ -54,14 +54,14 @@ class KWIVER_ALGO_OCV_EXPORT image_container
 {
 public:
 
-  enum ColorMode{RGB,BGR,OTHER_COLOR_MODE};
+  enum ColorMode{RGB_COLOR, BGR_COLOR, OTHER_COLOR};
 
   /// Constructor - from a cv::Mat
   explicit image_container(const cv::Mat& d, ColorMode cm);
 
   /// Constructor - convert kwiver image to cv::Mat
   explicit image_container(const vital::image& vital_image)
-  : data_(vital_to_ocv(vital_image, RGB)) {}
+  : data_(vital_to_ocv(vital_image, RGB_COLOR)) {}
 
   /// Constructor - convert base image container to cv::Mat
   explicit image_container(const vital::image_container& image_cont);
@@ -87,7 +87,7 @@ public:
   virtual size_t depth() const { return data_.channels(); }
 
   /// Get and in-memory image class to access the data
-  virtual vital::image get_image() const { return ocv_to_vital(data_, RGB); }
+  virtual vital::image get_image() const { return ocv_to_vital(data_, RGB_COLOR); }
 
   /// Access the underlying cv::Mat data structure
   cv::Mat get_Mat() const { return data_; }
@@ -119,7 +119,7 @@ protected:
  * \param img Image container to convert to cv::mat
  */
 KWIVER_ALGO_OCV_EXPORT cv::Mat image_container_to_ocv_matrix(const vital::image_container& img,
-                           image_container::ColorMode cm = image_container::BGR);
+                           image_container::ColorMode cm = image_container::BGR_COLOR);
 
 
 } // end namespace ocv

--- a/arrows/ocv/image_container.h
+++ b/arrows/ocv/image_container.h
@@ -57,11 +57,11 @@ public:
   enum ColorMode{RGB,BGR};
 
   /// Constructor - from a cv::Mat
-  explicit image_container(const cv::Mat& d, ColorMode cm = BGR);
+  explicit image_container(const cv::Mat& d, ColorMode cm);
 
   /// Constructor - convert kwiver image to cv::Mat
   explicit image_container(const vital::image& vital_image)
-  : data_(vital_to_ocv(vital_image)) {}
+  : data_(vital_to_ocv(vital_image, RGB)) {}
 
   /// Constructor - convert base image container to cv::Mat
   explicit image_container(const vital::image_container& image_cont);
@@ -87,19 +87,19 @@ public:
   virtual size_t depth() const { return data_.channels(); }
 
   /// Get and in-memory image class to access the data
-  virtual vital::image get_image() const { return ocv_to_vital(data_); }
+  virtual vital::image get_image() const { return ocv_to_vital(data_, RGB); }
 
   /// Access the underlying cv::Mat data structure
   cv::Mat get_Mat() const { return data_; }
 
   /// Convert an OpenCV cv::Mat to a VITAL image
-  static vital::image ocv_to_vital(const cv::Mat& img);
+  static vital::image ocv_to_vital(const cv::Mat& img, ColorMode cm);
 
   /// Convert an OpenCV cv::Mat type value to a vital::image_pixel_traits
   static vital::image_pixel_traits ocv_to_vital(int type);
 
   /// Convert a VITAL image to an OpenCV cv::Mat
-  static cv::Mat vital_to_ocv(const vital::image& img, ColorMode cm = BGR);
+  static cv::Mat vital_to_ocv(const vital::image& img, ColorMode cm);
 
   /// Convert a vital::image_pixel_traits to an OpenCV cv::Mat type integer
   static int vital_to_ocv(const vital::image_pixel_traits& pt);

--- a/arrows/ocv/image_io.cxx
+++ b/arrows/ocv/image_io.cxx
@@ -55,7 +55,7 @@ image_io
 ::load_(const std::string& filename) const
 {
   cv::Mat img = cv::imread(filename.c_str(), -1);
-  return vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR));
+  return vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR_COLOR));
 }
 
 
@@ -69,7 +69,7 @@ image_io
 ::save_(const std::string& filename,
        vital::image_container_sptr data) const
 {
-  cv::Mat img = ocv::image_container::vital_to_ocv(data->get_image(), ocv::image_container::BGR);
+  cv::Mat img = ocv::image_container::vital_to_ocv(data->get_image(), ocv::image_container::BGR_COLOR);
   cv::imwrite(filename.c_str(), img);
 }
 

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -140,7 +140,7 @@ refine_detections_write_to_disk
 ::refine( vital::image_container_sptr image_data,
           vital::detected_object_set_sptr detections ) const
 {
-  cv::Mat img = ocv::image_container::vital_to_ocv( image_data->get_image() );
+  cv::Mat img = ocv::image_container::vital_to_ocv( image_data->get_image(), ocv::image_container::BGR );
 
   for( auto det : *detections )
   {

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -140,7 +140,7 @@ refine_detections_write_to_disk
 ::refine( vital::image_container_sptr image_data,
           vital::detected_object_set_sptr detections ) const
 {
-  cv::Mat img = ocv::image_container::vital_to_ocv( image_data->get_image(), ocv::image_container::BGR );
+  cv::Mat img = ocv::image_container::vital_to_ocv( image_data->get_image(), ocv::image_container::BGR_COLOR );
 
   for( auto det : *detections )
   {

--- a/arrows/ocv/split_image.cxx
+++ b/arrows/ocv/split_image.cxx
@@ -64,11 +64,11 @@ split_image
 ::split(kwiver::vital::image_container_sptr image) const
 {
   std::vector< kwiver::vital::image_container_sptr > output;
-  cv::Mat cv_image = ocv::image_container::vital_to_ocv( image->get_image() );
+  cv::Mat cv_image = ocv::image_container::vital_to_ocv( image->get_image(), ocv::image_container::RGB );
   cv::Mat left_image = cv_image( cv::Rect( 0, 0, cv_image.cols/2, cv_image.rows ) );
   cv::Mat right_image = cv_image( cv::Rect( cv_image.cols/2, 0, cv_image.cols/2, cv_image.rows ) );
-  output.push_back( image_container_sptr( new ocv::image_container( left_image.clone() ) ) );
-  output.push_back( image_container_sptr( new ocv::image_container( right_image.clone() ) ) );
+  output.push_back( image_container_sptr( new ocv::image_container( left_image.clone(), ocv::image_container::RGB ) ) );
+  output.push_back( image_container_sptr( new ocv::image_container( right_image.clone(), ocv::image_container::RGB ) ) );
   return output;
 }
 

--- a/arrows/ocv/split_image.cxx
+++ b/arrows/ocv/split_image.cxx
@@ -64,11 +64,11 @@ split_image
 ::split(kwiver::vital::image_container_sptr image) const
 {
   std::vector< kwiver::vital::image_container_sptr > output;
-  cv::Mat cv_image = ocv::image_container::vital_to_ocv( image->get_image(), ocv::image_container::RGB );
+  cv::Mat cv_image = ocv::image_container::vital_to_ocv( image->get_image(), ocv::image_container::RGB_COLOR );
   cv::Mat left_image = cv_image( cv::Rect( 0, 0, cv_image.cols/2, cv_image.rows ) );
   cv::Mat right_image = cv_image( cv::Rect( cv_image.cols/2, 0, cv_image.cols/2, cv_image.rows ) );
-  output.push_back( image_container_sptr( new ocv::image_container( left_image.clone(), ocv::image_container::RGB ) ) );
-  output.push_back( image_container_sptr( new ocv::image_container( right_image.clone(), ocv::image_container::RGB ) ) );
+  output.push_back( image_container_sptr( new ocv::image_container( left_image.clone(), ocv::image_container::RGB_COLOR ) ) );
+  output.push_back( image_container_sptr( new ocv::image_container( right_image.clone(), ocv::image_container::RGB_COLOR ) ) );
   return output;
 }
 

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -137,7 +137,7 @@ TYPED_TEST(image_io, type)
   kwiver::vital::image_of<pix_t> img( 200, 300, TypeParam::depth );
   populate_vital_image<pix_t>( img );
 
-  auto const image_path = kwiver::testing::temp_file_name( "test-", ".tiff" );
+  auto const image_path = kwiver::testing::temp_file_name( "test-", ".png" );
 
   auto c = std::make_shared<simple_image_container>( img );
   ocv::image_io io;

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -159,7 +159,7 @@ void
 run_ocv_conversion_tests( cv::Mat const& img )
 {
   // Convert to a vital image and verify that the properties are correct
-  image const& vimg = ocv::image_container::ocv_to_vital( img );
+  image const& vimg = ocv::image_container::ocv_to_vital( img, ocv::image_container::RGB );
   EXPECT_EQ( sizeof(T), vimg.pixel_traits().num_bytes );
   EXPECT_EQ( image_pixel_traits_of<T>::static_type, vimg.pixel_traits().type );
   EXPECT_EQ( static_cast<size_t>( img.channels() ), vimg.depth() );
@@ -199,7 +199,7 @@ run_ocv_conversion_tests( cv::Mat const& img )
   }();
 
   // Convert back to cv::Mat and test again
-  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg );
+  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg, ocv::image_container::RGB );
   ASSERT_NE( nullptr, img2.data )
     << "OpenCV re-conversion did not produce a valid cv::Mat";
 
@@ -228,7 +228,7 @@ run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
                             bool requires_copy = false )
 {
   // convert to a cv::Mat and verify that the properties are correct
-  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img);
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::RGB);
   ASSERT_NE( nullptr, ocv_img.data )
     << "Vital image conversion did not produce a valid cv::Mat";
 
@@ -258,7 +258,7 @@ run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
   }();
 
   // Convert back to vital::image and test again
-  image img2 = ocv::image_container::ocv_to_vital( ocv_img );
+  image img2 = ocv::image_container::ocv_to_vital( ocv_img, ocv::image_container::RGB );
   EXPECT_EQ( sizeof(T), img2.pixel_traits().num_bytes );
   EXPECT_EQ( image_pixel_traits_of<T>::static_type, img2.pixel_traits().type );
   EXPECT_TRUE( equal_content( img, img2 ) );
@@ -349,12 +349,12 @@ TEST(image, bad_conversions)
 {
   // Some types not supported by OpenCV and should throw an exception
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<uint32_t>( 200, 300 ) ),
+                  image_of<uint32_t>( 200, 300 ), ocv::image_container::RGB ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<int64_t>( 200, 300 ) ),
+                  image_of<int64_t>( 200, 300 ), ocv::image_container::RGB ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<uint64_t>( 200, 300 ) ),
+                  image_of<uint64_t>( 200, 300 ), ocv::image_container::RGB ),
                 image_type_mismatch_exception );
 }

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -403,19 +403,19 @@ TYPED_TEST(image_bgr_conversion, bgra_to_rgba)
 TEST(image, bgr_to_rgb_bad_types)
 {
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<int8_t>{ 200, 300 },
+                  image_of<int8_t>{ 200, 300, 3 },
                   ocv::image_container::BGR_COLOR ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<int16_t>{ 200, 300 },
+                  image_of<int16_t>{ 200, 300, 3 },
                   ocv::image_container::BGR_COLOR ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<int32_t>{ 200, 300 },
+                  image_of<int32_t>{ 200, 300, 3 },
                   ocv::image_container::BGR_COLOR ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<double>{ 200, 300 },
+                  image_of<double>{ 200, 300, 3 },
                   ocv::image_container::BGR_COLOR ),
                 image_type_mismatch_exception );
 }

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -159,7 +159,7 @@ void
 run_ocv_conversion_tests( cv::Mat const& img )
 {
   // Convert to a vital image and verify that the properties are correct
-  image const& vimg = ocv::image_container::ocv_to_vital( img, ocv::image_container::RGB );
+  image const& vimg = ocv::image_container::ocv_to_vital( img, ocv::image_container::RGB_COLOR );
   EXPECT_EQ( sizeof(T), vimg.pixel_traits().num_bytes );
   EXPECT_EQ( image_pixel_traits_of<T>::static_type, vimg.pixel_traits().type );
   EXPECT_EQ( static_cast<size_t>( img.channels() ), vimg.depth() );
@@ -199,7 +199,7 @@ run_ocv_conversion_tests( cv::Mat const& img )
   }();
 
   // Convert back to cv::Mat and test again
-  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg, ocv::image_container::RGB );
+  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg, ocv::image_container::RGB_COLOR );
   ASSERT_NE( nullptr, img2.data )
     << "OpenCV re-conversion did not produce a valid cv::Mat";
 
@@ -228,7 +228,7 @@ run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
                             bool requires_copy = false )
 {
   // convert to a cv::Mat and verify that the properties are correct
-  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::RGB);
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::RGB_COLOR);
   ASSERT_NE( nullptr, ocv_img.data )
     << "Vital image conversion did not produce a valid cv::Mat";
 
@@ -258,7 +258,7 @@ run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
   }();
 
   // Convert back to vital::image and test again
-  image img2 = ocv::image_container::ocv_to_vital( ocv_img, ocv::image_container::RGB );
+  image img2 = ocv::image_container::ocv_to_vital( ocv_img, ocv::image_container::RGB_COLOR );
   EXPECT_EQ( sizeof(T), img2.pixel_traits().num_bytes );
   EXPECT_EQ( image_pixel_traits_of<T>::static_type, img2.pixel_traits().type );
   EXPECT_TRUE( equal_content( img, img2 ) );
@@ -352,7 +352,7 @@ TEST(image, bgr_to_rgb)
   // is natively created as OpenCV or vital, so we need to test both ways)
   kwiver::vital::image_of<unsigned char> img{ 200, 300, 3 };
   populate_vital_image<unsigned char>( img );
-  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR);
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR_COLOR);
   {
     int const num_c = ocv_img.channels();
     for( int j = 0; j < ocv_img.rows; ++j )
@@ -388,12 +388,12 @@ TEST(image, bad_conversions)
 {
   // Some types not supported by OpenCV and should throw an exception
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<uint32_t>( 200, 300 ), ocv::image_container::RGB ),
+                  image_of<uint32_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<int64_t>( 200, 300 ), ocv::image_container::RGB ),
+                  image_of<int64_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
                 image_type_mismatch_exception );
   EXPECT_THROW( ocv::image_container::vital_to_ocv(
-                  image_of<uint64_t>( 200, 300 ), ocv::image_container::RGB ),
+                  image_of<uint64_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
                 image_type_mismatch_exception );
 }

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -400,21 +400,24 @@ TYPED_TEST(image_bgr_conversion, bgra_to_rgba)
 }
 
 // ----------------------------------------------------------------------------
-template <typename T>
-class image_bgr_bad_conversion : public ::testing::Test
+TEST(image, bgr_to_rgb_bad_types)
 {
-};
-
-using image_bgr_bad_types = ::testing::Types<int8_t, int16_t, int32_t, double>;
-TYPED_TEST_CASE(image_bgr_bad_conversion, image_bgr_bad_types);
-
-// ----------------------------------------------------------------------------
-TYPED_TEST(image_bgr_bad_conversion, bgr_to_rgb_bad_types)
-{
-  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
-  populate_vital_image<TypeParam>( img );
-  EXPECT_THROW(ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR_COLOR),
-               image_type_mismatch_exception);
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int8_t>{ 200, 300 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int16_t>{ 200, 300 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int32_t>{ 200, 300 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<double>{ 200, 300 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -345,6 +345,45 @@ TYPED_TEST(image_conversion, vital_to_ocv_interleaved)
 }
 
 // ----------------------------------------------------------------------------
+TEST(image, bgr_to_rgb)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<unsigned char> img{ 200, 300, 3 };
+  populate_vital_image<unsigned char>( img );
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR);
+  {
+    int const num_c = ocv_img.channels();
+    for( int j = 0; j < ocv_img.rows; ++j )
+    {
+      for( int i = 0; i < ocv_img.cols; ++i )
+      {
+        ASSERT_EQ( img( i, j, 0 ), ocv_img.ptr<unsigned char>( j )[ num_c * i + 2 ] )
+            << "Pixels differ at " << i << ", " << j << ", (0,2)";
+      }
+    }
+    for( int j = 0; j < ocv_img.rows; ++j )
+    {
+      for( int i = 0; i < ocv_img.cols; ++i )
+      {
+        ASSERT_EQ( img( i, j, 1 ), ocv_img.ptr<unsigned char>( j )[ num_c * i + 1 ] )
+            << "Pixels differ at " << i << ", " << j << ", (1,1)";
+      }
+    }
+    for( int j = 0; j < ocv_img.rows; ++j )
+    {
+      for( int i = 0; i < ocv_img.cols; ++i )
+      {
+        ASSERT_EQ( img( i, j, 2 ), ocv_img.ptr<unsigned char>( j )[ num_c * i + 0 ] )
+            << "Pixels differ at " << i << ", " << j << ", (2,0)";
+      }
+    }
+  };
+}
+
+
+// ----------------------------------------------------------------------------
 TEST(image, bad_conversions)
 {
   // Some types not supported by OpenCV and should throw an exception

--- a/arrows/ocv/tests/test_image.cxx
+++ b/arrows/ocv/tests/test_image.cxx
@@ -346,15 +346,15 @@ TYPED_TEST(image_conversion, vital_to_ocv_interleaved)
 
 // ----------------------------------------------------------------------------
 template <typename T>
-class bgr_conversion : public ::testing::Test
+class image_bgr_conversion : public ::testing::Test
 {
 };
 
-using bgr_types = ::testing::Types<uint8_t, uint16_t, float>;
-TYPED_TEST_CASE(bgr_conversion, bgr_types);
+using image_bgr_types = ::testing::Types<uint8_t, uint16_t, float>;
+TYPED_TEST_CASE(image_bgr_conversion, image_bgr_types);
 
 // ----------------------------------------------------------------------------
-TYPED_TEST(bgr_conversion, bgr_to_rgb)
+TYPED_TEST(image_bgr_conversion, bgr_to_rgb)
 {
   kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
   populate_vital_image<TypeParam>( img );
@@ -376,7 +376,7 @@ TYPED_TEST(bgr_conversion, bgr_to_rgb)
 }
 
 // ----------------------------------------------------------------------------
-TYPED_TEST(bgr_conversion, bgra_to_rgba)
+TYPED_TEST(image_bgr_conversion, bgra_to_rgba)
 {
   kwiver::vital::image_of<TypeParam> img{ 200, 300, 4 };
   populate_vital_image<TypeParam>( img );
@@ -401,15 +401,15 @@ TYPED_TEST(bgr_conversion, bgra_to_rgba)
 
 // ----------------------------------------------------------------------------
 template <typename T>
-class bgr_bad_conversion : public ::testing::Test
+class image_bgr_bad_conversion : public ::testing::Test
 {
 };
 
-using bgr_bad_types = ::testing::Types<int8_t, int16_t, int32_t, double>;
-TYPED_TEST_CASE(bgr_bad_conversion, bgr_bad_types);
+using image_bgr_bad_types = ::testing::Types<int8_t, int16_t, int32_t, double>;
+TYPED_TEST_CASE(image_bgr_bad_conversion, image_bgr_bad_types);
 
 // ----------------------------------------------------------------------------
-TYPED_TEST(bgr_bad_conversion, bgr_to_rgb_bad_types)
+TYPED_TEST(image_bgr_bad_conversion, bgr_to_rgb_bad_types)
 {
   kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
   populate_vital_image<TypeParam>( img );

--- a/arrows/ocv/track_features_klt.cxx
+++ b/arrows/ocv/track_features_klt.cxx
@@ -456,7 +456,7 @@ track_features_klt
   }
 
 
-  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::RGB);
+  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::RGB_COLOR);
   cv::Mat cv_mask;
 
   // Only initialize a mask image if the given mask image container contained
@@ -482,7 +482,7 @@ track_features_klt
                    s.first_pixel(),
                    s.width(),  s.height(), 1 /*depth*/,
                    s.w_step(), s.h_step(), s.d_step(), s.pixel_traits());
-    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::OTHER_COLOR_MODE);
+    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::OTHER_COLOR);
   }
 
   //setup stuff complete

--- a/arrows/ocv/track_features_klt.cxx
+++ b/arrows/ocv/track_features_klt.cxx
@@ -456,7 +456,7 @@ track_features_klt
   }
 
 
-  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image());
+  cv::Mat cv_img = ocv::image_container::vital_to_ocv(image_data->get_image(), ocv::image_container::RGB);
   cv::Mat cv_mask;
 
   // Only initialize a mask image if the given mask image container contained
@@ -482,7 +482,7 @@ track_features_klt
                    s.first_pixel(),
                    s.width(),  s.height(), 1 /*depth*/,
                    s.w_step(), s.h_step(), s.d_step(), s.pixel_traits());
-    cv_mask = ocv::image_container::vital_to_ocv(i);
+    cv_mask = ocv::image_container::vital_to_ocv(i, ocv::image_container::OTHER_COLOR_MODE);
   }
 
   //setup stuff complete

--- a/arrows/vxl/tests/test_image.cxx
+++ b/arrows/vxl/tests/test_image.cxx
@@ -178,7 +178,13 @@ TYPED_TEST(image_io, type)
   kwiver::vital::image_of<pix_t> img( 200, 300, TypeParam::depth );
   populate_vital_image<pix_t>( img );
 
-  auto const image_path = kwiver::testing::temp_file_name( "test-", ".tiff" );
+  std::string ext = ".tiff";
+  if( img.depth() == 4 )
+  {
+    ext = ".png";
+  }
+
+  auto const image_path = kwiver::testing::temp_file_name( "test-", ext.c_str() );
 
   auto c = std::make_shared<simple_image_container>( img );
   vxl::image_io io;

--- a/arrows/vxl/tests/test_image.cxx
+++ b/arrows/vxl/tests/test_image.cxx
@@ -179,7 +179,7 @@ TYPED_TEST(image_io, type)
   populate_vital_image<pix_t>( img );
 
   auto const image_ext = ( img.depth() == 4 ? ".png" : ".tiff" );
-  auto const image_path = kwiver::testing::temp_file_name( "test-", ext.c_str() );
+  auto const image_path = kwiver::testing::temp_file_name( "test-", image_ext );
 
   auto c = std::make_shared<simple_image_container>( img );
   vxl::image_io io;

--- a/arrows/vxl/tests/test_image.cxx
+++ b/arrows/vxl/tests/test_image.cxx
@@ -178,12 +178,7 @@ TYPED_TEST(image_io, type)
   kwiver::vital::image_of<pix_t> img( 200, 300, TypeParam::depth );
   populate_vital_image<pix_t>( img );
 
-  std::string ext = ".tiff";
-  if( img.depth() == 4 )
-  {
-    ext = ".png";
-  }
-
+  auto const image_ext = ( img.depth() == 4 ? ".png" : ".tiff" );
   auto const image_path = kwiver::testing::temp_file_name( "test-", ext.c_str() );
 
   auto c = std::make_shared<simple_image_container>( img );

--- a/sprokit/processes/examples/process_template/template_process.cxx
+++ b/sprokit/processes/examples/process_template/template_process.cxx
@@ -171,10 +171,10 @@ template_process
 
     LOG_DEBUG( logger(), "Processing frame " << frame_time );
 
-    cv::Mat in_image = kwiver::arrows::ocv::image_container::vital_to_ocv( img->get_image() );
+    cv::Mat in_image = kwiver::arrows::ocv::image_container::vital_to_ocv( img->get_image(), kwiver::arrows::ocv::image_container::RGB );
 
     //++ Here is where the process does its work.
-    out_image = std::make_shared<kwiver::arrows::ocv::image_container>( d->process_image( in_image ) );
+    out_image = std::make_shared<kwiver::arrows::ocv::image_container>( d->process_image( in_image ), kwiver::arrows::ocv::image_container::RGB );
   }
 
 

--- a/sprokit/processes/examples/process_template/template_process.cxx
+++ b/sprokit/processes/examples/process_template/template_process.cxx
@@ -84,7 +84,8 @@ namespace group_ns {
 // config items
 // <name>, <type>, <default string>, <description string>
 create_config_trait( header, std::string, "top", "Header text for image display." );
-create_config_trait( footer, std::string, "bottom", "Footer text for image display. Displayed centered at bottom of image." );
+create_config_trait( footer, std::string, "bottom",
+                     "Footer text for image display. Displayed centered at bottom of image." );
 create_config_trait( gsd, double, "3.14159", "Meters per pixel scaling." );
 
 //----------------------------------------------------------------
@@ -170,11 +171,14 @@ template_process
     scoped_step_instrumentation();
 
     LOG_DEBUG( logger(), "Processing frame " << frame_time );
+    using namespace kwiver::arrows::ocv;
 
-    cv::Mat in_image = kwiver::arrows::ocv::image_container::vital_to_ocv( img->get_image(), kwiver::arrows::ocv::image_container::RGB );
+    cv::Mat in_image = image_container::vital_to_ocv( img->get_image(),
+                                                      image_container::RGB_COLOR );
 
     //++ Here is where the process does its work.
-    out_image = std::make_shared<kwiver::arrows::ocv::image_container>( d->process_image( in_image ), kwiver::arrows::ocv::image_container::RGB );
+    out_image = std::make_shared<image_container>( d->process_image( in_image ),
+                                                   image_container::RGB_COLOR );
   }
 
 

--- a/sprokit/processes/ocv/image_viewer_process.cxx
+++ b/sprokit/processes/ocv/image_viewer_process.cxx
@@ -244,7 +244,7 @@ image_viewer_process
 
   LOG_DEBUG( logger(), "Processing frame " << frame_time );
 
-  cv::Mat image = arrows::ocv::image_container::vital_to_ocv( img->get_image(), arrows::ocv::image_container::BGR );
+  cv::Mat image = arrows::ocv::image_container::vital_to_ocv( img->get_image(), arrows::ocv::image_container::BGR_COLOR );
 
   if ( d->m_annotate_image )
   {


### PR DESCRIPTION
Fix the opencv test fails because of RGB and BGR missmatch.  BGR and RGB are note explicit.