### PR TITLE
Removing use of auto keyword with Eigen data types.

### DIFF
--- a/vital/tests/test_camera_rpc.cxx
+++ b/vital/tests/test_camera_rpc.cxx
@@ -129,7 +129,7 @@ TEST_F(camera_rpc, identity)
 
   kwiver::vital::vector_3d pt(1.0, 2.0, 10.0);
 
-  auto img_pt = icam.project( pt );
+  kwiver::vital::vector_2d img_pt = icam.project( pt );
 
   EXPECT_MATRIX_EQ( img_pt, kwiver::vital::vector_2d(1.0, 2.0) );
 }
@@ -157,7 +157,7 @@ TEST_F(camera_rpc, projection)
 
   for (size_t i = 0; i < test_points.size(); ++i)
   {
-    auto img_pt = cam.project( test_points[i] );
+    kwiver::vital::vector_2d img_pt = cam.project( test_points[i] );
 
     EXPECT_MATRIX_NEAR( img_pt, test_image_points[i], epsilon );
   }
@@ -171,8 +171,9 @@ TEST_F(camera_rpc, back_projection)
 
   for (size_t i = 0; i < test_points.size(); ++i)
   {
-    auto img_pt = cam.project( test_points[i] );
-    auto new_pt = cam.back_project( img_pt, test_points[i][2] );
+    kwiver::vital::vector_2d img_pt = cam.project( test_points[i] );
+    kwiver::vital::vector_3d new_pt =
+      cam.back_project( img_pt, test_points[i][2] );
 
     EXPECT_MATRIX_NEAR( new_pt, test_points[i], epsilon );
   }

--- a/vital/types/camera_rpc.cxx
+++ b/vital/types/camera_rpc.cxx
@@ -188,7 +188,7 @@ void
 simple_camera_rpc
 ::jacobian( const vector_3d& pt, matrix_2x2d& J, vector_2d& norm_pt ) const
 {
-  auto pv = this->power_vector( pt );
+  Eigen::Matrix<double, 20, 1> pv = this->power_vector( pt );
   vector_4d ply = this->rpc_coeffs() * pv;
   vector_4d dx_ply = this->dx_coeffs_ * pv.head(10);
   vector_4d dy_ply = this->dy_coeffs_ * pv.head(10);


### PR DESCRIPTION
Removing a few more cases of where the auto keyword was being used with Eigen data types. The use of the auto keyword with Eigen data types is known to be problematic.

https://eigen.tuxfamily.org/dox/TopicPitfalls.html