### PR TITLE
Fix failing process test.

### DIFF
--- a/sprokit/processes/core/merge_images_process.cxx
+++ b/sprokit/processes/core/merge_images_process.cxx
@@ -165,9 +165,9 @@ merge_images_process::priv
 {
 }
 
-sprokit::process::port_info_t
+void
 merge_images_process
-::_input_port_info(port_t const& port_name)
+::input_port_undefined(port_t const& port_name)
 {
   LOG_TRACE( logger(), "Processing input port info: \"" << port_name << "\"" );
 
@@ -190,9 +190,6 @@ merge_images_process
       d->p_port_list.insert( port_name );
     }
   }
-
-  // call base class implementation
-  return process::_input_port_info( port_name );
 }
 
 

--- a/sprokit/processes/core/merge_images_process.h
+++ b/sprokit/processes/core/merge_images_process.h
@@ -61,9 +61,9 @@ class KWIVER_PROCESSES_NO_EXPORT merge_images_process
     virtual ~merge_images_process();
 
   protected:
-    virtual void _configure();
-    virtual void _step();
-    virtual sprokit::process::port_info_t _input_port_info(port_t const& port);
+    virtual void _configure() override;
+    virtual void _step() override;
+    virtual void input_port_undefined(port_t const& port) override;
 
   private:
     void make_ports();
@@ -75,4 +75,3 @@ class KWIVER_PROCESSES_NO_EXPORT merge_images_process
 
 
 } // end namespace
-

--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -276,10 +276,11 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   fact = vpm.ADD_PROCESS( kwiver::merge_images_process );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "merge_images" )
-      .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-      .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                      "Merge two images into one." )
-      .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                      "Merge multiple images into one." )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
+    .add_attribute( "no-test", "introspect" ); // do not include in introspection test
       ;
 
   fact = vpm.ADD_PROCESS( kwiver::read_track_descriptor_process );


### PR DESCRIPTION
One process was failing the process introspection test.
Updated the dynamic port approach to sue the new API.
Also marked that process as not testable in introspection test.