### PR TITLE
Relevancy/confidence in 19th column should apply to frames, not tracks.

### DIFF
--- a/track_oracle/file_formats/track_kw18/file_format_kw18.cxx
+++ b/track_oracle/file_formats/track_kw18/file_format_kw18.cxx
@@ -323,7 +323,7 @@ file_format_kw18
     // kw19 hacks
     if (this->opts.kw19_hack)
     {
-      relevancy( tracks.back().row ) = p.kw19;
+      relevancy( current_frame.row ) = p.kw19;
     }
 
   } // ... while non-blank lines exist


### PR DESCRIPTION
As written, when a 19th column is present in kw18, that value is
only applied to the track, not to the individual frames. So if you
have a track with three frames:

 track  frame   .... column-19

  1      10     ....  0.5
  1      11     ....  0.6
  1      12     ....  0.7

...then the relevancy will be assigned to track 1, and the value
will be the last one read (here, 0.7); the values of 0.5 and 0.6
are lost.

This fix applies the relevancy to the frames, not the track.

Since essentially the only use of having a 19th column in a kw18 is
to assign frame-level confidence values, and this is what the scoring
code expects, this will fix detection-mode scoring and shouldn't break
anything.