### PR TITLE
Use kwiver_create_python_init in case sprokit isn't enabled

### DIFF
--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -156,7 +156,7 @@ target_link_libraries(python-vital.types-object_track_set
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-sprokit_create_python_init(vital/types
+kwiver_create_python_init(vital/types
   bounding_box
   camera
   camera_intrinsics


### PR DESCRIPTION
This is the first commit from #566. This branch fixes the configuration bug that happens when kwiver is  configured without sprokit.