### PR TITLE
Alter the order of types based on dependencies across types

### DIFF
--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -172,19 +172,19 @@ kwiver_create_python_init(vital/types
   covariance
   descriptor
   descriptor_set
+  image
+  image_container
   detected_object_type
   detected_object
   detected_object_set
   eigen
   feature
   homography
-  image
-  image_container
   landmark
-  object_track_set
   rotation
   similarity
   timestamp
   track
   track_set
+  object_track_set
 )


### PR DESCRIPTION
detected_object  uses image based mask thus the image and image container must be registered before detected_object. Same reasoning for track_object_set coming after track and track_state.

