### PR TITLE
Add image file name support for VXL image reader

### DIFF
--- a/arrows/core/tests/test_video_input_image_list.cxx
+++ b/arrows/core/tests/test_video_input_image_list.cxx
@@ -253,7 +253,7 @@ TEST_F(video_input_image_list, metadata_map)
   while ( std::getline( list_file_stream, file_name ) )
   {
     auto md_file_name = md_map[frame_number][0]->find(
-        kwiver::vital::VITAL_META_IMAGE_FILENAME).as_string();
+        kwiver::vital::VITAL_META_IMAGE_URI).as_string();
     EXPECT_TRUE( md_file_name.find( file_name ) != std::string::npos )
       << "File path in metadata should contain " << file_name;
     frame_number++;

--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -397,7 +397,7 @@ video_input_image_list
   }
   // For now, the only metadata is the filename of the image
   auto md = std::make_shared<vital::metadata>();
-  md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME,
+  md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
                               *d->m_current_file ) );
   vital::metadata_vector mdv(1, md);
   return mdv;
@@ -415,7 +415,7 @@ video_input_image_list
       ++fn;
       // For now, the only metadata is the filename
       auto md = std::make_shared<vital::metadata>();
-      md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME, f ) );
+      md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI, f ) );
       vital::metadata_vector mdv(1, md);
       d->m_metadata_map[fn] = mdv;
     }

--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -92,7 +92,7 @@ public:
     // Include the path to the image
     if ( metadata )
     {
-      metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME,
+      metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
                                         paths.first) );
     }
 
@@ -313,7 +313,7 @@ video_input_pos
   if ( d->d_metadata )
   {
     d->d_metadata->set_timestamp( ts );
-    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME,
+    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
                                            d->d_current_files->first ) );
   }
 
@@ -362,7 +362,7 @@ video_input_pos
   if ( d->d_metadata )
   {
     d->d_metadata->set_timestamp( ts );
-    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_FILENAME,
+    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
                                            d->d_current_files->first ) );
   }
 

--- a/arrows/ocv/image_io.cxx
+++ b/arrows/ocv/image_io.cxx
@@ -57,7 +57,7 @@ image_io
 ::load_(const std::string& filename) const
 {
   auto md = std::shared_ptr<kwiver::vital::metadata>(new kwiver::vital::metadata());
-  md->add(NEW_METADATA_ITEM(kwiver::vital::VITAL_META_IMAGE_FILENAME, filename));
+  md->add(NEW_METADATA_ITEM(kwiver::vital::VITAL_META_IMAGE_URI, filename));
 
   cv::Mat img = cv::imread(filename.c_str(), -1);
   auto img_ptr = vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR_COLOR));

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -150,10 +150,10 @@ refine_detections_write_to_disk
   // Get input filename if it's in the vital_metadata
   std::string filename = "";
   auto md = image_data->get_metadata();
-  if( md && md->has(VITAL_META_IMAGE_FILENAME) )
+  if( md && md->has(VITAL_META_IMAGE_URI) )
   {
     // Get the full path, and then extract just the filename proper
-    filename = md->find(VITAL_META_IMAGE_FILENAME).as_string();
+    filename = md->find(VITAL_META_IMAGE_URI).as_string();
     std::string path_sep = "/";
 #ifdef WIN32
     path_sep = "\\"; // Windows likes to be different

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -230,7 +230,7 @@ public:
 
         meta->set_timestamp( ts );
 
-        meta->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_FILENAME,
+        meta->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_URI,
                                       video_path ) );
         this->metadata_collection.push_back( meta );
 
@@ -254,7 +254,7 @@ public:
 
       meta->set_timestamp(ts);
 
-      meta->add(NEW_METADATA_ITEM(vital::VITAL_META_VIDEO_FILENAME,
+      meta->add(NEW_METADATA_ITEM(vital::VITAL_META_VIDEO_URI,
         video_path));
 
       this->metadata_collection.push_back(meta);

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -56,16 +56,16 @@ basename_from_metadata(metadata_sptr md,
   typedef kwiversys::SystemTools  ST;
 
   std::string basename = "frame";
-  if( md && md->has( kwiver::vital::VITAL_META_IMAGE_FILENAME ) )
+  if( md && md->has( kwiver::vital::VITAL_META_IMAGE_URI ) )
   {
-    std::string img_name = md->find( VITAL_META_IMAGE_FILENAME ).as_string();
+    std::string img_name = md->find( VITAL_META_IMAGE_URI ).as_string();
     basename = ST::GetFilenameWithoutLastExtension( img_name );
   }
   else
   {
-    if ( md && md->has( kwiver::vital::VITAL_META_VIDEO_FILENAME ) )
+    if ( md && md->has( kwiver::vital::VITAL_META_VIDEO_URI ) )
     {
-      std::string vid_name = md->find( VITAL_META_VIDEO_FILENAME ).as_string();
+      std::string vid_name = md->find( VITAL_META_VIDEO_URI ).as_string();
       basename = ST::GetFilenameWithoutLastExtension( vid_name );
     }
     char frame_str[6];

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -62,8 +62,8 @@ CALL( PLATFORM_INDICATED_AIRSPEED, "Platform Indicated Airspeed",     double) \
 CALL( PLATFORM_DESIGNATION,        "Platform Designation",            std::string) \
 CALL( IMAGE_SOURCE_SENSOR,         "Image Source Sensor",             std::string) \
 CALL( IMAGE_COORDINATE_SYSTEM,     "Image Coordinate System",         std::string) \
-CALL( IMAGE_FILENAME,              "Image Filename",                  std::string) \
-CALL( VIDEO_FILENAME,              "Video Filename",                  std::string) \
+CALL( IMAGE_URI,                   "Image URI",                       std::string) \
+CALL( VIDEO_URI,                   "Video URI",                       std::string) \
 CALL( SENSOR_LOCATION,             "Sensor Geodetic Location",        geo_point) \
 CALL( SENSOR_ALTITUDE,             "Sensor Altitude",                 double) /* TODO: merge with previous? */ \
 CALL( SENSOR_HORIZONTAL_FOV,       "Sensor Horizontal Field of View", double) \


### PR DESCRIPTION
Added code to put image file name into the metadata structure that goes with the image_container. This support had been added to the OCV variant but not to the VXL variant.

Also changed the name of metadata tag for image_filename and video_filename to be IMAGE_URI and VIDEO_URI. This better describes what the contents could be. 