### PR TITLE
Simply the kwiver-config generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,39 +325,20 @@ if (fletch_FOUND)
   list( APPEND KWIVER_LIBRARY_DIRS "${fletch_ROOT}/lib")
 endif()
 
-kwiver_configure_file(kwiver-config
+configure_file(
   "${KWIVER_SOURCE_DIR}/CMake/kwiver-config-build.cmake.in"
   "${KWIVER_CONFIG_FILE}"
-  KWIVER_SOURCE_DIR
-  KWIVER_BINARY_DIR
-  KWIVER_ENABLE_PYTHON
-  BUILD_SHARED_LIBS
-  KWIVER_CMAKE_DIR
-  kwiver_libs
-  fletch_DIR
-  KWIVER_INCLUDE_DIRS
-  KWIVER_LIBRARY_DIRS
+  @ONLY
+  )
+
+# Configure install-tree CMake config file and export associated targets file
+configure_file(
+  "${KWIVER_SOURCE_DIR}/CMake/kwiver-config-install.cmake.in"
+  "${KWIVER_BINARY_DIR}/kwiver-config-install.cmake"
+  @ONLY
   )
 
 kwiver_export_targets("${KWIVER_BINARY_DIR}/kwiver-config-targets.cmake")
-
-# Configure install-tree CMake config file and export associated targets file
-set(KWIVER_CONFIG_INSTALL_FILE "${KWIVER_BINARY_DIR}/kwiver-config-install.cmake")
-kwiver_configure_file(kwiver-install-config
-  "${KWIVER_SOURCE_DIR}/CMake/kwiver-config-install.cmake.in"
-  "${KWIVER_CONFIG_INSTALL_FILE}"
-  KWIVER_SOURCE_DIR
-  KWIVER_BINARY_DIR
-  KWIVER_ENABLE_PYTHON
-  BUILD_SHARED_LIBS
-  CMAKE_INSTALL_PREFIX
-  kwiver_libs
-  fletch_DIR
-  KWIVER_INCLUDE_DIRS
-  KWIVER_LIBRARY_DIRS
-  LIB_SUFFIX
-  KWIVER_VERSION
-  )
 
 kwiver_install(
   FILES       "${KWIVER_CONFIG_INSTALL_FILE}"


### PR DESCRIPTION
The branch fixes the odd entries in kwiver-config-install.cmake and kwiver-config.cmake. Currently the Eigen3_INCLUDE_DIR and the fletch_INCLUDE_DIR are munged together so eigen cannot be found. Also the KWIVER_LIBRARIES values all have a trailing /.

This branch is currently up for evaluation only. I didn't really finish it yet. It needs to have more of the stuff that the suspect function is doing, removed. I didn't want to go too far down that road if I was missing something.
