### PR TITLE
Fix relative paths added by plugin_explorer.

### DIFF
--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -716,14 +716,13 @@ main( int argc, char* argv[] )
     return 1;
   }
 
-  //+ test for one of --factory or --type (is this desired?)
-
   // ========
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   if (!G_context.opt_skip_relative)
   {
-    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/modules");
-    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/sprokit");
+    // It is somewhat problematic to keep these in sync with the CMake values
+    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/modules");
+    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/sprokit");
   }
 
   char** newArgv = 0;


### PR DESCRIPTION
There are two paths that are added to the default search path to
locate plugins that are relative to the plugin_explorer tool.
These had gotten out of sync with the paths that are in the CMake
files.