### PR TITLE
Add process method to handle undefined ports.

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -12,8 +12,8 @@ Vital
  * Added constructors taking initalizer lists to mesh types for easier
    initialization.
 
-Vital Bindings 
- 
+Vital Bindings
+
 Arrows: Core
 
  * Added mesh_operations.h, initially with a function to triangulate a mesh.
@@ -33,10 +33,17 @@ Sprokit
 
 Sprokit: Processes
 
+  * Added new methods which are called when a requested port is
+    missing. This can be used to dynamically create ports. Previously
+    this was done by overriding the _{input,output}_port_info()
+    method.  The new approach is an optimization because the
+    _*_port_info() methods are also called to locate ports for data
+    transfer. The process specific override can add a lot of overhead
+    to the port info calls.
+
 Tools
 
 Unit Tests
 
 Bug Fixes
 --------
-

--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -91,9 +91,9 @@ input_adapter_process
 
 
 // ------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 input_adapter_process
-::_output_port_info( sprokit::process::port_t const& port )
+::output_port_undefined( sprokit::process::port_t const& port )
 {
   // If we have not created the port, then make a new one.
   if ( m_active_ports.count( port ) == 0 )
@@ -115,8 +115,6 @@ input_adapter_process
       m_active_ports.insert( port );
     }
   }
-
-  return process::_output_port_info(port);
 }
 
 

--- a/sprokit/processes/adapters/input_adapter_process.h
+++ b/sprokit/processes/adapters/input_adapter_process.h
@@ -70,7 +70,7 @@ public:
 private:
 
   // This is used to intercept connections and make ports JIT
-  virtual sprokit::process::port_info_t _output_port_info( sprokit::process::port_t const& port);
+  virtual void output_port_undefined( sprokit::process::port_t const& port) override;
 
 }; // end class input_adapter_process
 

--- a/sprokit/processes/adapters/output_adapter_process.cxx
+++ b/sprokit/processes/adapters/output_adapter_process.cxx
@@ -115,9 +115,9 @@ output_adapter_process
 
 
 // ------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 output_adapter_process
-::_input_port_info(port_t const& port)
+::input_port_undefined(port_t const& port)
 {
   // If we have not created the port, then make a new one.
   if ( m_active_ports.count( port ) == 0 )
@@ -136,8 +136,6 @@ output_adapter_process
     // Add to our list of existing ports
     m_active_ports.insert( port );
   }
-
-  return process::_input_port_info(port);
 }
 
 

--- a/sprokit/processes/adapters/output_adapter_process.h
+++ b/sprokit/processes/adapters/output_adapter_process.h
@@ -71,7 +71,7 @@ private:
   void _configure();
 
   // This is used to intercept connections and make ports JIT
-  virtual sprokit::process::port_info_t _input_port_info(port_t const& port);
+  virtual void input_port_undefined(port_t const& port) override;
 
   class priv;
   const std::unique_ptr<priv> d;

--- a/sprokit/processes/core/deserializer_process.cxx
+++ b/sprokit/processes/core/deserializer_process.cxx
@@ -266,9 +266,9 @@ deserializer_process
 
 
 // ----------------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 deserializer_process::
-_input_port_info(port_t const& port_name)
+input_port_undefined(port_t const& port_name)
 {
   LOG_TRACE( logger(), "Processing input port info: \"" << port_name << "\"" );
 
@@ -288,15 +288,13 @@ _input_port_info(port_t const& port_name)
         "serialized input" );
     }
   }
-
-  return process::_input_port_info( port_name );
 }
 
 
 // ----------------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 deserializer_process::
-_output_port_info(port_t const& port_name)
+output_port_undefined(port_t const& port_name)
 {
   LOG_TRACE( logger(), "Processing output port info: \"" << port_name << "\"" );
 
@@ -318,8 +316,6 @@ _output_port_info(port_t const& port_name)
         port_description_t( "deserialized data type" ) );
     }
   }
-
-  return process::_output_port_info( port_name );
 }
 
 
@@ -343,7 +339,7 @@ deserializer_process
 
   // pass to base class
   return process::_set_output_port_type( port_name, port_type );
-} // deserializer_process::_output_port_info
+}
 
 
 // ----------------------------------------------------------------

--- a/sprokit/processes/core/deserializer_process.h
+++ b/sprokit/processes/core/deserializer_process.h
@@ -57,8 +57,8 @@ protected:
   virtual void _init();
   virtual void _step();
 
-  virtual sprokit::process::port_info_t _input_port_info( port_t const& port );
-  virtual sprokit::process::port_info_t _output_port_info( port_t const& port );
+  virtual void input_port_undefined( port_t const& port ) override;
+  virtual void output_port_undefined( port_t const& port ) override;
 
   virtual bool _set_output_port_type(port_t const& port_name,
                                      port_type_t const& port_type);

--- a/sprokit/processes/core/merge_detection_sets_process.cxx
+++ b/sprokit/processes/core/merge_detection_sets_process.cxx
@@ -126,11 +126,11 @@ merge_detection_sets_process
 }
 
 // ----------------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 merge_detection_sets_process
-::_input_port_info(port_t const& port_name)
+::input_port_undefined(port_t const& port_name)
 {
-  LOG_TRACE( logger(), "Processing input port info: \"" << port_name << "\"" );
+  LOG_TRACE( logger(), "Processing undefined input port: \"" << port_name << "\"" );
 
   // Just create an input port to read detections from
   if (! kwiver::vital::starts_with( port_name, "_" ) )
@@ -151,9 +151,6 @@ merge_detection_sets_process
       d->p_port_list.insert( port_name );
     }
   }
-
-  // call base class implementation
-  return process::_input_port_info( port_name );
 }
 
 } // end namespace

--- a/sprokit/processes/core/merge_detection_sets_process.h
+++ b/sprokit/processes/core/merge_detection_sets_process.h
@@ -53,7 +53,7 @@ protected:
   virtual void _step();
   virtual void _init();
 
-  virtual sprokit::process::port_info_t _input_port_info( port_t const& port );
+  virtual void input_port_undefined( port_t const& port ) override;
 
 
 private:

--- a/sprokit/processes/core/print_config_process.cxx
+++ b/sprokit/processes/core/print_config_process.cxx
@@ -77,9 +77,9 @@ _configure()
 
 
 // ------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 print_config_process::
-_input_port_info(port_t const& port)
+input_port_undefined(port_t const& port)
 {
   // If we have not created the port, then make a new one.
   if ( d->m_active_ports.count( port ) == 0 )
@@ -89,7 +89,7 @@ _input_port_info(port_t const& port)
     LOG_TRACE( logger(), "Creating input port: \"" << port << "\" on process \"" << name() << "\"" );
 
     // create a new port
-    declare_input_port( port, // port name
+    declare_input_port( port,     // port name
                         type_any, // port data type expected
                         p_flags,
                         port_description_t("Input for " + port)
@@ -98,8 +98,6 @@ _input_port_info(port_t const& port)
     // Add to our list of existing ports
     d->m_active_ports.insert( port );
   }
-
-  return process::_input_port_info(port);
 }
 
 

--- a/sprokit/processes/core/print_config_process.h
+++ b/sprokit/processes/core/print_config_process.h
@@ -57,7 +57,7 @@ protected:
   virtual void _step();
 
   // This is used to intercept connections and make ports JIT
-  virtual sprokit::process::port_info_t _input_port_info(port_t const& port);
+  virtual void input_port_undefined(port_t const& port) override;
 
 private:
   class priv;

--- a/sprokit/processes/core/serializer_process.cxx
+++ b/sprokit/processes/core/serializer_process.cxx
@@ -248,11 +248,11 @@ serializer_process
 
 
 // ----------------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 serializer_process::
-_input_port_info(port_t const& port_name)
+input_port_undefined(port_t const& port_name)
 {
-  LOG_TRACE( logger(), "Processing input port info: \"" << port_name << "\"" );
+  LOG_TRACE( logger(), "Processing undefined input port: \"" << port_name << "\"" );
 
   if (! kwiver::vital::starts_with( port_name, "_" ) )
   {
@@ -272,16 +272,14 @@ _input_port_info(port_t const& port_name)
         port_description_t( "data type to be serialized" ) );
     }
   }
-
-  return process::_input_port_info( port_name );
 }
 
 // ----------------------------------------------------------------------------
-sprokit::process::port_info_t
+void
 serializer_process::
-_output_port_info(port_t const& port_name)
+output_port_undefined(port_t const& port_name)
 {
-  LOG_TRACE( logger(), "Processing output port info: \"" << port_name << "\"" );
+  LOG_TRACE( logger(), "Processing undefined output port: \"" << port_name << "\"" );
 
   // Just create an output port
   if (! kwiver::vital::starts_with( port_name, "_" ) )
@@ -301,8 +299,6 @@ _output_port_info(port_t const& port_name)
         "serialized output" );
     }
   }
-
-  return process::_output_port_info( port_name );
 }
 
 // ------------------------------------------------------------------
@@ -324,7 +320,7 @@ serializer_process
 
   // pass to base class
   return process::_set_input_port_type( port_name, port_type );
-} // serializer_process::_input_port_info
+}
 
 // ----------------------------------------------------------------
 void serializer_process

--- a/sprokit/processes/core/serializer_process.h
+++ b/sprokit/processes/core/serializer_process.h
@@ -58,11 +58,11 @@ protected:
   virtual void _init();
   virtual void _step();
 
-  virtual sprokit::process::port_info_t _input_port_info( port_t const& port );
-  virtual sprokit::process::port_info_t _output_port_info( port_t const& port );
+  virtual void input_port_undefined( port_t const& port ) override;
+  virtual void output_port_undefined( port_t const& port )override;
 
   virtual bool _set_input_port_type( port_t const&      port_name,
-                                     port_type_t const& port_type );
+                                     port_type_t const& port_type ) override;
 
 private:
   void make_config();

--- a/sprokit/processes/flow/collate_process.cxx
+++ b/sprokit/processes/flow/collate_process.cxx
@@ -377,9 +377,9 @@ collate_process
 
 // ------------------------------------------------------------------
 // Intercept input port connection so we can create the requested port
-process::port_info_t
+void
 collate_process
-::_input_port_info(port_t const& port)
+::input_port_undefined(port_t const& port)
 {
   // Is this a status port (starts with "status/")
   if (kwiver::vital::starts_with(port, priv::port_status_prefix))
@@ -436,8 +436,6 @@ collate_process
       required,
       port_description_t("An input for the " + tag + " data."));
   }
-
-  return process::_input_port_info(port);
 }
 
 

--- a/sprokit/processes/flow/collate_process.h
+++ b/sprokit/processes/flow/collate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,15 +78,9 @@ class PROCESSES_FLOW_NO_EXPORT collate_process
      */
     properties_t _properties() const;
 
-    /**
-     * \brief Input port information.
-     *
-     * \param port The port to get information about.
-     *
-     * \returns Information about an input port.
-     */
-    port_info_t _input_port_info(port_t const& port);
-  private:
+    void input_port_undefined(port_t const& port) override;
+
+private:
     class priv;
     std::unique_ptr<priv> d;
 };

--- a/sprokit/processes/flow/distribute_process.cxx
+++ b/sprokit/processes/flow/distribute_process.cxx
@@ -348,9 +348,9 @@ distribute_process
 
 // ------------------------------------------------------------------
 // Intercept the connect operation so we can create the needed output port
-process::port_info_t
+void
 distribute_process
-::_output_port_info(port_t const& port)
+::output_port_undefined(port_t const& port)
 {
   // Does this port name start with the status prefix "status/"
   if (kwiver::vital::starts_with(port, priv::port_status_prefix))
@@ -406,8 +406,6 @@ distribute_process
       required,
       port_description_t("An output for the " + tag + " data."));
   }
-
-  return process::_output_port_info(port);
 }
 
 

--- a/sprokit/processes/flow/distribute_process.h
+++ b/sprokit/processes/flow/distribute_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,14 +78,8 @@ class PROCESSES_FLOW_NO_EXPORT distribute_process
      */
     properties_t _properties() const;
 
-    /**
-     * \brief Output port information.
-     *
-     * \param port The port to get information about.
-     *
-     * \returns Information about an output port.
-     */
-    port_info_t _output_port_info(port_t const& port);
+    void output_port_undefined(port_t const& port) override;
+
   private:
     class priv;
     std::unique_ptr<priv> d;

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -496,6 +496,8 @@ process
   return _input_port_info(port);
 }
 
+
+// ------------------------------------------------------------------
 process::port_info_t
 process
 ::output_port_info(port_t const& port)
@@ -771,7 +773,17 @@ process::port_info_t
 process
 ::_input_port_info(port_t const& port)
 {
-  priv::port_map_t::const_iterator const i = d->input_ports.find(port);
+  priv::port_map_t::const_iterator i = d->input_ports.find(port);
+
+  if (i == d->input_ports.end())
+  {
+    // Port not found. Check with the process to see if it wants to
+    // define the port.
+    input_port_undefined( port );
+
+    // Update iterator
+    i = d->input_ports.find(port);
+  }
 
   if (i != d->input_ports.end())
   {
@@ -782,13 +794,29 @@ process
                d->name, port, input_ports());
 }
 
+// ------------------------------------------------------------------
+void
+process
+::input_port_undefined( port_t const& port )
+{
+}
 
 // ------------------------------------------------------------------
 process::port_info_t
 process
 ::_output_port_info(port_t const& port)
 {
-  priv::port_map_t::const_iterator const i = d->output_ports.find(port);
+  priv::port_map_t::const_iterator i = d->output_ports.find(port);
+
+  if (i == d->output_ports.end())
+  {
+    // Port not found. Check with the process to see if it wants to
+    // define the port.
+    output_port_undefined( port );
+
+    // Update iterator
+    i = d->output_ports.find(port);
+  }
 
   if (i != d->output_ports.end())
   {
@@ -799,6 +827,13 @@ process
                d->name, port, output_ports());
 }
 
+
+// ------------------------------------------------------------------
+void
+process
+::output_port_undefined( port_t const& port )
+{
+}
 
 // ------------------------------------------------------------------
 bool

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -811,6 +811,7 @@ class SPROKIT_PIPELINE_EXPORT process
      * \returns The names of all input ports available in the subclass.
      */
     virtual ports_t _input_ports() const;
+
     /**
      * \brief Subclass output ports.
      *
@@ -828,6 +829,22 @@ class SPROKIT_PIPELINE_EXPORT process
     virtual port_info_t _input_port_info(port_t const& port);
 
     /**
+     * \brief Process handler for undefined input port
+     *
+     * This method is called when port_info is is being requested for
+     * this process and the port is not defined. The default
+     * implementation is to do nothing, which will cause the process
+     * to throw an exception.
+     *
+     * The process can override this method and create the undefined
+     * port. This is a form of just-in-time port creation which is
+     * used for processes that can handle multiple inputs.
+     *
+     * \param port Name of the port
+     */
+    virtual void input_port_undefined(port_t const& port);
+
+    /**
      * \brief Subclass output port information.
      *
      * \param port The port to get information about.
@@ -835,6 +852,22 @@ class SPROKIT_PIPELINE_EXPORT process
      * \returns Information about an output port.
      */
     virtual port_info_t _output_port_info(port_t const& port);
+
+    /**
+     * \brief Process handler for undefined output port
+     *
+     * This method is called when port_info is is being requested for
+     * this process and the port is not defined. The default
+     * implementation is to do nothing, which will cause the process
+     * to throw an exception.
+     *
+     * The process can override this method and create the undefined
+     * port. This is a form of just-in-time port creation which is
+     * used for processes that can handle multiple outputs.
+     *
+     * \param port Name of the port
+     */
+    virtual void output_port_undefined(port_t const& port);
 
     /**
      * \brief Subclass input port type setting.


### PR DESCRIPTION
This method supports dynamically creating ports as they are
specified making connections. The previous approach to dynamically
creating ports was to override the _*_port_info() method. While
this approach works, the _*_port_info() call is also called when moving
data over an edge. The derived implementation of this method can
add considerable overhead if it is not carefully programmed. In
addition, it is not obvious that the _*_port_info() calls are part of
the data transfer operations, so efficiency may not be part of the
design.

These new methods are only called when a port is being requested of a
process and it is not defined. They are never called again after the
port has been defined, eliminating the need to highly optimize these
methods.