### PR TITLE
Fix PATH in setup_KWIVER.bat

### DIFF
--- a/CMake/setup_KWIVER.bat.in
+++ b/CMake/setup_KWIVER.bat.in
@@ -22,7 +22,7 @@ set config=release
 
 :Start
 
-set PATH=%~dp0/bin/%config%;%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%;@EXTRA_WIN32_PATH@
+set PATH=%PATH%;%~dp0/bin/%config%;%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%;@EXTRA_WIN32_PATH@
 
 set KWIVER_PLUGIN_PATH=%~dp0/lib/%config%/modules;%~dp0/lib/%config%/sprokit;%~dp0/lib/sprokit/%config%
 

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -281,6 +281,12 @@ Unit Tests
 Fixes since v1.1.1
 ------------------
 
+General
+
+ * Fixed an issue in the generated setup_KWIVER.bat script in which the
+   PATH environment variable was being replaced with KWIVER paths rather
+   than appending those paths.
+
 Sprokit
 
  * Top level pipeline descriptions that are sourced from a stream do


### PR DESCRIPTION
This fix was needed for me to package MAP-Tk.  It seems like the right thing to do, but I'm not sure if there was some other reason we were intentionally replacing rather than appending to PATH.