### PR TITLE
Lowercase the declarations of gpu_list (née GPU_list)

### DIFF
--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -106,9 +106,9 @@ class SRNN_tracking(KwiverProcess):
         KwiverProcess.__init__(self, conf)
 
         #GPU list
-        self.add_config_trait("GPU_list", "GPU_list", 'all',
+        self.add_config_trait("gpu_list", "gpu_list", 'all',
                               'define which GPU to use for SRNN tracking. only three options: None, all, 1,2')
-        self.declare_config_using_trait('GPU_list')
+        self.declare_config_using_trait('gpu_list')
 
         # siamese
         #----------------------------------------------------------------------------------
@@ -250,7 +250,7 @@ class SRNN_tracking(KwiverProcess):
 
         #GPU_list
         self._CPU_only_flag = False
-        GPU_list_str = self.config_value('GPU_list')
+        GPU_list_str = self.config_value('gpu_list')
 
         if GPU_list_str == 'None':
             self._CPU_only_flag = True

--- a/arrows/pytorch/resnet_descriptors.py
+++ b/arrows/pytorch/resnet_descriptors.py
@@ -53,9 +53,9 @@ class Resnet_descriptors(KwiverProcess):
         KwiverProcess.__init__(self, conf)
 
         # GPU list
-        self.add_config_trait("GPU_list", "GPU_list", 'all',
+        self.add_config_trait("gpu_list", "gpu_list", 'all',
                               'define which GPU to use for SRNN tracking. e.g., all, 1,2')
-        self.declare_config_using_trait('GPU_list')
+        self.declare_config_using_trait('gpu_list')
 
         # Resnet 
         #----------------------------------------------------------------------------------
@@ -97,7 +97,7 @@ class Resnet_descriptors(KwiverProcess):
         self._select_threshold = float(self.config_value('detection_select_threshold'))
 
         # GPU_list
-        GPU_list_str = self.config_value('GPU_list')
+        GPU_list_str = self.config_value('gpu_list')
         if GPU_list_str == 'all':
             self._GPU_list = None
         else:


### PR DESCRIPTION
These names are case-sensitive and all of VIAME's pipeline files
use it lowercase as `gpu_list`. This also makes `SRNN_tracking` and `resnet_descriptors` consistent with `pytorch_augmentation`.

Without this or a similar change, I see these two processes use their default value of `"all"` instead of whatever value is specified.