### PR TITLE
Speed up SRNN_tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build
 .ipynb_checkpoints
 
 *.swp
+*.swo

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -17,9 +17,6 @@ class TargetRNNDataLoader(data.Dataset):
         self._track_search_threshold = track_search_threshold
         self._rnnType = rnnType
 
-        self._tracks_num = len(track_set)
-        self._track_states_num = len(track_state_list)
-
         self._data_list = self._make_dataset()
 
     def _make_dataset(self):

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -31,10 +31,9 @@ class TargetRNNDataLoader(data.Dataset):
             else:
                 _rnnType = RnnType.Target_RNN_AIM
 
-            # only process active and un-unpdated track
+            # only process active and un-updated tracks
             if cur_track.active_flag and not cur_track.updated_flag and (_rnnType is self._rnnType):
                 for ts, track_state in enumerate(self._track_state_list):
-
                     # distance between the two bbox's x instead of center
                     dis = abs(cur_track[-1].bbox[0] - track_state.bbox[0])
 
@@ -127,7 +126,7 @@ class SRNN_matching(object):
         self._est_similarity(AIM_V_data_loader, RnnType.Target_RNN_AIM_V)
         self._est_similarity(AIM_data_loader, RnnType.Target_RNN_AIM)
 
-        # obtain the dict: similarity row idx->track_id
+        # obtain the list mapping: similarity row idx->track_id
         track_idx_list = [track.id for track in track_set]
 
         return self._similarity_mat.cpu().numpy(), track_idx_list

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -1,7 +1,6 @@
 import torch
 import torch.utils.data as data
 from torch import nn
-from torch.autograd import Variable
 
 import numpy as np
 import math
@@ -97,16 +96,18 @@ class SRNN_matching(object):
         
         if GPU_list is None:
             GPU_list = [x for x in range(torch.cuda.device_count())]
-            self._target_GPU = 0
+            target_GPU = 0
         else:
-            self._target_GPU = GPU_list[0]
+            target_GPU = GPU_list[0]
+
+        self._device = torch.device("cuda:{}".format(target_GPU))
 
         self._batch_size = batch_size
 
         # load target AIM model, trained with fixed variable timestep
         full_model_list = (RnnType.Appearance, RnnType.Motion, RnnType.Interaction)
         self._targetRNN_full_model = TargetLSTM(model_list=full_model_list)
-        self._targetRNN_full_model = self._targetRNN_full_model.cuda(self._target_GPU)
+        self._targetRNN_full_model = self._targetRNN_full_model.to(self._device)
 
         snapshot = torch.load(targetRNN_full_model_path)
         self._targetRNN_full_model.load_state_dict(snapshot['state_dict'])
@@ -115,7 +116,7 @@ class SRNN_matching(object):
 
         # load  target AIM_V model, but trained with variable timestep
         V_model_list = (RnnType.Appearance, RnnType.Motion, RnnType.Interaction)
-        self._targetRNN_AIM_V_model = TargetLSTM(model_list=V_model_list).cuda(self._target_GPU)
+        self._targetRNN_AIM_V_model = TargetLSTM(model_list=V_model_list).to(self._device)
 
         snapshot = torch.load(targetRNN_AIM_V_model_path)
         self._targetRNN_AIM_V_model.load_state_dict(snapshot['state_dict'])
@@ -126,7 +127,7 @@ class SRNN_matching(object):
         tracks_num = len(track_set)
         track_states_num = len(track_state_list)
 
-        self._similarity_mat = torch.FloatTensor(tracks_num, track_states_num).fill_(1.0).cuda(self._target_GPU)
+        self._similarity_mat = torch.FloatTensor(tracks_num, track_states_num).fill_(1.0).to(self._device)
 
         # obtain the dict: simailarity row idx->track_id
         track_idx_list = []
@@ -149,17 +150,17 @@ class SRNN_matching(object):
 
 
     def _est_similarity(self, loader, rnnType):
-
+        torch.set_grad_enabled(False)
         for (app_f_list, app_target_f, motion_f_list, motion_target_f, interaction_f_list, interaction_target_f, bbar_f_list, bbar_target_f, t, ts) in loader:
 
-            v_app_seq = Variable(app_f_list, volatile=True).cuda(self._target_GPU)
-            v_app_target =  Variable(app_target_f, volatile=True).cuda(self._target_GPU)
-            v_motion_seq = Variable(motion_f_list, volatile=True).cuda(self._target_GPU) 
-            v_motion_target = Variable(motion_target_f, volatile=True).cuda(self._target_GPU)
-            v_interaction_seq = Variable(interaction_f_list, volatile=True).cuda(self._target_GPU) 
-            v_interaction_target = Variable(interaction_target_f, volatile=True).cuda(self._target_GPU)
-            v_bbar_seq = Variable(bbar_f_list, volatile=True).cuda(self._target_GPU)
-            v_bbar_target = Variable(bbar_target_f, volatile=True).cuda(self._target_GPU)
+            v_app_seq = app_f_list.to(self._device)
+            v_app_target =  app_target_f.to(self._device)
+            v_motion_seq = motion_f_list.to(self._device) 
+            v_motion_target = motion_target_f.to(self._device)
+            v_interaction_seq = interaction_f_list.to(self._device) 
+            v_interaction_target = interaction_target_f.to(self._device)
+            v_bbar_seq = bbar_f_list.to(self._device)
+            v_bbar_target = bbar_target_f.cuda(self._device)
         
             if rnnType is RnnType.Target_RNN_AIM:
                 output = self._targetRNN_full_model(v_app_seq, v_app_target, v_motion_seq, v_motion_target, 
@@ -172,11 +173,13 @@ class SRNN_matching(object):
             output = F_softmax(output)
             pred = torch.max(output, 1)
     
-            label_mask = torch.ne(pred[1].data, 0)
+            #label_mask = torch.ne(pred[1].data, 0)
+            label_mask = torch.ne(pred[1].detach(), 0)
             
-            r_idx = t.cuda(self._target_GPU)[label_mask]
-            c_idx = ts.cuda(self._target_GPU)[label_mask]
-            val = -pred[0].data[label_mask]
+            r_idx = t.to(self._device)[label_mask]
+            c_idx = ts.to(self._device)[label_mask]
+            #val = -pred[0].data[label_mask]
+            val = -pred[0].detach()[label_mask]
             
             if len(r_idx) == 0:
                 pass

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -3,7 +3,6 @@ import torch.utils.data as data
 from torch import nn
 
 import numpy as np
-import math
 
 from kwiver.arrows.pytorch.models import TargetLSTM, get_config, RnnType
 
@@ -38,14 +37,14 @@ class TargetRNNDataLoader(data.Dataset):
                 _rnnType = RnnType.Target_RNN_AIM
 
             # only process active and un-unpdated track
-            if (cur_track.active_flag is True) and (cur_track.updated_flag is False) and (_rnnType is self._rnnType):
+            if cur_track.active_flag and not cur_track.updated_flag and (_rnnType is self._rnnType):
                 for ts in range(self._track_states_num):
 
                     # distance between the two bbox's x instead of center
-                    dis = math.fabs(cur_track[-1].bbox[0] - self._track_state_list[ts].bbox[0])
+                    dis = abs(cur_track[-1].bbox[0] - self._track_state_list[ts].bbox[0])
 
-                    bbox_area_ratio = float(cur_track[-1].bbox[2] * cur_track[-1].bbox[3]) / \
-                                        float(self._track_state_list[ts].bbox[2] * self._track_state_list[ts].bbox[3])
+                    bbox_area_ratio = (float(cur_track[-1].bbox[2] * cur_track[-1].bbox[3]) /
+                                       float(self._track_state_list[ts].bbox[2] * self._track_state_list[ts].bbox[3]))
                     if bbox_area_ratio < 1.0:
                         bbox_area_ratio = 1.0 / bbox_area_ratio
 
@@ -53,34 +52,30 @@ class TargetRNNDataLoader(data.Dataset):
                     if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and                      # track dis constraint
                         dis < self._track_search_threshold * self._track_state_list[ts].bbox[2] and         # track_state dis constraint
                         bbox_area_ratio < self._track_search_threshold):                                    # bbox area constraint
-                        cur_data_item = tuple()
+                        cur_data_item = []
 
                         #app feature and app target
                         app_f_tensor = torch.stack([cur_track[i].app_feature for i in range(-g_config.timeStep, 0)])
-                        cur_data_item = cur_data_item + (app_f_tensor, )
-                        cur_data_item = cur_data_item + (self._track_state_list[ts].app_feature, )
+                        cur_data_item += app_f_tensor, self._track_state_list[ts].app_feature
 
                         #motion feature and motion target
                         motion_f_tensor = torch.stack([cur_track[i].motion_feature for i in range(-g_config.timeStep, 0)])
-                        cur_data_item = cur_data_item + (motion_f_tensor, )
-                        motion_target_f = np.asarray(self._track_state_list[ts].bbox_center, dtype=np.float32).reshape(g_config.M_F_num) - \
-                                          np.asarray(cur_track[-1].bbox_center, dtype=np.float32).reshape(g_config.M_F_num)
-                        cur_data_item = cur_data_item + (torch.from_numpy(motion_target_f), )
+                        motion_target_f = (np.asarray(self._track_state_list[ts].bbox_center, dtype=np.float32).reshape(g_config.M_F_num) -
+                                           np.asarray(cur_track[-1].bbox_center, dtype=np.float32).reshape(g_config.M_F_num))
+                        cur_data_item += motion_f_tensor, torch.from_numpy(motion_target_f)
 
                         #interaction feature and interaction target
                         interaction_f_tensor = torch.stack([cur_track[i].interaction_feature for i in range(-g_config.timeStep, 0)])
-                        cur_data_item = cur_data_item + (interaction_f_tensor, )
-                        cur_data_item = cur_data_item + (self._track_state_list[ts].interaction_feature, )
+                        cur_data_item += interaction_f_tensor, self._track_state_list[ts].interaction_feature
 
                         #bbar feature and bbar target
                         bbar_f_tensor = torch.stack([cur_track[i].bbar_feature for i in range(-g_config.timeStep, 0)])
-                        cur_data_item = cur_data_item + (bbar_f_tensor, )
-                        cur_data_item = cur_data_item + (self._track_state_list[ts].bbar_feature, )
+                        cur_data_item += bbar_f_tensor, self._track_state_list[ts].bbar_feature
 
                         #corresponding position of the similarity matrix
-                        cur_data_item = cur_data_item + (t, ts,)
+                        cur_data_item += t, ts
 
-                        _data_list.append(cur_data_item)
+                        _data_list.append(tuple(cur_data_item))
 
         return _data_list
 

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -22,13 +22,13 @@ class TargetRNNDataLoader(data.Dataset):
         self._track_states_num = len(track_state_list)
 
         self._data_list = self._make_dataset()
-        
+
     def _make_dataset(self):
         _data_list = []
 
         for t in range(self._tracks_num):
             cur_track = self._track_set[t]
-            
+
             if len(cur_track) < g_config.timeStep:
                 # if the track does not have enough track_state, we will duplicate to time-step and use Target_RNN_AIM_V
                 _rnnType = RnnType.Target_RNN_AIM_V
@@ -42,15 +42,15 @@ class TargetRNNDataLoader(data.Dataset):
                 for ts in range(self._track_states_num):
 
                     # distance between the two bbox's x instead of center
-                    dis = math.fabs(cur_track[-1].bbox[0] - self._track_state_list[ts].bbox[0]) 
+                    dis = math.fabs(cur_track[-1].bbox[0] - self._track_state_list[ts].bbox[0])
 
                     bbox_area_ratio = float(cur_track[-1].bbox[2] * cur_track[-1].bbox[3]) / \
-                                        float(self._track_state_list[ts].bbox[2] * self._track_state_list[ts].bbox[3]) 
+                                        float(self._track_state_list[ts].bbox[2] * self._track_state_list[ts].bbox[3])
                     if bbox_area_ratio < 1.0:
                         bbox_area_ratio = 1.0 / bbox_area_ratio
 
                     # in the search area, we prepare data and calculate the similarity score
-                    if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and                      # track dis constraint  
+                    if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and                      # track dis constraint
                         dis < self._track_search_threshold * self._track_state_list[ts].bbox[2] and         # track_state dis constraint
                         bbox_area_ratio < self._track_search_threshold):                                    # bbox area constraint
                         cur_data_item = tuple()
@@ -66,7 +66,7 @@ class TargetRNNDataLoader(data.Dataset):
                         motion_target_f = np.asarray(self._track_state_list[ts].bbox_center, dtype=np.float32).reshape(g_config.M_F_num) - \
                                           np.asarray(cur_track[-1].bbox_center, dtype=np.float32).reshape(g_config.M_F_num)
                         cur_data_item = cur_data_item + (torch.from_numpy(motion_target_f), )
-            
+
                         #interaction feature and interaction target
                         interaction_f_tensor = torch.stack([cur_track[i].interaction_feature for i in range(-g_config.timeStep, 0)])
                         cur_data_item = cur_data_item + (interaction_f_tensor, )
@@ -76,24 +76,24 @@ class TargetRNNDataLoader(data.Dataset):
                         bbar_f_tensor = torch.stack([cur_track[i].bbar_feature for i in range(-g_config.timeStep, 0)])
                         cur_data_item = cur_data_item + (bbar_f_tensor, )
                         cur_data_item = cur_data_item + (self._track_state_list[ts].bbar_feature, )
-            
+
                         #corresponding position of the similarity matrix
                         cur_data_item = cur_data_item + (t, ts,)
-            
+
                         _data_list.append(cur_data_item)
 
         return _data_list
 
     def __getitem__(self, index):
-        return self._data_list[index] 
-    
+        return self._data_list[index]
+
     def __len__(self):
         return len(self._data_list)
 
 
 class SRNN_matching(object):
     def __init__(self, targetRNN_full_model_path, targetRNN_AIM_V_model_path, batch_size, GPU_list=None):
-        
+
         if GPU_list is None:
             GPU_list = [x for x in range(torch.cuda.device_count())]
             target_GPU = 0
@@ -142,7 +142,7 @@ class SRNN_matching(object):
         AIM_data_loader = torch.utils.data.DataLoader(
             TargetRNNDataLoader(track_set, track_state_list, track_search_threshold, RnnType.Target_RNN_AIM),
             batch_size=self._batch_size, shuffle=False, **kwargs)
-            
+
         self._est_similarity(AIM_V_data_loader, RnnType.Target_RNN_AIM_V)
         self._est_similarity(AIM_data_loader, RnnType.Target_RNN_AIM)
 
@@ -155,35 +155,34 @@ class SRNN_matching(object):
 
             v_app_seq = app_f_list.to(self._device)
             v_app_target =  app_target_f.to(self._device)
-            v_motion_seq = motion_f_list.to(self._device) 
+            v_motion_seq = motion_f_list.to(self._device)
             v_motion_target = motion_target_f.to(self._device)
-            v_interaction_seq = interaction_f_list.to(self._device) 
+            v_interaction_seq = interaction_f_list.to(self._device)
             v_interaction_target = interaction_target_f.to(self._device)
             v_bbar_seq = bbar_f_list.to(self._device)
             v_bbar_target = bbar_target_f.cuda(self._device)
-        
+
             if rnnType is RnnType.Target_RNN_AIM:
-                output = self._targetRNN_full_model(v_app_seq, v_app_target, v_motion_seq, v_motion_target, 
+                output = self._targetRNN_full_model(v_app_seq, v_app_target, v_motion_seq, v_motion_target,
                                                     v_interaction_seq, v_interaction_target, v_bbar_seq, v_bbar_target)
             elif rnnType is RnnType.Target_RNN_AIM_V:
-                output = self._targetRNN_AIM_V_model(v_app_seq, v_app_target, v_motion_seq, v_motion_target, 
+                output = self._targetRNN_AIM_V_model(v_app_seq, v_app_target, v_motion_seq, v_motion_target,
                                                   v_interaction_seq, v_interaction_target)
-    
+
             F_softmax = nn.Softmax()
             output = F_softmax(output)
             pred = torch.max(output, 1)
-    
+
             #label_mask = torch.ne(pred[1].data, 0)
             label_mask = torch.ne(pred[1].detach(), 0)
-            
+
             r_idx = t.to(self._device)[label_mask]
             c_idx = ts.to(self._device)[label_mask]
             #val = -pred[0].data[label_mask]
             val = -pred[0].detach()[label_mask]
-            
+
             if len(r_idx) == 0:
                 pass
             else:
                 for i in range(r_idx.size(0)):
                     self._similarity_mat[r_idx[i], c_idx[i]] = val[i]
-

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -32,7 +32,7 @@ class TargetRNNDataLoader(data.Dataset):
                 _rnnType = RnnType.Target_RNN_AIM
 
             # only process active and un-updated tracks
-            if cur_track.active_flag and not cur_track.updated_flag and (_rnnType is self._rnnType):
+            if self._track_set.is_track_active(cur_track) and not cur_track.updated_flag and (_rnnType is self._rnnType):
                 for ts, track_state in enumerate(self._track_state_list):
                     # distance between the two bbox's x instead of center
                     dis = abs(cur_track[-1].bbox[0] - track_state.bbox[0])

--- a/arrows/pytorch/SRNN_matching.py
+++ b/arrows/pytorch/SRNN_matching.py
@@ -123,8 +123,9 @@ class SRNN_matching(object):
             TargetRNNDataLoader(track_set, track_state_list, track_search_threshold, RnnType.Target_RNN_AIM),
             batch_size=self._batch_size, shuffle=False, **kwargs)
 
-        self._est_similarity(AIM_V_data_loader, RnnType.Target_RNN_AIM_V)
-        self._est_similarity(AIM_data_loader, RnnType.Target_RNN_AIM)
+        with torch.no_grad():
+            self._est_similarity(AIM_V_data_loader, RnnType.Target_RNN_AIM_V)
+            self._est_similarity(AIM_data_loader, RnnType.Target_RNN_AIM)
 
         # obtain the list mapping: similarity row idx->track_id
         track_idx_list = [track.id for track in track_set.iter_active()]
@@ -133,7 +134,6 @@ class SRNN_matching(object):
 
 
     def _est_similarity(self, loader, rnnType):
-        torch.set_grad_enabled(False)
         for (app_f_list, app_target_f, motion_f_list, motion_target_f, interaction_f_list, interaction_target_f, bbar_f_list, bbar_target_f, t, ts) in loader:
 
             v_app_seq = app_f_list.to(self._device)

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -390,11 +390,11 @@ class SRNN_tracking(KwiverProcess):
                     self._track_flag = True
                 else:
                     # check whether we need to terminate a track
-                    for ti in range(len(self._track_set)):
+                    for track in self._track_set:
                         # terminating a track based on readin_frame_id or original_frame_id gap
-                        self._track_set[ti].active_flag = self._track_set[ti].active_flag and not (
-                            self._step_id - self._track_set[ti][-1].frame_id > self._terminate_track_threshold
-                            or fid - self._track_set[ti][-1].sys_frame_id > self._sys_terminate_track_threshold
+                        track.active_flag = track.active_flag and not (
+                            self._step_id - track[-1].frame_id > self._terminate_track_threshold
+                            or fid - track[-1].sys_frame_id > self._sys_terminate_track_threshold
                         )
 
                     #print('track_set len {}'.format(len(self._track_set)))

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -183,13 +183,13 @@ class SRNN_tracking(KwiverProcess):
         # matching active track threshold
         self.add_config_trait("terminate_track_threshold", "terminate_track_threshold", '15',
                               'terminate the tracking if the target has been lost for more than '
-                              'termniate_track_threshold readin frames.')
+                              'terminate_track_threshold read-in frames.')
         self.declare_config_using_trait('terminate_track_threshold')
 
         # matching active track threshold
         self.add_config_trait("sys_terminate_track_threshold", "sys_terminate_track_threshold", '50',
                               'terminate the tracking if the target has been lost for more than '
-                              'termniate_track_threshold system (original) frames.')
+                              'terminate_track_threshold system (original) frames.')
         self.declare_config_using_trait('sys_terminate_track_threshold')
 
         # MOT gt detection
@@ -339,19 +339,19 @@ class SRNN_tracking(KwiverProcess):
 
             det_obj_set = DetectedObjectSet()
             if bbox_num == 0:
-                print('!!! No bbox is provided on this frame and skip this frame !!!')
+                print('!!! No bbox is provided on this frame.  Skipping this frame !!!')
             else:
                 # interaction features
                 grid_f_begin = timer()
                 grid_feature_list = self._grid(im.size, dos, self._GTbbox_flag)
                 grid_f_end = timer()
-                print('%%%grid feature eclapsed time: {}'.format(grid_f_end - grid_f_begin))
+                print('%%%grid feature elapsed time: {}'.format(grid_f_end - grid_f_begin))
 
                 # appearance features (format: pytorch tensor)
                 app_f_begin = timer()
                 pt_app_features = self._app_feature_extractor(dos, self._GTbbox_flag)
                 app_f_end = timer()
-                print('%%%app feature eclapsed time: {}'.format(app_f_end - app_f_begin))
+                print('%%%app feature elapsed time: {}'.format(app_f_end - app_f_begin))
 
                 track_state_list = []
                 next_trackID = int(self._track_set.get_max_track_ID()) + 1
@@ -384,7 +384,7 @@ class SRNN_tracking(KwiverProcess):
                                          detectedObject=d_obj, sys_frame_id=fid, sys_frame_time=ts)
                     track_state_list.append(cur_ts)
 
-                # if there is no tracks, generate new tracks from the track_state_list
+                # if there are no tracks, generate new tracks from the track_state_list
                 if not self._track_flag:
                     next_trackID = self._track_set.add_new_track_state_list(next_trackID, track_state_list, self._track_initialization_threshold)
                     self._track_flag = True
@@ -405,7 +405,7 @@ class SRNN_tracking(KwiverProcess):
                         IOU_begin = timer()
                         self._track_set, track_state_list = self._iou_tracker(self._track_set, track_state_list)
                         IOU_end = timer()
-                        print('%%%IOU tracking eclapsed time: {}'.format(IOU_end - IOU_begin))
+                        print('%%%IOU tracking elapsed time: {}'.format(IOU_end - IOU_begin))
 
                     #print('***track_set len {}'.format(len(self._track_set)))
                     #print('***track_state_list len {}'.format(len(track_state_list)))
@@ -414,7 +414,7 @@ class SRNN_tracking(KwiverProcess):
                     ttu_begin = timer()
                     similarity_mat, track_idx_list = self._SRNN_matching(self._track_set, track_state_list, self._ts_threshold)
                     ttu_end = timer()
-                    print('%%%SRNN assication eclapsed time: {}'.format(ttu_end - ttu_begin))
+                    print('%%%SRNN assication elapsed time: {}'.format(ttu_end - ttu_begin))
 
                     # reset update_flag
                     self._track_set.reset_updated_flag()
@@ -423,7 +423,7 @@ class SRNN_tracking(KwiverProcess):
                     hung_begin = timer()
                     row_idx_list, col_idx_list = sp.optimize.linear_sum_assignment(similarity_mat)
                     hung_end = timer()
-                    print('%%%Hungarian alogrithm eclapsed time: {}'.format(hung_end - hung_begin))
+                    print('%%%Hungarian algorithm elapsed time: {}'.format(hung_end - hung_begin))
 
                     for i in range(len(row_idx_list)):
                         r = row_idx_list[i]
@@ -438,7 +438,7 @@ class SRNN_tracking(KwiverProcess):
                             # add to existing track
                             self._track_set.update_track(track_idx_list[r], track_state_list[c])
 
-                    # for rest unmatched track_state, we initialize new tracks
+                    # for the remaining unmatched track states, we initialize new tracks
                     if len(track_state_list) - len(col_idx_list) > 0:
                         for i in range(len(track_state_list)):
                             if i not in col_idx_list and track_state_list[i].detectedObj.confidence() >= self._track_initialization_threshold:

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -390,12 +390,11 @@ class SRNN_tracking(KwiverProcess):
                     self._track_flag = True
                 else:
                     # check whether we need to terminate a track
-                    for track in self._track_set:
+                    for track in self._track_set.iter_active():
                         # terminating a track based on readin_frame_id or original_frame_id gap
-                        track.active_flag = track.active_flag and not (
-                            self._step_id - track[-1].frame_id > self._terminate_track_threshold
-                            or fid - track[-1].sys_frame_id > self._sys_terminate_track_threshold
-                        )
+                        if (self._step_id - track[-1].frame_id > self._terminate_track_threshold
+                            or fid - track[-1].sys_frame_id > self._sys_terminate_track_threshold):
+                            self._track_set.deactivate_track(track)
 
                     #print('track_set len {}'.format(len(self._track_set)))
                     #print('track_state_list len {}'.format(len(track_state_list)))

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -71,19 +71,19 @@ from kwiver.arrows.pytorch.models import get_config
 
 g_config = get_config()
 
-def print(msg):
-   import threading
-   import traceback
-   try:
-       msg = '[{}] {}'.format(threading.current_thread(), msg)
-   #    with open('database/Logs/SRNN_Tracking_Log', 'a') as f:
-   #        f.write(str(msg) + '\n')
-   except Exception as ex:
-       with open('database/Logs/SRNN_Tracking_Error_Log', 'a') as f:
-           f.write('Error durring print! Attempting to report\n')
-           f.write(repr(ex) + '\n')
-           f.write(traceback.format_exc() + '\n')
-           raise
+#def print(msg):
+   #import threading
+   #import traceback
+   #try:
+       #msg = '[{}] {}'.format(threading.current_thread(), msg)
+   ##    with open('database/Logs/SRNN_Tracking_Log', 'a') as f:
+   ##        f.write(str(msg) + '\n')
+   #except Exception as ex:
+       #with open('database/Logs/SRNN_Tracking_Error_Log', 'a') as f:
+           #f.write('Error durring print! Attempting to report\n')
+           #f.write(repr(ex) + '\n')
+           #f.write(traceback.format_exc() + '\n')
+           #raise
 
 def ts2ot_list(track_set):
     ot_list = [] 

--- a/arrows/pytorch/compute_resnet_descriptors.py
+++ b/arrows/pytorch/compute_resnet_descriptors.py
@@ -1,7 +1,6 @@
 import torch
 import resnet
 import torch.nn as nn
-from torch.autograd import Variable
 from torchvision import datasets, models, transforms
 
 weights_fp = "models/byte_200p/90001.pth.tar"
@@ -36,7 +35,7 @@ image_dataset = datasets.ImageFolder(data_folder, transform)
 dataloader = torch.utils.data.DataLoader(image_dataset, batch_size=batch_size, shuffle=True, num_workers=8)
 
 for inputs, labels in dataloader:
-    inputs = Variable( inputs.cuda() )
+    inputs = inputs.to(torch.device("cuda"))
     out = model( inputs )
     print( out.cpu().detach().numpy().shape )
     break

--- a/arrows/pytorch/iou_tracking.py
+++ b/arrows/pytorch/iou_tracking.py
@@ -8,21 +8,21 @@ class IOU_tracker(object):
 
     def _track_iou(self, track_set, track_state_list):
         # IOU based tracking
-        for t_idx in range(len(track_set)):
-            if len(track_state_list) > 0 and track_set[t_idx].active_flag is True:
+        for track in track_set:
+            if len(track_state_list) > 0 and track.active_flag is True:
                 # get det with highest iou
-                best_match = max(track_state_list, key=lambda x: self._iou_score(track_set[t_idx][-1].bbox, x.bbox))
+                best_match = max(track_state_list, key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
 
                 # sort the track state list in order to find the case that multiple bbox overlap with the current track
-                sorted_ts_list = sorted(track_state_list, key=lambda x: self._iou_score(track_set[t_idx][-1].bbox, x.bbox))
-                best_iou_score = self._iou_score(track_set[t_idx][-1].bbox, best_match.bbox)
+                sorted_ts_list = sorted(track_state_list, key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
+                best_iou_score = self._iou_score(track[-1].bbox, best_match.bbox)
 
                 if best_iou_score >= self._iou_accept_threshold:
 
                     # if no other bbox with overlap larger than iou_reject_threshold
-                    if len(sorted_ts_list) >= 2 and self._iou_score(track_set[t_idx][-1].bbox, sorted_ts_list[1].bbox) < self._iou_reject_threshold:
-                        track_set[t_idx].updated_flag = True
-                        track_set.update_track(track_set[t_idx].id, best_match)
+                    if len(sorted_ts_list) >= 2 and self._iou_score(track[-1].bbox, sorted_ts_list[1].bbox) < self._iou_reject_threshold:
+                        track.updated_flag = True
+                        track_set.update_track(track.id, best_match)
 
                         # remove from best matching detection from detections
                         del track_state_list[track_state_list.index(best_match)]

--- a/arrows/pytorch/iou_tracking.py
+++ b/arrows/pytorch/iou_tracking.py
@@ -1,10 +1,8 @@
-
-
 class IOU_tracker(object):
     def __init__(self, iou_accept_threshold, iou_reject_threshold):
         self._iou_accept_threshold = iou_accept_threshold
         self._iou_reject_threshold = iou_reject_threshold
-    
+
     def __call__(self, track_set, track_state_list):
         return self._track_iou(track_set, track_state_list)
 
@@ -25,7 +23,7 @@ class IOU_tracker(object):
                     if len(sorted_ts_list) >= 2 and self._iou_score(track_set[t_idx][-1].bbox, sorted_ts_list[1].bbox) < self._iou_reject_threshold:
                         track_set[t_idx].updated_flag = True
                         track_set.update_track(track_set[t_idx].id, best_match)
-    
+
                         # remove from best matching detection from detections
                         del track_state_list[track_state_list.index(best_match)]
 
@@ -34,15 +32,15 @@ class IOU_tracker(object):
     def _iou_score(self, bbox1, bbox2):
         """
         Calculates the intersection-over-union of two bounding boxes.
-        
+
         Args:
             bbox1 list of float: bounding box in format x1,y1,w,h
             bbox2 list of float: bounding box in format x1,y1,w,h.
-        
+
         Returns:
             int: intersection-over-onion of bbox1, bbox2
         """
-        
+
         (x1, y1, w1, h1) = bbox1
         (x2, y2, w2, h2) = bbox2
 
@@ -51,15 +49,15 @@ class IOU_tracker(object):
         overlap_y0 = max(y1, y2)
         overlap_x1 = min(x1 + w1, x2 + w2)
         overlap_y1 = min(y1 + h1, y2 + h2)
-        
+
         # check if there is an overlap
         if overlap_x1 - overlap_x0 <= 0 or overlap_y1 - overlap_y0 <= 0:
             return 0
-        
+
         # if yes, calculate the ratio of the overlap to each ROI size and the unified size
         size_1 = w1 * h1
         size_2 = w2 * h2
         size_intersection = (overlap_x1 - overlap_x0) * (overlap_y1 - overlap_y0)
         size_union = size_1 + size_2 - size_intersection
-        
+
         return float(size_intersection) / size_union

--- a/arrows/pytorch/iou_tracking.py
+++ b/arrows/pytorch/iou_tracking.py
@@ -13,7 +13,7 @@ class IOU_tracker(object):
                 # get det with highest iou
                 best_match = max(track_state_list, key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
 
-                # sort the track state list in order to find the case that multiple bbox overlap with the current track
+                # sort the track state list in order to check whether multiple bboxes overlap with the current track
                 sorted_ts_list = sorted(track_state_list, key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
                 best_iou_score = self._iou_score(track[-1].bbox, best_match.bbox)
 
@@ -24,7 +24,7 @@ class IOU_tracker(object):
                         track.updated_flag = True
                         track_set.update_track(track.id, best_match)
 
-                        # remove from best matching detection from detections
+                        # remove best matching detection from detections
                         del track_state_list[track_state_list.index(best_match)]
 
         return track_set, track_state_list
@@ -38,7 +38,7 @@ class IOU_tracker(object):
             bbox2 list of float: bounding box in format x1,y1,w,h.
 
         Returns:
-            int: intersection-over-onion of bbox1, bbox2
+            int: intersection-over-union of bbox1, bbox2
         """
 
         (x1, y1, w1, h1) = bbox1

--- a/arrows/pytorch/iou_tracking.py
+++ b/arrows/pytorch/iou_tracking.py
@@ -8,8 +8,8 @@ class IOU_tracker(object):
 
     def _track_iou(self, track_set, track_state_list):
         # IOU based tracking
-        for track in track_set:
-            if len(track_state_list) > 0 and track.active_flag is True:
+        if track_state_list:
+            for track in track_set.iter_active():
                 # get det with highest iou
                 best_match = max(track_state_list, key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
 

--- a/arrows/pytorch/models.py
+++ b/arrows/pytorch/models.py
@@ -38,7 +38,6 @@ class Siamese(nn.Module):
         self.resnet = models.resnet50(pretrained=False)
         self.num_fcin = self.resnet.fc.in_features
         self.resnet.fc = nn.Linear(self.num_fcin, 500)
-        self.pdist = nn.PairwiseDistance(1)
 
     def forward(self, input1):
         output1 = self.resnet(input1)
@@ -63,7 +62,7 @@ class AppearanceLSTM(nn.Module):
         self.fc2 = nn.Linear(g_config.K, 2)
         self.relu = nn.ReLU()
 
-    # FIXME: we may need to add hidden status from previous
+    # TODO: we may need to add hidden status from previous
     def forward(self, track_input, target_input):
         target_out = self.target_fc(target_input)
         r_out, (h_t, c_t) = self.lstm(track_input, None)

--- a/arrows/pytorch/pytorch_alexnet_f_extractor.py
+++ b/arrows/pytorch/pytorch_alexnet_f_extractor.py
@@ -79,7 +79,7 @@ class pytorch_resnet_f_extractor(object):
         self._device = torch.device("cuda:{}".format(self._target_GPU))
 
         # load the resnet50 model. Maybe this shouldn't be hardcoded?
-        self._resnet_model = models.resnet50().cuda(device=target_GPU)
+        self._resnet_model = models.resnet50().to(self._device)
         # changing the number of output layers, to allow for loading the model
         # might not be necessary 
         num_ftrs = self._resnet_model.fc.in_features

--- a/arrows/pytorch/pytorch_alexnet_f_extractor.py
+++ b/arrows/pytorch/pytorch_alexnet_f_extractor.py
@@ -6,7 +6,6 @@ import torch
 import torch.utils.data as data
 import torch.nn as nn
 from torchvision import models, transforms, datasets
-from torch.autograd import Variable
 
 from PIL import Image as pilImage
 
@@ -77,6 +76,8 @@ class pytorch_resnet_f_extractor(object):
         else:
             target_GPU = GPU_list[0]
 
+        self._device = torch.device("cuda:{}".format(self._target_GPU))
+
         # load the resnet50 model. Maybe this shouldn't be hardcoded?
         self._resnet_model = models.resnet50().cuda(device=target_GPU)
         # changing the number of output layers, to allow for loading the model
@@ -124,7 +125,7 @@ class pytorch_resnet_f_extractor(object):
         bbox_loader = torch.utils.data.DataLoader(bbox_loader_class, batch_size=self._b_size, shuffle=False, **kwargs)
 
         for idx, imgs in enumerate(bbox_loader):
-            v_imgs = Variable(imgs).cuda() # I removed volitile because of the version update
+            v_imgs = imgs.to(self._device)
             output = self._resnet_model(v_imgs)
 
             if idx == 0:

--- a/arrows/pytorch/pytorch_resnet_f_extractor.py
+++ b/arrows/pytorch/pytorch_resnet_f_extractor.py
@@ -6,7 +6,6 @@ import torch
 import torch.utils.data as data
 import torch.nn as nn
 from torchvision import models, transforms, datasets
-from torch.autograd import Variable
 
 from PIL import Image as pilImage
 
@@ -70,6 +69,8 @@ class pytorch_resnet_f_extractor(object):
         else:
             target_GPU = GPU_list[0]
 
+        self._device = torch.device("cuda:{}".format(target_GPU))
+
         # load the resnet50 model. Maybe this shouldn't be hardcoded?
         self._resnet_model = models.resnet50().cuda(device=target_GPU)
         #self._resnet_model.fc = nn.Linear(2048, 46)
@@ -107,8 +108,9 @@ class pytorch_resnet_f_extractor(object):
         bbox_loader_class = resnetDataLoader(bbox_list, self._transform, self._frame, self._img_size) 
         bbox_loader = torch.utils.data.DataLoader(bbox_loader_class, batch_size=self._b_size, shuffle=False, **kwargs)
 
+        torch.set_grad_enabled(False)
         for idx, imgs in enumerate(bbox_loader):
-            v_imgs = Variable(imgs).cuda() # I removed volitile because of the version update
+            v_imgs = imgs.to(self._device)
             output = self._resnet_model(v_imgs)
 
             if idx == 0:

--- a/arrows/pytorch/pytorch_resnet_f_extractor.py
+++ b/arrows/pytorch/pytorch_resnet_f_extractor.py
@@ -72,7 +72,8 @@ class pytorch_resnet_f_extractor(object):
         self._device = torch.device("cuda:{}".format(target_GPU))
 
         # load the resnet50 model. Maybe this shouldn't be hardcoded?
-        self._resnet_model = models.resnet50().cuda(device=target_GPU)
+        #self._resnet_model = models.resnet50().cuda(device=target_GPU)
+        self._resnet_model = models.resnet50().to(self._device)
         #self._resnet_model.fc = nn.Linear(2048, 46)
         print( resnet_model_path )
         weights = torch.load( resnet_model_path )

--- a/arrows/pytorch/resnet_descriptors.py
+++ b/arrows/pytorch/resnet_descriptors.py
@@ -32,41 +32,19 @@ from __future__ import division
 from __future__ import absolute_import
 
 import sys
-import torch
-from torchvision import models, transforms
-from torch.autograd import Variable
-from torch import nn
-import numpy as np
-import scipy as sp
-import scipy.optimize
 import threading
-
-from PIL import Image as pilImage
 
 from sprokit.pipeline import process
 from kwiver.kwiver_process import KwiverProcess
-from vital.types import Image
 from vital.types import DetectedObject, DetectedObjectSet
 from vital.types import new_descriptor
 
 from timeit import default_timer as timer
 
-from vital.types import ( 
-    ObjectTrackState,
-    Track,
-    ObjectTrackSet
-)
-
 from vital.util.VitalPIL import get_pil_image
 
 from kwiver.arrows.pytorch.grid import grid
-from kwiver.arrows.pytorch.track import track_state, track, track_set
-from kwiver.arrows.pytorch.SRNN_matching import SRNN_matching, RnnType # this might need to be changed
 from kwiver.arrows.pytorch.pytorch_resnet_f_extractor import pytorch_resnet_f_extractor # the feature extractor
-from kwiver.arrows.pytorch.iou_tracking import IOU_tracker
-
-from kwiver.arrows.pytorch.MOT_bbox import MOT_bbox, GTFileType
-from kwiver.arrows.pytorch.models import get_config
 
 class Resnet_descriptors(KwiverProcess):
 

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -247,24 +247,15 @@ class track_set(object):
 
         self._id_ts_dict[track.id] = track
 
-
     def add_new_track_state(self, track_id, track_state):
-        if track_id in self.get_all_trackID():
-            print("track ID exsit in the track set!!!")
-            raise RuntimeError
-
         new_track = track(track_id)
         new_track.append(track_state)
-        self._id_ts_dict[track_id] = new_track
+        self.add_new_track(new_track)
 
     def add_new_track_state_list(self, start_track_id, ts_list, thresh=0.0):
         counter = 0
         for i in range(len(ts_list)):
             cur_track_id = start_track_id + i
-            if cur_track_id in self.get_all_trackID():
-                print("track ID {} exsit in the track set!!!".format(cur_track_id))
-                raise RuntimeError
-
             if ts_list[i].detectedObj.confidence() >= thresh:
                 self.add_new_track_state(cur_track_id, ts_list[i])
                 counter = counter + 1

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -223,8 +223,7 @@ class track_set(object):
         return list(self._id_ts_dict.items())[idx][1]
 
     def __iter__(self):
-        for _, item in self._id_ts_dict.items():
-            yield item
+        return iter(self._id_ts_dict.values())
 
     def get_track(self, track_id):
         if track_id not in self._id_ts_dict:
@@ -239,7 +238,7 @@ class track_set(object):
         if len(self._id_ts_dict) == 0:
             return 0
         else:
-            return max(self.get_all_trackID())
+            return max(self._id_ts_dict)
 
     def add_new_track(self, track):
         if track.id in self.get_all_trackID():
@@ -278,7 +277,7 @@ class track_set(object):
         self._id_ts_dict[track_id].append(new_track_state)
 
     def reset_updated_flag(self):
-        for k in self._id_ts_dict.keys():
+        for k in self._id_ts_dict:
             self._id_ts_dict[k].updated_flag = False
 
 

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -253,13 +253,12 @@ class track_set(object):
         self.add_new_track(new_track)
 
     def add_new_track_state_list(self, start_track_id, ts_list, thresh=0.0):
-        counter = 0
-        for i in range(len(ts_list)):
-            cur_track_id = start_track_id + i
-            if ts_list[i].detectedObj.confidence() >= thresh:
-                self.add_new_track_state(cur_track_id, ts_list[i])
-                counter = counter + 1
-        return start_track_id + counter
+        track_id = start_track_id
+        for ts in ts_list:
+            if ts.detectedObj.confidence() >= thresh:
+                self.add_new_track_state(track_id, ts)
+                track_id += 1
+        return track_id
 
     def update_track(self, track_id, new_track_state):
         if track_id not in self._id_ts_dict:

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -212,7 +212,7 @@ class track_set(object):
         return iter(self._id_ts_dict.values())
 
     def iter_active(self):
-        return (self._id_ts_dict[i] for i in self._active_id_set)
+        return (self[i] for i in self._active_id_set)
 
     def __getitem__(self, track_id):
         try:
@@ -221,13 +221,10 @@ class track_set(object):
             raise IndexError
 
     def get_all_trackID(self):
-        return sorted(self._id_ts_dict.keys())
+        return sorted(self._id_ts_dict)
 
     def get_max_track_ID(self):
-        if len(self._id_ts_dict) == 0:
-            return 0
-        else:
-            return max(self._id_ts_dict)
+        return max(self._id_ts_dict) if self._id_ts_dict else 0
 
     def deactivate_track(self, track):
         del self._active_id_set[track.id]
@@ -257,14 +254,11 @@ class track_set(object):
         return track_id
 
     def update_track(self, track_id, new_track_state):
-        if track_id not in self._id_ts_dict:
-            raise IndexError
-
-        self._id_ts_dict[track_id].append(new_track_state)
+        self[track_id].append(new_track_state)
 
     def reset_updated_flag(self):
-        for k in self._id_ts_dict:
-            self._id_ts_dict[k].updated_flag = False
+        for track in self:
+            track.updated_flag = False
 
 
 if __name__ == '__main__':

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -184,12 +184,12 @@ class track(object):
         self._max_conf = val
 
     def append(self, new_track_state):
-        if len(self._track_state_list) == 0:
+        if not self._track_state_list:
             new_track_state.motion_feature = torch.FloatTensor(2).zero_()
         else:
             pre_bbox_center = np.asarray(self._track_state_list[-1].bbox_center, dtype=np.float32).reshape(2)
             cur_bbox_center = np.asarray(new_track_state.bbox_center, dtype=np.float32).reshape(2)
-            new_track_state._motion_feature = torch.from_numpy(cur_bbox_center - pre_bbox_center)
+            new_track_state.motion_feature = torch.from_numpy(cur_bbox_center - pre_bbox_center)
 
         new_track_state.track_id = self._track_id
         self._track_state_list.append(new_track_state)

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -241,8 +241,8 @@ class track_set(object):
             return max(self._id_ts_dict)
 
     def add_new_track(self, track):
-        if track.id in self.get_all_trackID():
-            print("track ID exsit in the track set!!!")
+        if track.id in self._id_ts_dict:
+            print("track ID exists in the track set!!!")
             raise RuntimeError
 
         self._id_ts_dict[track.id] = track

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -193,8 +193,8 @@ class track(object):
         du_track.updated_flag = self._updated_flag
         du_track.max_conf = self._max_conf
 
-        if len(du_track) < timestep_len:
-            du_track += [du_track[-1]] * (timestep_len - len(du_track))
+        for _ in range(timestep_len - len(du_track)):
+            du_track.append(du_track[-1])
 
         return du_track
 

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -20,7 +20,7 @@ class track_state(object):
         self._frame_id = frame_id
 
         self._detectedObj = detectedObject
-        
+
         self._sys_frame_id = sys_frame_id
         self._sys_frame_time = sys_frame_time
 
@@ -169,7 +169,7 @@ class track(object):
     @property
     def updated_flag(self):
         return self._updated_flag
-    
+
     @updated_flag.setter
     def updated_flag(self, val):
         self._updated_flag = val
@@ -197,7 +197,7 @@ class track(object):
             pre_bbox_center = np.asarray(self._track_state_list[-1].bbox_center, dtype=np.float32).reshape(2)
             cur_bbox_center = np.asarray(new_track_state.bbox_center, dtype=np.float32).reshape(2)
             new_track_state._motion_feature = torch.from_numpy(cur_bbox_center - pre_bbox_center)
-        
+
         new_track_state.track_id = self._track_id
         self._track_state_list.append(new_track_state)
         self._max_conf = max(self._max_conf, new_track_state.conf)
@@ -206,8 +206,8 @@ class track(object):
         if len(self._track_state_list) >= timestep_len:
             pass
         else:
-            #du_track = copy.deepcopy(self)  
-            du_track = track(self._track_id)  
+            #du_track = copy.deepcopy(self)
+            du_track = track(self._track_id)
             du_track.track_state_list = list(self._track_state_list)
             du_track.updated_flag = self._updated_flag
             du_track.active_flag = self._active_flag
@@ -230,7 +230,7 @@ class track_set(object):
     def __getitem__(self, idx):
         if idx >= len(self._id_ts_dict) or idx < 0:
             raise IndexError
-        # for Py3 
+        # for Py3
         return list(self._id_ts_dict.items())[idx][1]
 
     def __iter__(self):
@@ -245,7 +245,7 @@ class track_set(object):
 
     def get_all_trackID(self):
         return sorted(self._id_ts_dict.keys())
-    
+
     def get_max_track_ID(self):
         if len(self._id_ts_dict) == 0:
             return 0
@@ -258,17 +258,17 @@ class track_set(object):
             raise RuntimeError
 
         self._id_ts_dict[track.id] = track
-    
+
 
     def add_new_track_state(self, track_id, track_state):
         if track_id in self.get_all_trackID():
             print("track ID exsit in the track set!!!")
             raise RuntimeError
-        
+
         new_track = track(track_id)
         new_track.append(track_state)
         self._id_ts_dict[track_id] = new_track
-    
+
     def add_new_track_state_list(self, start_track_id, ts_list, thresh=0.0):
         counter = 0
         for i in range(len(ts_list)):
@@ -300,4 +300,3 @@ if __name__ == '__main__':
 
     for item in t[:]:
         print(item.motion_feature)
-

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -196,19 +196,15 @@ class track(object):
         self._max_conf = max(self._max_conf, new_track_state.conf)
 
     def duplicate_track_state(self, timestep_len = 6):
-        if len(self._track_state_list) >= timestep_len:
-            pass
-        else:
-            #du_track = copy.deepcopy(self)
-            du_track = track(self._track_id)
-            du_track.track_state_list = list(self._track_state_list)
-            du_track.updated_flag = self._updated_flag
-            du_track.active_flag = self._active_flag
-            du_track.max_conf = self._max_conf
+        #du_track = copy.deepcopy(self)
+        du_track = track(self._track_id)
+        du_track.track_state_list = list(self._track_state_list)
+        du_track.updated_flag = self._updated_flag
+        du_track.active_flag = self._active_flag
+        du_track.max_conf = self._max_conf
 
-            cur_size = len(du_track)
-            for i in range(timestep_len - cur_size):
-                du_track.append(du_track[-1])
+        if len(du_track) < timestep_len:
+            du_track += [du_track[-1]] * (timestep_len - len(du_track))
 
         return du_track
 

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -208,23 +208,17 @@ class track_set(object):
     def __len__(self):
         return len(self._id_ts_dict)
 
-    def __getitem__(self, idx):
-        if idx >= len(self._id_ts_dict) or idx < 0:
-            raise IndexError
-        # for Py3
-        return list(self._id_ts_dict.items())[idx][1]
-
     def __iter__(self):
         return iter(self._id_ts_dict.values())
 
     def iter_active(self):
         return (self._id_ts_dict[i] for i in self._active_id_set)
 
-    def get_track(self, track_id):
-        if track_id not in self._id_ts_dict:
+    def __getitem__(self, track_id):
+        try:
+            return self._id_ts_dict[track_id]
+        except KeyError:
             raise IndexError
-
-        return self._id_ts_dict[track_id]
 
     def get_all_trackID(self):
         return sorted(self._id_ts_dict.keys())

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -238,8 +238,8 @@ class track_set(object):
     def deactivate_track(self, track):
         del self._active_id_set[track.id]
 
-    def is_track_active(self, track):
-        return track.id in self._active_id_set
+    def active_count(self):
+        return len(self._active_id_set)
 
     def add_new_track(self, track):
         if track.id in self._id_ts_dict:

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -138,17 +138,10 @@ class track(object):
         return len(self._track_state_list)
 
     def __getitem__(self, idx):
-        if isinstance(idx, int):
-            if idx >= len(self._track_state_list):
-                raise IndexError
-            return self._track_state_list[idx]
-        elif isinstance(idx, slice):
-            start, stop, step = idx.indices(len(self))
-            return self._track_state_list[start:stop:step]
+        return self._track_state_list[idx]
 
     def __iter__(self):
-        for item in self._track_state_list:
-            yield item
+        return iter(self._track_state_list)
 
     @property
     def id(self):


### PR DESCRIPTION
These changes serve primarily to speed up the tracking done in `arrows/pytorch/SRNN_tracking.py`. The main algorithmic changes towards that end are as follows:
- Use iterators instead of indices for iteration where possible, bypassing a O(N) item look-up cost
- Maintain the set of active tracks, removing the need to check all tracks for their active status
- Only use the active tracks in the construction of the similarity matrix passed to the linear sum assignment problem solver

Note that the second change has been made in a way that breaks the backwards compatibility of the `track` and `track_set` classes in `arrows/pytorch/track.py`. Track activity is now managed at the `track_set`, not the `track` level, and `track_set.get_track` has been renamed to `track_set.__getitem__`, with the old O(N) `track_set.__getitem__` removed.

I have also done a small amount of refactoring and clean-up, along with a couple of bugfixes. The main one that could theoretically change behavior is the one for `track.add_new_track_state`, which previously could lead to overlapping track IDs being created if any track state's confidence was less than the supplied threshold. I've changed it to not skip an ID when a track state is skipped.

I've marked this as WIP mainly because I'm currently having a separate issue involving deactivated tracks and as such haven't been able to validate some of the changed code that only runs on active tracks.

**Edit:** The track activity issue was due to the interval before marking as inactive being less than a step. I've now been able to run it without obvious errors.

**TODO**:
- [X] Validate new code that only runs on active tracks