### PR TITLE
add vital/exceptions.h back to CMakeLists.txt

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -66,6 +66,7 @@ set( vital_public_headers
   any.h
   algorithm_capabilities.h
   attribute_set.h
+  exceptions.h
   iterator.h
 
   io/camera_from_metadata.h


### PR DESCRIPTION
This header was accidentally removed from CMakeLists when moving the
exceptions subdirectory to its own library.  This means exceptions.h
is no longer installed and it breaks projects building agains installed
KWIVER.