### PR TITLE
Report all python processes in a pipeline.

### DIFF
--- a/sprokit/src/schedulers/sync_scheduler.cxx
+++ b/sprokit/src/schedulers/sync_scheduler.cxx
@@ -88,21 +88,24 @@ sync_scheduler
 
   pipeline_t const p = pipeline();
 
-  process_t proc = p->get_python_process();
-  if(proc)
+  processes_t procs = p->get_python_processes();
+  if( ! procs.empty() )
   {
-        std::string const reason = "The process \'" + proc->name() + "\' of type \'" + proc->type()
-      + "\' is a python process and that type of process is not supported by this scheduler.";
+    std::stringstream str;
+    str << "This pipeline contains the following python processes which are not supported by this scheduler.\n";
+    for ( auto proc : procs )
+    {
+      str << "      \"" << proc->name() << "\" of type \"" << proc->type() << "\"\n";
+    }
 
-      VITAL_THROW( incompatible_pipeline_exception,
-                   reason);
+    VITAL_THROW( incompatible_pipeline_exception, str.str());
   }
 
   process::names_t const names = p->process_names();
 
   for (process::name_t const& name : names)
   {
-    proc = p->process_by_name(name);
+    auto proc = p->process_by_name(name);
     process::properties_t const consts = proc->properties();
 
     if (consts.count(process::property_unsync_output))

--- a/sprokit/src/schedulers/thread_per_process_scheduler.cxx
+++ b/sprokit/src/schedulers/thread_per_process_scheduler.cxx
@@ -43,6 +43,7 @@
 #include <boost/thread/thread.hpp>
 
 #include <memory>
+#include <sstream>
 
 /**
  * \file thread_per_process_scheduler.cxx
@@ -81,14 +82,17 @@ thread_per_process_scheduler
 
   pipeline_t const p = pipeline();
 
-  process_t proc = p->get_python_process();
-  if(proc)
+  processes_t procs = p->get_python_processes();
+  if( ! procs.empty() )
   {
-    std::string const reason = "The process \'" + proc->name() + "\' of type \'" + proc->type()
-      + "\' is a python process and that type of process is not supported by this scheduler.";
+    std::stringstream str;
+    str << "This pipeline contains the following python processes which are not supported by this scheduler.\n";
+    for ( auto proc : procs )
+    {
+      str << "      \"" << proc->name() << "\" of type \"" << proc->type() << "\"\n";
+    }
 
-    VITAL_THROW( incompatible_pipeline_exception,
-                 reason);
+    VITAL_THROW( incompatible_pipeline_exception, str.str());
   }
 
   process::names_t const names = p->process_names();
@@ -97,7 +101,7 @@ thread_per_process_scheduler
   // compatible with this scheduler.
   for (process::name_t const& name : names)
   {
-    proc = p->process_by_name(name);
+    auto proc = p->process_by_name(name);
     process::properties_t const consts = proc->properties();
 
     if (consts.count(process::property_no_threads))
@@ -105,8 +109,7 @@ thread_per_process_scheduler
       std::string const reason =
         "The process \'" + name + "\' does not support being in its own thread.";
 
-      VITAL_THROW( incompatible_pipeline_exception,
-                   reason);
+      VITAL_THROW( incompatible_pipeline_exception, reason);
     }
   }
 }

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -1182,25 +1182,25 @@ pipeline
 
 
 // ------------------------------------------------------------------
-process_t
+processes_t
 pipeline
-::get_python_process() const
+::get_python_processes() const
 {
   // Run through each process, checking to see if any are python
-  process_t python_process; // Start with a null pointer, return it if no python procs are found
+  processes_t python_processes; // Start with empty list
   for (priv::process_map_t::value_type const& process_index : d->process_map)
   {
     process_t proc = process_index.second;
     auto properties = proc->properties();
     if ( properties.find("_python") != properties.end() )
     {
-      python_process = proc;
-      break;
+      python_processes.push_back( proc );
     }
   }
 
-  return python_process;
+  return python_processes;
 }
+
 
 // ------------------------------------------------------------------
 pipeline::priv

--- a/sprokit/src/sprokit/pipeline/pipeline.h
+++ b/sprokit/src/sprokit/pipeline/pipeline.h
@@ -239,6 +239,9 @@ class SPROKIT_PIPELINE_EXPORT pipeline
      * connections/edges are cleared. Then all connections are
      * reestablished.
      *
+     * Note that setup_pipeline() must be called after reset to get
+     * the pipeline in running condition.
+     *
      * \throws reset_running_pipeline_exception Thrown when the
      * pipeline is running.
      */
@@ -493,9 +496,13 @@ class SPROKIT_PIPELINE_EXPORT pipeline
     /**
      * \brief Check to see if the pipeline has any python processes.
      *
-     * \returns Return a python process if any exist, or a null pointer otherwise
+     * This method returns a list python processes from the
+     * pipeline. An empty list is returned if there are no python
+     * processes.
+     *
+     * \returns Return a list of python processes
      */
-    process_t get_python_process() const;
+    processes_t get_python_processes() const;
 
   private:
     friend class scheduler;


### PR DESCRIPTION
When scheduler that does not support python processes gets a pipeline with python processes, it now reports all the python processes.