### PR TITLE
Reintroduce descriptor averaging

### DIFF
--- a/arrows/core/average_track_descriptors.cxx
+++ b/arrows/core/average_track_descriptors.cxx
@@ -121,10 +121,9 @@ average_track_descriptors
 
         if( ots && ots->detection && ots->detection->descriptor() )
         {
-          auto avg_it = d->m_history.find( track->id() );
           std::vector< double > descriptor = ots->detection->descriptor()->as_double();
           std::vector< double > average;
-          if( avg_it == d->m_history.end() )
+          if( !d->m_rolling && !d->m_history.count( track->id() ) )
           {
             // This is the first detection in the track, so output it
             // as-is.  This ensures that every input track has a
@@ -135,10 +134,10 @@ average_track_descriptors
           }
           else
           {
-            std::deque< std::vector< double > >& average_history = avg_it->second;
+            std::deque< std::vector< double > >& average_history = d->m_history[ track->id() ];
 
             average_history.push_back( std::move( descriptor ) );
-            if( average_history.size() != d->m_interval )
+            if( !d->m_rolling && average_history.size() != d->m_interval )
             {
               continue;
             }
@@ -175,7 +174,10 @@ average_track_descriptors
 
               if( d->m_rolling )
               {
-                average_history.pop_front();
+                if( average_history.size() == d->m_interval )
+                {
+                  average_history.pop_front();
+                }
               }
               else
               {

--- a/arrows/core/average_track_descriptors.cxx
+++ b/arrows/core/average_track_descriptors.cxx
@@ -30,6 +30,8 @@
 
 #include "average_track_descriptors.h"
 
+#include <deque>
+
 namespace kwiver {
 namespace arrows {
 namespace core {
@@ -39,18 +41,28 @@ namespace core {
 class average_track_descriptors::priv
 {
 public:
-  priv()
-  {}
+  priv( average_track_descriptors* parent )
+    : m_parent( parent )
+    , m_logger( kwiver::vital::get_logger( "average_track_descriptors" ) )
+    , m_rolling( false )
+    , m_interval( 5 )
+  { }
 
-  ~priv()
-  {}
+  ~priv() { }
+
+  average_track_descriptors* m_parent;
+  kwiver::vital::logger_handle_t m_logger;
+  bool m_rolling;
+  unsigned int m_interval;
+
+  std::map< vital::track_id_t, std::deque< std::vector< double > > > m_history;
 };
 
 
 // ==================================================================================
 average_track_descriptors
 ::average_track_descriptors()
-  : d( new priv() )
+  : d( new priv( this ) )
 {
 }
 
@@ -67,6 +79,8 @@ void
 average_track_descriptors
 ::set_configuration( vital::config_block_sptr config )
 {
+  d->m_rolling = config->get_value< bool >( "rolling", d->m_rolling );
+  d->m_interval = config->get_value< unsigned int >( "interval", d->m_interval );
 }
 
 
@@ -94,31 +108,77 @@ average_track_descriptors
     {
       if( !track )
       {
-        std::cout << "Warning: Invalid Track" << std::endl;
+        LOG_WARN( d->m_logger, "Warning: Invalid Track" );
         continue;
       }
 
       vital::track::history_const_itr it = track->find( ts.get_frame() );
       if( it != track->end() )
       {
+        std::deque< std::vector< double > >& average_history = d->m_history[ track->id() ];
+
         std::shared_ptr< vital::object_track_state > ots =
           std::dynamic_pointer_cast< vital::object_track_state >( *it );
 
         if( ots && ots->detection && ots->detection->descriptor() )
         {
-          vital::track_descriptor_sptr td = vital::track_descriptor::create( "cnn_descriptor" );
-  
-          td->add_track_id( track->id() );
-          td->set_descriptor( ots->detection->descriptor() );
-  
-          // Make history entry
-          if( ots->detection )
+          average_history.push_back( ots->detection->descriptor()->as_double() );
+          if( average_history.size() == d->m_interval )
           {
+            std::vector< double > average;
+            std::size_t i = 0;
+
+            bool done = false;
+            while( true )
+            {
+              double total = 0.0;
+
+              for( std::vector< double >& entry : average_history )
+              {
+                if( i >= entry.size() )
+                {
+                  done = true;
+                  break;
+                }
+
+                total += entry[ i ];
+              }
+
+              if( done )
+              {
+                break;
+              }
+              else
+              {
+                average.push_back( total / average_history.size() );
+                i++;
+              }
+            }
+
+            if( d->m_rolling )
+            {
+              average_history.pop_front();
+            }
+            else
+            {
+              average_history.clear();
+            }
+
+            vital::track_descriptor_sptr td = vital::track_descriptor::create( "cnn_descriptor" );
+
+            td->add_track_id( track->id() );
+
+            vital::track_descriptor::descriptor_data_sptr data(
+              new vital::track_descriptor::descriptor_data_t( average.size() ) );
+            std::copy( average.begin(), average.end(), data->raw_data() );
+            td->set_descriptor( data );
+
+            // Make history entry
             vital::track_descriptor::history_entry he( ts, ots->detection->bounding_box() );
             td->add_history_entry( he );
-          }
 
-          tds->push_back( td );
+            tds->push_back( td );
+          }
         }
       }
     }
@@ -133,7 +193,7 @@ vital::track_descriptor_set_sptr
 average_track_descriptors
 ::flush()
 {
-  return vital::track_descriptor_set_sptr();
+  return vital::track_descriptor_set_sptr( new vital::track_descriptor_set() );
 }
 
 


### PR DESCRIPTION
This PR reintroduces descriptor averaging (as implemented in 70c689e) and additionally changes it slightly to ensure that no tracks are dropped. For "non-rolling" mode this means treating the first detection specially and always outputting it. An additional change gives sensible behavior to rolling-window mode, generating output for every input detection.

Note that when integrating this with Viame, to avoid changing behavior where not desired, users of `average_track_descriptors` should set `interval` to 1.

Validation status:
- First two commits on top of older VIAME / KWIVER have been run to produce reasonable results
- All the changes compile on top of current `viame/master` (f1db431e1)