### PR TITLE
Change location for logger plugins.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ set( kwiver_plugin_process_instrumentation_subdir ${kwiver_plugin_subdir}/module
 set( kwiver_plugin_scheduler_subdir               ${kwiver_plugin_subdir}/processes )
 set( kwiver_plugin_module_subdir                  ${kwiver_plugin_subdir}/modules )
 set( kwiver_plugin_plugin_explorer_subdir         ${kwiver_plugin_subdir}/modules/plugin_explorer )
-set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/modules )
+set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/modules/logger )
 set( kwiver_plugin_applets                        ${kwiver_plugin_subdir}/modules/applets )
 
 ##

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -30,6 +30,11 @@ Vital Bindings
 
  * Added python bindings for timestamp class.
 
+Vital Logger
+
+ * Changed install location for logger plugins to kwiver/modules/logger
+   so it will not be seen by the main plugin loader.
+
 Arrows: Core
 
  * Added support for RPC cameras to the triangulate_landmark implementation.


### PR DESCRIPTION
This separates loading of the logger back-ends and the other
plugins.