### PR TITLE
WIP: Add Resnet descriptor CPU support

### DIFF
--- a/arrows/pytorch/CMakeLists.txt
+++ b/arrows/pytorch/CMakeLists.txt
@@ -72,4 +72,8 @@ if( KWIVER_ENABLE_PYTHON )
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/iou_tracking.py
     kwiver/arrows/pytorch
     iou_tracking)
+
+  kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/parse_gpu_list.py
+    kwiver/arrows/pytorch
+    parse_gpu_list)
 endif()

--- a/arrows/pytorch/CMakeLists.txt
+++ b/arrows/pytorch/CMakeLists.txt
@@ -11,15 +11,15 @@ if( KWIVER_ENABLE_PYTHON )
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/resnet_descriptors.py
     kwiver/processes
-	  resnet_descriptors)
+    resnet_descriptors)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/SRNN_tracking.py
     kwiver/processes
-	  SRNN_tracking)
+    SRNN_tracking)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/seg_detection.py
     kwiver/processes
-	  seg_detection)
+    seg_detection)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/pytorch_augmentation.py
     kwiver/processes
@@ -44,32 +44,32 @@ if( KWIVER_ENABLE_PYTHON )
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/track.py
     kwiver/arrows/pytorch
     track)
-  
+
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/models.py
     kwiver/arrows/pytorch
     models)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/SRNN_matching.py
     kwiver/arrows/pytorch
-	  SRNN_matching)
+    SRNN_matching)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/MOT_bbox.py
     kwiver/arrows/pytorch
-	  MOT_bbox)
+    MOT_bbox)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/seg_utils.py
     kwiver/arrows/pytorch
-	  seg_utils)
+    seg_utils)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/fcn_segmentation.py
     kwiver/arrows/pytorch
-	  fcn_segmentation)
+    fcn_segmentation)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/fcn_models.py
     kwiver/arrows/pytorch
-	  fcn_models)
+    fcn_models)
 
   kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/iou_tracking.py
     kwiver/arrows/pytorch
-	  iou_tracking)
+    iou_tracking)
 endif()

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -65,6 +65,7 @@ from kwiver.arrows.pytorch.track import track_state, track, track_set
 from kwiver.arrows.pytorch.SRNN_matching import SRNN_matching, RnnType
 from kwiver.arrows.pytorch.pytorch_siamese_f_extractor import pytorch_siamese_f_extractor
 from kwiver.arrows.pytorch.iou_tracking import IOU_tracker
+from kwiver.arrows.pytorch.parse_gpu_list import parse_gpu_list
 
 from kwiver.arrows.pytorch.MOT_bbox import MOT_bbox, GTFileType
 from kwiver.arrows.pytorch.models import get_config
@@ -249,27 +250,19 @@ class SRNN_tracking(KwiverProcess):
         self._track_initialization_threshold = float(self.config_value('track_initialization_threshold'))
 
         #GPU_list
-        self._CPU_only_flag = False
-        GPU_list_str = self.config_value('gpu_list')
-
-        if GPU_list_str == 'None':
-            self._CPU_only_flag = True
-        elif GPU_list_str == 'all':
-            self._GPU_list = None
-        else:
-            self._GPU_list = list(map(int, GPU_list_str.split(',')))
+        self._GPU_list = parse_gpu_list(self.config_value('gpu_list'))
 
         # Siamese model config
         siamese_img_size = int(self.config_value('siamese_model_input_size'))
         siamese_batch_size = int(self.config_value('siamese_batch_size'))
         siamese_model_path = self.config_value('siamese_model_path')
-        self._app_feature_extractor = pytorch_siamese_f_extractor(siamese_model_path, siamese_img_size, siamese_batch_size, self._GPU_list, self._CPU_only_flag)
+        self._app_feature_extractor = pytorch_siamese_f_extractor(siamese_model_path, siamese_img_size, siamese_batch_size, self._GPU_list)
 
         # targetRNN_full model config
         targetRNN_batch_size = int(self.config_value('targetRNN_batch_size'))
         targetRNN_AIM_model_path = self.config_value('targetRNN_AIM_model_path')
         targetRNN_AIM_V_model_path = self.config_value('targetRNN_AIM_V_model_path')
-        self._SRNN_matching = SRNN_matching(targetRNN_AIM_model_path, targetRNN_AIM_V_model_path, targetRNN_batch_size, self._GPU_list, self._CPU_only_flag)
+        self._SRNN_matching = SRNN_matching(targetRNN_AIM_model_path, targetRNN_AIM_V_model_path, targetRNN_batch_size, self._GPU_list)
 
         self._GTbbox_flag = False
         # use MOT gt detection

--- a/arrows/pytorch/SRNN_tracking.py
+++ b/arrows/pytorch/SRNN_tracking.py
@@ -65,7 +65,7 @@ from kwiver.arrows.pytorch.track import track_state, track, track_set
 from kwiver.arrows.pytorch.SRNN_matching import SRNN_matching, RnnType
 from kwiver.arrows.pytorch.pytorch_siamese_f_extractor import pytorch_siamese_f_extractor
 from kwiver.arrows.pytorch.iou_tracking import IOU_tracker
-from kwiver.arrows.pytorch.parse_gpu_list import parse_gpu_list
+from kwiver.arrows.pytorch.parse_gpu_list import gpu_list_desc, parse_gpu_list
 
 from kwiver.arrows.pytorch.MOT_bbox import MOT_bbox, GTFileType
 from kwiver.arrows.pytorch.models import get_config
@@ -108,7 +108,7 @@ class SRNN_tracking(KwiverProcess):
 
         #GPU list
         self.add_config_trait("gpu_list", "gpu_list", 'all',
-                              'define which GPU to use for SRNN tracking. only three options: None, all, 1,2')
+                              gpu_list_desc(use_for='SRNN tracking'))
         self.declare_config_using_trait('gpu_list')
 
         # siamese

--- a/arrows/pytorch/parse_gpu_list.py
+++ b/arrows/pytorch/parse_gpu_list.py
@@ -6,6 +6,15 @@ turning that into a Pytorch device.
 
 import torch
 
+def gpu_list_desc(use_for=None):
+    """Generate a description for a GPU list config trait.  The optional
+    use_for argument, if passed, causes text to be included that says
+    what task the GPU list will be used for.
+
+    """
+    return ('define which GPUs to use{}: "all", "None", or a comma-separated list, e.g. "1,2"'
+            .format('' if use_for is None else ' for ' + use_for))
+
 def parse_gpu_list(gpu_list_str):
     """Parse a string representing a list of GPU indices to a list of
     numeric GPU indices.  The indices should be separated by commas.

--- a/arrows/pytorch/parse_gpu_list.py
+++ b/arrows/pytorch/parse_gpu_list.py
@@ -1,0 +1,41 @@
+"""A small module to provide a consistent method for turning GPU list
+argument strings to processes into a list of GPU indices and for
+turning that into a Pytorch device.
+
+"""
+
+import torch
+
+def parse_gpu_list(gpu_list_str):
+    """Parse a string representing a list of GPU indices to a list of
+    numeric GPU indices.  The indices should be separated by commas.
+    Two special values are understood: the string "None" will produce
+    an empty list, and the string "all" will produce the value None
+    (which has a special meaning when picking a device).  Note that
+    "None" is the only way to produce an empty list; an empty string
+    won't work.
+
+    """
+    return ([] if gpu_list_str == 'None' else
+            None if gpu_list_str == 'all' else
+            list(map(int, gpu_list_str.split(','))))
+
+def get_device(gpu_list=None):
+    """Get a Pytorch device corresponding to one of the GPU indices listed
+    in gpu_list.  If gpu_list is empty, get the device corresponding
+    to the CPU instead.  If gpu_list is None (the default), enumerate
+    the available GPU indices and pick one as though the list had been
+    passed directly, except that in the case of there being no GPUs,
+    an IndexError will be thrown.
+
+    The return value is a pair of the device and a boolean that is
+    true if the returned device is a GPU device.
+
+    Note that we currently return the first listed device.
+
+    """
+    if gpu_list is None:
+        gpu_list = list(range(torch.cuda.device_count()))
+    elif not gpu_list:
+        return torch.device('cpu'), False
+    return torch.device('cuda:{}'.format(gpu_list[0])), True

--- a/arrows/pytorch/pytorch_resnet_f_extractor.py
+++ b/arrows/pytorch/pytorch_resnet_f_extractor.py
@@ -23,7 +23,7 @@ class resnetDataLoader(data.Dataset):# This is the same as the siamese one it wa
         bb = self._bbox_list[index].bounding_box()
 
         # unwrap
-        min_x = float( bb.min_x() ) 
+        min_x = float( bb.min_x() )
         min_y = float( bb.min_y() )
         max_x = float( bb.max_x() )
         max_y = float( bb.max_y() )
@@ -53,7 +53,7 @@ class resnetDataLoader(data.Dataset):# This is the same as the siamese one it wa
 
     def __len__(self):
         return self._bbox_list.size()
-    
+
 
 class pytorch_resnet_f_extractor(object):
     """
@@ -83,7 +83,7 @@ class pytorch_resnet_f_extractor(object):
 
         self._resnet_model.train( False ) # is this the same as eval() ?
         self._resnet_model.cuda() # move the model to the GPU
- 
+
         self._transform = transforms.Compose([
             transforms.Scale(img_size),
             transforms.ToTensor(),
@@ -104,9 +104,8 @@ class pytorch_resnet_f_extractor(object):
         return self._obtain_feature(bbox_list, MOT_flag)
 
     def _obtain_feature(self, bbox_list, MOT_flag):
-        
         kwargs = {'num_workers': 0, 'pin_memory': True}
-        bbox_loader_class = resnetDataLoader(bbox_list, self._transform, self._frame, self._img_size) 
+        bbox_loader_class = resnetDataLoader(bbox_list, self._transform, self._frame, self._img_size)
         bbox_loader = torch.utils.data.DataLoader(bbox_loader_class, batch_size=self._b_size, shuffle=False, **kwargs)
 
         torch.set_grad_enabled(False)

--- a/arrows/pytorch/pytorch_siamese_f_extractor.py
+++ b/arrows/pytorch/pytorch_siamese_f_extractor.py
@@ -25,7 +25,7 @@ class siameseDataLoader(data.Dataset):
             bb = self._bbox_list[index]
         else:
             bb = self._bbox_list[index].bounding_box()
-        
+
         im = self._frame_img.crop((float(bb.min_x()), float(bb.min_y()),
                       float(bb.max_x()), float(bb.max_y())))
 
@@ -39,10 +39,10 @@ class siameseDataLoader(data.Dataset):
 
     def __len__(self):
         if self._mot_flag is True:
-            return len(self._bbox_list) 
+            return len(self._bbox_list)
         else:
             return self._bbox_list.size()
-    
+
 
 class pytorch_siamese_f_extractor(object):
     """
@@ -94,9 +94,8 @@ class pytorch_siamese_f_extractor(object):
         return self._obtain_feature(bbox_list, MOT_flag)
 
     def _obtain_feature(self, bbox_list, MOT_flag):
-        
         kwargs = {'num_workers': 0, 'pin_memory': True}
-        bbox_loader_class = siameseDataLoader(bbox_list, self._transform, self._frame, self._img_size, MOT_flag) 
+        bbox_loader_class = siameseDataLoader(bbox_list, self._transform, self._frame, self._img_size, MOT_flag)
         bbox_loader = torch.utils.data.DataLoader(bbox_loader_class, batch_size=self._b_size, shuffle=False, **kwargs)
 
         torch.set_grad_enabled(False)
@@ -110,4 +109,3 @@ class pytorch_siamese_f_extractor(object):
                 app_features = torch.cat((app_features, output.data), dim=0)
 
         return app_features.cpu()
-    

--- a/arrows/pytorch/resnet_descriptors.py
+++ b/arrows/pytorch/resnet_descriptors.py
@@ -45,6 +45,7 @@ from vital.util.VitalPIL import get_pil_image
 
 from kwiver.arrows.pytorch.grid import grid
 from kwiver.arrows.pytorch.pytorch_resnet_f_extractor import pytorch_resnet_f_extractor # the feature extractor
+from kwiver.arrows.pytorch.parse_gpu_list import gpu_list_desc, parse_gpu_list
 
 class Resnet_descriptors(KwiverProcess):
 
@@ -54,7 +55,7 @@ class Resnet_descriptors(KwiverProcess):
 
         # GPU list
         self.add_config_trait("gpu_list", "gpu_list", 'all',
-                              'define which GPU to use for SRNN tracking. e.g., all, 1,2')
+                              gpu_list_desc(use_for='Resnet descriptors'))
         self.declare_config_using_trait('gpu_list')
 
         # Resnet
@@ -97,11 +98,7 @@ class Resnet_descriptors(KwiverProcess):
         self._select_threshold = float(self.config_value('detection_select_threshold'))
 
         # GPU_list
-        GPU_list_str = self.config_value('gpu_list')
-        if GPU_list_str == 'all':
-            self._GPU_list = None
-        else:
-            self._GPU_list = list(map(int, GPU_list_str.split(',')))
+        self._GPU_list = parse_gpu_list(self.config_value('gpu_list'))
 
         # Resnet model config
         resnet_img_size = int(self.config_value('resnet_model_input_size'))

--- a/arrows/pytorch/resnet_descriptors.py
+++ b/arrows/pytorch/resnet_descriptors.py
@@ -57,7 +57,7 @@ class Resnet_descriptors(KwiverProcess):
                               'define which GPU to use for SRNN tracking. e.g., all, 1,2')
         self.declare_config_using_trait('gpu_list')
 
-        # Resnet 
+        # Resnet
         #----------------------------------------------------------------------------------
         self.add_config_trait("resnet_model_path", "resnet_model_path",
                               'models/resnet50_default.pt',
@@ -140,7 +140,7 @@ class Resnet_descriptors(KwiverProcess):
             else:
                 # appearance features (format: pytorch tensor)
                 app_f_begin = timer()
-                pt_app_features = self._app_feature_extractor(dos, False) 
+                pt_app_features = self._app_feature_extractor(dos, False)
                 app_f_end = timer()
                 print('%%%app feature eclapsed time: {}'.format(app_f_end - app_f_begin))
 
@@ -184,4 +184,3 @@ def __sprokit_register__():
                                 Resnet_descriptors)
 
     process_factory.mark_process_module_as_loaded(module_name)
-


### PR DESCRIPTION
In terms of externally functionality, this PR furthers the changes of 1d964fba0561dd405c1bc5b191ccbc6c78510c0a to additionally cover `resnet_descriptors`, adding the ability to specify `gpu_list = None` in a pipeline file to use the CPU instead.

Internally, this PR cleans up some whitespace, changes how the CPU-only mode is specified, and creates a new module `parse_gpu_list` that holds some shared code related to turning the configuration strings into lists and devices.  CPU-only mode is specified by an empty list of GPU indices instead of a separate boolean parameter, which simplifies argument passing somewhat and exposes a similar interface to the pipeline files.

**TODO:**
- [ ] Potentially pick a better name for the `parse_gpu_list` module
- [ ] Verify that the changes to `pytorch_resnet_f_extractor` don't break GPU functionality