### PR TITLE
Don't import entire std namespace

### DIFF
--- a/vital/range/defs.h
+++ b/vital/range/defs.h
@@ -169,7 +169,8 @@ struct function_detail< ReturnType ( Object::* )( ArgsType... ) const >
 // ----------------------------------------------------------------------------
 namespace range_detail {
 
-using namespace std;
+using std::begin;
+using std::end;
 
 template < typename Range >
 struct range_helper


### PR DESCRIPTION
Avoid `using namespace std` in `range_detail`. Instead, only import the two functions we need; `std::begin` and `std::end`.

Addresses https://github.com/Kitware/kwiver/pull/557#pullrequestreview-137018217 (FYI @dstoup).