### PR TITLE
Major restructuring of serialization code

### DIFF
--- a/arrows/serialize/json/bounding_box.cxx
+++ b/arrows/serialize/json/bounding_box.cxx
@@ -44,9 +44,7 @@ namespace json {
 // ----------------------------------------------------------------------------
 bounding_box::
 bounding_box()
-{
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-}
+{ }
 
 
 bounding_box::
@@ -56,10 +54,10 @@ bounding_box::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 bounding_box::
-serialize( const data_serializer::serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::bounding_box_d bbox =
-    kwiver::vital::any_cast< kwiver::vital::bounding_box_d > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::bounding_box_d > ( element );
 
   std::stringstream msg;
   msg << "bounding_box "; // add type tag
@@ -73,11 +71,10 @@ serialize( const data_serializer::serialize_param_t& elements )
 
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-bounding_box::
-deserialize( std::shared_ptr< std::string > message )
+vital::any bounding_box::
+deserialize( const std::string& message )
 {
-  std::stringstream msg(*message);
+  std::stringstream msg(message);
   kwiver::vital::bounding_box_d bbox{ 0, 0, 0, 0 };
   std::string tag;
   msg >> tag;
@@ -85,7 +82,7 @@ deserialize( std::shared_ptr< std::string > message )
   if (tag != "bounding_box" )
   {
     LOG_ERROR( logger(), "Invalid data type tag received. Expected \"bounding_box\", received \""
-               << tag << "\". Message dropped." );
+               << tag << "\". Message dropped, returning default object." );
   }
   else
   {
@@ -93,10 +90,7 @@ deserialize( std::shared_ptr< std::string > message )
     load( ar, bbox );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(bbox);
-
-  return res;
+  return kwiver::vital::any(bbox);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/bounding_box.h
+++ b/arrows/serialize/json/bounding_box.h
@@ -59,8 +59,8 @@ public:
   bounding_box();
   virtual ~bounding_box();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& elements ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Converters that can be used in cases of nested structures
   static void save( cereal::JSONOutputArchive& archive, const kwiver::vital::bounding_box_d& bbox );

--- a/arrows/serialize/json/detected_object.cxx
+++ b/arrows/serialize/json/detected_object.cxx
@@ -49,9 +49,7 @@ namespace json {
 // ----------------------------------------------------------------------------
 detected_object::
 detected_object()
-{
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-}
+{ }
 
 
 detected_object::
@@ -61,11 +59,11 @@ detected_object::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object::
-serialize( const serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   // Get native data type from any
   kwiver::vital::detected_object_sptr obj =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_sptr > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_sptr > ( element );
 
   std::stringstream msg;
   msg << "detected_object ";
@@ -77,13 +75,11 @@ serialize( const serialize_param_t& elements )
   return std::make_shared< std::string > ( msg.str() );
 }
 
-
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object::
+deserialize( const std::string& message )
 {
-  std::stringstream msg(*message);
+  std::stringstream msg(message);
   auto obj = std::make_shared< kwiver::vital::detected_object >( kwiver::vital::bounding_box_d { 0, 0, 0, 0 } );
 
   std::string tag;
@@ -92,7 +88,7 @@ deserialize( std::shared_ptr< std::string > message )
   if (tag != "detected_object" )
   {
     LOG_ERROR( logger(), "Invalid data type tag received. Expected \"detected_object\", received \""
-               << tag << "\". Message dropped." );
+               << tag << "\". Message dropped. Default object returned." );
   }
   else
   {
@@ -100,10 +96,7 @@ deserialize( std::shared_ptr< std::string > message )
     load( ar, *obj );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(obj);
-
-  return res;
+  return kwiver::vital::any(obj);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/detected_object.h
+++ b/arrows/serialize/json/detected_object.h
@@ -59,8 +59,8 @@ public:
   detected_object();
   virtual ~detected_object();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& elements ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Converters that can be used in cases of nested structures
   static void save( cereal::JSONOutputArchive& archive, const kwiver::vital::detected_object& obj );

--- a/arrows/serialize/json/detected_object_set.cxx
+++ b/arrows/serialize/json/detected_object_set.cxx
@@ -50,9 +50,7 @@ namespace json {
 // ----------------------------------------------------------------------------
 detected_object_set::
 detected_object_set()
-{
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-}
+{ }
 
 
 
@@ -63,10 +61,10 @@ detected_object_set::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object_set::
-serialize( const serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::detected_object_set_sptr obj =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr > ( element );
 
   std::stringstream msg;
   msg << "detected_object_set ";
@@ -79,11 +77,10 @@ serialize( const serialize_param_t& elements )
 
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object_set::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object_set::
+deserialize( const std::string& message )
 {
-  std::stringstream msg(*message);
+  std::stringstream msg(message);
   kwiver::vital::detected_object_set* obj =  new kwiver::vital::detected_object_set();
 
   std::string tag;
@@ -100,11 +97,7 @@ deserialize( std::shared_ptr< std::string > message )
     load( ar, *obj );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(
-    kwiver::vital::detected_object_set_sptr( obj ) );
-
-  return res;
+  return kwiver::vital::any( kwiver::vital::detected_object_set_sptr( obj ) );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/detected_object_set.h
+++ b/arrows/serialize/json/detected_object_set.h
@@ -59,8 +59,8 @@ public:
   detected_object_set();
   virtual ~detected_object_set();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Converters that can be used in cases of nested structures
   static void save( cereal::JSONOutputArchive& archive, const kwiver::vital::detected_object_set& obj );

--- a/arrows/serialize/json/detected_object_type.cxx
+++ b/arrows/serialize/json/detected_object_type.cxx
@@ -45,9 +45,7 @@ namespace json {
 // ----------------------------------------------------------------------------
 detected_object_type::
 detected_object_type()
-{
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-}
+{ }
 
 
 detected_object_type::
@@ -57,10 +55,10 @@ detected_object_type::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object_type::
-serialize( const serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::detected_object_type dot =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_type > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_type > ( element );
 
   std::stringstream msg;
   msg << "detected_object_type ";
@@ -72,13 +70,11 @@ serialize( const serialize_param_t& elements )
   return std::make_shared< std::string > ( msg.str() );
 }
 
-
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object_type::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object_type::
+deserialize( const std::string& message )
 {
-  std::stringstream msg(*message);
+  std::stringstream msg(message);
   kwiver::vital::detected_object_type dot;
   std::string tag;
   msg >> tag;
@@ -94,10 +90,7 @@ deserialize( std::shared_ptr< std::string > message )
     load( ar, dot );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(dot);
-
-  return res;
+  return kwiver::vital::any(dot);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/detected_object_type.h
+++ b/arrows/serialize/json/detected_object_type.h
@@ -59,8 +59,8 @@ public:
   detected_object_type();
   virtual ~detected_object_type();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Converters that can be used in cases of nested structures
   static void save( cereal::JSONOutputArchive& archive, const kwiver::vital::detected_object_type& dot );

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -64,22 +64,14 @@ TEST( serialize, bounding_box )
   kwiver::vital::bounding_box_d bbox { 1, 2, 3, 4 };
 
   kwiver::vital::any bb_any( bbox );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp.emplace( kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME, bb_any);
-  auto mes = bbox_ser.serialize( sp );
-
-
-  // check element names
-  const auto& names = bbox_ser.element_names();
-
-  EXPECT_EQ( names.size(), 1 );
+  auto mes = bbox_ser.serialize( bb_any );
 
   // std::cout << "Serialized bbox: \"" << *mes << "\"\n";
   // std::cout << "List of element names: " << kwiver::vital::join( names, ", " ) << std::endl;
 
-  auto dser = bbox_ser.deserialize( mes );
+  auto dser = bbox_ser.deserialize( *mes );
   kwiver::vital::bounding_box_d bbox_dser =
-    kwiver::vital::any_cast< kwiver::vital::bounding_box_d >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+    kwiver::vital::any_cast< kwiver::vital::bounding_box_d >( dser );
 
   /* useful for debugging
   std::cout << "bbox_dser { " << bbox_dser.min_x() << ", "
@@ -103,17 +95,14 @@ TEST( serialize, detected_object_type )
   dot.set_score( "last", 121 );
 
   kwiver::vital::any dot_any( dot );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = dot_any;
-
-  auto mes = dot_ser.serialize( sp );
+  auto mes = dot_ser.serialize( dot_any );
 
   // useful for debugging
   // std::cout << "Serialized dot: \"" << *mes << "\"\n";
 
-  auto dser = dot_ser.deserialize( mes );
+  auto dser = dot_ser.deserialize( *mes );
   kwiver::vital::detected_object_type dot_dser =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_type >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_type >( dser );
 
   EXPECT_EQ( dot.size(), dot_dser.size() );
 
@@ -145,16 +134,13 @@ TEST( serialize, detected_object )
   obj->set_index( 1234 );
 
   kwiver::vital::any obj_any( obj );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = obj_any;
-
-  auto mes = obj_ser.serialize( sp );
+  auto mes = obj_ser.serialize( obj_any );
 
   // useful for debugging
   // std::cout << "Serialized dot: \"" << *mes << "\"\n";
 
-  auto dser = obj_ser.deserialize( mes );
-  auto obj_dser = kwiver::vital::any_cast< kwiver::vital::detected_object_sptr >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+  auto dser = obj_ser.deserialize( *mes );
+  auto obj_dser = kwiver::vital::any_cast< kwiver::vital::detected_object_sptr >( dser );
 
   EXPECT_EQ( obj->bounding_box(), obj_dser->bounding_box() );
   EXPECT_EQ( obj->index(), obj_dser->index() );
@@ -203,17 +189,13 @@ TEST( serialize, detected_object_set )
   dos->add( det_obj );
 
   kwiver::vital::any obj_any( dos );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = obj_any;
-
-  auto mes = obj_ser.serialize( sp );
+  auto mes = obj_ser.serialize( obj_any );
 
   // Useful for debugging
   // std::cout << "Serialized dos: \"" << *mes << "\"\n";
 
-  auto dser = obj_ser.deserialize( mes );
-  auto obj_dser_set = kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr >(
-    dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+  auto dser = obj_ser.deserialize( *mes );
+  auto obj_dser_set = kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr >( dser );
 
   EXPECT_EQ( 3, obj_dser_set->size() );
 
@@ -250,14 +232,12 @@ TEST( serialize, timestamp)
   kwiver::vital::timestamp tstamp{1, 1};
 
   kwiver::vital::any tstamp_any( tstamp );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp.emplace( kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME, tstamp_any);
 
-  auto mes = tstamp_ser.serialize( sp );
-  auto dser = tstamp_ser.deserialize ( mes );
+  auto mes = tstamp_ser.serialize( tstamp_any );
+  auto dser = tstamp_ser.deserialize ( *mes );
 
-  kwiver::vital::timestamp tstamp_dser = 
-    kwiver::vital::any_cast< kwiver::vital::timestamp >( 
-        dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME] );
+  kwiver::vital::timestamp tstamp_dser =
+    kwiver::vital::any_cast< kwiver::vital::timestamp >( dser );
+
   EXPECT_EQ( tstamp, tstamp_dser);
 }

--- a/arrows/serialize/json/timestamp.h
+++ b/arrows/serialize/json/timestamp.h
@@ -45,27 +45,28 @@ namespace arrows {
 namespace serialize {
 namespace json {
 
-  class KWIVER_SERIALIZE_JSON_EXPORT timestamp
-    : public vital::algorithm_impl< timestamp, vital::algo::data_serializer >
-  {
-    public:
-      static constexpr char const* name  = "kwiver:timestamp";
-      static constexpr char const* description = 
-        "Serializes a timestamp object using json notation";
+class KWIVER_SERIALIZE_JSON_EXPORT timestamp
+  : public vital::algorithm_impl< timestamp, vital::algo::data_serializer >
+{
+public:
+  static constexpr char const* name  = "kwiver:timestamp";
+  static constexpr char const* description =
+    "Serializes a timestamp object using json notation";
 
-      timestamp();
-      virtual ~timestamp();
+  timestamp();
+  virtual ~timestamp();
 
-      virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-      virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& elements ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
-      static void save( cereal::JSONOutputArchive& archive, 
-          const kwiver::vital::timestamp& tstamp);
+  static void save( cereal::JSONOutputArchive&      archive,
+                    const kwiver::vital::timestamp& tstamp );
 
-      static void load( cereal::JSONInputArchive& archive,
-          kwiver::vital::timestamp& tstamp);
+  static void load( cereal::JSONInputArchive& archive,
+                    kwiver::vital::timestamp& tstamp );
 
-  };
+};
+
 } } } }
 
 #endif

--- a/arrows/serialize/protobuf/bounding_box.cxx
+++ b/arrows/serialize/protobuf/bounding_box.cxx
@@ -39,8 +39,6 @@ namespace protobuf {
 bounding_box::
 bounding_box()
 {
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -54,10 +52,10 @@ bounding_box::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 bounding_box::
-serialize( const data_serializer::serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::bounding_box_d bbox =
-    kwiver::vital::any_cast< kwiver::vital::bounding_box_d > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::bounding_box_d > ( element );
 
   std::ostringstream msg;
   msg << "bounding_box "; // add type tag
@@ -74,13 +72,12 @@ serialize( const data_serializer::serialize_param_t& elements )
 }
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-bounding_box::
-deserialize( std::shared_ptr< std::string > message )
+vital::any bounding_box::
+deserialize( const std::string& message )
 {
   kwiver::vital::bounding_box_d bbox{ 0, 0, 0, 0 };
 
-  std::istringstream msg( *message );
+  std::istringstream msg( message );
   std::string tag;
   msg >> tag;
   msg.get();  // Eat the delimiter
@@ -102,10 +99,7 @@ deserialize( std::shared_ptr< std::string > message )
     convert_protobuf( proto_bbox, bbox );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(bbox);
-
-  return res;
+  return kwiver::vital::any(bbox);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/protobuf/bounding_box.h
+++ b/arrows/serialize/protobuf/bounding_box.h
@@ -55,8 +55,8 @@ public:
   bounding_box();
   virtual ~bounding_box();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Convert between native and protobuf formats
   static void convert_protobuf( const kwiver::protobuf::bounding_box&  proto_bbox,

--- a/arrows/serialize/protobuf/detected_object.cxx
+++ b/arrows/serialize/protobuf/detected_object.cxx
@@ -43,8 +43,6 @@ namespace protobuf {
 detected_object::
 detected_object()
 {
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -58,10 +56,10 @@ detected_object::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object::
-serialize( const data_serializer::serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::detected_object det_object =
-    kwiver::vital::any_cast< kwiver::vital::detected_object > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object > ( element );
 
   std::ostringstream msg;
   msg << "detected_object "; // add type tag
@@ -79,12 +77,12 @@ serialize( const data_serializer::serialize_param_t& elements )
 }
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object::
+deserialize( const std::string& message )
 {
-  std::istringstream msg( *message );
-  auto det_object_ptr = std::make_shared< kwiver::vital::detected_object >( kwiver::vital::bounding_box_d { 0, 0, 0, 0 } );
+  std::istringstream msg( message );
+  auto det_object_ptr = std::make_shared< kwiver::vital::detected_object >(
+    kwiver::vital::bounding_box_d { 0, 0, 0, 0 } );
 
   std::string tag;
   msg >> tag;
@@ -108,10 +106,7 @@ deserialize( std::shared_ptr< std::string > message )
     convert_protobuf( proto_det_object, *det_object_ptr );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any( det_object_ptr );
-
-  return res;
+  return kwiver::vital::any( det_object_ptr );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/protobuf/detected_object.h
+++ b/arrows/serialize/protobuf/detected_object.h
@@ -55,8 +55,8 @@ public:
   detected_object();
   virtual ~detected_object();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Convert between native and protobuf formats
   static void convert_protobuf( const kwiver::protobuf::detected_object&  proto_det_object,

--- a/arrows/serialize/protobuf/detected_object_set.cxx
+++ b/arrows/serialize/protobuf/detected_object_set.cxx
@@ -42,8 +42,6 @@ namespace protobuf {
 detected_object_set::
 detected_object_set()
 {
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -57,10 +55,10 @@ detected_object_set::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object_set::
-serialize( const data_serializer::serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::detected_object_set_sptr dos_sptr =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr > ( element );
 
   std::ostringstream msg;
   msg << "detected_object_set "; // add type tag
@@ -78,12 +76,11 @@ serialize( const data_serializer::serialize_param_t& elements )
 }
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object_set::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object_set::
+deserialize( const std::string& message )
 {
   auto dos_sptr = std::make_shared< kwiver::vital::detected_object_set >();
-  std::istringstream msg( *message );
+  std::istringstream msg( message );
 
   std::string tag;
   msg >> tag;
@@ -107,10 +104,7 @@ deserialize( std::shared_ptr< std::string > message )
     convert_protobuf( proto_dos, *dos_sptr );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(dos_sptr);
-
-  return res;
+  return kwiver::vital::any(dos_sptr);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/protobuf/detected_object_set.h
+++ b/arrows/serialize/protobuf/detected_object_set.h
@@ -55,8 +55,8 @@ public:
   detected_object_set();
   virtual ~detected_object_set();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Convert between native and protobuf formats
   static void convert_protobuf( const kwiver::protobuf::detected_object_set&  proto_dos,

--- a/arrows/serialize/protobuf/detected_object_type.cxx
+++ b/arrows/serialize/protobuf/detected_object_type.cxx
@@ -41,8 +41,6 @@ namespace protobuf {
 detected_object_type::
 detected_object_type()
 {
-  m_element_names.insert( DEFAULT_ELEMENT_NAME );
-
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -56,10 +54,10 @@ detected_object_type::
 // ----------------------------------------------------------------------------
 std::shared_ptr< std::string >
 detected_object_type::
-serialize( const data_serializer::serialize_param_t& elements )
+serialize( const vital::any& element )
 {
   kwiver::vital::detected_object_type dot =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_type > ( elements.at( DEFAULT_ELEMENT_NAME ) );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_type > ( element );
 
   std::ostringstream msg;
   msg << "detected_object_type "; // add type tag
@@ -77,12 +75,11 @@ serialize( const data_serializer::serialize_param_t& elements )
 }
 
 // ----------------------------------------------------------------------------
-vital::algo::data_serializer::deserialize_result_t
-detected_object_type::
-deserialize( std::shared_ptr< std::string > message )
+vital::any detected_object_type::
+deserialize( const std::string& message )
 {
   kwiver::vital::detected_object_type dot;
-  std::istringstream msg( *message );
+  std::istringstream msg( message );
 
   std::string tag;
   msg >> tag;
@@ -106,10 +103,7 @@ deserialize( std::shared_ptr< std::string > message )
     convert_protobuf( proto_dot, dot );
   }
 
-  deserialize_result_t res;
-  res[ DEFAULT_ELEMENT_NAME ] = kwiver::vital::any(dot);
-
-  return res;
+  return kwiver::vital::any(dot);
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/protobuf/detected_object_type.h
+++ b/arrows/serialize/protobuf/detected_object_type.h
@@ -55,8 +55,8 @@ public:
   detected_object_type();
   virtual ~detected_object_type();
 
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message );
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
 
   // Convert between native and protobuf formats
   static void convert_protobuf( const kwiver::protobuf::detected_object_type&  proto_bbox,

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -65,21 +65,12 @@ TEST( serialize, bounding_box )
   kwiver::vital::bounding_box_d bbox { 1, 2, 3, 4 };
 
   kwiver::vital::any bb_any( bbox );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp.emplace( kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME, bb_any);
-  auto mes = bbox_ser.serialize( sp );
-
-  // check element names
-  const auto& names = bbox_ser.element_names();
-
-  EXPECT_EQ( names.size(), 1 );
+  auto mes = bbox_ser.serialize( bb_any );
 
   std::cout << "Serialized bbox: \"" << *mes << "\"\n";
-  std::cout << "List of element names: " << kwiver::vital::join( names, ", " ) << std::endl;
 
-  auto dser = bbox_ser.deserialize( mes );
-  kwiver::vital::bounding_box_d bbox_dser =
-    kwiver::vital::any_cast< kwiver::vital::bounding_box_d >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+  auto dser = bbox_ser.deserialize( *mes );
+  kwiver::vital::bounding_box_d bbox_dser = kwiver::vital::any_cast< kwiver::vital::bounding_box_d >( dser );
 
   std::cout << "bbox_dser { " << bbox_dser.min_x() << ", "
             << bbox_dser.min_y() << ", "
@@ -101,16 +92,13 @@ TEST( serialize, detected_object_type )
   dot.set_score( "last", 121 );
 
   kwiver::vital::any dot_any( dot );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = dot_any;
-
-  auto mes = dot_ser.serialize( sp );
+  auto mes = dot_ser.serialize( dot_any );
 
   // std::cout << "Serialized dot: \"" << *mes << "\"\n";
 
-  auto dser = dot_ser.deserialize( mes );
+  auto dser = dot_ser.deserialize( *mes );
   kwiver::vital::detected_object_type dot_dser =
-    kwiver::vital::any_cast< kwiver::vital::detected_object_type >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+    kwiver::vital::any_cast< kwiver::vital::detected_object_type >( dser );
 
   EXPECT_EQ( dot.size(), dot_dser.size() );
 
@@ -142,15 +130,12 @@ TEST( serialize, detected_object )
   obj->set_index( 1234 );
 
   kwiver::vital::any obj_any( *obj );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = obj_any;
-
-  auto mes = obj_ser.serialize( sp );
+  auto mes = obj_ser.serialize( obj_any );
 
   // std::cout << "Serialized dot: \"" << *mes << "\"\n";
 
-  auto dser = obj_ser.deserialize( mes );
-  auto obj_dser = kwiver::vital::any_cast< kwiver::vital::detected_object_sptr >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+  auto dser = obj_ser.deserialize( *mes );
+  auto obj_dser = kwiver::vital::any_cast< kwiver::vital::detected_object_sptr >( dser );
 
   EXPECT_EQ( obj->bounding_box(), obj_dser->bounding_box() );
   EXPECT_EQ( obj->index(), obj_dser->index() );
@@ -175,6 +160,7 @@ TEST( serialize, detected_object )
   }
 }
 
+// ----------------------------------------------------------------------------
 TEST( serialize, detected_object_set )
 {
   kasp::detected_object_set obj_ser; // get serializer
@@ -198,15 +184,12 @@ TEST( serialize, detected_object_set )
   }
 
   kwiver::vital::any obj_any( ser_dos_sptr );
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] = obj_any;
-
-  auto mes = obj_ser.serialize( sp );
+  auto mes = obj_ser.serialize( obj_any );
 
   // std::cout << "Serialized dot: \"" << *mes << "\"\n";
 
-  auto dser = obj_ser.deserialize( mes );
-  auto deser_dos_sptr = kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr >( dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ] );
+  auto dser = obj_ser.deserialize( *mes );
+  auto deser_dos_sptr = kwiver::vital::any_cast< kwiver::vital::detected_object_set_sptr >( dser );
 
   for ( int i = 0; i < 10; i++ )
   {
@@ -234,53 +217,24 @@ TEST( serialize, detected_object_set )
         EXPECT_EQ( deser_it->second, deser_it->second );
       }
     }
-
-  }
-
-  /*
-  EXPECT_EQ( obj->bounding_box(), obj_dser->bounding_box() );
-  EXPECT_EQ( obj->index(), obj_dser->index() );
-  EXPECT_EQ( obj->confidence(), obj_dser->confidence() );
-  EXPECT_EQ( obj->detector_name(), obj_dser->detector_name() );
-
-  dot = obj->type();
-  if (dot)
-  {
-    auto dot_dser = obj_dser->type();
-
-    EXPECT_EQ( dot->size(), dot_dser->size() );
-
-    auto o_it = dot->begin();
-    auto d_it = dot_dser->begin();
-
-    for (size_t i = 0; i < dot->size(); ++i )
-    {
-      EXPECT_EQ( *(o_it->first), *(d_it->first) );
-      EXPECT_EQ( o_it->second, d_it->second );
-    }
-  }
-  */
+  } // end for
 }
 
+// ----------------------------------------------------------------------------
 TEST (serialize, timestamp)
 {
   kasp::timestamp tstamp_ser;
   kwiver::vital::timestamp tstamp{1, 1};
 
   kwiver::vital::any tstamp_any(tstamp);
-  kwiver::vital::algo::data_serializer::serialize_param_t sp;
-  sp.emplace( kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME, tstamp_any);
-  auto mes = tstamp_ser.serialize( sp );
- 
-  const auto& tags = tstamp_ser.element_names();
-  auto dser = tstamp_ser.deserialize( mes );
-  kwiver::vital::timestamp tstamp_dser = 
-    kwiver::vital::any_cast< kwiver::vital::timestamp > ( 
-        dser[ kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME ]);
 
-  std::cout << tstamp_dser.pretty_print() << std::endl;
-  
-  EXPECT_EQ (tstamp, tstamp_dser);  
-} 
+  auto mes = tstamp_ser.serialize( tstamp_any );
+  auto dser = tstamp_ser.deserialize( *mes );
 
+  kwiver::vital::timestamp tstamp_dser =
+    kwiver::vital::any_cast< kwiver::vital::timestamp > ( dser );
 
+  // std::cout << tstamp_dser.pretty_print() << std::endl;
+
+  EXPECT_EQ (tstamp, tstamp_dser);
+}

--- a/arrows/serialize/protobuf/timestamp.h
+++ b/arrows/serialize/protobuf/timestamp.h
@@ -40,26 +40,28 @@ namespace kwiver {
 namespace arrows {
 namespace serialize {
 namespace protobuf {
-  class KWIVER_SERIALIZE_PROTOBUF_EXPORT timestamp
-      : public vital::algorithm_impl< timestamp, vital::algo::data_serializer >
-  {
-    public:
-      static constexpr char const* name = "kwiver:timestamp";
-      static constexpr char const* description = 
-          "Serializes a timestamp using protobuf notation.";
 
-      timestamp();
-      virtual ~timestamp();
+class KWIVER_SERIALIZE_PROTOBUF_EXPORT timestamp
+  : public vital::algorithm_impl< timestamp, vital::algo::data_serializer >
+{
+public:
+  static constexpr char const* name = "kwiver:timestamp";
+  static constexpr char const* description =
+    "Serializes a timestamp using protobuf notation.";
 
-      virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements );
-      virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message);
+  timestamp();
+  virtual ~timestamp();
 
-      static void convert_protobuf( const kwiver::protobuf::timestamp& proto_tstamp,
-                                      kwiver::vital::timestamp& tstamp);
-      
-      static void convert_protobuf( const kwiver::vital::timestamp& tstamp,
-                                      kwiver::protobuf::timestamp& proto_tstamp);
-  };
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  virtual vital::any deserialize( const std::string& message ) override;
+
+  static void convert_protobuf( const kwiver::protobuf::timestamp&  proto_tstamp,
+                                kwiver::vital::timestamp&           tstamp );
+
+  static void convert_protobuf( const kwiver::vital::timestamp& tstamp,
+                                kwiver::protobuf::timestamp&    proto_tstamp );
+};
+
 } } } }
 
 #endif // ARROWS_SERIALIZATION_PROTOBUF_TIMESTAMP_H

--- a/sprokit/processes/core/deserializer_process.cxx
+++ b/sprokit/processes/core/deserializer_process.cxx
@@ -46,6 +46,7 @@
 #include <sprokit/pipeline/process_exception.h>
 
 #include <sstream>
+#include <cstdint>
 
 // ----------------------------------------------------------------------------
 namespace kwiver {
@@ -53,13 +54,18 @@ namespace kwiver {
 // (config-key, value-type, default-value, description )
 create_config_trait( serialization_type, std::string, "",
                      "Specifies the method used to serialize the data object. "
-                     "For example this could be json, or protobuf.");
+                     "For example this could be \"json\", or \"protobuf\".");
+
+create_config_trait( dump_message, bool, "false",
+                     "Dump printable version of serialized messages of set to true." );
 
 class deserializer_process::priv
 {
 public:
   priv();
   ~priv();
+
+  bool opt_dump_message;
 };
 
 // ============================================================================
@@ -90,6 +96,14 @@ deserializer_process
 
   // Examine the configuration
   m_serialization_type = config_value_using_trait( serialization_type );
+  d->opt_dump_message =  config_value_using_trait( dump_message );
+
+  if (m_serialization_type.empty())
+  {
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "\"serialization_type\" config parameter not specified");
+  }
+
 }
 
 
@@ -103,6 +117,11 @@ deserializer_process
 
   // Now that we have a "normal" output port, let Sprokit manage it
   this->set_data_checking_level( check_valid );
+
+  if (d->opt_dump_message)
+  {
+    dump_msg_spec();
+  }
 }
 
 
@@ -114,28 +133,119 @@ deserializer_process
   scoped_step_instrumentation();
 
   // Loop over all registered groups
-  for (const auto elem : m_port_group_list )
+  for (const auto msg_spec_it : m_message_spec_list )
   {
+    // Each iteration of this loop expects a multi-element message
+    // with the following format
+    //
+    // message ::= <message-type> <size-of-payload> <element-list>
+    // element_list ::= <element> <element_list>
+    // element ::= <element-name> <port-type> <length> <serialized-bytes>
+    //         |
+
     try
     {
-      const auto & pg = elem.second;
+      const auto& msg_spec = msg_spec_it.second;
 
       // Convert input back to vital type
-      auto message = grab_from_port_as< serialized_message_port_trait::type >( pg.m_serialized_port_name );
-      auto deser = pg.m_serializer->deserialize( message );
+      auto message = grab_from_port_as< serialized_message_port_trait::type >( msg_spec.m_serialized_port_name );
 
-      // loop over all items that are part of this group.
-      // This disassembles the input byte string into one or more concrete data types.
-      for ( auto pg_item : pg.m_items )
+      std::istringstream raw_stream( *message );
+      const int64_t end_offset = message->size();
+      int64_t current_remaining;
+
+      if (d->opt_dump_message)
       {
-        auto & item = pg_item.second;
-        LOG_TRACE( logger(), "Processing port: \"" << item.m_port_name
-                   << "\" of type \"" << item.m_port_type << "\"" );
+        decode_message( *message );
+      }
+
+      // check for expected message type
+      std::string msg_type;
+      raw_stream >> msg_type;
+
+      // This must be the expected message type.
+      if ( msg_type != msg_spec_it.first )
+      {
+        LOG_ERROR( logger(), "Unexpected message type. Expected \""
+                   << msg_spec_it.first << "\" but received \"" << msg_type << "\". Message dropped." );
+        return;
+      }
+
+      // number of bytes left in the buffer
+      int64_t payload_size;
+      raw_stream >> payload_size;
+
+      if ( payload_size != (end_offset - raw_stream.tellg()) )
+      {
+        LOG_WARN( logger(), "Payload size does not equal data count in stream." );
+      }
+
+      // Loop over all elements in the message
+      for ( size_t i = 0; i < msg_spec.m_elements.size(); ++i )
+      {
+        std::string element_name;
+        std::string port_type;
+
+        raw_stream >> element_name >> port_type;
+
+        // Find corresponding entry for element_name
+        if ( msg_spec.m_elements.count( element_name ) == 0 )
+        {
+          LOG_ERROR( logger(), "Message component \"" << element_name
+                     << "\" not specified for this process. Message dropped. " );
+          break;
+        }
+
+        // Get element specification
+        const auto& msg_elem = msg_spec.m_elements.at( element_name );
+
+        LOG_TRACE( logger(), "Processing port: \"" << msg_elem.m_port_name
+                   << "\" of type \"" << msg_elem.m_port_type << "\"" );
+
+        if ( port_type != msg_elem.m_port_type )
+        {
+          LOG_ERROR( logger(), "Message element type mismatch in message type \""
+                     << msg_type << "\". Expecting element type \""
+                     << msg_elem.m_port_type << "\" but received \""
+                     << port_type << "\"" );
+          break;
+        }
+
+        // Get size of next element
+        int64_t elem_size;
+        raw_stream >> elem_size;
+        raw_stream.get(); // eat delimiter
+
+        current_remaining = end_offset - raw_stream.tellg();
+        if ( elem_size > current_remaining )
+        {
+          LOG_ERROR( logger(), "Message size error. Current element size of "
+                     << elem_size << " bytes exceeds " << current_remaining
+                     << " remaining bytes in the payload." );
+        break; // go to next message
+        }
+
+        std::string elem_buffer( elem_size, 0 );
+        // raw_stream.read( elem_buffer.data(), elem_size );
+        raw_stream.read( &elem_buffer[0], elem_size );
+
+        current_remaining = end_offset - raw_stream.tellg();
+
+        // deserialize the data
+        auto deser_data = msg_elem.m_serializer->deserialize( elem_buffer );
 
         // Push one element from the deserializer to the correct port
-        sprokit::datum_t local_datum = sprokit::datum::new_datum( deser[ item.m_element_name ] );
-        push_datum_to_port( item.m_port_name, local_datum );
+        sprokit::datum_t local_datum = sprokit::datum::new_datum( deser_data );
+        push_datum_to_port( msg_elem.m_port_name, local_datum );
+      } // end for
+
+      // test residual payload size - should be zero
+      if ( current_remaining > 0 )
+      {
+        LOG_ERROR( logger(), "Message contained more elements than expected. Message processed with "
+                   << current_remaining << " bytes remaining." );
       }
+
     }
     catch ( const kwiver::vital::vital_exception& e )
     {
@@ -232,11 +342,13 @@ void deserializer_process
 ::make_config()
 {
   declare_config_using_trait( serialization_type );
+  declare_config_using_trait( dump_message );
 }
 
 // ------------------------------------------------------------------
 deserializer_process::priv
 ::priv()
+  : opt_dump_message( false )
 {
 }
 

--- a/sprokit/processes/core/serializer_base.cxx
+++ b/sprokit/processes/core/serializer_base.cxx
@@ -30,8 +30,12 @@
 
 #include "serializer_base.h"
 
+#include <vital/util/hex_dump.h>
+
 #include <string>
 #include <sstream>
+#include <iostream>
+#include <cstdint>
 
 namespace kwiver {
 
@@ -54,89 +58,72 @@ void
 serializer_base
 ::base_init()
 {
-  // scan through our port groups to make sure it all makes sense.
-  for ( auto elem : m_port_group_list )
+  // Scan through our port groups to make sure it all makes sense.
+  // The port group name is used as the message-name
+  for ( auto msg_elem : m_message_spec_list )
   {
-    auto & pg = m_port_group_list[elem.first];
+    auto& pg = m_message_spec_list[msg_elem.first];
 
     // A group must have at least one port
-    if (pg.m_items.size() < 1)
+    if (pg.m_elements.size() < 1)
     {
       std::stringstream str;
-      str <<  "There are no data items for group \"" << elem.first << "\"";
+      str <<  "There are no data elements for group \"" << msg_elem.first << "\"";
 
       VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
-    }
-
-    // determine which algorithm we should use. If m_algo_name is set
-    // at this point, we are dealing with a multi-item packing
-    // serializer.
-    //
-    // If it is not set, then we are dealing with a single item
-    // converter and can use the input port type as the algorithm name.
-    if ( pg.m_algo_name.empty() )
-    {
-      // There should only be one item in the group
-      if (pg.m_items.size() != 1)
-      {
-        std::stringstream str;
-        str <<  "Port group \"" << elem.first << "\" has more than one element.";
-
-        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
-      }
-
-      pg.m_algo_name = pg.m_items.cbegin()->second.m_port_type;
-
-      LOG_TRACE( m_logger, "Setting algo name for port group \"" << elem.first
-                 << "\" to \"" << pg.m_algo_name << "\"" );
     }
 
     // Test to see if the output port has been connected to.
     if ( ! pg.m_serialized_port_created )
     {
-      VITAL_THROW( sprokit::missing_connection_exception, m_proc.name(), elem.first,
+      VITAL_THROW( sprokit::missing_connection_exception, m_proc.name(), msg_elem.first,
                    "Output port has not been connected" );
     }
 
-    // create config items
-    // serialize-protobuf:type = <algo-name>
-    // serialize-protobuf:<algo-name>:foo = bar // possible but not likely
-
-    auto algo_config = kwiver::vital::config_block::empty_config();
-    const std::string ser_algo_type( "serialize-" + m_serialization_type );
-    const std::string ser_type( ser_algo_type + vital::config_block::block_sep + "type" );
-
-    algo_config->set_value( ser_type, pg.m_algo_name );
-
-    std::stringstream str;
-    algo_config->print( str );
-    LOG_TRACE( m_logger, "Creating algorithm for (config block):\n" << str.str() << std::endl );
-
-    vital::algorithm_sptr base_nested_algo;
-
-    // create serialization algorithm
-    vital::algorithm::set_nested_algo_configuration( ser_algo_type, // data type name
-                                                     ser_algo_type, // config block name
-                                                     algo_config,
-                                                     base_nested_algo );
-
-    pg.m_serializer = std::dynamic_pointer_cast< vital::algo::data_serializer > ( base_nested_algo );
-    if ( ! pg.m_serializer )
+    for ( auto it : pg.m_elements )
     {
+      auto& elem_spec = pg.m_elements.at(it.first);
+
+      // create config items
+      // serialize-protobuf:type = <algo-name>
+
+      auto algo_config = kwiver::vital::config_block::empty_config();
+
+      const std::string ser_algo_type( "serialize-" + m_serialization_type );
+      const std::string ser_type( ser_algo_type + vital::config_block::block_sep + "type" );
+
+      algo_config->set_value( ser_type, elem_spec.m_algo_name );
+
       std::stringstream str;
-      str << "Unable to create serializer for type \""
-          << pg.m_algo_name << "\" for " << m_serialization_type;
+      algo_config->print( str );
+      LOG_TRACE( m_logger, "Creating algorithm for (config block):\n" << str.str() << std::endl );
 
-      VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
-    }
+      vital::algorithm_sptr base_nested_algo;
 
-    if ( ! vital::algorithm::check_nested_algo_configuration( ser_algo_type,
-                                                              ser_algo_type,
-                                                              algo_config ) )
-    {
-      VITAL_THROW( sprokit::invalid_configuration_exception,
-                   m_proc.name(), "Configuration check failed." );
-    }
+      // create serialization algorithm
+      vital::algorithm::set_nested_algo_configuration( ser_algo_type, // data type name
+                                                       ser_algo_type, // config block name
+                                                       algo_config,
+                                                       base_nested_algo );
+
+      elem_spec.m_serializer = std::dynamic_pointer_cast< vital::algo::data_serializer > ( base_nested_algo );
+      if ( ! elem_spec.m_serializer )
+      {
+        std::stringstream str;
+        str << "Unable to create serializer for type \""
+            << elem_spec.m_algo_name << "\" for " << m_serialization_type;
+
+        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
+      }
+
+      if ( ! vital::algorithm::check_nested_algo_configuration( ser_algo_type,
+                                                                ser_algo_type,
+                                                                algo_config ) )
+      {
+        VITAL_THROW( sprokit::invalid_configuration_exception,
+                     m_proc.name(), "Configuration check failed." );
+      }
+    } // end for
   } // end for
 }
 
@@ -145,84 +132,56 @@ bool
 serializer_base::
 vital_typed_port_info( sprokit::process::port_t const& port_name )
 {
-  // split port name into algo and item.
-  // port_name ::= <group>/<algorithm>/<item>
+  // split port name into algo and element.
+  // port_name ::= <message-name>/<element>
   //
-  // Create port_group for <group>
-  // Add entry for item.
+  // Create message_spec for <message-name>
+  // Add entry for element.
 
   // Extract GROUP sub-string from port name
   sprokit::process::ports_t components;
   kwiver::vital::tokenize( port_name, components, "/" );
 
-  std::string group_name;
-  std::string algo_name;
-  std::string item_name;
+  std::string message_name;
+  std::string element_name;
 
-  switch (components.size())
+  if ( components.size() != 2 )
   {
-  case 1:
-    // No item specified. Assume a single item group
-    group_name = components[0];
-    item_name = kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME;
-    break;
-
-  case 3:
-    group_name = components[0];
-    algo_name = components[1];
-    item_name = components[2];
-    break;
-
-  default:
     LOG_ERROR( m_logger, "Port \"" << port_name
                << "\" does not have the correct format. "
-               "Must be in the form \"<group>/<algorithm>/<item>\" "
-               "or \"<item>\"." );
+               "Must be in the form \"<message-name>/<element>\"." );
     return false;
   }
+
+  message_name = components[0];
+  element_name = components[1];
 
   // if port has already been added, do nothing
-  if (m_port_group_list.count( group_name ) == 0 )
+  if (m_message_spec_list.count( message_name ) == 0 )
   {
     // create a new empty group
-    m_port_group_list[ group_name ] = port_group();
-    LOG_TRACE( m_logger, "Creating new group \"" << group_name << "\" for typed port" );
+    m_message_spec_list[ message_name ] = message_spec();
+    LOG_TRACE( m_logger, "Creating new group \"" << message_name << "\" for typed port" );
   }
 
-  port_group& pg = m_port_group_list[ group_name ];
+  message_spec& pg = m_message_spec_list[ message_name ];
 
-  // See if the item already exists in the item list. If so, then
+  // See if the element already exists in the element list. If so, then
   // the port has already been created.
-  if ( pg.m_items.count( item_name ) != 0 )
+  if ( pg.m_elements.count( element_name ) != 0 )
   {
     return false;
   }
 
-  port_group::data_item di;
+  message_spec::message_element di;
   di.m_port_name = port_name;
-  di.m_element_name = item_name;
+  di.m_element_name = element_name;
 
-  pg.m_items[item_name] = di;
-  pg.m_serialized_port_name = group_name; // expected port name
+  pg.m_elements[element_name] = di;
+  pg.m_serialized_port_name = message_name; // expected port name
 
-  if ( pg.m_algo_name.empty() )
-  {
-    pg.m_algo_name = algo_name; // can be empty string if single item group.
-  }
-  else
-  {
-    if ( pg.m_algo_name != algo_name )
-    {
-      LOG_ERROR( m_logger, "Port \"" << port_name
-                 << "\" has been declared with a different algorithm than previously declared. "
-                 << "Previously declared with algorithm \"" << pg.m_algo_name << "\".");
-      return false;
-    }
-  }
-
-  LOG_TRACE( m_logger, "Created port item \"" << item_name
-             << "\" for group \"" << group_name
-             << "\" with algo name \"" << algo_name << "\"" );
+  LOG_TRACE( m_logger, "Created port element \"" << element_name
+             << "\" for message name \"" << message_name << "\"" );
 
   return true;
 }
@@ -232,14 +191,14 @@ bool
 serializer_base::
 byte_string_port_info( sprokit::process::port_t const& port_name )
 {
-  if (m_port_group_list.count( port_name ) == 0 )
+  if (m_message_spec_list.count( port_name ) == 0 )
   {
     // create a new empty group
-    m_port_group_list[ port_name ] = port_group();
+    m_message_spec_list[ port_name ] = message_spec();
     LOG_TRACE( m_logger, "Creating new group for byte_string port \"" << port_name << "\"" );
   }
 
-  port_group& pg = m_port_group_list[ port_name ];
+  message_spec& pg = m_message_spec_list[ port_name ];
 
   if ( ! pg.m_serialized_port_created )
   {
@@ -262,40 +221,128 @@ serializer_base::
 set_port_type( sprokit::process::port_t const&      port_name,
                sprokit::process::port_type_t const& port_type )
 {
-  // Extract GROUP sub-string from port name
+  // Extract sub-strings from port name
   sprokit::process::ports_t components;
   kwiver::vital::tokenize( port_name, components, "/" );
-  std::string group_name;
-  std::string item_name;
+  std::string message_name;
+  std::string element_name;
 
-  switch (components.size())
+  if ( components.size() != 2 )
   {
-  case 1:
-    // No item specified. Assume a single item group
-    group_name = components[0];
-    item_name = kwiver::vital::algo::data_serializer::DEFAULT_ELEMENT_NAME;
-    break;
-
-  case 3:
-    group_name = components[0];
-    item_name = components[2];
-    break;
-
-  default:
     LOG_ERROR( m_logger, "Port \"" << port_name
                << "\" does not have the correct format. "
-               "Must be in the form \"<group>/<algorithm>/<item>\" "
-               "or \"<item>\"." );
+               "Must be in the form \"<group>/<algorithm>/<element>\" "
+               "or \"<element>\"." );
     return;
   }
 
+  message_name = components[0];
+  element_name = components[1];
+
   // update port handler
-  port_group& pg = m_port_group_list[group_name];
-  port_group::data_item& di = pg.m_items[item_name];
+  message_spec& pg = m_message_spec_list[message_name];
+  message_spec::message_element& di = pg.m_elements[element_name];
   di.m_port_type = port_type;
 
-  LOG_TRACE( m_logger, "Setting port type for group \"" << port_name
-             << "\" item \"" << item_name << "\" to \"" << port_type << "\"" );
+  // Currently, the algo name is the same as the data type on that port.
+  di.m_algo_name = port_type;
+
+  LOG_TRACE( m_logger, "Setting port type for message \"" << message_name
+             << "\" element \"" << element_name << "\" to \"" << port_type << "\"" );
 }
+
+// ----------------------------------------------------------------------------
+void serializer_base::
+decode_message( const std::string& message )
+{
+  std::istringstream raw_stream( message );
+  const int64_t end_offset = message.size();
+
+  // check for expected message type
+  std::string msg_type;
+  raw_stream >> msg_type;
+
+  // number of bytes left in the buffer
+  int64_t payload_size;
+  raw_stream >> payload_size;
+
+  std::cout << "Message tag: \"" << msg_type << "\"  Payload size in bytes: " << payload_size << std::endl;
+
+  if ( payload_size != (end_offset - raw_stream.tellg()) )
+  {
+    std::cout << "WARNING: Payload size does not equal data count in stream.\n";
+  }
+
+  while ( true )
+  {
+    std::string element_name;
+    std::string port_type;
+    int64_t elem_size;
+
+    raw_stream >> element_name >> port_type >> elem_size;
+    raw_stream.get(); // eat delimiter
+
+    std::cout << "   Element name: \"" << element_name
+              << "\"  Port type: \"" << port_type
+              << "\"  Element size: " << elem_size
+              << std::endl;
+
+    const int64_t current_remaining = end_offset - raw_stream.tellg();
+
+    if ( elem_size > current_remaining )
+    {
+      std::cout << "Message size error. Current element size of "
+                << elem_size << " bytes exceeds " << payload_size << " remaining bytes in the payload."
+                << std::endl;
+      return;
+    }
+
+
+    std::string elem_buffer( elem_size, 0 );
+    raw_stream.read( &elem_buffer[0], elem_size );
+
+    // Dump the serialized data element
+    kwiver::vital::hex_dump( std::cout, elem_buffer.c_str(), elem_size );
+    std::cout << std::endl;
+
+    // check to see if we are at the end
+    if ( elem_size == current_remaining )
+    {
+      break;
+    }
+  } // end while
+
+}
+
+// ----------------------------------------------------------------------------
+void serializer_base::
+dump_msg_spec()
+{
+  for ( const auto it : m_message_spec_list )
+  {
+    std::cout << "Message tag: " << it.first << std::endl;
+
+    const auto& msg_spec = it.second;
+
+    std::cout << "   Serialized port name: " << msg_spec.m_serialized_port_name << std::endl;
+
+    for ( const auto elem_it : msg_spec.m_elements )
+    {
+      const auto& msg_elem = elem_it.second;
+
+      std::cout << "    Msg element: " << elem_it.first << std::endl
+                << "        Port name: " << msg_elem.m_port_name << std::endl
+                << "        Port type: " << msg_elem.m_port_type << std::endl
+                << "        Element name: " << msg_elem.m_element_name << std::endl
+                << "        Algo name: " << msg_elem.m_algo_name << std::endl;
+    } // end for
+
+    std::cout << std::endl;
+
+  } // end for
+
+}
+
+
 
 } // end namespace kwiver

--- a/sprokit/processes/core/serializer_base.h
+++ b/sprokit/processes/core/serializer_base.h
@@ -93,6 +93,15 @@ public:
   void set_port_type( sprokit::process::port_t const&      port_name,
                       sprokit::process::port_type_t const& port_type );
 
+  /**
+   * @brief Analyze message and print components
+   *
+   * @param message The serialized message
+   */
+  void decode_message( const std::string& message );
+
+  void dump_msg_spec();
+
 
 protected:
   sprokit::process& m_proc; // associated process
@@ -104,40 +113,41 @@ protected:
    * A port group defines a set of ports that provide data to a single
    * serializer algo.
    */
-  struct port_group
+  struct message_spec
   {
-    port_group()
+    message_spec()
       : m_serialized_port_created(false)
     {}
 
     // This struct defines a single port.
-    struct data_item
+    struct message_element
     {
-      // Port name to write datum to
+      // Full Port name to write datum to
       sprokit::process::port_t m_port_name;
 
-      // canonical port type name string
+      // canonical (logical) port type name string
       sprokit::process::port_type_t m_port_type;
 
       // name of data element to pass to serializer
       std::string m_element_name;
+
+      // Algorithm name as constructed from serialization type and data type
+      std::string m_algo_name;
+
+      // Algorithm handles a group of data items
+      vital::algo::data_serializer_sptr m_serializer;
     };
 
-    // indexed by algorithm element_name
-    std::map< std::string, data_item > m_items;
+    // indexed by m_element_name
+    std::map< std::string, message_element > m_elements;
 
     // port to read serialized data from
     sprokit::process::port_t m_serialized_port_name;
     bool m_serialized_port_created;
-
-    std::string m_algo_name;
-
-    // Algorithm handles a group of data items
-    vital::algo::data_serializer_sptr m_serializer;
   };
 
-  // map is indexed by group/port name
-  std::map< std::string, port_group > m_port_group_list;
+  // map is indexed by message-name
+  std::map< std::string, message_spec > m_message_spec_list;
 
 
 private:

--- a/sprokit/processes/core/serializer_process.cxx
+++ b/sprokit/processes/core/serializer_process.cxx
@@ -52,30 +52,26 @@ namespace kwiver {
 /**
  * \class serializer_process
  *
- * \brief Process for serializing data items into a byte string.
+ * \brief Process for serializing data elements into a byte string.
  *
- * \process Serialize incoming data items into a byte stream. An
+ * \process Serialize incoming data elements into a byte stream. An
  * instance of this process can serialize multiple streams of input
  * data into output byte strings.
  *
  * \iports
  *
  * Input ports are dynamically created as needed. Port name must
- * have the format \iport{algo/item} or \iport{algo}.
+ * have the format \iport{message/element}.
  *
  * \oports
  *
  * \oport{algo} Output ports are dynamically created as needed and
  * must correspond to the algo name from an input port.
  *
- * The "algo" part of a port name must correspond to a loadable
- * serializer algorithm. The "item" part of the input port name must
- * correspond to an element name expected by the serializer instance.
- *
  * \code
  process ser :: serializer
 
- # select the serializing method to apply to all data items.
+ # select the serializing method to apply to all data elements.
  serialization_type = json
 
  # -- connect inputs to algo that generates image and mask messages
@@ -97,11 +93,16 @@ create_config_trait( serialization_type, std::string, "",
                      "Specifies the method used to serialize the data object. "
                      "For example this could be \"json\", or \"protobuf\".");
 
+  create_config_trait( dump_message, bool, "false",
+                     "Dump printable version of serialized messages of set to true." );
+
 class serializer_process::priv
 {
 public:
   priv();
   ~priv();
+
+  bool opt_dump_message;
 };
 
 // ============================================================================
@@ -132,6 +133,7 @@ serializer_process
 
   // Examine the configuration
   m_serialization_type = config_value_using_trait( serialization_type );
+  d->opt_dump_message =  config_value_using_trait( dump_message );
 
   if (m_serialization_type.empty())
   {
@@ -151,6 +153,11 @@ serializer_process
 
   // Now that we have a "normal" input ports let Sprokit manager them
   this->set_data_checking_level( check_valid );
+
+  if (d->opt_dump_message)
+  {
+    dump_msg_spec();
+  }
 }
 
 
@@ -161,38 +168,72 @@ serializer_process
 {
   scoped_step_instrumentation();
 
-  // Loop over all registered groups
-  for (const auto elem : m_port_group_list )
+  // Loop over all registered messages
+  for ( auto msg_spec_it : m_message_spec_list )
   {
-    const auto & pg = m_port_group_list[elem.first];
+    // Each iteration of this loop assembles a multi-element message
+    // with the following format
+    //
+    // message ::= <message-type> <size-of-payload> <element-list>
+    // element_list ::= <element> <element_list>
+    // element ::= <element-name> <port-type> <length> <serialized-bytes>
+    //         |
 
-    vital::algo::data_serializer::serialize_param_t sp;
+    std::ostringstream message_str;
+    const auto & msg_spec = m_message_spec_list[msg_spec_it.first];
 
-    // loop over all items that are part of this group.
+    // Add message type string
+    message_str << msg_spec_it.first << " ";
+
+    std::ostringstream ser_elements;
+
+    // loop over all elements that are part of this group.
     // This assembles the output byte string from one or more concrete data types.
-    for ( auto pg_item : pg.m_items )
+    for ( auto msg_elem_it : msg_spec.m_elements )
     {
-      auto & item = pg_item.second;
-      LOG_TRACE( logger(), "Processing port: \"" << item.m_port_name
-                 << "\" of type \"" << item.m_port_type << "\"" );
+      const auto& element = msg_elem_it.second;
+      LOG_TRACE( logger(), "Processing port: \"" << element.m_port_name
+                 << "\" of type \"" << element.m_port_type << "\"" );
 
       // Convert input datum to a serialized message
-      auto datum = grab_datum_from_port( item.m_port_name );
+      auto datum = grab_datum_from_port( element.m_port_name );
       auto local_datum = datum->get_datum<kwiver::vital::any>();
-      sp[ item.m_element_name ] = local_datum;
+      std::shared_ptr< std::string > message;
+      try
+      {
+        // Serialize the collected set of inputs
+        message = element.m_serializer->serialize( local_datum );
+      }
+      catch ( const kwiver::vital::vital_exception& e )
+      {
+        // can be kwiver::vital::serialization_exception or kwiver::vital::bad_any_cast
+        LOG_ERROR( logger(), "Error serializing data element \"" << element.m_element_name
+                   << "\" for message type \"" << msg_spec_it.first << "\" : " << e.what() );
+        break;
+      }
+
+      LOG_TRACE( logger(), "Adding element: \"" << element.m_element_name
+                 << "\"  Port type: \"" << element.m_port_type << "\"  Size: "
+                 << message->size() );
+
+      // Add element name and port type to output followed by serialized data
+      ser_elements << element.m_element_name << " "
+                   << element.m_port_type << " "
+                   << message->size() << " "
+                   << *message;
+    } // end for
+
+    // Add payload length to output buffer before the serialized elements.
+    message_str << ser_elements.str().size()+1 << " " << ser_elements.str();
+
+    if (d->opt_dump_message)
+    {
+      decode_message( message_str.str() );
     }
 
-    try
-    {
-      // Serialize the collected set of inputs
-      auto message = pg.m_serializer->serialize( sp );
-      push_to_port_as < serialized_message_port_trait::type >( pg.m_serialized_port_name, message );
-    }
-    catch ( const kwiver::vital::vital_exception& e )
-    {
-      // can be kwiver::vital::serialization_exception or kwiver::vital::bad_any_cast
-      LOG_ERROR( logger(), "Error serializing data element: " << e.what() );
-    }
+    // Push whole serialized message to port
+    auto msg_buffer = std::make_shared< std::string >( message_str.str() );
+    push_to_port_as < serialized_message_port_trait::type >( msg_spec.m_serialized_port_name, msg_buffer );
 
   } // end for
 
@@ -283,11 +324,13 @@ void serializer_process
 ::make_config()
 {
   declare_config_using_trait( serialization_type );
+  declare_config_using_trait( dump_message );
 }
 
 // ------------------------------------------------------------------
 serializer_process::priv
 ::priv()
+  : opt_dump_message( false )
 {
 }
 

--- a/sprokit/tests/pipelines/test_serializer.pipe
+++ b/sprokit/tests/pipelines/test_serializer.pipe
@@ -17,18 +17,19 @@ process sim :: detected_object_input
 # --------------------------------------------------
 process ser :: serializer
         serialization_type = json
+##        dump_message = true
 
-connect from sim.detected_object_set to ser.dos
+connect from sim.detected_object_set to ser.msg-dos/dos
 
 # --------------------------------------------------
 process dser :: deserializer
         serialization_type = json
 
-connect from ser.dos to dser.dos
+connect from ser.msg-dos to dser.msg-dos
 
 # --------------------------------------------------
 process sink :: detected_object_output
         file_name = junk
         writer:type = csv
 
-connect from dser.dos to sink.detected_object_set
+connect from dser.msg-dos/dos to sink.detected_object_set

--- a/vital/algo/data_serializer.cxx
+++ b/vital/algo/data_serializer.cxx
@@ -45,46 +45,11 @@ namespace kwiver {
 namespace vital {
 namespace algo {
 
-const std::string data_serializer::DEFAULT_ELEMENT_NAME {"datum"};
-
 // ----------------------------------------------------------------------------
 data_serializer
 ::data_serializer()
 {
   attach_logger( "data_serializer" );
-}
-
-
-// ----------------------------------------------------------------------------
-bool
-data_serializer
-::check_element_names( serialize_param_t elements )
-{
-  for ( const auto it : elements )
-  {
-    if ( m_element_names.count( it.first ) == 0 )
-    {
-      // throw error
-      std::stringstream str;
-      str << "Element name \"" << it.first
-          << "\" is not in the supported set. Supported elements are: "
-          << kwiver::vital::join( m_element_names, ", " );
-
-      throw std::runtime_error( str.str() );
-    }
-  } // end for
-
-  // Check for all allowable names being in the map;
-  return (elements.size() == m_element_names.size() );
-}
-
-
-// ----------------------------------------------------------------------------
-const std::set< std::string >&
-data_serializer
-::element_names() const
-{
-  return m_element_names;
 }
 
 } } }

--- a/vital/algo/data_serializer.h
+++ b/vital/algo/data_serializer.h
@@ -58,12 +58,6 @@ namespace algo {
  * actually doing the serialization depends on the concrete
  * implementation.
  *
- * This interface allows an implementation to serialize one or more
- * data items into a single transport message byte string by accepting
- * and producing a map of data items indexed by the set of names known
- * to the implementation. It is expected that the element names will
- * reflect the semantic data type.
- *
  * It is expected that implementations of this interface will not
  * require any implementation specific configuration parameters. This
  * is because the implementation is selected at run time based on the
@@ -78,8 +72,6 @@ class VITAL_ALGO_EXPORT data_serializer
   : public kwiver::vital::algorithm_def< data_serializer >
 {
 public:
-  using serialize_param_t = std::map< std::string, vital::any >;
-  using deserialize_result_t = std::map< std::string, vital::any >;
 
   /// Return the name of this algorithm
   static std::string static_type_name() { return "data_serializer"; }
@@ -109,7 +101,7 @@ public:
    * @throws kwiver::vital::bad_any_cast
    * @throws kwiver::vital::serialization - for unexpected element name
    */
-  virtual std::shared_ptr< std::string > serialize( const serialize_param_t& elements ) = 0;
+  virtual std::shared_ptr< std::string > serialize( const vital::any& element ) = 0;
 
   /// Deserialize byte string into data type.
   /**
@@ -138,44 +130,14 @@ public:
    * @throws kwiver::vital::bad_any_cast
    * @throws kwiver::vital::serialization - for unexpected element name
    */
-  virtual deserialize_result_t deserialize( std::shared_ptr< std::string > message ) = 0;
-
-  /// Return list of data elements handled.
-  /**
-   * This method returns the set of supported data element names.
-   *
-   *
-   * @return Set of supported data element names.
-   */
-  virtual const std::set< std::string >& element_names() const;
+  virtual vital::any deserialize( const std::string& message ) = 0;
 
   virtual void set_configuration( kwiver::vital::config_block_sptr config ) { }
   virtual bool check_configuration(config_block_sptr config) const { return true; }
 
-  /**
-   * This is the default element name for implementations that only
-   * support a single data element.
-   */
-  static const std::string DEFAULT_ELEMENT_NAME;
-
 protected:
   data_serializer();
 
-  /// Validate element names against supported set.
-  /**
-   * This method validates the supplied group of element names from
-   * the map against the supported set. An exception is thrown if a
-   * name is found in the map and it is not in the set of element
-   * names.
-   *
-   */
-  bool check_element_names( serialize_param_t elements);
-
-  /**
-   * Set of supported data element names. It is expected that the
-   * implementation will directly add the supported names to this set.
-   */
-  std::set< std::string > m_element_names;
 };
 
 /// Shared pointer for detect_features algorithm definition class

--- a/vital/util/hex_dump.cxx
+++ b/vital/util/hex_dump.cxx
@@ -50,6 +50,7 @@ hex_dump( std::ostream& os,
   auto oldFormat = os.flags();
   auto oldFillChar = os.fill();
   constexpr std::size_t maxline { 8 };
+  size_t offset { 0 };
 
   // create a place to store text version of string
   char renderString[maxline + 1];
@@ -58,11 +59,17 @@ hex_dump( std::ostream& os,
   // convenience cast
   const unsigned char* buf { reinterpret_cast< const unsigned char* > ( buffer ) };
 
-  for ( std::size_t linecount = maxline; bufsize; --bufsize, ++buf )
+  os << std::setw( 4 )  << std::setfill( '0' ) << std::hex
+     << offset << ": ";
+  ++offset;
+
+  for ( std::size_t linecount = maxline; bufsize; --bufsize, ++buf, ++offset )
   {
     os  << std::setw( 2 ) << std::setfill( '0' ) << std::hex
         << static_cast< unsigned > ( *buf ) << ' ';
+
     *rsptr++ = std::isprint( *buf ) ? *buf : '.';
+
     if ( --linecount == 0 )
     {
       *rsptr++ = '\0';        // terminate string
@@ -71,10 +78,16 @@ hex_dump( std::ostream& os,
         os << " | " << renderString;
       }
       os << '\n';
+
+      os << std::setw( 4 )  << std::setfill( '0' ) << std::hex
+         << offset << ": ";
+
       rsptr = renderString;
+
       linecount = std::min( maxline, bufsize );
     }
-  }
+  } //end for
+
   // emit newline if we haven't already
   if ( rsptr != renderString )
   {
@@ -89,6 +102,7 @@ hex_dump( std::ostream& os,
     os << '\n';
   }
 
+  // restore context
   os.fill( oldFillChar );
   os.flags( oldFormat );
   return os;

--- a/vital/util/hex_dump.h
+++ b/vital/util/hex_dump.h
@@ -49,10 +49,10 @@ namespace vital {
  * See this Stackexchange entry for further discussion:
  * https://codereview.stackexchange.com/questions/165120/printing-hex-dumps-for-diagnostics
  *
- * @param[out] os Output stream for the formatted string
- * @param[in,out] buffer Input buffer to dump
- * @param[in] bufsize Length of input buffer or number of bytes to dump
- * @param[in] showPrintableCharacter \b true will print printable characters along with hex
+ * @param os Output stream for the formatted string
+ * @param buffer Input buffer to dump
+ * @param bufsize Length of input buffer or number of bytes to dump
+ * @param showPrintableCharacter \b true will print printable characters along with hex
  */
 VITAL_UTIL_EXPORT std::ostream& hex_dump( std::ostream& os,
                                           const void*   buffer,


### PR DESCRIPTION
- Removing support for multi-data-item serializers
- Changing serializer algo parameters to single element
- New serialized message format which is more introsepctable.
- Messages are assembled by the serializer from single data elements
- Changing [de]serializer process port syntax and semantics.