### PR TITLE
disable 4 ocv_SURF tests for mac

### DIFF
--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -109,6 +109,16 @@ algorithms_create_plugin( kwiver_algo_ocv
   register_algorithms.cxx
   )
 
+# Mac needs a seperate test directory
 if (KWIVER_ENABLE_TESTS)
-  add_subdirectory(tests)
+  if (APPLE)
+    add_subdirectory(tests_apple)
+  else() 
+    add_subdirectory(tests)
+  endif()
 endif()
+
+#if (KWIVER_ENABLE_TESTS)
+#  add_subdirectory(tests)
+#endif()
+

--- a/arrows/ocv/tests_apple/CMakeLists.txt
+++ b/arrows/ocv/tests_apple/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(arrows_test_ocv)
+
+include(kwiver-test-setup)
+
+set(test_libraries      vital vital_vpm kwiver_algo_ocv )
+
+##############################
+# Algorithms OpenCV tests
+##############################
+kwiver_discover_gtests(ocv algo_config                 LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv bounding_box                LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv descriptor_set              LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv distortion                  LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv estimate_pnp                LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv estimate_homography         LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv feature_set                 LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv image                       LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv match_set                   LIBRARIES ${test_libraries})

--- a/arrows/ocv/tests_apple/test_algo_config.cxx
+++ b/arrows/ocv/tests_apple/test_algo_config.cxx
@@ -1,0 +1,243 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Tests involving OCV nested algorithms and their parameter
+ *        interactions with kwiver::vital::config_block objects.
+ */
+
+#include <test_gtest.h>
+
+// Get headers of optional algos for ``MAPTK_OCV_HAS_*`` defines
+#include <arrows/ocv/detect_features_AGAST.h>
+#include <arrows/ocv/detect_features_MSD.h>
+#include <arrows/ocv/detect_features_STAR.h>
+#include <arrows/ocv/extract_descriptors_BRIEF.h>
+#include <arrows/ocv/extract_descriptors_DAISY.h>
+#include <arrows/ocv/extract_descriptors_FREAK.h>
+#include <arrows/ocv/extract_descriptors_LATCH.h>
+#include <arrows/ocv/extract_descriptors_LUCID.h>
+#include <arrows/ocv/feature_detect_extract_SIFT.h>
+#include <arrows/ocv/feature_detect_extract_SURF.h>
+
+#include <arrows/ocv/detect_features.h>
+#include <arrows/ocv/extract_descriptors.h>
+#include <arrows/ocv/match_features.h>
+
+#include <vital/exceptions.h>
+#include <vital/logger/logger.h>
+#include <vital/vital_types.h>
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <opencv2/core/core.hpp>
+
+#include <iostream>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+struct algorithm_test
+{
+  char const* const name;
+  std::function<algorithm_sptr ()> factory;
+};
+
+// ----------------------------------------------------------------------------
+void
+PrintTo( algorithm_test const& v, ::std::ostream* os )
+{
+  (*os) << v.name;
+}
+
+// ----------------------------------------------------------------------------
+class algo_config : public ::testing::TestWithParam<algorithm_test>
+{
+};
+
+// ----------------------------------------------------------------------------
+// Test that we can get, set and check the configurations for OCV feature
+// detector implementations
+TEST_P(algo_config, defaults)
+{
+  auto a = GetParam().factory();
+
+  logger_handle_t log = get_logger(
+    "arrows.test.plugins.ocv.ocv_algo_config_defaults" );
+
+  LOG_INFO(log, "Testing configuration for algorithm instance @" << a.get() );
+  LOG_INFO(log, "-- Algorithm info: " << a->type_name() << "::"
+                << a->impl_name() );
+  kwiver::vital::config_block_sptr c = a->get_configuration();
+  LOG_INFO(log, "-- default config:");
+  for ( auto const& key : c->available_values() )
+  {
+    LOG_INFO( log, "\t// " << c->get_description(key) << "\n" <<
+                   "\t" << key << " = " <<
+                   c->get_value<kwiver::vital::config_block_key_t>( key ) );
+  }
+
+  // Checking and setting the config of algo. Default should always be valid
+  // thus passing check.
+  LOG_INFO(log, "-- checking default config");
+  EXPECT_TRUE( a->check_configuration( c ) );
+
+  LOG_INFO(log, "-- Setting default config and checking again");
+  a->set_configuration( c );
+  EXPECT_TRUE( a->check_configuration( c ) );
+}
+
+// ----------------------------------------------------------------------------
+// Test that setting and checking and empty configuration block is a valid
+// operation
+TEST_P(algo_config, empty_config)
+{
+  auto a = GetParam().factory();
+
+  logger_handle_t log = get_logger(
+    "arrows.test.plugins.ocv.algo_empty_config" );
+
+  // Checking an empty config. Since there is literally nothing in the config,
+  // we should pass here, as the default configuration should be used which
+  // should pass (see test "ocv_algo_config_defaults")
+  LOG_INFO(log, "Checking empty config for algorithm instance @" << a.get() );
+  LOG_INFO(log, "-- Algorithm info: " << a->type_name() << "::"
+                << a->impl_name() );
+  kwiver::vital::config_block_sptr
+    empty_conf = kwiver::vital::config_block::empty_config();
+  EXPECT_TRUE( a->check_configuration( empty_conf ) )
+    << a->type_name() + "::" + a->impl_name();
+
+  // Should be able to set an empty config as defaults should take over.
+  LOG_INFO(log, "-- setting empty config");
+  a->set_configuration(empty_conf);
+
+  // This should also pass as we take an empty type as a "use the default"
+  // message
+  EXPECT_TRUE( a->check_configuration( a->get_configuration() ) );
+}
+
+// ----------------------------------------------------------------------------
+#define ALGORITHM( t, n ) \
+  algorithm_test{ n, []{ return algo::t::create( n ); } }
+
+auto detect_features_algorithms = []()
+{
+  return ::testing::Values(
+      ALGORITHM( detect_features, "ocv_BRISK" )
+    , ALGORITHM( detect_features, "ocv_FAST" )
+    , ALGORITHM( detect_features, "ocv_GFTT" )
+    , ALGORITHM( detect_features, "ocv_MSER" )
+    , ALGORITHM( detect_features, "ocv_ORB" )
+    , ALGORITHM( detect_features, "ocv_simple_blob" )
+
+#ifdef KWIVER_OCV_HAS_AGAST
+    , ALGORITHM( detect_features, "ocv_AGAST" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_SIFT
+    , ALGORITHM( detect_features, "ocv_SIFT" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_STAR
+    , ALGORITHM( detect_features, "ocv_STAR" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_SURF
+    , ALGORITHM( detect_features, "ocv_SURF" )
+#endif
+  );
+};
+
+INSTANTIATE_TEST_CASE_P(
+  detect_features,
+  algo_config,
+  detect_features_algorithms()
+);
+
+INSTANTIATE_TEST_CASE_P(
+  match_features,
+  algo_config,
+  ::testing::Values(
+      ALGORITHM( match_features, "ocv_brute_force" )
+    , ALGORITHM( match_features, "ocv_flann_based" )
+  )
+);
+
+auto extract_descriptors_algorithms = []()
+{
+  return ::testing::Values(
+      ALGORITHM( extract_descriptors, "ocv_BRISK" )
+    , ALGORITHM( extract_descriptors, "ocv_ORB" )
+
+#ifdef KWIVER_OCV_HAS_BRIEF
+    , ALGORITHM( extract_descriptors, "ocv_BRIEF" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_DAISY
+    , ALGORITHM( extract_descriptors, "ocv_DAISY" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_FREAK
+    , ALGORITHM( extract_descriptors, "ocv_FREAK" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_LATCH
+    , ALGORITHM( extract_descriptors, "ocv_LATCH" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_LUCID
+    , ALGORITHM( extract_descriptors, "ocv_LUCID" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_SIFT
+    , ALGORITHM( extract_descriptors, "ocv_SIFT" )
+#endif
+
+#ifdef KWIVER_OCV_HAS_SURF
+    , ALGORITHM( extract_descriptors, "ocv_SURF" )
+#endif
+  );
+};
+
+INSTANTIATE_TEST_CASE_P(
+  extract_descriptors,
+  algo_config,
+  extract_descriptors_algorithms()
+);

--- a/arrows/ocv/tests_apple/test_algo_config.cxx
+++ b/arrows/ocv/tests_apple/test_algo_config.cxx
@@ -179,9 +179,11 @@ auto detect_features_algorithms = []()
     , ALGORITHM( detect_features, "ocv_STAR" )
 #endif
 
+/* Disable ocv_SURF tests as they are broken on mac
 #ifdef KWIVER_OCV_HAS_SURF
     , ALGORITHM( detect_features, "ocv_SURF" )
 #endif
+*/
   );
 };
 
@@ -230,9 +232,11 @@ auto extract_descriptors_algorithms = []()
     , ALGORITHM( extract_descriptors, "ocv_SIFT" )
 #endif
 
+/* Disable ocv_SURF tests as they are broken on mac
 #ifdef KWIVER_OCV_HAS_SURF
     , ALGORITHM( extract_descriptors, "ocv_SURF" )
 #endif
+*/
   );
 };
 

--- a/arrows/ocv/tests_apple/test_bounding_box.cxx
+++ b/arrows/ocv/tests_apple/test_bounding_box.cxx
@@ -1,0 +1,69 @@
+/*ckwg +29
+ * Copyright 2016-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test VXL bundle adjustment functionality
+ */
+
+#include <arrows/ocv/bounding_box.h>
+
+#include <gtest/gtest.h>
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(bounding_box, convert_bb2ocv)
+{
+  kwiver::vital::bounding_box<double> bbox( 1, 3, 10, 34 );
+  auto const& vbox = kwiver::arrows::ocv::convert( bbox );
+
+  EXPECT_EQ( bbox.min_x(), vbox.x );
+  EXPECT_EQ( bbox.min_y(), vbox.y );
+  EXPECT_EQ( bbox.width(), vbox.width );
+  EXPECT_EQ( bbox.height(), vbox.height );
+}
+
+// ----------------------------------------------------------------------------
+TEST(bounding_box, convert_ocv2bb)
+{
+  CvRect vbox= cvRect( 1, 3, 10, 34 );
+  auto const& bbox = kwiver::arrows::ocv::convert<double>( vbox );
+
+  EXPECT_EQ( vbox.x, bbox.min_x() );
+  EXPECT_EQ( vbox.y, bbox.min_y() );
+  EXPECT_EQ( vbox.width, bbox.width() );
+  EXPECT_EQ( vbox.height, bbox.height() );
+}

--- a/arrows/ocv/tests_apple/test_descriptor_set.cxx
+++ b/arrows/ocv/tests_apple/test_descriptor_set.cxx
@@ -1,0 +1,176 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV descriptor_set class
+ */
+
+#include <arrows/ocv/descriptor_set.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+struct byte {}; // This is just a tag type that will show in the test name
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(descriptor_set, default_set)
+{
+  ocv::descriptor_set ds;
+  EXPECT_EQ( 0, ds.size() );
+  EXPECT_TRUE( ds.descriptors().empty() );
+}
+
+// ----------------------------------------------------------------------------
+TEST(descriptor_set, populated_set)
+{
+  static constexpr unsigned num_desc = 100;
+  static constexpr unsigned dim = 128;
+
+  cv::Mat data(num_desc, dim, CV_64F);
+  cv::randu(data, 0, 1);
+  ocv::descriptor_set ds(data);
+
+  EXPECT_EQ( num_desc,  ds.size() );
+  EXPECT_EQ( data.data, ds.ocv_desc_matrix().data )
+    << "descriptor_set should contain original cv::Mat";
+
+  std::vector<descriptor_sptr> desc = ds.descriptors();
+  EXPECT_EQ( ds.size(), desc.size() );
+
+  for ( unsigned i = 0; i < num_desc; ++i )
+  {
+    SCOPED_TRACE( "At descriptor " + std::to_string(i) );
+    ASSERT_EQ( dim, desc[i]->size() );
+
+    std::vector<double> vals = desc[i]->as_double();
+    cv::Mat row = data.row(i);
+    ASSERT_TRUE( std::equal( vals.begin(), vals.end(), row.begin<double>() ) );
+  }
+}
+
+namespace {
+
+// ----------------------------------------------------------------------------
+void test_conversions(const cv::Mat& data)
+{
+  SCOPED_TRACE( "Data size: " + std::to_string( data.rows ) + "x" +
+                                std::to_string( data.cols ) );
+
+  ocv::descriptor_set ds(data);
+  EXPECT_EQ( data.rows, static_cast<int>( ds.size() ) );
+
+  std::vector<descriptor_sptr> desc = ds.descriptors();
+  EXPECT_EQ( ds.size(), desc.size() );
+
+  cv::Mat double_data;
+  data.convertTo(double_data, CV_64F);
+
+  [&]{
+    for ( unsigned i = 0; i < desc.size(); ++i )
+    {
+      SCOPED_TRACE( "At descriptor " + std::to_string(i) );
+      ASSERT_EQ( data.cols, static_cast<int>( desc[i]->size() ) );
+
+      auto const& vals = desc[i]->as_double();
+      auto const& byte_vals = desc[i]->as_bytes();
+      ASSERT_EQ( desc[i]->num_bytes(), byte_vals.size() );
+
+      cv::Mat row = double_data.row(i);
+      ASSERT_TRUE( std::equal(vals.begin(), vals.end(), row.begin<double>() ) );
+    }
+  }();
+
+  simple_descriptor_set simp_ds(desc);
+  cv::Mat recon_mat = ocv::descriptors_to_ocv_matrix(simp_ds);
+  EXPECT_NE( data.data, recon_mat.data )
+    << "Reconstructed matrix should point to new memory, not original";
+  EXPECT_EQ( data.type(), recon_mat.type() );
+  EXPECT_EQ( data.size(), recon_mat.size() );
+  EXPECT_EQ( 0, cv::countNonZero( recon_mat != data ) );
+}
+
+// ----------------------------------------------------------------------------
+template <typename T> cv::Mat rand_mat(int r, int c);
+
+// ----------------------------------------------------------------------------
+template <> inline cv::Mat rand_mat<double>(int r, int c)
+{
+  cv::Mat m(r, c, CV_64F);
+  cv::randu(m, 0.0, 1.0);
+  return m;
+}
+
+// ----------------------------------------------------------------------------
+template <> inline cv::Mat rand_mat<float>(int r, int c)
+{
+  cv::Mat m(r, c, CV_32F);
+  cv::randu(m, 0.0f, 1.0f);
+  return m;
+}
+
+// ----------------------------------------------------------------------------
+template <> inline cv::Mat rand_mat<::byte>(int r, int c)
+{
+  cv::Mat m(r, c, CV_8U);
+  cv::randu(m, 0, 255);
+  return m;
+}
+
+}
+
+// ----------------------------------------------------------------------------
+template <typename T>
+class descriptor_set_conversion : public ::testing::Test
+{
+};
+
+using conversion_types =
+  ::testing::Types<::byte, float, double>;
+TYPED_TEST_CASE(descriptor_set_conversion, conversion_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(descriptor_set_conversion, conversion)
+{
+  test_conversions( rand_mat<TypeParam>( 1,   50 ) );
+  test_conversions( rand_mat<TypeParam>( 64,  50 ) );
+  test_conversions( rand_mat<TypeParam>( 128, 1  ) );
+  test_conversions( rand_mat<TypeParam>( 125, 20 ) );
+  test_conversions( rand_mat<TypeParam>( 256, 10 ) );
+}

--- a/arrows/ocv/tests_apple/test_distortion.cxx
+++ b/arrows/ocv/tests_apple/test_distortion.cxx
@@ -1,0 +1,139 @@
+/*ckwg +29
+ * Copyright 2015-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief tests comparing MAP-Tk lens distortion to OpenCV
+ */
+
+#include <test_eigen.h>
+#include <test_random_point.h>
+
+#include <vital/types/camera_intrinsics.h>
+
+#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/core/eigen.hpp>
+#include <arrows/ocv/camera_intrinsics.h>
+
+using namespace kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+static void test_distortion(const Eigen::VectorXd& d)
+{
+  simple_camera_intrinsics K;
+  K.set_dist_coeffs(d.transpose());
+
+  cv::Mat cam_mat;
+  cv::eigen2cv(K.as_matrix(), cam_mat);
+
+  cv::Mat d_cvmat;
+  cv::eigen2cv(d, d_cvmat);
+
+  std::vector<double> cv_dist = kwiver::arrows::ocv::dist_coeffs_to_ocv(d_cvmat);
+
+  cv::Mat dist = cv::Mat(cv_dist);
+
+  cv::Mat tvec = cv::Mat::zeros(1,3,CV_64F);
+  cv::Mat rvec = tvec;
+
+  std::cout << "K = " << cam_mat << "\nd = " << dist <<std::endl;
+
+  for(unsigned int i = 1; i<100; ++i)
+  {
+    vector_2d test_pt = kwiver::testing::random_point2d(0.5);
+    // the distortion model is only valid within about a unit distance
+    // from the origin in normalized coordinates
+    // project distant points back onto the unit circle
+    if (test_pt.norm() > 1.0)
+    {
+      test_pt.normalize();
+    }
+    vector_2d distorted_test = K.distort(test_pt);
+    std::cout << "test point: "<< test_pt.transpose() << "\n"
+              << "distorted: " << distorted_test.transpose() << std::endl;
+    std::vector<cv::Point3d> in_pts;
+    std::vector<cv::Point2d> out_pts;
+    in_pts.push_back(cv::Point3d(test_pt.x(), test_pt.y(), 1.0));
+    cv::projectPoints(in_pts, rvec, tvec, cam_mat, dist, out_pts);
+    vector_2d cv_distorted_test(out_pts[0].x, out_pts[0].y);
+
+    std::cout << "OpenCV distorted: " << cv_distorted_test.transpose()
+              << std::endl;
+
+    EXPECT_MATRIX_NEAR( distorted_test, cv_distorted_test, 1e-12 );
+  }
+}
+
+// ----------------------------------------------------------------------------
+TEST(distortion, distort_r1)
+{
+  Eigen::VectorXd d(1);
+  d << -0.01;
+  test_distortion(d);
+}
+
+// ----------------------------------------------------------------------------
+TEST(distortion, distort_r2)
+{
+  Eigen::VectorXd d(2);
+  d << -0.03, 0.007;
+  test_distortion(d);
+}
+
+// ----------------------------------------------------------------------------
+TEST(distortion, distort_r3)
+{
+  Eigen::VectorXd d(5);
+  d << -0.03, 0.01, 0, 0, -0.02;
+  test_distortion(d);
+}
+
+// ----------------------------------------------------------------------------
+TEST(distortion, distort_tang_r3)
+{
+  Eigen::VectorXd d(5);
+  d << -0.03, 0.01, -1e-3, 5e-4, -0.02;
+  test_distortion(d);
+}
+
+// ----------------------------------------------------------------------------
+TEST(distortion, distort_tang_r6)
+{
+  Eigen::VectorXd d(8);
+  d << -0.03, 0.01, -1e-3, 5e-4, -0.02, 1e-4, -2e-3, 3e-4;
+  test_distortion(d);
+}

--- a/arrows/ocv/tests_apple/test_estimate_fundamental_matrix.cxx
+++ b/arrows/ocv/tests_apple/test_estimate_fundamental_matrix.cxx
@@ -1,0 +1,61 @@
+/*ckwg +29
+ * Copyright 2016-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arrows/ocv/estimate_fundamental_matrix.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+using ocv::estimate_fundamental_matrix;
+
+static constexpr double ideal_tolerance = 1e-6;
+static constexpr double outlier_tolerance = 0.01;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(estimate_fundamental_matrix, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  EXPECT_NE( nullptr, algo::estimate_fundamental_matrix::create("ocv") );
+}
+
+// ----------------------------------------------------------------------------
+#include <arrows/tests/test_estimate_fundamental_matrix.h>

--- a/arrows/ocv/tests_apple/test_estimate_homography.cxx
+++ b/arrows/ocv/tests_apple/test_estimate_homography.cxx
@@ -1,0 +1,74 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV homography estimation algorithm
+ */
+
+#include <test_eigen.h>
+#include <test_random_point.h>
+
+#include <arrows/ocv/estimate_homography.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::testing;
+using namespace kwiver::arrows;
+
+using ocv::estimate_homography;
+
+static constexpr double ideal_matrix_tolerance = 1e-4;
+static constexpr double ideal_norm_tolerance = 1e-4;
+
+static constexpr double noisy_matrix_tolerance = 0.1;
+static constexpr double noisy_norm_tolerance = 0.2;
+
+static constexpr double outlier_matrix_tolerance = 1e-4;
+static constexpr double outlier_norm_tolerance = 1e-4;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(estimate_homography, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  EXPECT_NE( nullptr, algo::estimate_homography::create("ocv") );
+}
+
+// ----------------------------------------------------------------------------
+#include <arrows/tests/test_estimate_homography.h>

--- a/arrows/ocv/tests_apple/test_estimate_pnp.cxx
+++ b/arrows/ocv/tests_apple/test_estimate_pnp.cxx
@@ -1,0 +1,65 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arrows/ocv/estimate_pnp.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+using ocv::estimate_pnp;
+
+static constexpr double ideal_rotation_tolerance = 1e-6;
+static constexpr double ideal_center_tolerance = 1e-6;
+static constexpr double noisy_rotation_tolerance = 0.008;
+static constexpr double noisy_center_tolerance = 0.05;
+static constexpr double outlier_rotation_tolerance = 0.008;
+static constexpr double outlier_center_tolerance = 0.05;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(estimate_pnp, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  EXPECT_NE( nullptr, algo::estimate_pnp::create("ocv") );
+}
+
+// ----------------------------------------------------------------------------
+#include <arrows/tests/test_estimate_pnp.h>

--- a/arrows/ocv/tests_apple/test_feature_set.cxx
+++ b/arrows/ocv/tests_apple/test_feature_set.cxx
@@ -1,0 +1,113 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV feature_set class
+ */
+
+#include <test_common.h>
+
+#include <arrows/ocv/feature_set.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(feature_set, default_set)
+{
+  ocv::feature_set fs;
+  if (fs.size() != 0)
+  {
+    TEST_ERROR("Default features_set is not empty");
+  }
+  if (!fs.features().empty())
+  {
+    TEST_ERROR("Default features_set produces non-empty features");
+  }
+}
+
+// ----------------------------------------------------------------------------
+// It seems operator== on cv::Keypoint is not defined in OpenCV
+static bool keypoints_equal(const cv::KeyPoint& kp1, const cv::KeyPoint& kp2)
+{
+  return kp1.angle == kp2.angle &&
+         kp1.class_id == kp2.class_id &&
+         kp1.octave == kp2.octave &&
+         kp1.pt == kp2.pt &&
+         kp1.response == kp2.response &&
+         kp1.size == kp2.size;
+}
+
+// ----------------------------------------------------------------------------
+TEST(feature_set, populated_set)
+{
+  static constexpr unsigned num_feat = 100;
+
+  std::vector<cv::KeyPoint> kpts;
+  for ( unsigned i = 0; i < num_feat; ++i )
+  {
+    cv::KeyPoint kp(i/2.0f, i/3.0f, i/10.0f, (i*3.14159f)/num_feat, 100.0f/i);
+    kpts.push_back(kp);
+  }
+
+  ocv::feature_set fs(kpts);
+  EXPECT_EQ( num_feat, fs.size() );
+
+  std::vector<cv::KeyPoint> kpts2 = fs.ocv_keypoints();
+  EXPECT_TRUE( std::equal( kpts.begin(), kpts.end(),
+                           kpts2.begin(), keypoints_equal ) );
+
+  std::vector<feature_sptr> feats = fs.features();
+  EXPECT_EQ( fs.size(), feats.size() );
+
+  [&]{
+    for ( unsigned i = 0; i < num_feat; ++i )
+    {
+      SCOPED_TRACE( "At feature " + std::to_string(i) );
+      ASSERT_EQ( typeid(float), feats[i]->data_type() );
+    }
+  }();
+
+  simple_feature_set simp_fs(feats);
+  kpts2 = ocv::features_to_ocv_keypoints(simp_fs);
+  EXPECT_TRUE( std::equal( kpts.begin(), kpts.end(),
+                           kpts2.begin(), keypoints_equal ) )
+    << "Conversion to and from ARROWS features should preserve cv::KeyPoints";
+}

--- a/arrows/ocv/tests_apple/test_image.cxx
+++ b/arrows/ocv/tests_apple/test_image.cxx
@@ -1,0 +1,436 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV image class
+ */
+
+#include <test_tmpfn.h>
+
+#include <arrows/tests/test_image.h>
+
+#include <arrows/ocv/image_container.h>
+#include <arrows/ocv/image_io.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(image, create)
+{
+  plugin_manager::instance().load_all_plugins();
+
+  std::shared_ptr<algo::image_io> img_io;
+  ASSERT_NE(nullptr, img_io = algo::image_io::create("ocv"));
+
+  algo::image_io* img_io_ptr = img_io.get();
+  EXPECT_EQ(typeid(ocv::image_io), typeid(*img_io_ptr))
+    << "Factory method did not construct the correct type";
+}
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern; the dynamic range is
+// stretched between minv and maxv
+template <typename T>
+void
+populate_ocv_image(cv::Mat& img, T minv, T maxv)
+{
+  const double range = static_cast<double>(maxv) - static_cast<double>(minv);
+  const double offset = - minv;
+  const unsigned num_c = img.channels();
+  for( unsigned int p=0; p<num_c; ++p )
+  {
+    for( unsigned int j=0; j<static_cast<unsigned int>(img.rows); ++j )
+    {
+      for( unsigned int i=0; i<static_cast<unsigned int>(img.cols); ++i )
+      {
+        auto const val = static_cast<T>(value_at(i, j, p) * range + offset);
+        img.template ptr<T>(j)[num_c * i + p] = val;
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Helper function to populate the image with a pattern
+template <typename T>
+void
+populate_ocv_image(cv::Mat& img)
+{
+  const T minv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::min() : T(0);
+  const T maxv = std::numeric_limits<T>::is_integer ? std::numeric_limits<T>::max() : T(1);
+  populate_ocv_image(img, minv, maxv);
+}
+
+} // end anonymous namespace
+
+// ----------------------------------------------------------------------------
+template <typename T, int Depth>
+struct image_type
+{
+  using pixel_type = T;
+  static constexpr int depth = Depth;
+};
+
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_io : public ::testing::Test
+{
+};
+
+using io_types = ::testing::Types<
+  image_type<byte, 1>,
+  image_type<byte, 3>,
+  image_type<byte, 4>,
+  image_type<uint16_t, 1>,
+  image_type<uint16_t, 3>,
+  image_type<uint16_t, 4>
+  >;
+
+TYPED_TEST_CASE(image_io, io_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_io, type)
+{
+  using pix_t = typename TypeParam::pixel_type;
+  kwiver::vital::image_of<pix_t> img( 200, 300, TypeParam::depth );
+  populate_vital_image<pix_t>( img );
+
+  auto const image_path = kwiver::testing::temp_file_name( "test-", ".png" );
+
+  auto c = std::make_shared<simple_image_container>( img );
+  ocv::image_io io;
+  io.save( image_path, c );
+  image_container_sptr c2 = io.load( image_path );
+  kwiver::vital::image img2 = c2->get_image();
+  EXPECT_EQ( img.pixel_traits(), img2.pixel_traits() );
+  EXPECT_EQ( img.depth(), img2.depth() );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( 0, std::remove( image_path.c_str() ) )
+    << "Failed to delete temporary image file.";
+}
+
+namespace {
+
+// ----------------------------------------------------------------------------
+template <typename T>
+void
+run_ocv_conversion_tests( cv::Mat const& img )
+{
+  // Convert to a vital image and verify that the properties are correct
+  image const& vimg = ocv::image_container::ocv_to_vital( img, ocv::image_container::RGB_COLOR );
+  EXPECT_EQ( sizeof(T), vimg.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, vimg.pixel_traits().type );
+  EXPECT_EQ( static_cast<size_t>( img.channels() ), vimg.depth() );
+  EXPECT_EQ( static_cast<size_t>( img.rows ), vimg.height() );
+  EXPECT_EQ( static_cast<size_t>( img.cols ), vimg.width() );
+  EXPECT_EQ( img.data, vimg.first_pixel() )
+    << "vital::image should share memory with cv::Mat";
+
+  // Don't try to compare images if they don't have the same layout!
+  ASSERT_FALSE( ::testing::Test::HasNonfatalFailure() );
+
+  [&]{
+    int const num_c = img.channels();
+    for( int c = 0; c < num_c; ++c )
+    {
+      for( int j = 0; j < img.rows; ++j )
+      {
+        for( int i = 0; i < img.cols; ++i )
+        {
+#if __GNUC__ == 4 && __GNUC_MINOR__ == 9
+          // GCC 4.9.x has a really screwy bug where using sizeof inside of a
+          // lambda inside of a template function (e.g. here) on an expression
+          // which contains an explicit template parameter (whether or not
+          // said parameter depends on the outer function's template parameter)
+          // causes an error. This bug gets tripped by GTEST_IS_NULL_LITERAL_.
+          // Work around the issue by expanding out ASSERT_EQ and substituting
+          // false for the GTEST_IS_NULL_LITERAL_ invocation.
+          ASSERT_PRED_FORMAT2(
+            ::testing::internal::EqHelper<false>::Compare,
+            img.ptr<T>( j )[ num_c * i + c ], vimg.at<T>( i, j, c ) );
+#else
+          ASSERT_EQ( img.ptr<T>( j )[ num_c * i + c ], vimg.at<T>( i, j, c ) );
+#endif
+        }
+      }
+    }
+  }();
+
+  // Convert back to cv::Mat and test again
+  cv::Mat img2 = ocv::image_container::vital_to_ocv( vimg, ocv::image_container::RGB_COLOR );
+  ASSERT_NE( nullptr, img2.data )
+    << "OpenCV re-conversion did not produce a valid cv::Mat";
+
+  EXPECT_EQ( img.type(), img2.type() );
+  ASSERT_EQ( img.channels(), img2.channels() );
+
+  std::vector<cv::Mat> channels1( img.channels() );
+  std::vector<cv::Mat> channels2( img2.channels() );
+  cv::split( img, channels1 );
+  cv::split( img2, channels2 );
+
+  for ( unsigned c = 0; c < channels1.size(); ++c )
+  {
+    SCOPED_TRACE( "In channel " + std::to_string(c) );
+    EXPECT_EQ( 0, cv::countNonZero( channels1[c] != channels2[c] ) );
+  }
+
+  EXPECT_EQ( img2.data, img.data )
+    << "re-converted cv::Mat should share memory with original";
+}
+
+// ----------------------------------------------------------------------------
+template <typename T>
+void
+run_vital_conversion_tests( kwiver::vital::image_of<T> const& img,
+                            bool requires_copy = false )
+{
+  // convert to a cv::Mat and verify that the properties are correct
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::RGB_COLOR);
+  ASSERT_NE( nullptr, ocv_img.data )
+    << "Vital image conversion did not produce a valid cv::Mat";
+
+  EXPECT_EQ( cv::Mat_<T>{}.type() & 0x7, ocv_img.type() & 0x7 );
+  EXPECT_EQ( img.depth(), ocv_img.channels() );
+  EXPECT_EQ( img.height(), ocv_img.rows );
+  EXPECT_EQ( img.width(), ocv_img.cols );
+  if ( !requires_copy )
+  {
+    EXPECT_EQ( img.first_pixel(), reinterpret_cast<T*>( ocv_img.data ) )
+      << "cv::Mat should share memory with vital::image";
+  }
+
+  [&]{
+    int const num_c = ocv_img.channels();
+    for( int c = 0; c < num_c; ++c )
+    {
+      for( int j = 0; j < ocv_img.rows; ++j )
+      {
+        for( int i = 0; i < ocv_img.cols; ++i )
+        {
+          ASSERT_EQ( img( i, j, c ), ocv_img.ptr<T>( j )[ num_c * i + c ] )
+            << "Pixels differ at " << i << ", " << j << ", " << c;
+        }
+      }
+    }
+  }();
+
+  // Convert back to vital::image and test again
+  image img2 = ocv::image_container::ocv_to_vital( ocv_img, ocv::image_container::RGB_COLOR );
+  EXPECT_EQ( sizeof(T), img2.pixel_traits().num_bytes );
+  EXPECT_EQ( image_pixel_traits_of<T>::static_type, img2.pixel_traits().type );
+  EXPECT_TRUE( equal_content( img, img2 ) );
+  EXPECT_EQ( reinterpret_cast<T*>( ocv_img.data ), img2.first_pixel() );
+  if ( !requires_copy )
+  {
+    EXPECT_EQ( img.first_pixel(), img2.first_pixel() )
+      << "re-converted vital::image should share memory with original";
+  }
+}
+
+} // end anonymous namespace
+
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_conversion : public ::testing::Test
+{
+};
+
+using conversion_types =
+  ::testing::Types<uint8_t, int8_t, uint16_t, int16_t, int32_t, float, double>;
+TYPED_TEST_CASE(image_conversion, conversion_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_single_channel)
+{
+  // Create single-channel cv::Mat and convert to and from vital images
+  cv::Mat_<TypeParam> img{ cv::Size{ 100, 200 } };
+  populate_ocv_image<TypeParam>( img );
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_multi_channel)
+{
+  // Create multi-channel cv::Mat and convert to and from vital images
+  cv::Mat_<cv::Vec<TypeParam, 3>> img{ cv::Size{ 100, 200 } };
+  populate_ocv_image<TypeParam>( img );
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, ocv_to_vital_cropped)
+{
+  // Create cropped cv::Mat and convert to and from vital images
+  cv::Mat_<cv::Vec<TypeParam, 3>> img{ cv::Size{ 200, 300 } };
+  populate_ocv_image<TypeParam>( img );
+  cv::Rect window( cv::Point{ 40, 50 }, cv::Point{ 140, 250 } );
+  cv::Mat_<cv::Vec<TypeParam, 3>> img_crop{ img, window };
+  run_ocv_conversion_tests<TypeParam>( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_single_channel)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 1 };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_multi_channel)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img, true );
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_conversion, vital_to_ocv_interleaved)
+{
+  // Create vital images and convert to and from cv::Mat
+  // (note: different code paths are taken depending on whether the image
+  // is natively created as OpenCV or vital, so we need to test both ways)
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3, true };
+  populate_vital_image<TypeParam>( img );
+  run_vital_conversion_tests( img );
+}
+
+// ----------------------------------------------------------------------------
+template <typename T>
+class image_bgr_conversion : public ::testing::Test
+{
+};
+
+using image_bgr_types = ::testing::Types<uint8_t, uint16_t, float>;
+TYPED_TEST_CASE(image_bgr_conversion, image_bgr_types);
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_bgr_conversion, bgr_to_rgb)
+{
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 3 };
+  populate_vital_image<TypeParam>( img );
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR_COLOR);
+  {
+    int const num_c = ocv_img.channels();
+    for( int j = 0; j < ocv_img.rows; ++j )
+    {
+      for( int i = 0; i < ocv_img.cols; ++i )
+      {
+        for( int c = 0; c < 3; ++c )
+        {
+          ASSERT_EQ( img( i, j, c ), ocv_img.ptr<TypeParam>( j )[ num_c * i + (2-c) ] )
+              << "Pixels differ at " << i << ", " << j << ", (" << c << "," << (2-c) << ")";
+        }
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+TYPED_TEST(image_bgr_conversion, bgra_to_rgba)
+{
+  kwiver::vital::image_of<TypeParam> img{ 200, 300, 4 };
+  populate_vital_image<TypeParam>( img );
+  cv::Mat ocv_img =  ocv::image_container::vital_to_ocv(img, ocv::image_container::BGR_COLOR);
+  {
+    int const num_c = ocv_img.channels();
+    for( int j = 0; j < ocv_img.rows; ++j )
+    {
+      for( int i = 0; i < ocv_img.cols; ++i )
+      {
+        for( int c = 0; c < 3; ++c )
+        {
+          ASSERT_EQ( img( i, j, c ), ocv_img.ptr<TypeParam>( j )[ num_c * i + (2-c) ] )
+              << "Pixels differ at " << i << ", " << j << ", (" << c << "," << (2-c) << ")";
+        }
+        ASSERT_EQ( img( i, j, 3 ), ocv_img.ptr<TypeParam>( j )[ num_c * i + (3) ] )
+              << "Pixels differ at " << i << ", " << j << ", (3,3)";
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+TEST(image, bgr_to_rgb_bad_types)
+{
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int8_t>{ 200, 300, 3 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int16_t>{ 200, 300, 3 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int32_t>{ 200, 300, 3 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<double>{ 200, 300, 3 },
+                  ocv::image_container::BGR_COLOR ),
+                image_type_mismatch_exception );
+}
+
+// ----------------------------------------------------------------------------
+TEST(image, bad_conversions)
+{
+  // Some types not supported by OpenCV and should throw an exception
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<uint32_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<int64_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
+                image_type_mismatch_exception );
+  EXPECT_THROW( ocv::image_container::vital_to_ocv(
+                  image_of<uint64_t>( 200, 300 ), ocv::image_container::RGB_COLOR ),
+                image_type_mismatch_exception );
+}

--- a/arrows/ocv/tests_apple/test_match_set.cxx
+++ b/arrows/ocv/tests_apple/test_match_set.cxx
@@ -1,0 +1,95 @@
+/*ckwg +29
+ * Copyright 2013-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief test OCV match set class
+ */
+
+#include <arrows/ocv/match_set.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(match_set, default_set)
+{
+  ocv::match_set ms;
+  EXPECT_EQ( 0, ms.size() );
+  EXPECT_TRUE( ms.matches().empty() );
+}
+
+// ----------------------------------------------------------------------------
+// It seems operator== on cv::DMatch is not defined in OpenCV
+static bool dmatch_equal(const cv::DMatch& dm1, const cv::DMatch& dm2)
+{
+  return dm1.queryIdx == dm2.queryIdx &&
+         dm1.trainIdx == dm2.trainIdx &&
+         dm1.imgIdx == dm2.imgIdx &&
+         dm1.distance == dm2.distance;
+}
+
+// ----------------------------------------------------------------------------
+TEST(match_set, populated_set)
+{
+  static constexpr unsigned num_matches = 100;
+
+  std::vector<cv::DMatch> dms;
+  for (unsigned i=0; i<num_matches; ++i)
+  {
+    cv::DMatch dm(i, num_matches-i-1, FLT_MAX);
+    dms.push_back(dm);
+  }
+
+  ocv::match_set ms(dms);
+  EXPECT_EQ( num_matches, ms.size() );
+
+  std::vector<cv::DMatch> dms2 = ms.ocv_matches();
+  EXPECT_TRUE( std::equal( dms.begin(), dms.end(),
+                           dms2.begin(), dmatch_equal ) );
+
+  std::vector<match> mats = ms.matches();
+  EXPECT_EQ( ms.size(), mats.size() );
+
+  simple_match_set simp_ms(mats);
+  dms2 = ocv::matches_to_ocv_dmatch(simp_ms);
+  EXPECT_TRUE( std::equal( dms.begin(), dms.end(),
+                           dms2.begin(), dmatch_equal ) )
+    << "Conversion to and from ARROWS features should preserve cv::DMatch";
+}


### PR DESCRIPTION
This PR creates an Apple specific test directory for /arrows/ocv/tests. The reason for this is so that the broken tests only get disabled on Apple, instead of all platforms. 

This allows our Mac dashboards to report more useful information while these tests are broken.