### PR TITLE
Dev/deboostify track oracle

### DIFF
--- a/track_oracle/core/CMakeLists.txt
+++ b/track_oracle/core/CMakeLists.txt
@@ -83,7 +83,6 @@ target_link_libraries( track_oracle
   PUBLIC               scoring_aries_interface
                        vnl
                        vgl
-                       ${Boost_THREAD_LIBRARY}
                        ${Boost_SYSTEM_LIBRARY}
   PRIVATE              vital_logger
                        vital

--- a/track_oracle/core/CMakeLists.txt
+++ b/track_oracle/core/CMakeLists.txt
@@ -83,7 +83,6 @@ target_link_libraries( track_oracle
   PUBLIC               scoring_aries_interface
                        vnl
                        vgl
-                       ${Boost_SYSTEM_LIBRARY}
   PRIVATE              vital_logger
                        vital
                        ${TRACK_ORACLE_SCORABLE_MGRS_LIBRARY}

--- a/track_oracle/core/state_flags.cxx
+++ b/track_oracle/core/state_flags.cxx
@@ -8,8 +8,8 @@
 
 #include <string>
 #include <sstream>
+#include <mutex>
 
-#include <boost/thread/mutex.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <tinyxml.h>
@@ -55,7 +55,7 @@ struct state_flags_backend
 
 private:
   static state_flags_backend* impl;
-  boost::mutex api_lock;
+  std::mutex api_lock;
   string special_slot_zero_tag;
 };
 
@@ -77,7 +77,7 @@ pair< size_t, size_t >
 state_flags_backend
 ::set_flag( const string& component, const string& status )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   // first, locate or assign the component
   string_index_map_t& c = this->component_map;
@@ -112,7 +112,7 @@ map< string, string >
 state_flags_backend
 ::get_map( const vector<size_t>& data )
 {
-  boost::unique_lock< boost::mutex > lock( api_lock );
+  std::lock_guard< std::mutex > lock( api_lock );
 
   map< string, string > ret;
 

--- a/track_oracle/core/state_flags.cxx
+++ b/track_oracle/core/state_flags.cxx
@@ -10,12 +10,13 @@
 #include <sstream>
 #include <mutex>
 
-#include <boost/algorithm/string.hpp>
-
 #include <tinyxml.h>
 
 #include <track_oracle/core/track_oracle_core.h>
 #include <track_oracle/core/element_descriptor.h>
+
+#include <vital/util/tokenize.h>
+#include <vital/util/string.h>
 
 #include <vital/logger/logger.h>
 static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
@@ -260,11 +261,11 @@ istream& operator>>( istream& is, state_flag_type& t )
   if ( is >> text )
   {
     vector<string> tokens;
-    boost::split( tokens, text, boost::is_any_of( ",|+" ));
+    kwiver::vital::tokenize( text, tokens, ",|+" );
     for (size_t i=0; i<tokens.size(); ++i)
     {
       string& token = tokens[i];
-      boost::trim(token);
+      kwiver::vital::string_trim(token);
       if (token.empty()) continue;
       size_t c = token.find( ':' );
       if ( c == string::npos )

--- a/track_oracle/core/track_oracle_core.cxx
+++ b/track_oracle/core/track_oracle_core.cxx
@@ -7,8 +7,7 @@
 #include "track_oracle_core.h"
 #include <track_oracle/core/element_descriptor.h>
 #include <track_oracle/core/track_oracle_core_impl.h>
-
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 
 using std::ostream;
@@ -18,7 +17,7 @@ using std::vector;
 
 namespace // anon
 {
-boost::mutex instance_lock;
+std::mutex instance_lock;
 };
 
 namespace kwiver {
@@ -30,7 +29,7 @@ track_oracle_core
 {
   if ( ! track_oracle_core::impl )
   {
-    boost::unique_lock< boost::mutex > lock( instance_lock );
+    std::lock_guard< std::mutex > lock( instance_lock );
     if ( ! track_oracle_core::impl )
     {
       track_oracle_core::impl = new track_oracle_core_impl();

--- a/track_oracle/core/track_oracle_core_impl.cxx
+++ b/track_oracle/core/track_oracle_core_impl.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "track_oracle_core_impl.h"
+#include <mutex>
 #include <stdexcept>
 #include <limits>
 #include <algorithm>
@@ -147,7 +148,7 @@ vector< field_handle_type >
 track_oracle_core_impl
 ::get_all_field_handles() const
 {
- boost::unique_lock< boost::mutex > lock( this->api_lock );
+ std::lock_guard< std::mutex > lock( this->api_lock );
  vector< field_handle_type > ret;
  for (const auto p: this->name_pool)
  {
@@ -172,7 +173,7 @@ field_handle_type
 track_oracle_core_impl
 ::lookup_by_name( const string& name ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_lookup_by_name( name );
 }
 
@@ -189,7 +190,7 @@ element_descriptor
 track_oracle_core_impl
 ::get_element_descriptor( field_handle_type f ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< field_handle_type, element_store_base* >::const_iterator probe = this->element_pool.find( f );
   return
     ( probe != this->element_pool.end() )
@@ -201,7 +202,7 @@ const element_store_base*
 track_oracle_core_impl
 ::get_element_store_base( field_handle_type f ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< field_handle_type, element_store_base* >::const_iterator probe = this->element_pool.find( f );
   return
     ( probe != this->element_pool.end() )
@@ -213,7 +214,7 @@ element_store_base*
 track_oracle_core_impl
 ::get_mutable_element_store_base( field_handle_type f ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< field_handle_type, element_store_base* >::const_iterator probe = this->element_pool.find( f );
   return
     ( probe != this->element_pool.end() )
@@ -239,7 +240,7 @@ bool
 track_oracle_core_impl
 ::field_has_row( oracle_entry_handle_type row, field_handle_type field )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_field_has_row( row, field );
 }
 
@@ -247,7 +248,7 @@ vector< field_handle_type >
 track_oracle_core_impl
 ::fields_at_row( oracle_entry_handle_type row ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   vector< field_handle_type > ret;
   for (map< field_handle_type, element_store_base* >::const_iterator i = this->element_pool.begin();
        i != this->element_pool.end();
@@ -265,7 +266,7 @@ vector< vector< field_handle_type > >
 track_oracle_core_impl
 ::fields_at_rows( const vector<oracle_entry_handle_type>& rows ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   vector< vector< field_handle_type > > ret( rows.size() );
 
   vector< oracle_entry_handle_type > sorted_rows( rows );
@@ -291,7 +292,7 @@ oracle_entry_handle_type
 track_oracle_core_impl
 ::get_next_handle()
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return ++this->row_count;
 }
 
@@ -299,7 +300,7 @@ handle_list_type
 track_oracle_core_impl
 ::get_domain( domain_handle_type domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   handle_list_type ret;
 
   //
@@ -331,7 +332,7 @@ domain_handle_type
 track_oracle_core_impl
 ::lookup_domain( const string& domain_name, bool create_if_not_found )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< string, domain_handle_type >::iterator probe =  this->domain_names.find( domain_name );
 
   // return if found
@@ -351,7 +352,7 @@ domain_handle_type
 track_oracle_core_impl
 ::create_domain( )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   // pre-incrementing ensures that DOMAIN_ALL can never be allocated
   domain_handle_type h = ++this->last_domain_allocated;
   this->domain_names[ vul_sprintf("anon_domain_%d", static_cast<int>( h )) ] = h;
@@ -364,7 +365,7 @@ domain_handle_type
 track_oracle_core_impl
 ::create_domain( const handle_list_type& handles )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   // pre-incrementing ensures that DOMAIN_ALL can never be allocated
   domain_handle_type h = ++this->last_domain_allocated;
   this->domain_names[ vul_sprintf("anon_domain_%d", static_cast<int>( h )) ] = h;
@@ -388,7 +389,7 @@ bool
 track_oracle_core_impl
 ::is_domain_defined( const domain_handle_type& domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   return (this->domain_pool.find( domain ) != this->domain_pool.end() );
 }
@@ -397,7 +398,7 @@ bool
 track_oracle_core_impl
 ::release_domain( const domain_handle_type& domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   map< domain_handle_type, handle_list_type >::iterator probe = this->domain_pool.find( domain );
   if (probe == this->domain_pool.end())
@@ -460,7 +461,7 @@ bool
 track_oracle_core_impl
 ::add_to_domain( const handle_list_type& handles, const domain_handle_type& domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< domain_handle_type, handle_list_type >::iterator i = domain_pool.find( domain );
   if ( i == domain_pool.end() ) return false;
   i->second.insert( i->second.end(), handles.begin(), handles.end() );
@@ -471,7 +472,7 @@ bool
 track_oracle_core_impl
 ::add_to_domain( const track_handle_type& track, const domain_handle_type& domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< domain_handle_type, handle_list_type >::iterator i = domain_pool.find( domain );
   if ( i == domain_pool.end() ) return false;
   i->second.push_back( track.row );
@@ -482,7 +483,7 @@ bool
 track_oracle_core_impl
 ::set_domain( const handle_list_type& handles, domain_handle_type domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   map< domain_handle_type, handle_list_type >::iterator i = domain_pool.find( domain );
   if ( i == domain_pool.end() ) return false;
   i->second = handles;
@@ -500,7 +501,7 @@ frame_handle_list_type
 track_oracle_core_impl
 ::get_frames( const track_handle_type& t )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_get_frames( t );
 }
 
@@ -508,7 +509,7 @@ void
 track_oracle_core_impl
 ::set_frames( const track_handle_type& t, const frame_handle_list_type& frames )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   this->unlocked_get_field< frame_handle_list_type >( t.row, this->lookup_required_field( "__frame_list" )) = frames;
 }
 
@@ -516,7 +517,7 @@ size_t
 track_oracle_core_impl
 ::get_n_frames( const track_handle_type& t )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_get_field< frame_handle_list_type >( t.row, this->lookup_required_field( "__frame_list" )).size();
 }
 
@@ -536,7 +537,7 @@ track_oracle_core_impl
     return false;
   }
 
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   bool all_okay = true;
   for ( map< field_handle_type, element_store_base* >::iterator i = this->element_pool.begin();
         i != this->element_pool.end();
@@ -632,7 +633,7 @@ bool
 track_oracle_core_impl
 ::write_kwiver( ostream& os, const track_handle_list_type& tracks )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   os << "<kwiver>\n"
      << "<!--\n"
      << "  File of " << tracks.size() << " tracks emitted by track_oracle's kwiver writer\n"
@@ -694,7 +695,7 @@ bool
 track_oracle_core_impl
 ::write_csv( ostream& os, const track_handle_list_type& tracks, bool csv_v1_semantics )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   field_handle_type world_gcs_fh = this->unlocked_lookup_by_name( "world_gcs" );
   if ( world_gcs_fh == INVALID_FIELD_HANDLE )
@@ -934,7 +935,7 @@ csv_handler_map_type
 track_oracle_core_impl
 ::get_csv_handler_map( const vector< string >& headers )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
 
   map< string, field_handle_type > header_map;

--- a/track_oracle/core/track_oracle_core_impl.h
+++ b/track_oracle/core/track_oracle_core_impl.h
@@ -12,10 +12,10 @@
 
 #include <map>
 #include <string>
+#include <mutex>
+
 #include <track_oracle/core/track_oracle_core.h>
 #include <track_oracle/core/element_store.h>
-
-#include <boost/thread/mutex.hpp>
 
 namespace  // anon
 {
@@ -79,7 +79,7 @@ private:
   template< typename T > std::pair< std::map<oracle_entry_handle_type, T>*, T > lookup_table( field_handle_type field );
 
   // giant mutex for a blunt approach to thread safety
-  mutable boost::mutex api_lock;
+  mutable std::mutex api_lock;
 
   // throws if the field doesn't exist
   field_handle_type lookup_required_field( const std::string& fn ) const;

--- a/track_oracle/core/track_oracle_core_impl.txx
+++ b/track_oracle/core/track_oracle_core_impl.txx
@@ -11,6 +11,7 @@
 #include <utility>
 #include <limits>
 #include <algorithm>
+#include <mutex>
 
 #include <vital/logger/logger.h>
 static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
@@ -95,7 +96,7 @@ field_handle_type
 track_oracle_core_impl
 ::create_element( const element_descriptor& e )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_create_element<T>( e );
 }
 
@@ -129,7 +130,7 @@ void
 track_oracle_core_impl
 ::remove_field( oracle_entry_handle_type row, field_handle_type field )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   pair< map< oracle_entry_handle_type, T >*, T > probe = this->lookup_table<T>( field );
   probe.first->erase( row );
 }
@@ -156,7 +157,7 @@ T&
 track_oracle_core_impl
 ::get_field( oracle_entry_handle_type track, field_handle_type field )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_get_field<T>( track, field );
 }
 
@@ -165,7 +166,7 @@ pair< bool, T >
 track_oracle_core_impl
 ::get( oracle_entry_handle_type row, field_handle_type field )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   const pair< map< oracle_entry_handle_type, T >*, T> f_probe = this->lookup_table<T>( field );
   typename map< oracle_entry_handle_type, T >::const_iterator probe = f_probe.first->find( row );
   return
@@ -180,7 +181,7 @@ oracle_entry_handle_type
 track_oracle_core_impl
 ::lookup( field_handle_type field, const T& val, domain_handle_type domain )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   pair< map< oracle_entry_handle_type, T >*, T > probe = this->lookup_table<T>( field );
   map< oracle_entry_handle_type, T >& data_column = *(probe.first);
   if ( domain == DOMAIN_ALL )

--- a/track_oracle/data_terms/CMakeLists.txt
+++ b/track_oracle/data_terms/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries( data_terms
   PRIVATE              scoring_aries_interface
                        vital_logger
                        vital
-                       ${Boost_SYSTEM_LIBRARY}
   INTERFACE            vgl
 )
 set_target_properties( data_terms PROPERTIES CXX_VISIBILITY_PRESET default)

--- a/track_oracle/event_adapter.cxx
+++ b/track_oracle/event_adapter.cxx
@@ -11,7 +11,6 @@
 #include <sstream>
 
 #include <vul/vul_awk.h>
-#include <vul/vul_reg_exp.h>
 
 #include <track_oracle/aries_interface/aries_interface.h>
 #include <track_oracle/data_terms/data_terms.h>

--- a/track_oracle/example/CMakeLists.txt
+++ b/track_oracle/example/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries( track_oracle_example
   data_terms
   vital
   vital_logger
-  ${Boost_SYSTEM_LIBRARY}
 )
 
 #
@@ -26,7 +25,6 @@ target_link_libraries( track_reader_example
  track_oracle
  data_terms
  track_oracle_file_formats
- ${Boost_SYSTEM_LIBRARY}
 )
 
 if( KWIVER_ENABLE_KPF )

--- a/track_oracle/file_formats/CMakeLists.txt
+++ b/track_oracle/file_formats/CMakeLists.txt
@@ -131,8 +131,7 @@ target_link_libraries( track_oracle_file_formats
                        ${TRACK_FILTER_KWE_LIBRARY}
                        ${TRACK_ORACLE_APIX_LIBRARY}
                        ${TRACK_KPF_LIBRARIES}
-                       
-  PRIVATE              ${Boost_THREAD_LIBRARY}
-                       vital
+
+  PRIVATE              vital
                        vul
 )

--- a/track_oracle/file_formats/aoi_utils/CMakeLists.txt
+++ b/track_oracle/file_formats/aoi_utils/CMakeLists.txt
@@ -27,5 +27,4 @@ target_link_libraries( track_oracle_aoi_utils
                        track_scorable_mgrs
                        vital_logger
                        vgl
-                       ${Boost_REGEX_LIBRARY}
 )

--- a/track_oracle/file_formats/aoi_utils/aoi_utils.cxx
+++ b/track_oracle/file_formats/aoi_utils/aoi_utils.cxx
@@ -18,7 +18,6 @@
 #include <track_oracle/track_scorable_mgrs/scorable_mgrs.h>
 
 #include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
 
 using std::vector;
 using std::map;
@@ -66,10 +65,10 @@ parse_aoi_string( const string& s,
   string::const_iterator a( s.begin() ), b( s.end() );
   if ( regex_match( a, b, what, pixel_geom_re ))
   {
-    int w = boost::lexical_cast<int>( string( what[1].first, what[1].second ) );
-    int h = boost::lexical_cast<int>( string( what[2].first, what[2].second ) );
-    int x = boost::lexical_cast<int>( string( what[3].first, what[3].second ) );
-    int y = boost::lexical_cast<int>( string( what[4].first, what[4].second ) );
+    int w = std::stoi( string( what[1].first, what[1].second ) );
+    int h = std::stoi( string( what[2].first, what[2].second ) );
+    int x = std::stoi( string( what[3].first, what[3].second ) );
+    int y = std::stoi( string( what[4].first, what[4].second ) );
     flavor = ::kwiver::track_oracle::aoi_utils::aoi_t::PIXEL;
     points.push_back( vgl_point_2d<double>(x,   y   ));
     points.push_back( vgl_point_2d<double>(x+w, y   ));
@@ -92,8 +91,8 @@ parse_aoi_string( const string& s,
   // start picking off the numbers
   while ( regex_search( a, b, what, float_pair_re ) )
   {
-    double x = boost::lexical_cast<double>( string( what[1].first, what[1].second ));
-    double y = boost::lexical_cast<double>( string( what[2].first, what[2].second ));
+    double x = std::stod( string( what[1].first, what[1].second ));
+    double y = std::stor( string( what[2].first, what[2].second ));
     points.push_back( vgl_point_2d<double>( x, y ));
     a = what[2].second;
   }

--- a/track_oracle/file_formats/aoi_utils/aoi_utils.cxx
+++ b/track_oracle/file_formats/aoi_utils/aoi_utils.cxx
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <sstream>
+#include <regex>
 
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_polygon.h>
@@ -17,7 +18,6 @@
 
 #include <track_oracle/track_scorable_mgrs/scorable_mgrs.h>
 
-#include <boost/regex.hpp>
 
 using std::vector;
 using std::map;
@@ -55,20 +55,20 @@ parse_aoi_string( const string& s,
   flavor = ::kwiver::track_oracle::aoi_utils::aoi_t::INVALID;
   points.clear();
 
-  boost::regex pixel_geom_re( "(\\d+)x(\\d+)([\\+\\-]\\d+)([\\+\\-]\\d+)" );
-  boost::regex float_pair_re( "^\\s*\\:?\\s*([\\d\\+\\-\\.eE]+)\\s*\\,\\s*([\\d\\+\\-\\.eE]+)" );
-  boost::regex pixel_tag_re ( "^\\s*[Pp]" );
+  std::regex pixel_geom_re( "(\\d+)x(\\d+)([\\+\\-]\\d+)([\\+\\-]\\d+)" );
+  std::regex float_pair_re( "^\\s*\\:?\\s*([\\d\\+\\-\\.eE]+)\\s*\\,\\s*([\\d\\+\\-\\.eE]+)" );
+  std::regex pixel_tag_re ( "^\\s*[Pp]" );
 
-  boost::match_results< string::const_iterator > what;
+  std::smatch what;
 
   // special case: is it a geometry string?
   string::const_iterator a( s.begin() ), b( s.end() );
-  if ( regex_match( a, b, what, pixel_geom_re ))
+  if ( std::regex_match( a, b, what, pixel_geom_re ))
   {
-    int w = std::stoi( string( what[1].first, what[1].second ) );
-    int h = std::stoi( string( what[2].first, what[2].second ) );
-    int x = std::stoi( string( what[3].first, what[3].second ) );
-    int y = std::stoi( string( what[4].first, what[4].second ) );
+    int w = std::stoi( what.str(1) );
+    int h = std::stoi( what.str(2) );
+    int x = std::stoi( what.str(3) );
+    int y = std::stoi( what.str(4) );
     flavor = ::kwiver::track_oracle::aoi_utils::aoi_t::PIXEL;
     points.push_back( vgl_point_2d<double>(x,   y   ));
     points.push_back( vgl_point_2d<double>(x+w, y   ));
@@ -78,7 +78,7 @@ parse_aoi_string( const string& s,
   }
 
   // otherwise, is it a pixel or a lat/lon?
-  if ( regex_search( a, b, what, pixel_tag_re ))
+  if ( std::regex_search( a, b, what, pixel_tag_re ))
   {
     flavor = ::kwiver::track_oracle::aoi_utils::aoi_t::PIXEL;
     a = what[1].second;
@@ -89,10 +89,10 @@ parse_aoi_string( const string& s,
   }
 
   // start picking off the numbers
-  while ( regex_search( a, b, what, float_pair_re ) )
+  while ( std::regex_search( a, b, what, float_pair_re ) )
   {
-    double x = std::stod( string( what[1].first, what[1].second ));
-    double y = std::stor( string( what[2].first, what[2].second ));
+    double x = std::stod( what.str(1) );
+    double y = std::stor( what.str(2) );
     points.push_back( vgl_point_2d<double>( x, y ));
     a = what[2].second;
   }

--- a/track_oracle/file_formats/file_format_manager.cxx
+++ b/track_oracle/file_formats/file_format_manager.cxx
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <sstream>
+#include <mutex>
 #include <vul/vul_string.h>
 #include <vul/vul_file.h>
 
@@ -45,8 +46,6 @@
 #include <track_oracle/file_formats/track_kwiver/file_format_kwiver.h>
 #include <track_oracle/core/schema_algorithm.h>
 
-#include <boost/thread/mutex.hpp>
-
 #include <vital/logger/logger.h>
 static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
 
@@ -63,7 +62,7 @@ using std::vector;
 
 namespace // anon
 {
-boost::mutex instance_lock;
+std::mutex instance_lock;
 };
 
 namespace kwiver {
@@ -78,7 +77,7 @@ struct file_format_manager_impl
   schema_map_type schemata;          // an instance of each schema
 
   // giant mutex for a blunt approach to thread safety
-  mutable boost::mutex api_lock;
+  mutable std::mutex api_lock;
 
   // what formats match the globs?
   vector< file_format_enum > unlocked_globs_match( string fn );
@@ -97,7 +96,7 @@ struct file_format_manager_impl
 file_format_manager_impl
 ::file_format_manager_impl()
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   // register all the formats.
   // when adding a new format, the only things you should need to do
@@ -157,7 +156,7 @@ vector< file_format_enum >
 file_format_manager_impl
 ::globs_match( string fn )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   return this->unlocked_globs_match( fn );
 }
 
@@ -165,7 +164,7 @@ file_format_enum
 file_format_manager_impl
 ::detect_format( const string& fn )
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
 
   // the assumption here is that multiple formats may match a glob,
   // but only one should pass inspection.  Add a check to verify this.
@@ -240,7 +239,7 @@ file_format_base*
 file_format_manager_impl
 ::get_format( file_format_enum fmt ) const
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   format_map_cit probe = formats.find( fmt );
   return
     (probe == formats.end())
@@ -251,7 +250,7 @@ file_format_manager_impl
 file_format_manager_impl
 ::~file_format_manager_impl()
 {
-  boost::unique_lock< boost::mutex > lock( this->api_lock );
+  std::lock_guard< std::mutex > lock( this->api_lock );
   for (format_map_cit i = formats.begin(); i != formats.end(); ++i)
   {
     delete i->second;
@@ -268,7 +267,7 @@ file_format_manager
 {
   if ( ! file_format_manager::impl )
   {
-    boost::unique_lock< boost::mutex > lock( instance_lock );
+    std::lock_guard< std::mutex > lock( instance_lock );
     if ( ! file_format_manager::impl )
     {
       file_format_manager::impl = new file_format_manager_impl();

--- a/track_oracle/file_formats/kpf_utils/CMakeLists.txt
+++ b/track_oracle/file_formats/kpf_utils/CMakeLists.txt
@@ -42,6 +42,5 @@ target_link_libraries( kpf_utils
                        kwiver_algo_kpf
   PRIVATE              vital_logger
                        logging_map
-                       kwiversys
                        ${YAML_CPP_LIBRARIES}
 )

--- a/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
+++ b/track_oracle/file_formats/kpf_utils/kpf_utils.cxx
@@ -63,11 +63,10 @@ static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __
 #include <arrows/kpf/yaml/kpf_reader.h>
 #include <arrows/kpf/yaml/kpf_yaml_parser.h>
 
-#include <kwiversys/RegularExpression.hxx>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <regex>
 
 using std::map;
 using std::make_pair;
@@ -96,9 +95,10 @@ get_optional_fields()
   string kpf_key_str( KPF::style2str( KPF::packet_style::KV ));
   string kpf_cset_str( KPF::style2str( KPF::packet_style::CSET ));
   // Note that these regexs are tied to the synthesized field names in the reader.
-  kwiversys::RegularExpression field_dbl("^([a-zA-Z0-9]+)_([0-9]+)$");
-  kwiversys::RegularExpression field_kv("^"+kpf_key_str+"_([a-zA-Z0-9]+)$");
-  kwiversys::RegularExpression field_cset("^"+kpf_cset_str+"_([0-9]+)$");
+  std::regex field_dbl("^([a-zA-Z0-9]+)_([0-9]+)$");
+  std::regex field_kv("^"+kpf_key_str+"_([a-zA-Z0-9]+)$");
+  std::regex field_cset("^"+kpf_cset_str+"_([0-9]+)$");
+  std::smatch matches;
 
   for (auto i: track_oracle_core::get_all_field_handles())
   {
@@ -108,13 +108,13 @@ get_optional_fields()
     if (e.typeid_str == dbltype)
     {
       // did we find two matches and is the first a KPF style?
-      if (field_dbl.find( e.name ))
+      if ( std::regex_search( e.name, matches, field_dbl ))
       {
-        auto style = KPF::str2style( field_dbl.match(1) );
+        auto style = KPF::str2style( matches.str(1) );
         if (style != KPF::packet_style::INVALID )
         {
           // Convert the domain and associate a packet with the field
-          optional_fields[i] = KPF::packet_t( KPF::packet_header_t( style, stoi( field_dbl.match(2) )));
+          optional_fields[i] = KPF::packet_t( KPF::packet_header_t( style, stoi( matches.str(2) )));
 
         } // ...not a valid KPF domain
       } // ... didn't find two matches
@@ -123,11 +123,11 @@ get_optional_fields()
     // Is the type string?
     else if (e.typeid_str == strtype)
     {
-      if (field_kv.find( e.name ))
+      if ( std::regex_search( e.name, matches, field_kv ))
       {
         // Create a partial KV packet with the key
         KPF::packet_t p( (KPF::packet_header_t( KPF::packet_style::KV )) );
-        p.kv.key = field_kv.match(1);
+        p.kv.key = matches.str(1);
         optional_fields[i] = p;
 
       } // ...didn't get exactly one match
@@ -136,13 +136,13 @@ get_optional_fields()
     // Is the type a map<size_t, double>?
     else if (e.typeid_str == csettype)
     {
-      if (field_cset.find( e.name ))
+      if ( std::regex_search( e.name, matches, field_cset ))
       {
         // Convert the domain, associate a packet with the field
         optional_fields[i] =
           KPF::packet_t(
             KPF::packet_header_t(KPF::packet_style::CSET,
-                                 stoi( field_cset.match(1))));
+                                 stoi( matches.str(1))));
       } // ...didn't match the cset name
     } // ...didn't match the cset type
 

--- a/track_oracle/file_formats/track_4676/file_format_4676.cxx
+++ b/track_oracle/file_formats/track_4676/file_format_4676.cxx
@@ -14,8 +14,6 @@
 
 #include <tinyxml.h>
 
-#include <boost/lexical_cast.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -74,9 +72,9 @@ extract_track(STANAG_4676::Track::sptr t,
 
   try
   {
-    track.external_id() = boost::lexical_cast<int>(t->getNumber());
+    track.external_id() = t->getNumber().stoi();
   }
-  catch (boost::bad_lexical_cast const&)
+  catch (const std::invalid_argument&)
   {
     LOG_ERROR("Failed to convert track number '" << t->getNumber()
               << "'; ignoring track\n");

--- a/track_oracle/file_formats/track_4676/track_4676.h
+++ b/track_oracle/file_formats/track_4676/track_4676.h
@@ -14,12 +14,12 @@
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_point_3d.h>
 
-#include <boost/uuid/uuid.hpp>
+#include <vital/types/uid.h>
 
 namespace vidtk
 {
 
-typedef boost::uuids::uuid uuid_t;
+typedef viat::uid uuid_t;
 
 struct track_4676_type: public track_base< track_4676_type >
 {

--- a/track_oracle/file_formats/track_apix/CMakeLists.txt
+++ b/track_oracle/file_formats/track_apix/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries( track_apix
   PRIVATE              kwiver_geographic
                        ${SHAPELIB_LIBRARY}
                        ${Boost_DATE_TIME_LIBRARY}
-                       vul
 )
 
 

--- a/track_oracle/file_formats/track_apix/file_format_apix.cxx
+++ b/track_oracle/file_formats/track_apix/file_format_apix.cxx
@@ -10,10 +10,10 @@
 #include <fstream>
 #include <sstream>
 #include <cstdio>
+#include <regex>
 
 #include <shapefil.h>
 #include <geographic/geo_coords.h>
-#include <vul/vul_reg_exp.h>
 
 
 #include <vital/logger/logger.h>

--- a/track_oracle/file_formats/track_csv/file_format_csv.cxx
+++ b/track_oracle/file_formats/track_csv/file_format_csv.cxx
@@ -17,9 +17,6 @@
 #include <track_oracle/core/state_flags.h>
 #include <track_oracle/data_terms/data_terms.h>
 
-#include <boost/smart_ptr.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <vul/vul_timer.h>
 #include <vul/vul_file.h>
 #include <vul/vul_sprintf.h>

--- a/track_oracle/file_formats/track_csv/file_format_csv.cxx
+++ b/track_oracle/file_formats/track_csv/file_format_csv.cxx
@@ -293,8 +293,8 @@ file_format_csv
   // of the track_sequence header. (frame_sequence may be
   // missing if no frame data is recorded.)
 
-  vector<string>::iterator track_sequence_probe = find( headers.begin(), headers.end(), "_track_sequence" );
-  vector<string>::iterator external_id_probe = find( headers.begin(), headers.end(),  "external_id" );
+  vector<string>::iterator track_sequence_probe = find( headers.begin(), headers.end(), string("_track_sequence") );
+  vector<string>::iterator external_id_probe = find( headers.begin(), headers.end(),  string("external_id") );
 
   if (( track_sequence_probe == headers.end() ) &&
       ( external_id_probe == headers.end() ))

--- a/track_oracle/file_formats/track_csv/file_format_csv.cxx
+++ b/track_oracle/file_formats/track_csv/file_format_csv.cxx
@@ -18,7 +18,6 @@
 #include <track_oracle/data_terms/data_terms.h>
 
 #include <boost/smart_ptr.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
 #include <vul/vul_timer.h>
@@ -393,7 +392,7 @@ file_format_csv
     bool row_is_track = ( values[ frame_index ].empty() );
     if (row_is_track)
     {
-      unsigned this_id = boost::lexical_cast<unsigned>( values[ sequence_index ]);
+      unsigned this_id = std::stoul( values[ sequence_index ] );
 
       // do we need to create a new row?
       if ( sequence_to_handle_map.find( this_id ) == sequence_to_handle_map.end() )
@@ -413,7 +412,7 @@ file_format_csv
         ? values[frame_index]
         : values[sequence_index];
 
-      unsigned this_frame_belongs_to = boost::lexical_cast<unsigned>( parent_probe_target_string );
+      unsigned this_frame_belongs_to = std::stoul( parent_probe_target_string );
       map< size_t, track_handle_type >::const_iterator parent_probe =
         sequence_to_handle_map.find( this_frame_belongs_to );
       if (parent_probe == sequence_to_handle_map.end() )

--- a/track_oracle/file_formats/track_csv/file_format_csv.cxx
+++ b/track_oracle/file_formats/track_csv/file_format_csv.cxx
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <fstream>
 #include <vector>
+#include <algorithm>
 
 #include <vital/logger/logger.h>
 static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
@@ -293,8 +294,8 @@ file_format_csv
   // of the track_sequence header. (frame_sequence may be
   // missing if no frame data is recorded.)
 
-  vector<string>::iterator track_sequence_probe = find( headers.begin(), headers.end(), string("_track_sequence") );
-  vector<string>::iterator external_id_probe = find( headers.begin(), headers.end(),  string("external_id") );
+  vector<string>::iterator track_sequence_probe = std::find( headers.begin(), headers.end(), "_track_sequence" );
+  vector<string>::iterator external_id_probe = std::find( headers.begin(), headers.end(), "external_id" );
 
   if (( track_sequence_probe == headers.end() ) &&
       ( external_id_probe == headers.end() ))

--- a/track_oracle/file_formats/track_e2at_callout/CMakeLists.txt
+++ b/track_oracle/file_formats/track_e2at_callout/CMakeLists.txt
@@ -33,5 +33,4 @@ target_link_libraries( track_e2at_callout
   PRIVATE              data_terms
                        track_oracle_tokenizers
                        vital_logger
-                       vul
 )

--- a/track_oracle/file_formats/track_e2at_callout/file_format_e2at_callout.cxx
+++ b/track_oracle/file_formats/track_e2at_callout/file_format_e2at_callout.cxx
@@ -9,8 +9,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include <vul/vul_reg_exp.h>
+#include <regex>
 
 #include <track_oracle/utils/tokenizers.h>
 #include <track_oracle/data_terms/data_terms.h>
@@ -39,10 +38,11 @@ namespace { // anon
 pair< string, double >
 parse_time( const string& s )
 {
-  vul_reg_exp re("^([0-9]+):([0-9]+)$");
-  if ( re.find( s ) )
+  std::regex re("^([0-9]+):([0-9]+)$");
+  std::smatch matches;
+  if ( std::regex_search( s, matches, re ) )
   {
-    istringstream iss( re.match(1) + " " +re.match(2) );
+    istringstream iss( matches.str(1) + " " + matches.str(2) );
     double min, sec;
     if ( (iss >> min >> sec ))
     {
@@ -64,25 +64,26 @@ parse_latlon( const string& s,
               double& lat,
               double& lon )
 {
-  vul_reg_exp re("([0-9\\-\\.]+)([NnSs])([0-9\\-\\.]+)([WwEe])");
-  if ( ! re.find( s )) return false;
-  istringstream latss( re.match(1) ), lonss( re.match(3) );
+  std::regex re("([0-9\\-\\.]+)([NnSs])([0-9\\-\\.]+)([WwEe])");
+  std::smatch matches;
+  if ( ! std::regex_search( s, matches, re )) return false;
+  istringstream latss( matches[1] ), lonss( matches[3] );
   if ( ! ( latss >> lat ))
   {
-    LOG_ERROR( main_logger, "Logic error: expected to parse a latitude from '" << re.match(1) << "'" );
+    LOG_ERROR( main_logger, "Logic error: expected to parse a latitude from '" << matches[1] << "'" );
     return false;
   }
   if ( ! ( lonss >> lon ))
   {
-    LOG_ERROR( main_logger, "Logic error: expected to parse a longitude from '" << re.match(3) << "'" );
+    LOG_ERROR( main_logger, "Logic error: expected to parse a longitude from '" << matches[3] << "'" );
     return false;
   }
-  char ns = re.match(2)[0];
+  char ns = matches.str(2)[0];
   if ((ns == 's') || (ns == 'S'))
   {
     lat = -1.0 * lat;
   }
-  char ew = re.match(4)[0];
+  char ew = matches.str(4)[0];
   if ((ew == 'w') || (ew == 'W'))
   {
     lon = -1.0 * lon;

--- a/track_oracle/file_formats/track_filter_kwe/track_filter_kwe.cxx
+++ b/track_oracle/file_formats/track_filter_kwe/track_filter_kwe.cxx
@@ -9,9 +9,9 @@
 #include <cmath>
 #include <iostream>
 #include <fstream>
+#include <regex>
 
 #include <vul/vul_awk.h>
-#include <vul/vul_reg_exp.h>
 #include <vul/vul_timer.h>
 #include <vul/vul_sprintf.h>
 #include <vul/vul_file.h>
@@ -71,7 +71,8 @@ track_filter_kwe_type
 
   string line;
   size_t nlines = 0;
-  vul_reg_exp comment_re( "^ *#" );
+  std::regex comment_re( "^ *#" );
+  std::smatch matches;
   vul_timer timer;
   size_t file_size = vul_file::size( fn );
   while (getline( is, line ))
@@ -85,7 +86,7 @@ track_filter_kwe_type
       timer.mark();
     }
 
-    if ( comment_re.find( line )) continue;
+    if ( std::regex_search( line, matches, comment_re )) continue;
 
     event_data_block b;
     if ( ! event_adapter::parse_kwe_line( line, b, wmsgs ))  return false;

--- a/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
+++ b/track_oracle/file_formats/track_kpf_geom/file_format_kpf_geom.cxx
@@ -49,8 +49,6 @@ static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __
 #include <track_oracle/utils/logging_map.h>
 #include <track_oracle/file_formats/kpf_utils/kpf_utils.h>
 
-#include <kwiversys/RegularExpression.hxx>
-
 #include <yaml-cpp/yaml.h>
 
 #include <iostream>

--- a/track_oracle/file_formats/track_kwxml/file_format_kwxml.cxx
+++ b/track_oracle/file_formats/track_kwxml/file_format_kwxml.cxx
@@ -15,7 +15,6 @@
 #include <vul/vul_reg_exp.h>
 
 #include <tinyxml.h>
-#include <boost/lexical_cast.hpp>
 
 #include <track_oracle/utils/tokenizers.h>
 #include <track_oracle/utils/logging_map.h>
@@ -937,8 +936,7 @@ file_format_kwxml
         }
         try
         {
-          meta.timestamp_microseconds_since_1970 =
-            boost::lexical_cast<long long>(str_time_stamp);
+          meta.timestamp_microseconds_since_1970 = std::stoll( str_time_stamp );
         }
         catch(...)
         {

--- a/track_oracle/file_formats/track_kwxml/file_format_kwxml.cxx
+++ b/track_oracle/file_formats/track_kwxml/file_format_kwxml.cxx
@@ -12,8 +12,6 @@
 #include <cstdio>
 #include <utility>
 
-#include <vul/vul_reg_exp.h>
-
 #include <tinyxml.h>
 
 #include <track_oracle/utils/tokenizers.h>

--- a/track_oracle/file_formats/track_vatic/file_format_vatic.cxx
+++ b/track_oracle/file_formats/track_vatic/file_format_vatic.cxx
@@ -12,7 +12,7 @@
 #include <cstdio>
 #include <cctype>
 
-#include <boost/tokenizer.hpp>
+#include <vital/util/tokenize.h>
 
 #include <vital/logger/logger.h>
 static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __FILE__ ) );
@@ -45,14 +45,9 @@ file_format_vatic
   if ( line.find( "\"" ) == string::npos ) return false;
 
   {
-    boost::char_separator<char> sep(" ");
-    boost::tokenizer<boost::char_separator<char> > tokens(line, sep);
-    for ( boost::tokenizer<boost::char_separator<char> >::iterator it = tokens.begin();
-          it != tokens.end();
-          ++it)
-    {
-      fields.push_back(*it);
-    }
+    vector< string > fields;
+    const bool doTrimEmpty = true;
+    kwiver::vital::tokenize( line, fields, " ", doTrimEmpty );
     if (fields.size() < 10  || !isdigit(fields[6][0]))
     {
       return false;

--- a/track_oracle/file_formats/track_xgtf/CMakeLists.txt
+++ b/track_oracle/file_formats/track_xgtf/CMakeLists.txt
@@ -33,6 +33,5 @@ target_link_libraries( track_xgtf
                        vgl
   PRIVATE              track_oracle_tokenizers
                        logging_map
-                       vul
                        ${TinyXML_LIBRARY}
 )

--- a/track_oracle/file_formats/track_xgtf/file_format_xgtf.cxx
+++ b/track_oracle/file_formats/track_xgtf/file_format_xgtf.cxx
@@ -6,7 +6,6 @@
 
 #include "file_format_xgtf.h"
 
-#include <vul/vul_reg_exp.h>
 #include <vgl/vgl_point_2d.h>
 
 #include <tinyxml.h>

--- a/track_oracle/file_formats/track_xgtf/file_format_xgtf.cxx
+++ b/track_oracle/file_formats/track_xgtf/file_format_xgtf.cxx
@@ -11,8 +11,6 @@
 
 #include <tinyxml.h>
 
-#include <boost/lexical_cast.hpp>
-
 #include <track_oracle/utils/tokenizers.h>
 #include <track_oracle/utils/logging_map.h>
 #include <track_oracle/file_formats/track_xgtf/track_xgtf.h>


### PR DESCRIPTION
Remove Boost dependencies from the active parts of track_oracle.

There are references to boost's time/date utilities in the 4676 and APIX formats, but these are disabled for other reasons.
