### PR TITLE
Refactor plugin build/install directory names.

### DIFF
--- a/CMake/setup_KWIVER.bat.in
+++ b/CMake/setup_KWIVER.bat.in
@@ -7,7 +7,7 @@
 :: where as an install directory does not (bin/*.dlls)
 if exist %~dp0/bin/kwiversys.dll (
   set config=
-  
+
   if not [%1] == [] echo setting up an install directory, ignoring provided configuration.
   GOTO Start
 )
@@ -24,7 +24,7 @@ set config=release
 
 set PATH=%~dp0/bin/%config%;%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%;@EXTRA_WIN32_PATH@
 
-set KWIVER_PLUGIN_PATH=%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%
+set KWIVER_PLUGIN_PATH=%~dp0/lib/%config%/@kwiver_plugin_module_subdir@;%~dp0/lib/%config%/sprokit;%~dp0/lib/@kwiver_plugin_process_subdir@/%config%
 
 :: Set default log reporting level for default logger.
 :: set KWIVER_DEFAULT_LOG_LEVEL=info

--- a/CMake/setup_KWIVER.sh.in
+++ b/CMake/setup_KWIVER.sh.in
@@ -6,7 +6,7 @@ this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export VG_PLUGIN_PATH=$this_dir
 export PATH=$this_dir/bin:$PATH
 export @LIBRARY_PATH_VAR@=$this_dir/lib:$@LIBRARY_PATH_VAR@
-export KWIVER_PLUGIN_PATH=$this_dir/lib/modules:$this_dir/lib/sprokit:$KWIVER_PLUGIN_PATH
+export KWIVER_PLUGIN_PATH=$this_dir/lib/@kwiver_plugin_module_subdir@:$this_dir/lib/@kwiver_plugin_process_subdir@:$KWIVER_PLUGIN_PATH
 
 # Set default log reporting level for default logger.
 # export KWIVER_DEFAULT_LOG_LEVEL=info

--- a/CMake/utils/algorithm-utils-targets.cmake
+++ b/CMake/utils/algorithm-utils-targets.cmake
@@ -67,7 +67,7 @@ function(algorithms_create_plugin    base_lib)
   set( plugin_name   "${base_lib}_plugin" )
 
   # create module library given generated source, linked to given library
-  set(library_subdir /modules)
+  set(library_subdir /${kwiver_plugin_module_subdir})
   set(no_version ON)
 
   kwiver_add_plugin( ${plugin_name}

--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -362,7 +362,7 @@ endfunction()
 
 ####
 # This function adds the supplied paths to the default set of paths
-# searched at runtime for modules.
+# searched at **runtime** for modules.
 #
 # Uses the global option KWIVER_USE_CONFIGURATION_SUBDIRECTORY
 # to control adding config specific directories to the path.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set( kwiver_plugin_process_instrumentation_subdir kwiver/modules ) # with module
 set( kwiver_plugin_scheduler_subdir               kwiver/processes ) # with processes for now
 set( kwiver_plugin_module_subdir                  kwiver/modules )
 set( kwiver_plugin_plugin_explorer_subdir         kwiver/modules/plugin_explorer )
+set( kwiver_plugin_logger_subdir                  kwiver/modules )
 
 ##
 # System specific compiler flags
@@ -230,7 +231,7 @@ file( COPY log4cxx.properties       DESTINATION  "${KWIVER_BINARY_DIR}" )
 install( FILES log4cxx.properties   DESTINATION ${CMAKE_INSTALL_PREFIX} )
 
 if ( KWIVER_ENABLE_LOG4CXX )
-  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export VITAL_LOGGER_FACTORY=$this_dir/lib/modules/vital_log4cxx_logger\n" )
+  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export VITAL_LOGGER_FACTORY=$this_dir/lib/${kwiver_plugin_logger_subdir}/vital_log4cxx_logger\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export LOG4CXX_CONFIGURATION=$this_dir/log4cxx.properties\n" )
   if(WIN32)
     message(STATUS "Log4CXX is not supported on windows, if no other logger is provided, the default will be used")
@@ -243,7 +244,7 @@ file( COPY log4cplus.properties       DESTINATION  "${KWIVER_BINARY_DIR}" )
 install( FILES log4cplus.properties   DESTINATION ${CMAKE_INSTALL_PREFIX} )
 
 if ( KWIVER_ENABLE_LOG4CPLUS )
-  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export VITAL_LOGGER_FACTORY=$this_dir/lib/modules/vital_log4cplus_logger\n" )
+  file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export VITAL_LOGGER_FACTORY=$this_dir/lib/${kwiver_plugin_logger_subdir}/vital_log4cplus_logger\n" )
   file( APPEND "${KWIVER_SETUP_SCRIPT_FILE}" "export LOG4CPLUS_CONFIGURATION=$this_dir/log4cplus.properties\n" )
 
   file( APPEND "${KWIVER_SETUP_BATCH_FILE}" "set VITAL_LOGGER_FACTORY=vital_log4cplus_logger\n" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,14 @@ set(BUILD_SHARED_LIBS ${KWIVER_BUILD_SHARED})
 #
 include(kwiver-utils)
 
+# Set directories where loadable modules are stored.
+# These subdirs are under .../lib/
+set( kwiver_plugin_process_subdir                 kwiver/processes )
+set( kwiver_plugin_process_instrumentation_subdir kwiver/modules ) # with modules for now
+set( kwiver_plugin_scheduler_subdir               kwiver/processes ) # with processes for now
+set( kwiver_plugin_module_subdir                  kwiver/modules )
+set( kwiver_plugin_plugin_explorer_subdir         kwiver/modules/plugin_explorer )
+
 ##
 # System specific compiler flags
 include(kwiver-flags)

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -8,6 +8,14 @@ fixes over the previous v1.2.0 release.
 Updates since v1.2.0
 --------------------
 
+ * Loadable modules (algorithms and processes) have been moved under
+   the .../lib/kwiver sugdirectory so that they will not conflict with
+   other packages.
+
+ * Replaces sprokit_private_header_group with kwiver equivalent.
+
+ * Remove unused sprokit cmake support.
+
 Vital
 
 

--- a/extras/RightTrack/CMakeLists.txt
+++ b/extras/RightTrack/CMakeLists.txt
@@ -17,5 +17,5 @@ kwiver_add_plugin( RightTrack_plugin
                    "${RIGHT_TRACK_LIB}"
                    vcl vpl vul vsl
                    sprokit_pipeline
-  SUBDIR           modules
+  SUBDIR           ${kwiver_plugin_process_instrumentation_subdir}
   )

--- a/extras/process_instrumentation/CMakeLists.txt
+++ b/extras/process_instrumentation/CMakeLists.txt
@@ -24,7 +24,7 @@ kwiver_add_plugin( instrumentation_plugin
                    vital_util
                    vital_logger
                    sprokit_pipeline
-  SUBDIR           modules
+  SUBDIR           ${kwiver_plugin_process_instrumentation_subdir}
   )
 
 
@@ -32,7 +32,7 @@ if (KWIVER_ENABLE_TOOLS)
 ###
 #     plugins for plugin explorer
 kwiver_add_plugin( process_instrumentation_plugin
-  SUBDIR   modules/plugin_explorer
+  SUBDIR   ${kwiver_plugin_plugin_explorer_subdir}
   SOURCES  process_instrumentation_plugin.cxx
   PRIVATE  vital
            vital_vpm

--- a/sprokit/conf/sprokit-macro-targets.cmake
+++ b/sprokit/conf/sprokit-macro-targets.cmake
@@ -2,13 +2,6 @@
 # The following functions are defined:
 #
 #   sprokit_install
-#   sprokit_add_executable
-#   sprokit_add_library
-#   sprokit_private_header_group
-#   sprokit_private_template_group
-#   sprokit_install_pipelines
-#   sprokit_install_clusters
-#   sprokit_install_includes
 #
 # The following variables may be used to control the behavior of the functions:
 #
@@ -47,28 +40,6 @@
 #   sprokit_install([args])
 #     A wrapper around the install call which recognizes the 'no_install'
 #     variable.
-#
-#   sprokit_add_executable(name [source ...])
-#     Creates an executable that is built into the correct directory and is
-#     installed.
-#
-#   sprokit_add_library(name [source ...])
-#     Creates a library named that is built into the correct directory and
-#     is installed. Additionally, the 'library_subdir' variable can be set to
-#     put the library in the correct place on DLL systems (see the CMake
-#     documentation on LIBRARY_OUTPUT_DIRECTORY).
-#
-#   sprokit_private_header_group([source ...])
-#   sprokit_private_template_group([source ...])
-#     Add 'sources' to a subdirectory within IDEs which display sources for
-#     each target. Useful for separating installed files from private files in
-#     the UI.
-#
-#   sprokit_install_pipelines([pipeline ...])
-#   sprokit_install_clusters([cluster ...])
-#   sprokit_install_includes([include ...])
-#     Install pipeline files into the correct
-#     location.
 #
 
 ###
@@ -109,45 +80,4 @@ function (sprokit_install)
   endif ()
 
   install(${ARGN})
-endfunction ()
-
-###
-#
-function (sprokit_private_header_group)
-  source_group("Header Files\\Private"
-    FILES ${ARGN})
-endfunction ()
-
-###
-#
-function (sprokit_private_template_group)
-  source_group("Template Files\\Private"
-    FILES ${ARGN})
-endfunction ()
-
-###
-#
-function (sprokit_install_pipelines)
-  sprokit_install(
-    FILES       ${ARGN}
-    DESTINATION share/sprokit/pipelines
-    COMPONENT   pipeline)
-endfunction ()
-
-###
-# for cluster definitions
-function (sprokit_install_clusters)
-  sprokit_install(
-    FILES       ${ARGN}
-    DESTINATION share/sprokit/pipelines/clusters
-    COMPONENT   pipeline)
-endfunction ()
-
-###
-# for pipeline fragment files that are included
-function (sprokit_install_includes)
-  sprokit_install(
-    FILES       ${ARGN}
-    DESTINATION share/sprokit/pipelines/include
-    COMPONENT   pipeline)
 endfunction ()

--- a/sprokit/processes/CMakeLists.txt
+++ b/sprokit/processes/CMakeLists.txt
@@ -43,7 +43,7 @@ if (KWIVER_ENABLE_TOOLS)
 ###
 #     plugins for plugin explorer
 kwiver_add_plugin( process_explorer_plugin
-  SUBDIR   modules/plugin_explorer
+  SUBDIR   ${kwiver_plugin_plugin_explorer_subdir}
   SOURCES  process_explorer_plugin.cxx
   PRIVATE  vital
            vital_vpm

--- a/sprokit/processes/adapters/CMakeLists.txt
+++ b/sprokit/processes/adapters/CMakeLists.txt
@@ -64,7 +64,7 @@ set( proc_sources
 ###
 # make processes plugin
 kwiver_add_plugin( kwiver_processes_adapter
-  SUBDIR          sprokit
+  SUBDIR          ${kwiver_plugin_process_subdir}
   SOURCES         ${proc_sources}
   PRIVATE         kwiver_adapter sprokit_pipeline
                   vital_config

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -5,7 +5,7 @@ project( kwiver_processes )
 
 set( sources
   register_processes.cxx
-  
+
   associate_detections_to_tracks_process.cxx
   close_loops_process.cxx
   compute_association_matrix_process.cxx
@@ -13,10 +13,10 @@ set( sources
   compute_stereo_depth_map_process.cxx
   compute_track_descriptors_process.cxx
   detect_features_if_keyframe_process.cxx
-  detect_features_process.cxx  
+  detect_features_process.cxx
   detected_object_output_process.cxx
   detected_object_input_process.cxx
-  detected_object_filter_process.cxx  
+  detected_object_filter_process.cxx
   draw_detected_object_set_process.cxx
   draw_tracks_process.cxx
   extract_descriptors_process.cxx
@@ -49,7 +49,7 @@ set( private_headers
   compute_stereo_depth_map_process.h
   compute_track_descriptors_process.h
   detect_features_if_keyframe_process.h
-  detect_features_process.h  
+  detect_features_process.h
   detected_object_output_process.h
   detected_object_input_process.h
   detected_object_filter_process.h
@@ -82,13 +82,13 @@ kwiver_private_header_group( ${private_headers} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
 kwiver_add_plugin( kwiver_processes
-  SUBDIR           sprokit
-  SOURCES        ${sources}
-                 ${private_headers}
+  SUBDIR           ${kwiver_plugin_process_subdir}
+  SOURCES          ${sources}
+                   ${private_headers}
   PRIVATE          sprokit_pipeline
                    kwiver_algo_core
                    kwiversys
                    vital vital_vpm vital_logger vital_config
-                 ${Boost_SYSTEM_LIBRARY}
-                 ${Boost_FILESYSTEM_LIBRARY}
+                   ${Boost_SYSTEM_LIBRARY}
+                   ${Boost_FILESYSTEM_LIBRARY}
 )

--- a/sprokit/processes/examples/process_template/CMakeLists.txt
+++ b/sprokit/processes/examples/process_template/CMakeLists.txt
@@ -39,9 +39,9 @@ endif()
 ##++ This builds a plugin containing the specified process(s)
 ##++ Replace "template_process" with the desired name of the plugin file
 kwiver_add_plugin( template_processes
-  SUBDIR           sprokit
-  SOURCES        ${sources}
-                 ${private_headers}
+  SUBDIR           ${kwiver_plugin_process_subdir}
+  SOURCES          ${sources}
+                   ${private_headers}
   PRIVATE          sprokit_pipeline
                    vital vital_vpm vital_logger vital_config
                    kwiver_algo_ocv

--- a/sprokit/processes/flow/CMakeLists.txt
+++ b/sprokit/processes/flow/CMakeLists.txt
@@ -15,9 +15,9 @@ set(flow_private_headers
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
-sprokit_private_header_group(${flow_private_headers})
+kwiver_private_header_group(${flow_private_headers})
 kwiver_add_plugin(processes_flow
-  SUBDIR      sprokit
+  SUBDIR      ${kwiver_plugin_process_subdir}
   SOURCES     ${flow_srcs}
               ${flow_private_headers}
   PRIVATE     sprokit_pipeline

--- a/sprokit/processes/matlab/CMakeLists.txt
+++ b/sprokit/processes/matlab/CMakeLists.txt
@@ -20,15 +20,15 @@ include_directories( "${CMAKE_CURRENT_BINARY_DIR}" )
 include_directories( "${Matlab_INCLUDE_DIRS}" )
 
 kwiver_add_plugin( kwiver_processes_matlab
-  SUBDIR           sprokit
-  SOURCES        ${sources}
-                 ${private_headers}
+  SUBDIR           ${kwiver_plugin_process_subdir}
+  SOURCES          ${sources}
+                   ${private_headers}
   PRIVATE          sprokit_pipeline
                    kwiver_algo_core
                    kwiver_algo_matlab
                    kwiversys
                    vital vital_vpm vital_logger vital_config
-                 ${Boost_SYSTEM_LIBRARY}
-                 ${Boost_FILESYSTEM_LIBRARY}
-                 ${Matlab_LIBRARIES}
+                   ${Boost_SYSTEM_LIBRARY}
+                   ${Boost_FILESYSTEM_LIBRARY}
+                   ${Matlab_LIBRARIES}
 )

--- a/sprokit/processes/ocv/CMakeLists.txt
+++ b/sprokit/processes/ocv/CMakeLists.txt
@@ -23,12 +23,12 @@ if( OpenCV_VERSION VERSION_LESS "2.4" )
 endif()
 
 kwiver_add_plugin( kwiver_processes_ocv
-  SUBDIR           sprokit
-  SOURCES        ${sources}
-                 ${private_headers}
+  SUBDIR           ${kwiver_plugin_process_subdir}
+  SOURCES          ${sources}
+                   ${private_headers}
   PRIVATE          sprokit_pipeline
                    kwiver_algo_core kwiver_algo_ocv
                    vital vital_vpm vital_logger vital_config
                    kwiversys
-                 ${OpenCV_LIBS}
+                   ${OpenCV_LIBS}
  )

--- a/sprokit/processes/vxl/CMakeLists.txt
+++ b/sprokit/processes/vxl/CMakeLists.txt
@@ -18,9 +18,9 @@ kwiver_private_header_group( ${private_headers} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
 kwiver_add_plugin( kwiver_processes_vxl
-  SUBDIR          sprokit
-  SOURCES       ${sources}
-                ${private_headers}
+  SUBDIR          ${kwiver_plugin_process_subdir}
+  SOURCES         ${sources}
+                  ${private_headers}
   PRIVATE         sprokit_pipeline
                   kwiver_algo_core kwiver_algo_vxl
                   vital vital_vpm vital_logger vital_config

--- a/sprokit/src/bindings/python/modules/CMakeLists.txt
+++ b/sprokit/src/bindings/python/modules/CMakeLists.txt
@@ -13,14 +13,14 @@ set(python_noarch TRUE)
 sprokit_create_python_init(sprokit/modules)
 set(python_noarch FALSE)
 
-sprokit_private_header_group(${modules_python_private_headers})
+kwiver_private_header_group(${modules_python_private_headers})
 
 if(UNIX)
   add_definitions( -DSPROKIT_LOAD_PYLIB_SYM )
 endif()
 
 kwiver_add_plugin(modules_python
-  SUBDIR          sprokit
+  SUBDIR          ${kwiver_plugin_process_subdir}
   SOURCES         ${modules_python_srcs}
                   ${modules_python_private_headers}
   PRIVATE         sprokit_pipeline

--- a/sprokit/src/processes/clusters/CMakeLists.txt
+++ b/sprokit/src/processes/clusters/CMakeLists.txt
@@ -36,9 +36,9 @@ sprokit_configure_file(cluster-paths.h
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
-sprokit_private_header_group(${clusters_private_headers})
+kwiver_private_header_group(${clusters_private_headers})
 kwiver_add_plugin(processes_clusters
-  SUBDIR       sprokit
+  SUBDIR       ${kwiver_plugin_process_subdir}
   SOURCES      ${clusters_srcs}
                ${clusters_private_headers}
   PUBLIC       vital_logger

--- a/sprokit/src/processes/examples/CMakeLists.txt
+++ b/sprokit/src/processes/examples/CMakeLists.txt
@@ -49,12 +49,12 @@ set(examples_private_headers
 
 set(no_install FALSE)
 
-sprokit_private_header_group(${examples_private_headers})
+kwiver_private_header_group(${examples_private_headers})
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
 kwiver_add_plugin(processes_examples
-  SUBDIR         sprokit
+  SUBDIR         ${kwiver_plugin_process_subdir}
   SOURCES        ${examples_srcs}
                  ${examples_private_headers}
   PRIVATE        sprokit_pipeline

--- a/sprokit/src/schedulers/CMakeLists.txt
+++ b/sprokit/src/schedulers/CMakeLists.txt
@@ -15,7 +15,7 @@ set( private_headers
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
-sprokit_private_header_group(${private_headers})
+kwiver_private_header_group(${private_headers})
 
 kwiver_add_plugin( schedulers
   SOURCES         ${source}
@@ -28,7 +28,7 @@ kwiver_add_plugin( schedulers
                   ${Boost_THREAD_LIBRARY}
                   ${Boost_SYSTEM_LIBRARY}
                   ${CMAKE_THREAD_LIBS_INIT}
-  SUBDIR          sprokit
+  SUBDIR          ${kwiver_plugin_process_subdir}
   )
 
 add_subdirectory(examples)

--- a/sprokit/src/schedulers/examples/CMakeLists.txt
+++ b/sprokit/src/schedulers/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ set(examples_private_headers
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
-sprokit_private_header_group(${examples_private_headers})
+kwiver_private_header_group(${examples_private_headers})
 
 kwiver_add_plugin( schedulers_examples
   SOURCES        ${examples_srcs}
@@ -24,5 +24,5 @@ kwiver_add_plugin( schedulers_examples
                  ${Boost_THREAD_LIBRARY}
                  ${Boost_SYSTEM_LIBRARY}
                  ${CMAKE_THREAD_LIBS_INIT}
-  SUBDIR         sprokit
+  SUBDIR         ${kwiver_plugin_scheduler_subdir}
   )

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -97,7 +97,7 @@ set_source_files_properties(edge.cxx
   PROPERTIES
   COMPILE_DEFINITIONS "SPROKIT_DEFAULT_EDGE_CAPACITY=${SPROKIT_DEFAULT_EDGE_CAPACITY}" )
 
-sprokit_private_header_group(${pipeline_private_headers})
+kwiver_private_header_group(${pipeline_private_headers})
 
 kwiver_add_library(sprokit_pipeline
   ${pipeline_srcs}

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -48,12 +48,11 @@ set(pipeline_headers
 
 set(pipeline_private_headers)
 
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} sprokit )
+kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_process_subdir} )
 set( sprokit_default_module_paths ${kwiver_module_path_result} )
 
-
 if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${sprokit_output_dir} sprokit )
+  kwiver_make_module_path( ${sprokit_output_dir} ${kwiver_plugin_process_subdir} )
   list( INSERT sprokit_default_module_paths 0 "${kwiver_module_path_result}" )
 endif ()
 

--- a/sprokit/src/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline_util/CMakeLists.txt
@@ -89,7 +89,7 @@ set_source_files_properties(load_pipe.cxx
   PROPERTIES
     COMPILE_DEFINITIONS "${load_pipe_build_options}")
 
-sprokit_private_header_group(${pipeline_util_private_headers})
+kwiver_private_header_group(${pipeline_util_private_headers})
 
 kwiver_add_library(sprokit_pipeline_util
   ${pipeline_util_srcs}

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -32,8 +32,8 @@ sprokit_discover_tests(edge edge_libraries test_edge.cxx)
 ##############################
 function (sprokit_add_test_plugin    name    directory)
   kwiver_add_plugin("${name}"
-    SUBDIR   sprokit
-    SOURCES  ${ARGN}
+    SUBDIR     ${kwiver_plugin_process_subdir}
+    SOURCES    ${ARGN}
     PRIVATE    vital_vpm
                sprokit_pipeline)
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -234,11 +234,11 @@ endif()
 # Build a default set of plugin path dirs
 # Provide that list as the default value for the path option.
 
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} modules )
+kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_module_subdir} )
 set( vital_default_module_path ${kwiver_module_path_result} )
 
 if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} modules )
+  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_module_subdir} )
   set( vital_default_module_path ${kwiver_module_path_result} ${vital_default_module_path} )
 endif()
 

--- a/vital/algo/CMakeLists.txt
+++ b/vital/algo/CMakeLists.txt
@@ -149,7 +149,7 @@ if (KWIVER_ENABLE_TOOLS)
 ###
 #     plugins for plugin explorer
 kwiver_add_plugin( algo_explorer_plugin
-  SUBDIR   modules/plugin_explorer
+  SUBDIR   ${kwiver_plugin_plugin_explorer_subdir}
   SOURCES  algo_explorer_plugin.cxx
   PRIVATE  vital
            vital_vpm

--- a/vital/logger/CMakeLists.txt
+++ b/vital/logger/CMakeLists.txt
@@ -65,7 +65,7 @@ if (KWIVER_ENABLE_LOG4CXX)
     SOURCES          log4cxx_factory.cxx
     PRIVATE          ${log4cxx_lib}
                      kwiversys vital_logger
-    SUBDIR           ${kwiver_plugin_module_subdir}
+    SUBDIR           ${kwiver_plugin_logger_subdir}
     )
 
 kwiver_install_headers(
@@ -86,7 +86,7 @@ if (KWIVER_ENABLE_LOG4CPLUS)
     PRIVATE          ${log4cplus_lib}
                      kwiversys vital_logger
                      log4cplus::log4cplus
-    SUBDIR           ${kwiver_plugin_module_subdir}
+    SUBDIR           ${kwiver_plugin_logger_subdir}
     )
 
 kwiver_install_headers(

--- a/vital/logger/CMakeLists.txt
+++ b/vital/logger/CMakeLists.txt
@@ -65,9 +65,9 @@ if (KWIVER_ENABLE_LOG4CXX)
     SOURCES          log4cxx_factory.cxx
     PRIVATE          ${log4cxx_lib}
                      kwiversys vital_logger
-    SUBDIR           modules
+    SUBDIR           ${kwiver_plugin_module_subdir}
     )
-    
+
 kwiver_install_headers(
   ${CMAKE_CURRENT_BINARY_DIR}/vital_log4cxx_logger_export.h
   NOPATH
@@ -86,9 +86,9 @@ if (KWIVER_ENABLE_LOG4CPLUS)
     PRIVATE          ${log4cplus_lib}
                      kwiversys vital_logger
                      log4cplus::log4cplus
-    SUBDIR           modules
+    SUBDIR           ${kwiver_plugin_module_subdir}
     )
-    
+
 kwiver_install_headers(
   ${CMAKE_CURRENT_BINARY_DIR}/vital_log4cplus_logger_export.h
   NOPATH


### PR DESCRIPTION
Converted the approach of explicitly naming the plugin install subdir
to use a CMake symbol that is centrally assigned. Makes it clear where
different plugin types should go. Makes it easy to change install
subdir for plugins.