### PR TITLE
Created new GDAL image container

### DIFF
--- a/arrows/gdal/CMakeLists.txt
+++ b/arrows/gdal/CMakeLists.txt
@@ -2,6 +2,7 @@
 # structures
 
 set( gdal_headers_public
+  image_container.h
   image_io.h
   )
 
@@ -16,6 +17,7 @@ kwiver_install_headers(
   )
 
 set( gdal_sources
+  image_container.cxx
   image_io.cxx
   )
 

--- a/arrows/gdal/image_container.cxx
+++ b/arrows/gdal/image_container.cxx
@@ -1,0 +1,245 @@
+/*ckwg +29
+ * Copyright 2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief GDAL image_container implementation
+ */
+
+#include "image_container.h"
+
+#include <vital/exceptions/io.h>
+#include <vital/types/metadata_traits.h>
+
+using namespace kwiver::vital;
+
+namespace kwiver {
+namespace arrows {
+namespace gdal {
+
+// ----------------------------------------------------------------------------
+void add_rpc_metadata(char* raw_md, vital::metadata_sptr md)
+{
+  std::istringstream md_string(raw_md);
+
+  // Get the key
+  std::string key;
+  if ( !std::getline( md_string, key, '=') )
+  {
+    return;
+  }
+
+  // Get the value
+  std::string value;
+  if ( !std::getline( md_string, value, '=') )
+  {
+    return;
+  }
+
+#define MAP_METADATA_SCALAR( GN, KN )                       \
+if ( key == #GN)                                            \
+{                                                           \
+  md->add( NEW_METADATA_ITEM(                               \
+    vital::VITAL_META_RPC_ ## KN, std::stod( value ) ) ) ;  \
+}                                                           \
+
+#define MAP_METADATA_COEFF( GN, KN )          \
+if ( key == #GN)                              \
+{                                             \
+  md->add( NEW_METADATA_ITEM(                 \
+    vital::VITAL_META_RPC_ ## KN, value ) );  \
+}                                             \
+
+  MAP_METADATA_SCALAR( HEIGHT_OFF,   HEIGHT_OFFSET )
+  MAP_METADATA_SCALAR( HEIGHT_SCALE, HEIGHT_SCALE )
+  MAP_METADATA_SCALAR( LONG_OFF,     LONG_OFFSET )
+  MAP_METADATA_SCALAR( LONG_SCALE,   LONG_SCALE )
+  MAP_METADATA_SCALAR( LAT_OFF,      LAT_OFFSET )
+  MAP_METADATA_SCALAR( LAT_SCALE,    LAT_SCALE )
+  MAP_METADATA_SCALAR( LINE_OFF,     ROW_OFFSET )
+  MAP_METADATA_SCALAR( LINE_SCALE,   ROW_SCALE )
+  MAP_METADATA_SCALAR( SAMP_OFF,     COL_OFFSET )
+  MAP_METADATA_SCALAR( SAMP_SCALE,   COL_SCALE )
+
+  MAP_METADATA_COEFF( LINE_NUM_COEFF, ROW_NUM_COEFF )
+  MAP_METADATA_COEFF( LINE_DEN_COEFF, ROW_DEN_COEFF )
+  MAP_METADATA_COEFF( SAMP_NUM_COEFF, COL_NUM_COEFF )
+  MAP_METADATA_COEFF( SAMP_DEN_COEFF, COL_DEN_COEFF )
+
+#undef MAP_METADATA_SCALAR
+#undef MAP_METADATA_COEFF
+}
+
+vital::polygon::point_t apply_geo_transform(double gt[], double x, double y)
+{
+  vital::polygon::point_t retVal;
+  retVal[0] = gt[0] + gt[1]*x + gt[2]*y;
+  retVal[1] = gt[3] + gt[4]*x + gt[5]*y;
+  return retVal;
+}
+
+// ----------------------------------------------------------------------------
+image_container
+::image_container(const std::string& filename)
+{
+  GDALAllRegister();
+
+  gdal_dataset_.reset(
+    static_cast<GDALDataset*>(GDALOpen( filename.c_str(), GA_ReadOnly ) ) );
+
+  if ( !gdal_dataset_ )
+  {
+    VITAL_THROW( vital::invalid_file, filename, "GDAL could not load file.");
+  }
+
+  // Get image pixel traits based on the GDAL raster type.
+  // TODO: deal or provide warning if bands have different types.
+  auto bandType = gdal_dataset_->GetRasterBand(1)->GetRasterDataType();
+  switch (bandType)
+  {
+    case (GDT_Byte):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<uint8_t>();
+      break;
+    }
+    case (GDT_UInt16):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<uint16_t>();
+      break;
+    }
+    case (GDT_Int16):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<int16_t>();
+      break;
+    }
+    case (GDT_UInt32):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<uint32_t>();
+      break;
+    }
+    case (GDT_Int32):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<int32_t>();
+      break;
+    }
+    case (GDT_Float32):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<float>();
+      break;
+    }
+    case (GDT_Float64):
+    {
+      pixel_traits_ = vital::image_pixel_traits_of<double>();
+      break;
+    }
+    default:
+    {
+      std::stringstream ss;
+      ss << "kwiver::arrows::gdal::image_io::load(): "
+         << "Unknown or unsupported pixal type: "
+         << GDALGetDataTypeName(bandType);
+      VITAL_THROW( vital::image_type_mismatch_exception, ss.str() );
+      break;
+    }
+  }
+
+  vital::metadata_sptr md = std::make_shared<vital::metadata>();
+
+  md->add( NEW_METADATA_ITEM(
+    kwiver::vital::VITAL_META_IMAGE_URI, filename ) );
+
+  // Get geotransform and calculate corner points
+  double geo_transform[6];
+  gdal_dataset_->GetGeoTransform(geo_transform);
+
+  OGRSpatialReference osrs;
+  osrs.importFromWkt( gdal_dataset_->GetProjectionRef() );
+
+  // If coordinate system available - calculate corner points.
+  if ( osrs.GetAuthorityCode("GEOGCS") )
+  {
+    vital::polygon points;
+    points.push_back( apply_geo_transform(geo_transform, 0, 0) );
+    points.push_back( apply_geo_transform(geo_transform, 0, height() ) );
+    points.push_back( apply_geo_transform(geo_transform, width(), 0) );
+    points.push_back( apply_geo_transform(geo_transform, width(), height() ) );
+
+    md->add( NEW_METADATA_ITEM( vital::VITAL_META_CORNER_POINTS,
+      vital::geo_polygon( points, atoi( osrs.GetAuthorityCode("GEOGCS") ) ) ) );
+  }
+
+  // Get RPC metadata
+  char** rpc_metadata = gdal_dataset_->GetMetadata("RPC");
+  if (CSLCount(rpc_metadata) > 0)
+  {
+    for (int i = 0; rpc_metadata[i] != NULL; ++i)
+    {
+      add_rpc_metadata( rpc_metadata[i] , md );
+    }
+  }
+
+  this->set_metadata( md );
+}
+
+// ----------------------------------------------------------------------------
+/// The size of the image data in bytes
+size_t
+image_container
+::size() const
+{
+  return width() * height() * depth() * pixel_traits_.num_bytes;
+}
+
+// ----------------------------------------------------------------------------
+/// Return a vital image. Unlike other image container must allocate memory.
+vital::image
+image_container
+::get_image() const
+{
+  vital::image img( width(), height(), depth(), false, pixel_traits_ );
+
+  // Loop over bands and copy data
+  CPLErr err;
+  for (int i = 1; i <= depth(); ++i)
+  {
+    GDALRasterBand* band = gdal_dataset_->GetRasterBand(i);
+    auto bandType = band->GetRasterDataType();
+    err = band->RasterIO(GF_Read, 0, 0, width(), height(),
+      static_cast<void*>(reinterpret_cast<GByte*>(
+        img.first_pixel()) + (i-1)*img.d_step()*img.pixel_traits().num_bytes),
+      width(), height(), bandType, 0, 0);
+  }
+
+  return img;
+}
+
+} // end namespace gdal
+} // end namespace arrows
+} // end namespace kwiver

--- a/arrows/gdal/image_container.h
+++ b/arrows/gdal/image_container.h
@@ -30,54 +30,61 @@
 
 /**
  * \file
- * \brief GDAL image_io implementation
+ * \brief GDAL image_container inteface
  */
 
-#include "image_io.h"
+#ifndef KWIVER_ARROWS_GDAL_IMAGE_CONTAINER_H_
+#define KWIVER_ARROWS_GDAL_IMAGE_CONTAINER_H_
 
-#include <arrows/gdal/image_container.h>
 
-#include <vital/exceptions/algorithm.h>
-// #include <vital/exceptions/io.h>
-// #include <vital/types/metadata.h>
-// #include <vital/types/metadata_traits.h>
+#include <vital/vital_config.h>
+#include <arrows/gdal/kwiver_algo_gdal_export.h>
 
-// #include <gdal_priv.h>
-// #include <ogr_spatialref.h>
+#include <vital/types/image_container.h>
 
-//#include <sstream>
+#include <gdal_priv.h>
 
 namespace kwiver {
 namespace arrows {
 namespace gdal {
 
-/// Load image image from the file
-/**
- * \param filename the path to the file the load
- * \returns an image container refering to the loaded image
- */
-vital::image_container_sptr
-image_io
-::load_(const std::string& filename) const
+/// This image container wraps a cv::Mat
+class KWIVER_ALGO_GDAL_EXPORT image_container
+  : public vital::image_container
 {
-  return vital::image_container_sptr( new gdal::image_container( filename ) );
-}
+public:
 
+  /// Constructor - from file
+  explicit image_container(const std::string& filename);
 
-/// Save image image to a file
-/**
- * \param filename the path to the file to save.
- * \param data The image container refering to the image to write.
- */
-void
-image_io
-::save_(const std::string& filename,
-       vital::image_container_sptr data) const
-{
-  VITAL_THROW( vital::algorithm_exception, this->type_name(), this->impl_name(),
-               "Saving to file not supported." );
-}
+  /// The size of the image data in bytes
+  /**
+   * This size includes all allocated image memory,
+   * which could be larger than width*height*depth.
+   */
+  virtual size_t size() const;
+
+  /// The width of the image in pixels
+  virtual size_t width() const { return gdal_dataset_->GetRasterXSize(); }
+
+  /// The height of the image in pixels
+  virtual size_t height() const { return gdal_dataset_->GetRasterYSize(); }
+
+  /// The depth (or number of channels) of the image
+  virtual size_t depth() const { return gdal_dataset_->GetRasterCount(); }
+
+  /// Get image. Unlike other image container must allocate memory
+  virtual vital::image get_image() const;
+
+protected:
+
+  std::shared_ptr<GDALDataset> gdal_dataset_;
+  vital::image_pixel_traits pixel_traits_;
+};
+
 
 } // end namespace gdal
 } // end namespace arrows
 } // end namespace kwiver
+
+#endif // KWIVER_ARROWS_GDAL_IMAGE_CONTAINER_H_

--- a/arrows/gdal/image_io.cxx
+++ b/arrows/gdal/image_io.cxx
@@ -38,14 +38,6 @@
 #include <arrows/gdal/image_container.h>
 
 #include <vital/exceptions/algorithm.h>
-// #include <vital/exceptions/io.h>
-// #include <vital/types/metadata.h>
-// #include <vital/types/metadata_traits.h>
-
-// #include <gdal_priv.h>
-// #include <ogr_spatialref.h>
-
-//#include <sstream>
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/gdal/image_io.h
+++ b/arrows/gdal/image_io.h
@@ -49,12 +49,6 @@ class KWIVER_ALGO_GDAL_EXPORT image_io
   : public vital::algorithm_impl<image_io, vital::algo::image_io>
 {
 public:
-  /// Constructor
-  image_io();
-
-  /// Destructor
-  virtual ~image_io();
-
   // No configuration for this class yet
   /// \cond DoxygenSuppress
   virtual void set_configuration(vital::config_block_sptr /*config*/) { }


### PR DESCRIPTION
Reworked the GDAL arrow so there is a GDAL specific image container that holds and manages the GDAL data set rather copying the data to a vital image right away. This will make it more memory efficient when the sub image accessor is put in place.