### PR TITLE
Fixed a failing test for RPC back projection

### DIFF
--- a/vital/types/camera_rpc.cxx
+++ b/vital/types/camera_rpc.cxx
@@ -189,7 +189,7 @@ simple_camera_rpc
 ::jacobian( const vector_3d& pt, matrix_2x2d& J, vector_2d& norm_pt ) const
 {
   auto pv = this->power_vector( pt );
-  auto ply = this->rpc_coeffs() * pv;
+  vector_4d ply = this->rpc_coeffs() * pv;
   vector_4d dx_ply = this->dx_coeffs_ * pv.head(10);
   vector_4d dy_ply = this->dy_coeffs_ * pv.head(10);
 


### PR DESCRIPTION
Replace "auto" with concrete type "vector_4d" to force Eigen
to evaluate the multiplication immediately.