### PR TITLE
Process names should not end with "process".

### DIFF
--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -296,7 +296,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
 
   fact = vpm.ADD_PROCESS( kwiver::keyframe_selection_process);
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "keyframe_selection_process")
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "keyframe_selection")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name)
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                     "Selects keyframes from a track set.")
@@ -305,7 +305,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
 
   fact = vpm.ADD_PROCESS( kwiver::detect_features_if_keyframe_process);
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "detect_features_if_keyframe_process")
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "detect_features_if_keyframe")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name)
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                     "Detects feautres in an image if it is a keyframe.")
@@ -314,7 +314,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
 
   fact = vpm.ADD_PROCESS( kwiver::close_loops_process);
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "close_loops_process")
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "close_loops")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name)
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
                     "Detects loops in a track set using features with descriptors.")


### PR DESCRIPTION
The name of a process should not end in "_process". That can be determined from context. It is standard practice to end a process definition class with "_process" though.

A possible side effect of this change is to disrupt some pipeline files that use these processes.