### PR TITLE
Mesh Triangulation

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -32,6 +32,7 @@ set( plugin_core_headers
   match_features_fundamental_matrix.h
   match_features_homography.h
   match_tracks.h
+  mesh_operations.h
   read_object_track_set_kw18.h
   read_track_descriptor_set_csv.h
   render_mesh_depth_map.h
@@ -103,6 +104,7 @@ set( plugin_core_sources
   match_features_fundamental_matrix.cxx
   match_features_homography.cxx
   match_tracks.cxx
+  mesh_operations.cxx
   read_object_track_set_kw18.cxx
   read_track_descriptor_set_csv.cxx
   render_mesh_depth_map.cxx

--- a/arrows/core/mesh_operations.cxx
+++ b/arrows/core/mesh_operations.cxx
@@ -1,0 +1,110 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Implementation of mesh operations
+ */
+
+#include "mesh_operations.h"
+
+
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+using namespace kwiver::vital;
+
+/// Subdivide mesh faces into triangle
+std::unique_ptr<mesh_regular_face_array<3> >
+mesh_triangulate(const mesh_face_array_base& faces)
+{
+  std::unique_ptr<mesh_regular_face_array<3> > tris(new mesh_regular_face_array<3>);
+  int group = -1;
+  if (faces.has_groups())
+    group = 0;
+  for (unsigned int f=0; f<faces.size(); ++f) {
+    for (unsigned i=2; i<faces.num_verts(f); ++i)
+      tris->push_back(mesh_tri(faces(f,0),faces(f,i-1),faces(f,i)));
+    if (group >= 0 && f+1 >= faces.groups()[group].second) {
+      tris->make_group(faces.groups()[group++].first);
+    }
+  }
+  return tris;
+}
+
+
+/// Subdivide quadrilaterals into triangle
+std::unique_ptr<mesh_regular_face_array<3> >
+mesh_triangulate(const mesh_regular_face_array<4>& faces)
+{
+  std::unique_ptr<mesh_regular_face_array<3> > tris(new mesh_regular_face_array<3>);
+  int group = -1;
+  if (faces.has_groups())
+    group = 0;
+  for (unsigned int f=0; f<faces.size(); ++f) {
+    const mesh_regular_face<4>& face = faces[f];
+    tris->push_back(mesh_tri(face[0],face[1],face[2]));
+    tris->push_back(mesh_tri(face[0],face[2],face[3]));
+    if (group >= 0 && f+1 >= faces.groups()[group].second) {
+      tris->make_group(faces.groups()[group++].first);
+    }
+  }
+  return tris;
+}
+
+
+/// Triangulate the faces of the mesh (in place)
+void
+mesh_triangulate(mesh& mesh)
+{
+  switch (mesh.faces().regularity())
+  {
+    case 3: break;
+    case 4:
+    {
+      std::unique_ptr<mesh_face_array_base> tris(
+          mesh_triangulate(static_cast<const mesh_regular_face_array<4>&>(mesh.faces())));
+      mesh.set_faces(std::move(tris));
+      break;
+    }
+    default:
+    {
+      std::unique_ptr<mesh_face_array_base> tris(mesh_triangulate(mesh.faces()));
+      mesh.set_faces(std::move(tris));
+      break;
+    }
+  }
+}
+
+}
+}
+}

--- a/arrows/core/mesh_operations.cxx
+++ b/arrows/core/mesh_operations.cxx
@@ -45,16 +45,22 @@ using namespace kwiver::vital;
 
 /// Subdivide mesh faces into triangle
 std::unique_ptr<mesh_regular_face_array<3> >
-mesh_triangulate(const mesh_face_array_base& faces)
+mesh_triangulate(mesh_face_array_base const& faces)
 {
   std::unique_ptr<mesh_regular_face_array<3> > tris(new mesh_regular_face_array<3>);
   int group = -1;
   if (faces.has_groups())
+  {
     group = 0;
-  for (unsigned int f=0; f<faces.size(); ++f) {
+  }
+  for (unsigned int f=0; f<faces.size(); ++f)
+  {
     for (unsigned i=2; i<faces.num_verts(f); ++i)
-      tris->push_back(mesh_tri(faces(f,0),faces(f,i-1),faces(f,i)));
-    if (group >= 0 && f+1 >= faces.groups()[group].second) {
+    {
+      tris->push_back(mesh_tri(faces(f, 0), faces(f, i-1), faces(f, i)));
+    }
+    if (group >= 0 && f+1 >= faces.groups()[group].second)
+    {
       tris->make_group(faces.groups()[group++].first);
     }
   }
@@ -64,17 +70,21 @@ mesh_triangulate(const mesh_face_array_base& faces)
 
 /// Subdivide quadrilaterals into triangle
 std::unique_ptr<mesh_regular_face_array<3> >
-mesh_triangulate(const mesh_regular_face_array<4>& faces)
+mesh_triangulate(mesh_regular_face_array<4> const& faces)
 {
   std::unique_ptr<mesh_regular_face_array<3> > tris(new mesh_regular_face_array<3>);
   int group = -1;
   if (faces.has_groups())
+  {
     group = 0;
-  for (unsigned int f=0; f<faces.size(); ++f) {
+  }
+  for (unsigned int f=0; f<faces.size(); ++f)
+  {
     const mesh_regular_face<4>& face = faces[f];
-    tris->push_back(mesh_tri(face[0],face[1],face[2]));
-    tris->push_back(mesh_tri(face[0],face[2],face[3]));
-    if (group >= 0 && f+1 >= faces.groups()[group].second) {
+    tris->push_back(mesh_tri(face[0], face[1], face[2]));
+    tris->push_back(mesh_tri(face[0], face[2], face[3]));
+    if (group >= 0 && f+1 >= faces.groups()[group].second)
+    {
       tris->make_group(faces.groups()[group++].first);
     }
   }
@@ -91,8 +101,8 @@ mesh_triangulate(mesh& mesh)
     case 3: break;
     case 4:
     {
-      std::unique_ptr<mesh_face_array_base> tris(
-          mesh_triangulate(static_cast<const mesh_regular_face_array<4>&>(mesh.faces())));
+      std::unique_ptr<mesh_face_array_base> tris( mesh_triangulate(
+        static_cast<mesh_regular_face_array<4> const&>(mesh.faces())));
       mesh.set_faces(std::move(tris));
       break;
     }

--- a/arrows/core/mesh_operations.h
+++ b/arrows/core/mesh_operations.h
@@ -50,6 +50,9 @@ namespace core {
 /**
  * \param [in]  faces  An array of generic mesh faces to triangulate
  * \returns     An array of triangles covering the input faces
+ *
+ * \note This implementation assumes that each face is convex and does not
+ *       consider mesh geometry when deciding how to best split faces.
  */
 KWIVER_ALGO_CORE_EXPORT
 std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
@@ -60,6 +63,9 @@ mesh_triangulate(kwiver::vital::mesh_face_array_base const& faces);
 /**
  * \param [in]  faces  An array of quad mesh faces to triangulate
  * \returns     An array of triangles covering the input faces
+ *
+ * \note This implementation assumes that each face is convex and does not
+ *       consider mesh geometry when deciding how to best split faces.
  */
 KWIVER_ALGO_CORE_EXPORT
 std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
@@ -69,6 +75,9 @@ mesh_triangulate(kwiver::vital::mesh_regular_face_array<4> const& faces);
 /// Triangulate the faces of the mesh (in place)
 /**
  * \param [in,out]  mesh  A mesh to triangulate faces in place
+ *
+ * \note This implementation assumes that each face is convex and does not
+ *       consider mesh geometry when deciding how to best split faces.
  */
 KWIVER_ALGO_CORE_EXPORT
 void

--- a/arrows/core/mesh_operations.h
+++ b/arrows/core/mesh_operations.h
@@ -53,7 +53,7 @@ namespace core {
  */
 KWIVER_ALGO_CORE_EXPORT
 std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
-mesh_triangulate(const kwiver::vital::mesh_face_array_base& faces);
+mesh_triangulate(kwiver::vital::mesh_face_array_base const& faces);
 
 
 /// Subdivide quadrilaterals into triangles
@@ -63,7 +63,7 @@ mesh_triangulate(const kwiver::vital::mesh_face_array_base& faces);
  */
 KWIVER_ALGO_CORE_EXPORT
 std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
-mesh_triangulate(const kwiver::vital::mesh_regular_face_array<4>& faces);
+mesh_triangulate(kwiver::vital::mesh_regular_face_array<4> const& faces);
 
 
 /// Triangulate the faces of the mesh (in place)

--- a/arrows/core/mesh_operations.h
+++ b/arrows/core/mesh_operations.h
@@ -1,0 +1,81 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Operations to modify meshes
+ */
+
+#ifndef KWIVER_ARROWS_CORE_MESH_OPERATIONS_H
+#define KWIVER_ARROWS_CORE_MESH_OPERATIONS_H
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/types/mesh.h>
+
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+
+/// Subdivide mesh faces into triangles
+/**
+ * \param [in]  faces  An array of generic mesh faces to triangulate
+ * \returns     An array of triangles covering the input faces
+ */
+KWIVER_ALGO_CORE_EXPORT
+std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
+mesh_triangulate(const kwiver::vital::mesh_face_array_base& faces);
+
+
+/// Subdivide quadrilaterals into triangles
+/**
+ * \param [in]  faces  An array of quad mesh faces to triangulate
+ * \returns     An array of triangles covering the input faces
+ */
+KWIVER_ALGO_CORE_EXPORT
+std::unique_ptr<kwiver::vital::mesh_regular_face_array<3> >
+mesh_triangulate(const kwiver::vital::mesh_regular_face_array<4>& faces);
+
+
+/// Triangulate the faces of the mesh (in place)
+/**
+ * \param [in,out]  mesh  A mesh to triangulate faces in place
+ */
+KWIVER_ALGO_CORE_EXPORT
+void
+mesh_triangulate(kwiver::vital::mesh& mesh);
+
+
+}
+}
+}
+#endif // KWIVER_ARROWS_CORE_MESH_OPERATIONS_H

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ kwiver_discover_gtests(core epipolar_geometry         LIBRARIES ${test_libraries
 kwiver_discover_gtests(core feature_descriptor_io     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core interpolate_camera        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core interpolate_track_spline  LIBRARIES ${test_libraries})
+kwiver_discover_gtests(core mesh_operations           LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core render_mesh_depth_map     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core track_set_impl            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core triangle_scan_iterator    LIBRARIES ${test_libraries})

--- a/arrows/core/tests/test_mesh_operations.cxx
+++ b/arrows/core/tests/test_mesh_operations.cxx
@@ -1,0 +1,94 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <arrows/core/mesh_operations.h>
+
+#include <vital/types/mesh.h>
+
+
+using namespace kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+
+// ----------------------------------------------------------------------------
+kwiver::vital::mesh_sptr generate_mesh()
+{
+  std::unique_ptr<mesh_vertex_array_base>
+    verts(new mesh_vertex_array<3>(
+  {
+    {-1, -1, -1},
+    {-1, -1,  1},
+    {-1,  1, -1},
+    {-1,  1,  1},
+    { 1, -1, -1},
+    { 1, -1,  1},
+    { 1,  1, -1},
+    { 1,  1,  1}
+  }));
+
+  std::unique_ptr<mesh_regular_face_array<4>>
+    faces(new mesh_regular_face_array<4>(
+  {
+    {0, 2, 3, 1},
+    {0, 4, 6, 2},
+    {5, 7, 6, 4},
+    {1, 3, 7, 5},
+    {2, 6, 7, 3},
+    {4, 0, 1, 5}
+  }));
+
+  return std::make_shared<mesh>(std::move(verts), std::move(faces));
+}
+
+
+// ----------------------------------------------------------------------------
+TEST(mesh_operations, triangulate_mesh)
+{
+  // Mesh
+  mesh_sptr mesh = generate_mesh();
+
+  EXPECT_EQ( mesh->faces().regularity(), 4 );
+  EXPECT_EQ( mesh->num_faces(), 6 );
+
+  kwiver::arrows::core::mesh_triangulate(*mesh);
+
+  EXPECT_EQ( mesh->faces().regularity(), 3 );
+  EXPECT_EQ( mesh->num_faces(), 12 );
+}

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -13,6 +13,9 @@ Vital Bindings
  
 Arrows: Core
 
+ * Added mesh_operations.h, initially with a function to triangulate a mesh.
+   That is, subdivide mesh faces into triangles.
+
 Arrows: FFmpeg
 
 Arrows: GDAL

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -9,6 +9,9 @@ Updates since v1.3.0
 
 Vital
 
+ * Added constructors taking initalizer lists to mesh types for easier
+   initialization.
+
 Vital Bindings 
  
 Arrows: Core

--- a/vital/types/mesh.cxx
+++ b/vital/types/mesh.cxx
@@ -404,7 +404,6 @@ mesh
 ::merge(const mesh& other)
 {
   const unsigned num_v = this->num_verts();
-  const unsigned num_e = this->num_edges();
   faces_ = merge_face_arrays(*this->faces_,*other.faces_,verts_->size());
   verts_->append(*other.verts_);
 

--- a/vital/types/mesh.h
+++ b/vital/types/mesh.h
@@ -135,6 +135,10 @@ public:
   mesh_vertex_array<d>(const std::vector<vert_t>& verts)
   : verts_(verts) {}
 
+  /// Constructor (from initializer list)
+  mesh_vertex_array<d>(const std::initializer_list<vert_t>& verts)
+  : verts_(verts) {}
+
   /// Produce a clone of this object (dynamic copy)
   virtual mesh_vertex_array_base* clone() const
   {
@@ -211,6 +215,14 @@ public:
     assert(verts.size()==s);
     std::copy(verts.begin(), verts.end(), verts_);
   }
+
+  /// Constructor from an initializer list
+  mesh_regular_face(const std::initializer_list<unsigned int>& verts)
+  {
+    assert(verts.size()==s);
+    std::copy(verts.begin(), verts.end(), verts_);
+  }
+
 
   /// return the number of vertices
   unsigned int num_verts() const { return s; }
@@ -356,6 +368,10 @@ public:
   mesh_face_array(const std::vector<std::vector<unsigned int> >& faces)
   : faces_(faces) {}
 
+  /// Constructor (from an initializer list)
+  mesh_face_array(const std::initializer_list<std::vector<unsigned int> >& faces)
+  : faces_(faces) {}
+
   /// Copy Constructor
   mesh_face_array(const mesh_face_array& other)
   : mesh_face_array_base(other), faces_(other.faces_) {}
@@ -441,6 +457,10 @@ public:
 
   /// Constructor (from a vector)
   mesh_regular_face_array<s>(const std::vector<mesh_regular_face<s> >& faces) : faces_(faces) {}
+
+  /// Constructor (from an initializer list)
+  mesh_regular_face_array<s>(const std::initializer_list<mesh_regular_face<s> >& faces)
+    : faces_(faces) {}
 
   /// returns the number of vertices per face if the same for all faces
   /**


### PR DESCRIPTION
Add functions to subdivide mesh faces into triangles.  Also provide initialization list constructors for mesh types to make it easier to construct a mesh in code (e.g. in tests).