### PR TITLE
Add filename and image coords to ocv refine output filename

### DIFF
--- a/arrows/ocv/image_io.cxx
+++ b/arrows/ocv/image_io.cxx
@@ -37,6 +37,8 @@
 
 #include <arrows/ocv/image_container.h>
 
+#include <vital/types/metadata_traits.h>
+
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
@@ -54,8 +56,13 @@ vital::image_container_sptr
 image_io
 ::load_(const std::string& filename) const
 {
+  auto md = std::shared_ptr<kwiver::vital::metadata>(new kwiver::vital::metadata());
+  md->add(NEW_METADATA_ITEM(kwiver::vital::VITAL_META_IMAGE_FILENAME, filename));
+
   cv::Mat img = cv::imread(filename.c_str(), -1);
-  return vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR));
+  auto img_ptr = vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR));
+  img_ptr->set_metadata(md);
+  return img_ptr;
 }
 
 

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -144,18 +144,6 @@ refine_detections_write_to_disk
 
   for( auto det : *detections )
   {
-    // Generate output filename
-    std::string ofn;
-    size_t max_len = d_->pattern.size() + 4096;
-    ofn.resize( max_len );
-    int num_bytes = snprintf( &ofn[0], max_len, d_->pattern.c_str(), d_->id++ );
-
-    if( num_bytes < 0 )
-    {
-      LOG_ERROR( logger(), "Could not format output file name: \"" << d_->pattern << "\"" );
-    }
-
-    // Output image to file
     vital::bounding_box_d bbox = det->bounding_box();
 
     cv::Size s = img.size();
@@ -164,6 +152,20 @@ refine_detections_write_to_disk
 
     bbox = intersection( bounds, bbox );
 
+    // Generate output filename
+    std::string ofn;
+    size_t max_len = d_->pattern.size() + 4096;
+    ofn.resize( max_len );
+    int num_bytes = snprintf( &ofn[0], max_len, d_->pattern.c_str(), d_->id++,
+                                                bbox.upper_left()[0], bbox.upper_left()[1],
+                                                bbox.width(), bbox.height() );
+
+    if( num_bytes < 0 )
+    {
+      LOG_ERROR( logger(), "Could not format output file name: \"" << d_->pattern << "\"" );
+    }
+
+    // Output image to file
     // Make CV rect for out bbox coordinates
     cv::Rect r( bbox.upper_left()[0], bbox.upper_left()[1],
       bbox.width(), bbox.height() );

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -111,7 +111,7 @@ refine_detections_write_to_disk
   config->set_value( "pattern", d_->pattern,
                      "The output pattern for writing images to disk. "
                      "Parameters that may be included in the pattern are "
-                     "the id (an integer) and four values for the chip coordinate: "
+                     "the id (an integer), the source image filename (a string), and four values for the chip coordinate: "
                      "top left x, top left y, width, height (all floating point numbers). "
                      "For information on how to format the pattern, see "
                      "www.cplusplus.com/reference/cstdio/printf." );

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -109,7 +109,12 @@ refine_detections_write_to_disk
   vital::config_block_sptr config = vital::algo::refine_detections::get_configuration();
 
   config->set_value( "pattern", d_->pattern,
-                     "The output pattern for writing images to disk." );
+                     "The output pattern for writing images to disk. "
+                     "Parameters that may be included in the pattern are "
+                     "the id (an integer) and four values for the chip coordinate: "
+                     "top left x, top left y, width, height (all floating point numbers). "
+                     "For information on how to format the pattern, see "
+                     "www.cplusplus.com/reference/cstdio/printf." );
 
   return config;
 }

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -163,7 +163,6 @@ refine_detections_write_to_disk
     {
       filename = filename.substr(filename_pos+path_sep.length());
     }
-
   }
 
   for( auto det : *detections )


### PR DESCRIPTION
We don't have any filename utilities as dependencies besides boost::filesystem right now, do we? I'd be happy to update that filename code if we do.