### PR TITLE
Merge pull request #693 from Kitware/dev/fix-vital-python-init

### DIFF
--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -172,14 +172,14 @@ kwiver_create_python_init(vital/types
   covariance
   descriptor
   descriptor_set
+  image
+  image_container
   detected_object_type
   detected_object
   detected_object_set
   eigen
   feature
   homography
-  image
-  image_container
   landmark
   rotation
   similarity


### PR DESCRIPTION
Alter the order of types based on dependencies across types