### PR TITLE
Update default algorithm logger.

### DIFF
--- a/vital/algo/algorithm.cxx
+++ b/vital/algo/algorithm.cxx
@@ -57,7 +57,7 @@ void
 algorithm
 ::attach_logger( std::string const& name )
 {
-  m_logger = kwiver::vital::get_logger( name );
+  m_logger = kwiver::vital::get_logger( std::string( "vital.algorithm." + name ) );
 }
 
 


### PR DESCRIPTION
The logger now prefixes the algorithm name with the appropriate
prefix.