### PR TITLE
Cleanup code

### DIFF
--- a/doc/manuals/sprokit/pipeline_declaration.rst
+++ b/doc/manuals/sprokit/pipeline_declaration.rst
@@ -201,6 +201,10 @@ configurations into smaller reusable pieces.
 
 ``include filename``
 
+The ``filename`` specified may contain references to an ENV or SYSENV
+macro. The macro reference is expanded before the file is located. No
+other macro providers are supported.
+
 If the file name is not an absolute path, it is located by scanning
 the current config search path.  The manner in which the config
 include path is created is described in a following section.  If the

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
@@ -63,7 +63,7 @@ protected:
     std::stringstream str;
     str <<  "Entry for provider \"" << provider << "\" does not have an element \""
         << entry << "\"";
-    VITAL_THROW( provider_error_exception, str.str() );
+    throw provider_error_exception( str.str() );
 
     // Could do a log message instead
     return true;
@@ -74,7 +74,7 @@ protected:
   {
     std::stringstream str;
     str << "Provider \"" << provider << "\" is not available";
-    VITAL_THROW( provider_error_exception, str.str() );
+    throw provider_error_exception( str.str() );
 
     // Could do a log message instead
     return true;
@@ -210,8 +210,7 @@ bakery_base
       }
       else
       {
-        VITAL_THROW( unrecognized_config_flag_exception,
-                     full_key, flag);
+        throw unrecognized_config_flag_exception( full_key, flag);
       }
     } // end foreach over flags
   }
@@ -227,8 +226,7 @@ bakery_base
     catch ( const provider_error_exception &e )
     {
       // Rethrow exception after adding location
-      VITAL_THROW( provider_error_exception,
-                   e.what(), value.loc );
+      throw provider_error_exception( e.what(), value.loc );
     }
   }
 
@@ -318,9 +316,9 @@ extract_configuration_from_decls( bakery_base::config_decls_t& configs )
       }
       else
       {
-        VITAL_THROW( relativepath_exception,
-                     "Can not resolve relative path because original source file is not known.",
-                     info.defined_loc );
+        throw relativepath_exception(
+               "Can not resolve relative path because original source file is not known.",
+               info.defined_loc );
       }
     }
 

--- a/sprokit/src/sprokit/pipeline_util/export_dot.cxx
+++ b/sprokit/src/sprokit/pipeline_util/export_dot.cxx
@@ -37,8 +37,6 @@
 #include <sprokit/pipeline/process.h>
 #include <sprokit/pipeline/process_cluster.h>
 
-#include <boost/ref.hpp>
-
 #include <map>
 #include <ostream>
 #include <queue>

--- a/sprokit/src/sprokit/pipeline_util/pipe_parser.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipe_parser.cxx
@@ -272,7 +272,6 @@ parse_cluster( std::istream& input, const std::string& name )
     if ( t->token_type() == TK_PROCESS )
     {
       PARSER_TRACE( "parse_cluster processes: " << *t );
-
       m_lexer.unget_token( t );
       process_pipe_block ppb;
       process_definition( ppb );


### PR DESCRIPTION
- Improve documentation for pipeline include command
- Use basic throw for pipeline errors. The error location should focus
  on the location in the file being processes not the source code
- Replace string trim functions in the lexer to use the vital version