### PR TITLE
Remove dynamicCast from ocv SURF arrow for OCV 3

### DIFF
--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -189,7 +189,8 @@ detect_features_SURF
 #ifndef KWIVER_HAS_OPENCV_VER_3
   p_->update( detector );
 #else
-  // version 3.x doesn't have parameter update methods
+  // Create a new detector rather than update on version 3.
+  // Use of the update function requires a dynamic_cast which fails on Mac
   detector = p_->create();
 #endif
 }
@@ -239,7 +240,8 @@ extract_descriptors_SURF
 #ifndef KWIVER_HAS_OPENCV_VER_3
   p_->update( extractor );
 #else
-  // version 3.x doesn't have parameter update methods
+  // Create a new detector rather than update on version 3.
+  // Use of the update function requires a dynamic_cast which fails on Mac
   extractor = p_->create();
 #endif
 }

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,23 +88,16 @@ public:
 #endif
   }
 
+#ifndef KWIVER_HAS_OPENCV_VER_3
   // Update algorithm with current parameter
   void update( cv::Ptr<cv_SURF_t> a ) const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
     a->set( "hessianThreshold", hessian_threshold );
     a->set( "nOctaves", n_octaves );
     a->set( "nOctaveLayers", n_octave_layers );
     a->set( "extended", extended );
     a->set( "upright", upright );
-#else
-    a->setHessianThreshold( hessian_threshold );
-    a->setNOctaves( n_octaves );
-    a->setNOctaveLayers( n_octave_layers );
-    a->setExtended( extended );
-    a->setUpright( upright );
 #endif
-  }
 
   // Update config block with current parameter values
   void update_config( config_block_sptr config ) const

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -97,6 +97,7 @@ public:
     a->set( "nOctaveLayers", n_octave_layers );
     a->set( "extended", extended );
     a->set( "upright", upright );
+  }
 #endif
 
   // Update config block with current parameter values

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -195,7 +195,8 @@ detect_features_SURF
 #ifndef KWIVER_HAS_OPENCV_VER_3
   p_->update( detector );
 #else
-  p_->update( detector.dynamicCast<cv_SURF_t>() );
+  // version 3.x doesn't have parameter update methods
+  detector = p_->create();
 #endif
 }
 
@@ -244,7 +245,8 @@ extract_descriptors_SURF
 #ifndef KWIVER_HAS_OPENCV_VER_3
   p_->update( extractor );
 #else
-  p_->update( extractor.dynamicCast<cv_SURF_t>() );
+  // version 3.x doesn't have parameter update methods
+  extractor = p_->create();
 #endif
 }
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -51,10 +51,6 @@ Arrows: GDAL
 
 Arrows: OpenCV
 
-  * Fix and issue in the feature_detect_extract_SURF arrow. The arrow was using a dynamicCast
-    which causes a segfault on the Mac. On the Mac, symbols exported from an image loaded with
-    RTLD_GLOBAL mode are not available to other images unless built with -flat_namespace.
-
 Arrows: Serialization
 
   * Addded JSON Serializers for:
@@ -93,3 +89,7 @@ Bug Fixes
 
  * Fixed a problem where ports that were not supplied data in the
    input_adapter_process were incorrectly reported.
+
+ * Fix and issue in the feature_detect_extract_SURF arrow. The arrow was using a dynamicCast
+   which causes a segfault on the Mac. On the Mac, symbols exported from an image loaded with
+   RTLD_GLOBAL mode are not available to other images unless built with -flat_namespace.

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -51,6 +51,10 @@ Arrows: GDAL
 
 Arrows: OpenCV
 
+  * Fix and issue in the feature_detect_extract_SURF arrow. The arrow was using a dynamicCast
+    which causes a segfault on the Mac. On the Mac, symbols exported from an image loaded with
+    RTLD_GLOBAL mode are not available to other images unless built with -flat_namespace.
+
 Arrows: Serialization
 
   * Addded JSON Serializers for:


### PR DESCRIPTION
This branch replicates the approach taken in the SIFT arrow which avoids doing a dynamicCast of the detector and extractor objects when it's time to update the object. For OCV 3 we just create a new one which does the same thing.

The problem of invalid dynamicCasted objects on the mac is coming specifically from algorithms that exist in the contrib package. Other arrows, e.g. ORB do the dynamicCast but don't segfault. It's possible that contrib libraries are being built differently, which is something to look into if we want consistency in the approaches. Until then this patch makes the SURF arrow functional on the mac and should make the dashboard tests pass. 