### PR TITLE
Sprokit processes is not getting the cmake_poicy directive, needs manual addition

### DIFF
--- a/sprokit/processes/CMakeLists.txt
+++ b/sprokit/processes/CMakeLists.txt
@@ -2,6 +2,13 @@
 # Kwiver processes
 #
 
+# This policy is new in CMake 3.12. The NEW behavior uses the <PackageName>_ROOT variable in
+# find_package(<PackageName>) calls.
+# See: https://cmake.org/cmake/help/git-stage/policy/CMP0074.html
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 include_directories( ${sprokit_source_dir}/src
                      ${sprokit_binary_dir}/src   # for generated files
                      ${CMAKE_CURRENT_SOURCE_DIR} # for trait support files


### PR DESCRIPTION
Not sure why there is a disconnect between kwiver and sprokit processes with regard to the cmake_policy but a few optional switches revealed places that weren't setting CMP0074 to NEW.
