### PR TITLE
Remove unused boost_system_library links

### DIFF
--- a/arrows/burnout/CMakeLists.txt
+++ b/arrows/burnout/CMakeLists.txt
@@ -12,7 +12,6 @@ set( sources
 set( burnout_linked_libs
   ${VIDTK_LIBRARIES}
   kwiversys
-  ${Boost_SYSTEM_LIBRARY}
   ${Boost_FILESYSTEM_LIBRARY}
   kwiver_algo_ocv
   kwiver_algo_vxl )

--- a/arrows/darknet/CMakeLists.txt
+++ b/arrows/darknet/CMakeLists.txt
@@ -17,7 +17,6 @@ set( Darknet_linked_libs
   ${Darknet_LIBRARIES}
   kwiversys
   ${OpenCV_LIBS}
-  ${Boost_SYSTEM_LIBRARY}
   ${Boost_FILESYSTEM_LIBRARY}
   kwiver_algo_ocv )
 

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -89,6 +89,5 @@ kwiver_add_plugin( kwiver_processes
                    kwiver_algo_core
                    kwiversys
                    vital vital_vpm vital_logger vital_config
-                 ${Boost_SYSTEM_LIBRARY}
                  ${Boost_FILESYSTEM_LIBRARY}
 )

--- a/sprokit/processes/matlab/CMakeLists.txt
+++ b/sprokit/processes/matlab/CMakeLists.txt
@@ -28,7 +28,6 @@ kwiver_add_plugin( kwiver_processes_matlab
                    kwiver_algo_matlab
                    kwiversys
                    vital vital_vpm vital_logger vital_config
-                 ${Boost_SYSTEM_LIBRARY}
                  ${Boost_FILESYSTEM_LIBRARY}
                  ${Matlab_LIBRARIES}
 )

--- a/sprokit/src/bindings/python/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/bindings/python/sprokit/pipeline/CMakeLists.txt
@@ -29,7 +29,6 @@ _sprokit_add_python_library(modules
 target_link_libraries(python-sprokit.pipeline-modules
   PRIVATE             sprokit_pipeline
                       sprokit_python_util
-                      ${Boost_SYSTEM_LIBRARY}
                       vital_vpm
   )
 

--- a/sprokit/src/bindings/python/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/src/bindings/python/sprokit/pipeline_util/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(python-sprokit.pipeline_util-bake
     sprokit_pipeline_util
     sprokit_python_util
     ${Boost_IOSTREAMS_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
     vital_vpm
   )
 

--- a/sprokit/src/processes/clusters/CMakeLists.txt
+++ b/sprokit/src/processes/clusters/CMakeLists.txt
@@ -45,6 +45,5 @@ kwiver_add_plugin(processes_clusters
   PRIVATE      sprokit_pipeline_util
                sprokit_pipeline
                ${Boost_FILESYSTEM_LIBRARY}
-               ${Boost_SYSTEM_LIBRARY}
                vital_vpm vital_util kwiversys
   )

--- a/sprokit/src/processes/examples/CMakeLists.txt
+++ b/sprokit/src/processes/examples/CMakeLists.txt
@@ -59,6 +59,5 @@ kwiver_add_plugin(processes_examples
                  ${examples_private_headers}
   PRIVATE        sprokit_pipeline
                  ${Boost_FILESYSTEM_LIBRARY}
-                 ${Boost_SYSTEM_LIBRARY}
                  vital_vpm
   )

--- a/sprokit/src/schedulers/CMakeLists.txt
+++ b/sprokit/src/schedulers/CMakeLists.txt
@@ -26,7 +26,6 @@ kwiver_add_plugin( schedulers
                   ${Boost_CHRONO_LIBRARY}
                   ${Boost_DATE_TIME_LIBRARY}
                   ${Boost_THREAD_LIBRARY}
-                  ${Boost_SYSTEM_LIBRARY}
                   ${CMAKE_THREAD_LIBS_INIT}
   SUBDIR          sprokit
   )

--- a/sprokit/src/schedulers/examples/CMakeLists.txt
+++ b/sprokit/src/schedulers/examples/CMakeLists.txt
@@ -22,7 +22,6 @@ kwiver_add_plugin( schedulers_examples
                  ${Boost_CHRONO_LIBRARY}
                  ${Boost_DATE_TIME_LIBRARY}
                  ${Boost_THREAD_LIBRARY}
-                 ${Boost_SYSTEM_LIBRARY}
                  ${CMAKE_THREAD_LIBS_INIT}
   SUBDIR         sprokit
   )

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -109,7 +109,6 @@ target_link_libraries(sprokit_pipeline
   PUBLIC              vital_config
                       vital_logger
                       ${Boost_CHRONO_LIBRARY}
-                      ${Boost_SYSTEM_LIBRARY}
   PRIVATE             ${Boost_FILESYSTEM_LIBRARY}
                       ${Boost_DATE_TIME_LIBRARY}
                       ${Boost_THREAD_LIBRARY}

--- a/sprokit/src/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline_util/CMakeLists.txt
@@ -100,7 +100,6 @@ kwiver_add_library(sprokit_pipeline_util
 target_link_libraries(sprokit_pipeline_util
   PUBLIC      sprokit_pipeline
             ${Boost_FILESYSTEM_LIBRARY}
-            ${Boost_SYSTEM_LIBRARY}
   PRIVATE     vital_config
               vital_util
               vital_exceptions

--- a/sprokit/src/sprokit/python/util/CMakeLists.txt
+++ b/sprokit/src/sprokit/python/util/CMakeLists.txt
@@ -25,8 +25,7 @@ kwiver_add_library(sprokit_python_util
 target_link_libraries(sprokit_python_util
   LINK_PUBLIC     ${PYTHON_LIBRARIES}
   LINK_PRIVATE    ${Boost_IOSTREAMS_LIBRARY}
-                  ${Boost_SYSTEM_LIBRARY})
-
+  )
 kwiver_install_headers(
     SUBDIR     sprokit/python/util
     ${python_util_headers}

--- a/sprokit/src/sprokit/tools/CMakeLists.txt
+++ b/sprokit/src/sprokit/tools/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(sprokit_tools
                ${Boost_PROGRAM_OPTIONS_LIBRARY}
 
   PRIVATE      ${Boost_FILESYSTEM_LIBRARY}
-               ${Boost_SYSTEM_LIBRARY}
                vital_config vital_util
   )
 

--- a/sprokit/src/tools/CMakeLists.txt
+++ b/sprokit/src/tools/CMakeLists.txt
@@ -34,20 +34,18 @@ add_tool(pipe_config
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
-
+  )
 add_tool(pipe_to_dot
   sprokit_tools
   sprokit_pipeline
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
-
+  )
 add_tool(pipeline_runner
   sprokit_tools
   sprokit_pipeline
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
+  )

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -2,7 +2,6 @@ project(sprokit_test_pipeline)
 
 set(test_libraries
   vital_config vital_vpm
-  ${Boost_SYSTEM_LIBRARY}
   sprokit_pipeline
   )
 
@@ -22,7 +21,6 @@ sprokit_discover_tests(stamp test_libraries test_stamp.cxx)
 set(edge_libraries
   ${test_libraries}
   ${Boost_THREAD_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
   ${Boost_CHRONO_LIBRARY})
 
 sprokit_discover_tests(edge edge_libraries test_edge.cxx)

--- a/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
@@ -7,8 +7,7 @@ set(test_libraries
   vital_vpm
   kwiversys
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
-
+  )
 set(sprokit_test_pipelines_directory
   "${sprokit_test_data_directory}/pipelines")
 

--- a/sprokit/tests/sprokit/test/CMakeLists.txt
+++ b/sprokit/tests/sprokit/test/CMakeLists.txt
@@ -6,7 +6,6 @@ sprokit_discover_tests(test test_libraries test_test.cxx)
 
 set(test_libraries
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
   ${CMAKE_DL_LIBS}
   )
 

--- a/track_oracle/core/CMakeLists.txt
+++ b/track_oracle/core/CMakeLists.txt
@@ -84,7 +84,6 @@ target_link_libraries( track_oracle
                        vnl
                        vgl
                        ${Boost_THREAD_LIBRARY}
-                       ${Boost_SYSTEM_LIBRARY}
   PRIVATE              vital_logger
                        vital
                        ${TRACK_ORACLE_SCORABLE_MGRS_LIBRARY}

--- a/track_oracle/data_terms/CMakeLists.txt
+++ b/track_oracle/data_terms/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries( data_terms
   PRIVATE              scoring_aries_interface
                        vital_logger
                        vital
-                       ${Boost_SYSTEM_LIBRARY}
   INTERFACE            vgl
 )
 set_target_properties( data_terms PROPERTIES CXX_VISIBILITY_PRESET default)

--- a/track_oracle/example/CMakeLists.txt
+++ b/track_oracle/example/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries( track_oracle_example
   data_terms
   vital
   vital_logger
-  ${Boost_SYSTEM_LIBRARY}
 )
 
 #
@@ -26,7 +25,6 @@ target_link_libraries( track_reader_example
  track_oracle
  data_terms
  track_oracle_file_formats
- ${Boost_SYSTEM_LIBRARY}
 )
 
 if( KWIVER_ENABLE_KPF )


### PR DESCRIPTION
Boost_SYSTEM_LIBRARY is linked throughout kwiver but never used. Some of those links are public which pollutes the link lines of consumers. This branch removes them all.  