### PR TITLE
Replace the target level definitions with a global def.

### DIFF
--- a/CMake/kwiver-config-build.cmake.in
+++ b/CMake/kwiver-config-build.cmake.in
@@ -23,6 +23,13 @@ if (WIN32)
   set(SETUP_BATCH_FILES "@SETUP_BATCH_FILES@")
   add_definitions(-DBOOST_ALL_NO_LIB)
   add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
+  if(${MSVC_VERSION} GREATER_EQUAL 1915)
+    # You must acknowledge that you understand MSVC
+    # resolved a byte alignment issue in this compiler.
+    # We get this due to using Eigen objects and
+    # allocating those objects with make_shared
+    add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+  endif()
 endif ()
 
 set(KWIVER_LIBRARY_DIR         "@KWIVER_BINARY_DIR@/lib")

--- a/CMake/kwiver-config-install.cmake.in
+++ b/CMake/kwiver-config-install.cmake.in
@@ -11,6 +11,13 @@ if (WIN32)
   set(libdir "bin")
   add_definitions(-DBOOST_ALL_NO_LIB)
   add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
+  if(${MSVC_VERSION} GREATER_EQUAL 1915)
+    # You must acknowledge that you understand MSVC
+    # resolved a byte alignment issue in this compiler.
+    # We get this due to using Eigen objects and
+    # allocating those objects with make_shared
+    add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+  endif()
 else ()
   set(libdir "lib@LIB_SUFFIX@")
 endif ()

--- a/CMake/kwiver-flags-msvc.cmake
+++ b/CMake/kwiver-flags-msvc.cmake
@@ -24,3 +24,10 @@ endif()
 add_definitions(-DWIN32_LEAN_AND_MEAN)
 add_definitions(-DNOMINMAX)
 add_definitions(-DWINDOWS_EXTRA_LEAN)
+if(${MSVC_VERSION} GREATER_EQUAL 1915)
+  # You must acknowledge that you understand MSVC
+  # resolved a byte alignment issue in this compiler.
+  # We get this due to using Eigen objects and
+  # allocating those objects with make_shared
+  add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+endif()

--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -135,14 +135,6 @@ function(kwiver_add_executable name)
   if(NOT component)
     set(component runtime)
   endif()
-  
-  if(MSVC)
-    if(${MSVC_VERSION} GREATER_EQUAL 1915)
-      # You must acknowledge that you understand MSVC resolved a byte alignment issue in this compiler
-      # We get this due to using Eigen objects and allocating those objects with make_shared
-      target_compile_definitions( ${name} PRIVATE _ENABLE_EXTENDED_ALIGNED_STORAGE )
-    endif()
-  endif()
 
   # Add to global collection variable
   set_property(GLOBAL APPEND
@@ -197,15 +189,7 @@ function(kwiver_add_library     name)
       set( props )
     endif()
   endif()
-  
-  if(MSVC)
-    if(${MSVC_VERSION} GREATER_EQUAL 1915)
-      # You must acknowledge that you understand MSVC resolved a byte alignment issue in this compiler
-      # We get this due to using Eigen objects and allocating those objects with make_shared
-      target_compile_definitions( ${name} PRIVATE _ENABLE_EXTENDED_ALIGNED_STORAGE )
-    endif()
-  endif()
-  
+
   set_target_properties("${name}"
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}${library_subdir_suffix}"


### PR DESCRIPTION
Several test targets were not included in this definition when applied at the target level. This branch applies the definition more broadly, which is the right thing here since VS will fail if anything is missing it.