### PR TITLE
Fix compilation errors in the dev/add-set-iteration branch

### DIFF
--- a/arrows/core/tests/test_feature_descriptor_io.cxx
+++ b/arrows/core/tests/test_feature_descriptor_io.cxx
@@ -324,9 +324,9 @@ TEST(feature_descriptor_io, write_mixed_descriptor_dim)
   descriptor_set_sptr descriptors1 = make_n_descriptors<int16_t>(50, 128);
   descriptor_set_sptr descriptors2 = make_n_descriptors<int16_t>(50, 64);
 
-  std::vector<descriptor_sptr> desc_vec( descriptors1->begin(), descriptors1->end() );
+  std::vector<descriptor_sptr> desc_vec( descriptors1->cbegin(), descriptors1->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() );
-  desc_vec.insert( desc_vec.end(), descriptors2->begin(), descriptors2->end() );
+  desc_vec.insert( desc_vec.cend(), descriptors2->cbegin(), descriptors2->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() + descriptors2->size() );
 
   descriptor_set_sptr descriptors = std::make_shared<simple_descriptor_set>(desc_vec);
@@ -348,9 +348,9 @@ TEST(feature_descriptor_io, write_mixed_descriptor_type)
   descriptor_set_sptr descriptors1 = make_n_descriptors<uint16_t>(50, 96);
   descriptor_set_sptr descriptors2 = make_n_descriptors<uint32_t>(50, 96);
 
-  std::vector<descriptor_sptr> desc_vec( descriptors1->begin(), descriptors1->end() );
+  std::vector<descriptor_sptr> desc_vec( descriptors1->cbegin(), descriptors1->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() );
-  desc_vec.insert( desc_vec.end(), descriptors2->begin(), descriptors2->end() );
+  desc_vec.insert( desc_vec.cend(), descriptors2->cbegin(), descriptors2->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() + descriptors2->size() );
 
   descriptor_set_sptr descriptors = std::make_shared<simple_descriptor_set>(desc_vec);

--- a/arrows/core/tests/test_feature_descriptor_io.cxx
+++ b/arrows/core/tests/test_feature_descriptor_io.cxx
@@ -326,7 +326,7 @@ TEST(feature_descriptor_io, write_mixed_descriptor_dim)
 
   std::vector<descriptor_sptr> desc_vec( descriptors1->cbegin(), descriptors1->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() );
-  desc_vec.insert( desc_vec.cend(), descriptors2->cbegin(), descriptors2->cend() );
+  desc_vec.insert( desc_vec.end(), descriptors2->cbegin(), descriptors2->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() + descriptors2->size() );
 
   descriptor_set_sptr descriptors = std::make_shared<simple_descriptor_set>(desc_vec);
@@ -350,7 +350,7 @@ TEST(feature_descriptor_io, write_mixed_descriptor_type)
 
   std::vector<descriptor_sptr> desc_vec( descriptors1->cbegin(), descriptors1->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() );
-  desc_vec.insert( desc_vec.cend(), descriptors2->cbegin(), descriptors2->cend() );
+  desc_vec.insert( desc_vec.end(), descriptors2->cbegin(), descriptors2->cend() );
   EXPECT_EQ( desc_vec.size(), descriptors1->size() + descriptors2->size() );
 
   descriptor_set_sptr descriptors = std::make_shared<simple_descriptor_set>(desc_vec);

--- a/arrows/ocv/tests/test_descriptor_set.cxx
+++ b/arrows/ocv/tests/test_descriptor_set.cxx
@@ -149,7 +149,7 @@ void test_conversions(const cv::Mat& data)
   }();
 
   simple_descriptor_set simp_ds(
-      std::vector<descriptor_sptr>( ds.begin(), ds.end() ) );
+      std::vector<descriptor_sptr>( ds.cbegin(), ds.cend() ) );
   cv::Mat recon_mat = ocv::descriptors_to_ocv_matrix(simp_ds);
   EXPECT_NE( data.data, recon_mat.data )
     << "Reconstructed matrix should point to new memory, not original";

--- a/arrows/vxl/match_features_constrained.cxx
+++ b/arrows/vxl/match_features_constrained.cxx
@@ -91,8 +91,8 @@ public:
     std::vector<rsdl_point> fixedpts;
     const std::vector<feature_sptr> &feat1_vec = feat1->features();
     const std::vector<feature_sptr> &feat2_vec = feat2->features();
-    const std::vector<descriptor_sptr> desc1_vec( desc1->begin(), desc1->end() );
-    const std::vector<descriptor_sptr> desc2_vec( desc2->begin(), desc2->end() );
+    const std::vector<descriptor_sptr> desc1_vec( desc1->cbegin(), desc1->cend() );
+    const std::vector<descriptor_sptr> desc2_vec( desc2->cbegin(), desc2->cend() );
 
     for (unsigned int i = 0; i < feat2_vec.size(); i++)
     {

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -41,6 +41,9 @@ Vital
  * Added ``kwiver::vital::set`` mixin class to define standard set methods as
    well as iterability.
 
+ * Added iterator, const_iterator and iterable classes to support container-
+   independent iteration.
+
 Vital Bindings
 
 Arrows: Core

--- a/sprokit/processes/core/compute_track_descriptors_process.cxx
+++ b/sprokit/processes/core/compute_track_descriptors_process.cxx
@@ -241,9 +241,11 @@ compute_track_descriptors_process
       if( d->inject_to_detections )
       {
         // Reset all descriptors stored in detections
-        for( vital::detected_object_sptr det : *detections )
+        auto dsib = detections->cbegin();
+        auto dsie = detections->cend();
+        for( auto det = dsib; det != dsie; ++det )
         {
-          det->set_descriptor( vital::detected_object::descriptor_sptr() );
+          (*det)->set_descriptor( vital::detected_object::descriptor_sptr() );
         }
 
         // Inject computed descriptors

--- a/vital/bindings/python/vital/types/detected_object_set.cxx
+++ b/vital/bindings/python/vital/types/detected_object_set.cxx
@@ -98,7 +98,7 @@ PYBIND11_MODULE(detected_object_set, m)
       return self.at(idx);
     })
 
-  .def("__iter__", [](det_obj_set &self) { return py::make_iterator(self.begin(), self.end()); },
+  .def("__iter__", [](det_obj_set &self) { return py::make_iterator(self.cbegin(), self.cend()); },
           py::keep_alive<0, 1>())
 
   .def("__nice__", [](det_obj_set& self) -> std::string {

--- a/vital/tests/test_image_container_set.cxx
+++ b/vital/tests/test_image_container_set.cxx
@@ -122,7 +122,7 @@ TEST( simple_image_container_set, expected_iteration )
 
   LOG_INFO( test_logger, "Testing iter pos 0" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[0] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 1 );
@@ -133,7 +133,7 @@ TEST( simple_image_container_set, expected_iteration )
   ++sic_it;
   LOG_INFO( test_logger, "Testing iter pos 1" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[1] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 2 );
@@ -144,7 +144,7 @@ TEST( simple_image_container_set, expected_iteration )
   ++sic_it;
   LOG_INFO( test_logger, "Testing iter pos 2" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[2] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 3 );
@@ -154,7 +154,7 @@ TEST( simple_image_container_set, expected_iteration )
   ++sic_it;
   LOG_INFO( test_logger, "Testing end pos" );
   EXPECT_EQ( vec_it, img_vec.end() );
-  EXPECT_EQ( sic_it, sics.end() );
+  EXPECT_EQ( sic_it, sics.cend() );
 }
 
 // ----------------------------------------------------------------------------
@@ -174,7 +174,7 @@ TEST( simple_image_container_set, expected_iteration_const )
 
   LOG_INFO( test_logger, "Testing iter pos 0" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[0] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 1 );
@@ -185,7 +185,7 @@ TEST( simple_image_container_set, expected_iteration_const )
   ++sic_it;
   LOG_INFO( test_logger, "Testing iter pos 1" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[1] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 2 );
@@ -196,7 +196,7 @@ TEST( simple_image_container_set, expected_iteration_const )
   ++sic_it;
   LOG_INFO( test_logger, "Testing iter pos 2" );
   EXPECT_NE( vec_it, img_vec.end() );
-  EXPECT_NE( sic_it, sics.end() );
+  EXPECT_NE( sic_it, sics.cend() );
   EXPECT_EQ( *sic_it, img_vec[2] );
   EXPECT_EQ( *sic_it, *vec_it );
   EXPECT_EQ( (*sic_it)->width(), 3 );
@@ -207,7 +207,7 @@ TEST( simple_image_container_set, expected_iteration_const )
   ++sic_it;
   LOG_INFO( test_logger, "Testing end pos" );
   EXPECT_EQ( vec_it, img_vec.end() );
-  EXPECT_EQ( sic_it, sics.end() );
+  EXPECT_EQ( sic_it, sics.cend() );
 }
 
 // ----------------------------------------------------------------------------
@@ -225,88 +225,88 @@ TEST( simple_image_container_set, multiple_iterators )
 
   EXPECT_EQ( *it1, img_vec[0] );
   EXPECT_EQ( (*it1)->width(), 1 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[0] );
   EXPECT_EQ( (*it2)->width(), 1 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   // Move one iterator forward two and the other just one.
   ++it1; ++it1;
   ++it2;
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   // Make new iterator, which should point to the beginning.
   simple_image_container_set::iterator it3 = sics.begin();
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[0] );
   EXPECT_EQ( (*it3)->width(), 1 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Only move the newest iterator forward one.
   ++it3;
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[1] );
   EXPECT_EQ( (*it3)->width(), 2 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Move it1 forward to end.
   ++it1;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[1] );
   EXPECT_EQ( (*it3)->width(), 2 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Move it3 to end.
   ++it3; ++it3;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it3, sics.cend() );
 
   // Move it2 forward one.
   ++it2;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[2] );
   EXPECT_EQ( (*it2)->width(), 3 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it3, sics.cend() );
 
   // Move it2 to end
   ++it2;
-  EXPECT_EQ( it1, sics.end() );
-  EXPECT_EQ( it2, sics.end() );
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
+  EXPECT_EQ( it2, sics.cend() );
+  EXPECT_EQ( it3, sics.cend() );
 }
 
 // ----------------------------------------------------------------------------
@@ -324,86 +324,86 @@ TEST( simple_image_container_set, multiple_iterators_const )
 
   EXPECT_EQ( *it1, img_vec[0] );
   EXPECT_EQ( (*it1)->width(), 1 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[0] );
   EXPECT_EQ( (*it2)->width(), 1 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   // Move one iterator forward two and the other just one.
   ++it1; ++it1;
   ++it2;
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   // Make new iterator, which should point to the beginning.
   simple_image_container_set::iterator it3 = sics.begin();
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[0] );
   EXPECT_EQ( (*it3)->width(), 1 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Only move the newest iterator forward one.
   ++it3;
   EXPECT_EQ( *it1, img_vec[2] );
   EXPECT_EQ( (*it1)->width(), 3 );
-  EXPECT_NE( it1, sics.end() );
+  EXPECT_NE( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[1] );
   EXPECT_EQ( (*it3)->width(), 2 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Move it1 forward to end.
   ++it1;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
   EXPECT_EQ( *it3, img_vec[1] );
   EXPECT_EQ( (*it3)->width(), 2 );
-  EXPECT_NE( it3, sics.end() );
+  EXPECT_NE( it3, sics.cend() );
 
   // Move it3 to end.
   ++it3; ++it3;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[1] );
   EXPECT_EQ( (*it2)->width(), 2 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it3, sics.cend() );
 
   // Move it2 forward one.
   ++it2;
-  EXPECT_EQ( it1, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
 
   EXPECT_EQ( *it2, img_vec[2] );
   EXPECT_EQ( (*it2)->width(), 3 );
-  EXPECT_NE( it2, sics.end() );
+  EXPECT_NE( it2, sics.cend() );
 
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it3, sics.cend() );
 
   // Move it2 to end
   ++it2;
-  EXPECT_EQ( it1, sics.end() );
-  EXPECT_EQ( it2, sics.end() );
-  EXPECT_EQ( it3, sics.end() );
+  EXPECT_EQ( it1, sics.cend() );
+  EXPECT_EQ( it2, sics.cend() );
+  EXPECT_EQ( it3, sics.cend() );
 }

--- a/vital/types/descriptor_request.h
+++ b/vital/types/descriptor_request.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2018 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This branch fixes the compiler errors in the dev/add-set-iteration branch. Admittedly, the change in compute_track_descriptors_process.cxx is not ideal but it does fix the issues. I am certainly open to a more correct fix if someone wants to investigate further.
