### PR TITLE
improve render mesh

### DIFF
--- a/arrows/core/render_mesh_depth_map.cxx
+++ b/arrows/core/render_mesh_depth_map.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, SAS.
+ * Copyright 2018 by Kitware, SAS., 2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,6 +46,7 @@ namespace arrows {
 namespace core {
 
 
+/// This function renders a depth map of a triangular mesh seen by a camera
 vital::image_container_sptr render_mesh_depth_map(vital::mesh_sptr mesh, vital::camera_perspective_sptr camera)
 {
   vital::mesh_vertex_array<3>& vertices = dynamic_cast< vital::mesh_vertex_array<3>& >(mesh->vertices());
@@ -91,6 +92,7 @@ vital::image_container_sptr render_mesh_depth_map(vital::mesh_sptr mesh, vital::
 }
 
 
+/// This function renders a height map of a triangular mesh
 vital::image_container_sptr render_mesh_height_map(vital::mesh_sptr mesh, vital::camera_sptr camera)
 {
   vital::image_of<double> height_map(camera->image_width(), camera->image_height(), 1);
@@ -147,6 +149,7 @@ vital::image_container_sptr render_mesh_height_map(vital::mesh_sptr mesh, vital:
 }
 
 
+/// This function converts a depth map into a height map obtained with a perspective camera
 void depth_map_to_height_map(vital::camera_perspective_sptr const& camera,
                              vital::image_of<double>& depth_map,
                              vital::image_of<double>& height_map)
@@ -184,6 +187,7 @@ triangle_attribute_vector(vital::vector_2d const& v1,
 }
 
 
+/// This functions renders a triangle and fills it with depth
 void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, const vital::vector_2d& v3,
                      double depth_v1, double depth_v2, double depth_v3,
                      vital::image_of<double>& depth_img)

--- a/arrows/core/render_mesh_depth_map.cxx
+++ b/arrows/core/render_mesh_depth_map.cxx
@@ -100,13 +100,8 @@ vital::image_container_sptr render_mesh_depth_map(vital::mesh_sptr mesh, vital::
 vital::image_container_sptr render_mesh_height_map(vital::mesh_sptr mesh, vital::camera_sptr camera)
 {
   vital::image_of<double> height_map(camera->image_width(), camera->image_height(), 1);
-  for (unsigned int j = 0; j < height_map.height(); ++j)
-  {
-    for (unsigned int i = 0; i < height_map.width(); ++i)
-    {
-      height_map(i, j) = std::numeric_limits<double>::infinity();
-    }
-  }
+  // fill each pixel with infinity
+  transform_image(height_map, [](double){ return std::numeric_limits<double>::infinity(); } );
 
   if (mesh->faces().regularity() == 3)
   {

--- a/arrows/core/render_mesh_depth_map.cxx
+++ b/arrows/core/render_mesh_depth_map.cxx
@@ -66,18 +66,25 @@ vital::image_container_sptr render_mesh_depth_map(vital::mesh_sptr mesh, vital::
   if (mesh->faces().regularity() == 3)
   {
     auto const& triangles = static_cast< const vital::mesh_regular_face_array<3>& >(mesh->faces());
-    double d1, d2, d3;
     for (auto const& tri : triangles)
     {
+      double const& d1 = depths[tri[0]];
+      double const& d2 = depths[tri[1]];
+      double const& d3 = depths[tri[2]];
+      // for now, skip any triangle that is even partly behind the camera
+      // TODO clip triangles that are partly behind the camera
+      if (d1 <= 0.0 || d2 <= 0.0 || d3 <= 0.0)
+      {
+        continue;
+      }
+
       vital::vector_2d const& v1 = points_2d[tri[0]];
       vital::vector_2d const& v2 = points_2d[tri[1]];
       vital::vector_2d const& v3 = points_2d[tri[2]];
 
-      d1 = -1.0 / depths[tri[0]];
-      d2 = -1.0 / depths[tri[1]];
-      d3 = -1.0 / depths[tri[2]];
-
-      render_triangle(v1, v2, v3, d1, d2, d3, zbuffer);
+      render_triangle(v1, v2, v3,
+                      -1.0 / d1, -1.0 / d2, -1.0 / d3,
+                      zbuffer);
     }
     transform_image(zbuffer, [](double d){ return std::isinf(d) ? d : (-1.0 / d); } );
   }

--- a/arrows/core/render_mesh_depth_map.h
+++ b/arrows/core/render_mesh_depth_map.h
@@ -98,6 +98,24 @@ void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, con
                      vital::image_of<double>& depth_img);
 
 
+/// Compute a triangle attribute linear interpolation vector
+/**
+  * \param v1 [in]  2D triangle vertex
+  * \param v2 [in]  2D triangle vertex
+  * \param v3 [in]  2D triangle vertex
+  * \param a1 [in]  attribute value associated with v1
+  * \param a2 [in]  attribute value associated with v2
+  * \param a3 [in]  attribute value associated with v3
+  * \returns a 3D vector V such that the dot product of V and (x,y,1) is the
+  *          interpolated attribute value at location (x,y)
+  */
+vital::vector_3d
+triangle_attribute_vector(vital::vector_2d const& v1,
+                          vital::vector_2d const& v2,
+                          vital::vector_2d const& v3,
+                          double a1, double a2, double a3);
+
+
 /// This function renders a triangle and linearly interpolating attributes
 /**
  * \param v1 [in] 2D triangle point
@@ -125,19 +143,9 @@ void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, con
   double attrib_v3_d = static_cast<double>(attrib_v3);
 
   // Linear interpolation attributes
-  vital::vector_3d b1(v2.x()-v1.x(), v2.y()-v1.y(), attrib_v2_d - attrib_v1_d);
-  vital::vector_3d b2(v3.x()-v1.x(), v3.y()-v1.y(), attrib_v3_d - attrib_v1_d);
-  vital::vector_3d n = b1.cross(b2);
-  double A = -n.x()/n.z();
-  double B = -n.y()/n.z();
-  double C = (v1.x() * n.x() + v1.y() * n.y() + attrib_v1_d * n.z()) / n.z();
+  auto Va = triangle_attribute_vector(v1, v2, v3, attrib_v1_d, attrib_v2_d, attrib_v3_d);
   // Linear interpolation depth
-  vital::vector_3d b1_d(v2.x()-v1.x(), v2.y()-v1.y(), depth_v2 - depth_v1);
-  vital::vector_3d b2_d(v3.x()-v1.x(), v3.y()-v1.y(), depth_v3 - depth_v1);
-  vital::vector_3d n_d = b1_d.cross(b2_d);
-  double A_d = -n_d.x()/n_d.z();
-  double B_d = -n_d.y()/n_d.z();
-  double C_d = (v1.x() * n_d.x() + v1.y() * n_d.y() + depth_v1 * n_d.z()) / n_d.z();
+  auto Vd = triangle_attribute_vector(v1, v2, v3, depth_v1, depth_v2, depth_v3);
 
   for (tsi.reset(); tsi.next(); )
   {
@@ -147,12 +155,12 @@ void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, con
     int min_x = std::max(0, tsi.start_x());
     int max_x = std::min(static_cast<int>(img.width()) - 1, tsi.end_x());
 
-    double new_i = B * y + C;
-    double new_i_d = B_d * y + C_d;
+    double new_i = Va.y() * y + Va.z();
+    double new_i_d = Vd.y() * y + Vd.z();
     for (int x = min_x; x <= max_x; ++x)
     {
-      double attrib = new_i + A * x;
-      double depth = new_i_d + A_d * x;
+      double attrib = new_i + Va.x() * x;
+      double depth = new_i_d + Vd.x() * x;
       if (depth < depth_img(x, y))
       {
         img(x, y) =  static_cast<T>(attrib);
@@ -184,12 +192,7 @@ void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, con
   triangle_scan_iterator tsi(v1, v2, v3);
 
   // Linear interpolation depth
-  vital::vector_3d b1(v2.x()-v1.x(), v2.y()-v1.y(), depth_v2 - depth_v1);
-  vital::vector_3d b2(v3.x()-v1.x(), v3.y()-v1.y(), depth_v3 - depth_v1);
-  vital::vector_3d n = b1.cross(b2);
-  double A = -n.x()/n.z();
-  double B = -n.y()/n.z();
-  double C = (v1.x() * n.x() + v1.y() * n.y() + depth_v1 * n.z()) / n.z();
+  auto Vd = triangle_attribute_vector(v1, v2, v3, depth_v1, depth_v2, depth_v3);
 
   for (tsi.reset(); tsi.next(); )
   {
@@ -199,10 +202,10 @@ void render_triangle(const vital::vector_2d& v1, const vital::vector_2d& v2, con
     int min_x = std::max(0, tsi.start_x());
     int max_x = std::min(static_cast<int>(img.width()) - 1, tsi.end_x());
 
-    double new_i = B * y + C;
+    double new_i = Vd.y() * y + Vd.z();
     for (int x = min_x; x <= max_x; ++x)
     {
-      double depth = new_i + A * x;
+      double depth = new_i + Vd.x() * x;
       if (depth < depth_img(x, y))
       {
         depth_img(x, y) = depth;


### PR DESCRIPTION
This branch make some improvements to mesh rendering.  Including some code refactoring, optimization, and partial handling of points behind the camera.  For now it just skips all triangle that have a vertex behind the camera, which is better than rendering garbage, but it really needs to clip and partially render those triangles instead.