### PR TITLE
Updating ocv arrow detection output filename to include chip coords

### DIFF
--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -110,7 +110,12 @@ refine_detections_write_to_disk
   vital::config_block_sptr config = vital::algo::refine_detections::get_configuration();
 
   config->set_value( "pattern", d_->pattern,
-                     "The output pattern for writing images to disk." );
+                     "The output pattern for writing images to disk. "
+                     "Parameters that may be included in the pattern are "
+                     "the id (an integer) and four values for the chip coordinate: "
+                     "top left x, top left y, width, height (all floating point numbers). "
+                     "For information on how to format the pattern, see "
+                     "www.cplusplus.com/reference/cstdio/printf." );
 
   return config;
 }

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -151,18 +151,6 @@ refine_detections_write_to_disk
 
   for( auto det : *detections )
   {
-    // Generate output filename
-    std::string ofn;
-    size_t max_len = d_->pattern.size() + 4096;
-    ofn.resize( max_len );
-    int num_bytes = snprintf( &ofn[0], max_len, d_->pattern.c_str(), d_->id++ );
-
-    if( num_bytes < 0 )
-    {
-      LOG_ERROR( logger(), "Could not format output file name: \"" << d_->pattern << "\"" );
-    }
-
-    // Output image to file
     vital::bounding_box_d bbox = det->bounding_box();
 
     cv::Size s = img.size();
@@ -171,6 +159,20 @@ refine_detections_write_to_disk
 
     bbox = intersection( bounds, bbox );
 
+    // Generate output filename
+    std::string ofn;
+    size_t max_len = d_->pattern.size() + 4096;
+    ofn.resize( max_len );
+    int num_bytes = snprintf( &ofn[0], max_len, d_->pattern.c_str(), d_->id++,
+                                                bbox.upper_left()[0], bbox.upper_left()[1],
+                                                bbox.width(), bbox.height() );
+
+    if( num_bytes < 0 )
+    {
+      LOG_ERROR( logger(), "Could not format output file name: \"" << d_->pattern << "\"" );
+    }
+
+    // Output image to file
     // Make CV rect for out bbox coordinates
     cv::Rect r( bbox.upper_left()[0], bbox.upper_left()[1],
       bbox.width(), bbox.height() );


### PR DESCRIPTION
If the string format in the config has more than one input, it now tries to include top left x, top left y, width, and height before the id. So we can do something like `detection_%05d` to only produce id, as before, or we can do `detection_%05d_%fx%f+%f+%f` to include the coordinates.