### PR TITLE
Use vital::uid for track_oracle track_uuid

### DIFF
--- a/track_oracle/core/kwiver_io_helpers.cxx
+++ b/track_oracle/core/kwiver_io_helpers.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2014-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -211,6 +211,22 @@ ostream& kwiver_write( ostream& os, const vital::timestamp& ts )
 {
   pair< string, string > ts_strings = kwiver_ts_to_strings( ts );
   os << ts_strings.first << ":" << ts_strings.second;
+  return os;
+}
+
+//
+// vital::uid
+//
+
+bool kwiver_read( const string& s, vital::uid& uid)
+{
+  uid = s;
+  return true;
+}
+
+ostream& kwiver_write( ostream& os, const vital::uid& uid )
+{
+  os << uid.value();
   return os;
 }
 

--- a/track_oracle/core/kwiver_io_helpers.h
+++ b/track_oracle/core/kwiver_io_helpers.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2014-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -19,6 +19,7 @@
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_point_3d.h>
 #include <vital/types/timestamp.h>
+#include <vital/types/uid.h>
 
 namespace kwiver {
 namespace track_oracle {
@@ -43,6 +44,9 @@ TRACK_ORACLE_EXPORT bool kwiver_ts_string_read( const std::string& frame_str,
                                                 vital::timestamp& t );
 TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, vital::timestamp& ts );
 TRACK_ORACLE_EXPORT std::ostream& kwiver_write( std::ostream& os, const vital::timestamp& ts );
+
+TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, vital::uid& uid );
+TRACK_ORACLE_EXPORT std::ostream& kwiver_write( std::ostream& os, const vital::uid& uid );
 
 TRACK_ORACLE_EXPORT bool kwiver_read( const std::string& s, kpf_cset_type& cset );
 TRACK_ORACLE_EXPORT std::ostream&  kwiver_write( std::ostream& os, const kpf_cset_type& cset );

--- a/track_oracle/core/track_oracle_instances_old_style.cxx
+++ b/track_oracle/core/track_oracle_instances_old_style.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2014-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -14,6 +14,7 @@
 #include <vgl/vgl_point_3d.h>
 
 #include <vital/types/timestamp.h>
+#include <vital/types/uid.h>
 
 #include <track_oracle/core/state_flags.h>
 
@@ -66,6 +67,7 @@ TRACK_ORACLE_INSTANTIATE_OLD_STYLE_DEFAULT_OUTPUT(vgl_point_2d<double>);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_DEFAULT_OUTPUT(vgl_point_3d<double>);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_DEFAULT_OUTPUT(kwiver::vital::timestamp);
 TRACK_ORACLE_INSTANTIATE_OLD_STYLE_DEFAULT_OUTPUT(std::vector< kwiver::vital::timestamp >);
+TRACK_ORACLE_INSTANTIATE_OLD_STYLE_DEFAULT_OUTPUT(kwiver::vital::uid);
 
 /// Shouldn't need to distinguish between these, but VS9 has a bug:
 /// http://connect.microsoft.com/VisualStudio/feedback/details/753981

--- a/track_oracle/data_terms/data_terms.cxx
+++ b/track_oracle/data_terms/data_terms.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2014-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -364,6 +364,20 @@ ostream& time_stamp::to_csv( ostream& os, const vital::timestamp& ts ) const
   pair< string, string > ts_strings = kwiver_ts_to_strings( ts );
   os << ts_strings.first << "," << ts_strings.second;
   return os;
+}
+
+//
+// uid
+//
+
+ostream& track_uuid::to_stream( ostream& os, const vital::uid& uid ) const
+{
+  return kwiver_write( os, uid );
+}
+
+bool track_uuid::from_str( const string& s, vital::uid& uid ) const
+{
+  return kwiver_read( s, uid );
 }
 
 } // ...tracking

--- a/track_oracle/data_terms/data_terms.h
+++ b/track_oracle/data_terms/data_terms.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2014-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -46,6 +46,7 @@
 #include <vgl/vgl_point_3d.h>
 
 #include <vital/types/timestamp.h>
+#include <vital/types/uid.h>
 
 class TiXmlElement;
 
@@ -94,7 +95,7 @@ namespace tracking {
   DECL_DT_W_STR( latitude,  double, "latitude, -90 to 90" );
   DECL_DT_W_STR( longitude, double, "longitude, -180 to 180" );
   DECL_DT_RW_STRXMLCSV( time_stamp, vital::timestamp, "timestamp (carries both time and framenumber); epoch is data-dependent" );
-  DECL_DT( track_uuid, std::string, "UUID associated with the track" );
+  DECL_DT_RW_STR( track_uuid, vital::uid, "UUID associated with the track" );
   DECL_DT( track_style, std::string, "track_style, typically indicating the source (tracker, detector, etc.)" );
 
 } // ...tracking


### PR DESCRIPTION
Change data type of track_oracle's `track_uuid` to `kwiver::vital::uid`, rather than std::string. This was originally a `boost::uuid_t` and was changed to `std::string` in order to remove the boost dependency at a time before `vital::uid` existed. However, since the intent is to hold a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier), and `vital::uid` is intended to be used for this purpose, it is a more appropriate type for the field.