### PR TITLE
Remove environment call

### DIFF
--- a/CMake/utils/kwiver-utils-tests.cmake
+++ b/CMake/utils/kwiver-utils-tests.cmake
@@ -90,13 +90,6 @@ function (kwiver_build_test name libraries)
   target_link_libraries(test-${name}
     LINK_PRIVATE
       ${${libraries}})
-  if(MSVC)
-    # Call setup batch before gtest inspects our executable
-    string(LENGTH ${KWIVER_TEST_BATCH_FILE} len)
-    math(EXPR len "${len}-4")# take off extension so 'call' is not prefixed to cmd
-    string(SUBSTRING ${KWIVER_TEST_BATCH_FILE} 0 ${len} bat)
-    add_custom_command(TARGET test-${name} POST_BUILD COMMAND "${bat}")
-  endif()
   kwiver_declare_test(${name})
   
 endfunction ()


### PR DESCRIPTION
This call does not do what I was hoping it would do.
To get google tests to compile in MSVC with out setting environment variables prior to starting MSVC we need to modify the way we use Google Tests

More on that later, for now, revert to the same behavior we had previous to this change