### PR TITLE
Document average_track_descriptor's config parameters

### DIFF
--- a/arrows/core/average_track_descriptors.cxx
+++ b/arrows/core/average_track_descriptors.cxx
@@ -76,6 +76,27 @@ average_track_descriptors
 
 
 // ----------------------------------------------------------------------------------
+vital::config_block_sptr
+average_track_descriptors
+::get_configuration() const
+{
+  // Get base config from base class
+  vital::config_block_sptr config = vital::algorithm::get_configuration();
+
+  config->set_value( "rolling", d->m_rolling,
+    "When set, produce an output for each input as the rolling average"
+    " of the last N descriptors, where N is the interval.  When reset,"
+    " produce an output only for the first input and then every Nth input"
+    " thereafter for any given track." );
+  config->set_value( "interval", d->m_interval,
+    "When the interval is N, every descriptor output (after the first N inputs)"
+    " is based on the last N descriptors seen as input for the given track." );
+
+  return config;
+}
+
+
+// ----------------------------------------------------------------------------------
 void
 average_track_descriptors
 ::set_configuration( vital::config_block_sptr config )

--- a/arrows/core/average_track_descriptors.h
+++ b/arrows/core/average_track_descriptors.h
@@ -54,6 +54,7 @@ public:
   average_track_descriptors();
   virtual ~average_track_descriptors();
 
+  virtual vital::config_block_sptr get_configuration() const;
   virtual void set_configuration( vital::config_block_sptr config );
   virtual bool check_configuration( vital::config_block_sptr config ) const;
 


### PR DESCRIPTION
This PR addresses the concern voiced here (https://github.com/Kitware/kwiver/pull/648#issuecomment-448295657) that the configuration parameters for `average_track_descriptors` are undocumented.

I haven't tested this or finished building it, but with the project I'm on for this winding down, I thought I'd at least push the code up and create this PR.