### PR TITLE
Examples broke when ColorMode was added to ocv_to_vital API

### DIFF
--- a/examples/cpp/how_to_part_01_images.cpp
+++ b/examples/cpp/how_to_part_01_images.cpp
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2017 by Kitware, Inc.
+* Copyright 2017-2018 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -98,7 +98,7 @@ void how_to_part_01_images()
   // And that we tell our application CMake targets about OpenCV (See the CMakeLists.txt for this file)
   cv::Mat mat;
   // First, convert the image to an OpenCV image object
-  mat = kwiver::arrows::ocv::image_container::vital_to_ocv(ocv_img->get_image());
+  mat = kwiver::arrows::ocv::image_container::vital_to_ocv(ocv_img->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR );
   cv::namedWindow("Image loaded by OpenCV", cv::WINDOW_AUTOSIZE);// Create a window for display.
   cv::imshow("Image loaded by OpenCV", mat);                     // Show our image inside it.
   cv::waitKey(5);
@@ -106,7 +106,7 @@ void how_to_part_01_images()
   cvDestroyWindow("Image loaded by OpenCV");
 
   // We can do the same, even if the image was originally loaded with VXL
-  mat = kwiver::arrows::ocv::image_container::vital_to_ocv(vxl_img->get_image());
+  mat = kwiver::arrows::ocv::image_container::vital_to_ocv(vxl_img->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR);
   cv::namedWindow("Image loaded by VXL", cv::WINDOW_AUTOSIZE);// Create a window for display.
   cv::imshow("Image loaded by VXL", mat);                     // Show our image inside it.
   cv::waitKey(5);
@@ -131,7 +131,7 @@ void how_to_part_01_images()
   std::vector<kwiver::vital::image_container_sptr> ocv_imgs = ocv_split->split(vxl_img);
   for (kwiver::vital::image_container_sptr i : ocv_imgs)
   {
-    mat = kwiver::arrows::ocv::image_container::vital_to_ocv(i->get_image());
+    mat = kwiver::arrows::ocv::image_container::vital_to_ocv(i->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR);
     cv::namedWindow("OpenCV Split Image", cv::WINDOW_AUTOSIZE);// Create a window for display.
     cv::imshow("OpenCV Split Image", mat);                     // Show our image inside it.
     cv::waitKey(5);
@@ -142,7 +142,7 @@ void how_to_part_01_images()
   std::vector<kwiver::vital::image_container_sptr> vxl_imgs = ocv_split->split(ocv_img);
   for (kwiver::vital::image_container_sptr i : vxl_imgs)
   {
-    mat = kwiver::arrows::ocv::image_container::vital_to_ocv(i->get_image());
+    mat = kwiver::arrows::ocv::image_container::vital_to_ocv(i->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR);
     cv::namedWindow("VXL Split Image", cv::WINDOW_AUTOSIZE);// Create a window for display.
     cv::imshow("VXL Split Image", mat);                     // Show our image inside it.
     cv::waitKey(5);

--- a/examples/cpp/how_to_part_02_detections.cpp
+++ b/examples/cpp/how_to_part_02_detections.cpp
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2017 by Kitware, Inc.
+* Copyright 2017-2018 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -69,11 +69,11 @@ void how_to_part_02_detections()
 
   // We can take this detection set and create a new image with the detections overlaid on the image
   kwiver::vital::algo::draw_detected_object_set_sptr drawer = kwiver::vital::algo::draw_detected_object_set::create("ocv");
-  drawer->set_configuration(drawer->get_configuration());// This will default the configuration 
+  drawer->set_configuration(drawer->get_configuration());// This will default the configuration
   kwiver::vital::image_container_sptr hough_img = drawer->draw(hough_detections, ocv_img);
 
   // Let's see what it looks like
-  cv::Mat hough_mat = kwiver::arrows::ocv::image_container::vital_to_ocv(hough_img->get_image());
+  cv::Mat hough_mat = kwiver::arrows::ocv::image_container::vital_to_ocv(hough_img->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR);
   cv::namedWindow("Hough Detections", cv::WINDOW_AUTOSIZE);// Create a window for display.
   cv::imshow("Hough Detections", hough_mat);                     // Show our image inside it.
   cv::waitKey(5);
@@ -139,7 +139,7 @@ void how_to_part_02_detections()
 
   kwiver::vital::image_container_sptr img_detections = drawer->draw(detections, ocv_img);
   // Let's see what it looks like
-  cv::Mat mat = kwiver::arrows::ocv::image_container::vital_to_ocv(img_detections->get_image());
+  cv::Mat mat = kwiver::arrows::ocv::image_container::vital_to_ocv(img_detections->get_image(), kwiver::arrows::ocv::image_container::RGB_COLOR);
   cv::namedWindow("Detections", cv::WINDOW_AUTOSIZE);// Create a window for display.
   cv::imshow("Detections", mat);                     // Show our image inside it.
   cv::waitKey(5);


### PR DESCRIPTION
@judajake Make sure the changes here make sense. This patch fixes the extras code that broke with API changes to ocv_to_vital. I am not certain that the actual format used for this code matters, but it is supposed to serve as an actual example so best to get it right.