### PR TITLE
Remove uses of vcl_vector to support latest vxl

### DIFF
--- a/arrows/vxl/estimate_essential_matrix.cxx
+++ b/arrows/vxl/estimate_essential_matrix.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -139,7 +139,7 @@ estimate_essential_matrix
   vital_to_vpgl_calibration(*cal1, vcal1);
   vital_to_vpgl_calibration(*cal2, vcal2);
 
-  vcl_vector<vgl_point_2d<double> > right_points, left_points;
+  std::vector<vgl_point_2d<double> > right_points, left_points;
   for(const vector_2d& v : pts1)
   {
     right_points.push_back(vgl_point_2d<double>(v.x(), v.y()));

--- a/arrows/vxl/estimate_fundamental_matrix.cxx
+++ b/arrows/vxl/estimate_fundamental_matrix.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -148,7 +148,7 @@ estimate_fundamental_matrix
            std::vector<bool>& inliers,
            double inlier_scale) const
 {
-  vcl_vector<vgl_homg_point_2d<double> > right_points, left_points;
+  std::vector<vgl_homg_point_2d<double> > right_points, left_points;
   for(const vector_2d& v : pts1)
   {
     right_points.push_back(vgl_homg_point_2d<double>(v.x(), v.y()));

--- a/arrows/vxl/estimate_similarity_transform.cxx
+++ b/arrows/vxl/estimate_similarity_transform.cxx
@@ -41,7 +41,6 @@
 #include <vital/exceptions/algorithm.h>
 #include <vital/types/rotation.h>
 
-#include <vcl_vector.h>
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_quaternion.h>
 #include <vnl/vnl_vector_fixed.h>

--- a/arrows/vxl/optimize_cameras.cxx
+++ b/arrows/vxl/optimize_cameras.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2014-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,6 @@
 #include <arrows/vxl/camera.h>
 #include <arrows/vxl/camera_map.h>
 
-#include <vcl_vector.h>
 #include <vgl/vgl_homg_point_3d.h>
 #include <vgl/vgl_point_2d.h>
 #include <vnl/algo/vnl_levenberg_marquardt.h>
@@ -65,8 +64,8 @@ namespace // anonymous
 /// trace statement.
 vpgl_perspective_camera<double>
 opt_orient_pos(vpgl_perspective_camera<double> const& camera,
-               vcl_vector<vgl_homg_point_3d<double> > const& world_points,
-               vcl_vector<vgl_point_2d<double> > const& image_points)
+               std::vector<vgl_homg_point_3d<double> > const& world_points,
+               std::vector<vgl_point_2d<double> > const& image_points)
 {
   const vpgl_calibration_matrix<double>& K = camera.get_calibration();
   vgl_point_3d<double> c = camera.get_camera_center();
@@ -118,8 +117,8 @@ optimize_cameras
   // For each camera in the input map, create corresponding point sets for 2D
   // and 3D coordinates of tracks and matching landmarks, respectively, for
   // that camera's frame.
-  vcl_vector< vgl_point_2d<double> > pts_2d;
-  vcl_vector< vgl_homg_point_3d<double> > pts_3d;
+  std::vector< vgl_point_2d<double> > pts_2d;
+  std::vector< vgl_homg_point_3d<double> > pts_3d;
   vector_2d tmp_2d;
   vector_3d tmp_3d;
   for( unsigned int i=0; i<features.size(); ++i )


### PR DESCRIPTION
Something in the latest VXL broke our few uses of vcl_vector but we really shouldn't be using it anyway.