### PR TITLE
Move our local implementation of optional to public area.

### DIFF
--- a/sprokit/src/sprokit/pipeline/edge.cxx
+++ b/sprokit/src/sprokit/pipeline/edge.cxx
@@ -35,7 +35,6 @@
 #include "types.h"
 
 #include <vital/logger/logger.h>
-#include <vital/internal/optional.h>
 
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>

--- a/sprokit/src/sprokit/pipeline/edge.h
+++ b/sprokit/src/sprokit/pipeline/edge.h
@@ -35,7 +35,7 @@
 
 #include <vital/config/config_block.h>
 #include <vital/noncopyable.h>
-#include <vital/internal/optional.h>
+#include <vital/optional.h>
 
 #include "types.h"
 

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -36,7 +36,7 @@
 
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/string.h>
-#include <vital/internal/optional.h>
+#include <vital/optional.h>
 
 #include <boost/assign/ptr_map_inserter.hpp>
 #include <boost/ptr_container/ptr_map.hpp>

--- a/sprokit/src/sprokit/pipeline_util/cluster_bakery.h
+++ b/sprokit/src/sprokit/pipeline_util/cluster_bakery.h
@@ -38,7 +38,7 @@
 
 #include "bakery_base.h"
 
-#include <vital/internal/optional.h>
+#include <vital/optional.h>
 
 #include <vector>
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -69,6 +69,7 @@ set( vital_public_headers
   attribute_set.h
   exceptions.h
   iterator.h
+  optional.h
 
   io/camera_from_metadata.h
   io/camera_io.h


### PR DESCRIPTION
optional was part of the public interface and not installing
it caused problems for projects that use kwiver. The include
file has been streamlined and moved to the public API.