### PR TITLE
Resolve ambiguous type when including pybind11

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process.cxx
@@ -146,7 +146,7 @@ void declare_configuration_key_4(sprokit::process &self,
                                  kwiver::vital::config_block_description_t const& description_,
                                  bool tunable_);
 
-wrap_edge_datum peek_at_port(sprokit::process &self, sprokit::process::port_t const& port, size_t idx);
+wrap_edge_datum peek_at_port(sprokit::process &self, sprokit::process::port_t const& port, std::size_t idx);
 wrap_edge_datum grab_from_port(sprokit::process &self, sprokit::process::port_t const& port);
 sprokit::datum grab_datum_from_port(sprokit::process &self, sprokit::process::port_t const& port);
 object grab_value_from_port(sprokit::process &self, sprokit::process::port_t const& port);
@@ -775,7 +775,7 @@ declare_configuration_key_4(sprokit::process &self,
 }
 
 wrap_edge_datum
-peek_at_port(sprokit::process &self, sprokit::process::port_t const& port, size_t idx)
+peek_at_port(sprokit::process &self, sprokit::process::port_t const& port, std::size_t idx)
 {
   sprokit::process* self_ptr = &self;
   return wrap_edge_datum(((wrap_process*) self_ptr)->peek_at_port(port, idx));

--- a/vital/types/descriptor.h
+++ b/vital/types/descriptor.h
@@ -133,10 +133,10 @@ public:
   /// Return the descriptor as a vector of doubles
   std::vector< double > as_double() const
   {
-    const size_t length = this->size();
+    const std::size_t length = this->size();
     std::vector< double > double_data( length );
 
-    for ( size_t i = 0; i < length; ++i )
+    for ( std::size_t i = 0; i < length; ++i )
     {
       double_data[i] = static_cast< double > ( this->raw_data()[i] );
     }


### PR DESCRIPTION
pybind11 seems to make its own alias for size_t in its own namespace
They both resolve to the same thing, but msvc gets confused for some reason

Here is the definition in question

https://github.com/pybind/pybind11/blob/master/include/pybind11/detail/common.h#L298
