### PR TITLE
Dev/rtd fix

### DIFF
--- a/doc/manuals/conf.py
+++ b/doc/manuals/conf.py
@@ -48,7 +48,7 @@ breathe_default_project = "kwiver"
 import subprocess, os
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    subprocess.call('cd ..; doxygen', shell=True)
+    subprocess.call('doxygen', shell=True)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/manuals/conf.py
+++ b/doc/manuals/conf.py
@@ -48,7 +48,7 @@ breathe_default_project = "kwiver"
 import subprocess, os
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    subprocess.call('cd ../doxygen; doxygen', shell=True)
+    subprocess.call('cd ..; doxygen', shell=True)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This should get doxygen running on RTD so breathe can connect it to our documentation

https://kwiver.readthedocs.io/en/dev-rtd_fix/vital/detectors.html

