### PR TITLE
Fixed crash of core:video_input_filter.metadata_map.

### DIFF
--- a/arrows/core/video_input_filter.cxx
+++ b/arrows/core/video_input_filter.cxx
@@ -363,7 +363,10 @@ video_input_filter
   auto internal_map = d->d_video_input->metadata_map()->metadata();
   auto start = internal_map.find(d->c_start_at_frame);
   auto stop = internal_map.find(d->c_stop_after_frame);
-  stop++; // stop frame should be included
+  if (stop != internal_map.end() )
+  {
+    stop++; // stop frame should be included
+  }
 
   if (d->c_stop_after_frame > 0)
   {


### PR DESCRIPTION
Fixed crash of core:video_input_filter.metadata_map. There was a case where a std::map iterator was incremented when it was at the end.