### PR TITLE
Fix include directive bug

### DIFF
--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -354,56 +354,10 @@ get_next_token()
   if ( m_priv->m_cur_char == m_priv->m_input_line.end() )
   {
     // get new line
-    while ( ! m_priv->get_line() )
+    if ( ! get_next_line() )
     {
-      // EOF encountered
-      m_priv->m_include_stack.pop_back();
-
-      // check for the real end of input
-      if ( m_priv->m_include_stack.empty() )
-      {
-        // return EOF token
-        return std::make_shared< token > ( TK_EOF, "E-O-F" );
-      }
-    } // end while
-
-    // get new line could check for "include" keyword and handle that operation.
-    // Check for include directive - starts with "include " or "!include"
-    if ( *m_priv->m_cur_char == '!' )
-    {
-      m_priv->m_cur_char++;
-    }
-
-    if ( kwiver::vital::starts_with(std::string (m_priv->m_cur_char, m_priv->m_input_line.end() ),
-                                    "include " ) )
-    {
-      // process include directive
-      m_priv->m_cur_char += 8;
-
-      std::string file_name( m_priv->m_cur_char, m_priv->m_input_line.end() );
-      kwiver::vital::string_trim( file_name );
-
-      // Perform macro substitutions first
-      file_name = m_priv->m_token_expander.expand_token( file_name );
-
-      kwiver::vital::config_path_t resolv_filename = m_priv->resolve_file_name( file_name );
-      if ( "" == resolv_filename ) // could not resolve
-      {
-        std::ostringstream sstr;
-        sstr << file_name << " included from " << current_location()
-             << " could not be found in search path.";
-
-        VITAL_THROW( sprokit::file_no_exist_exception, sstr.str() );
-      }
-
-      LOG_TRACE( m_logger, "Including file: \"" << resolv_filename << "\"" );
-      m_priv->flush_line();
-
-      // Push the current location onto the include stack
-      m_priv->m_include_stack.push_back( std::make_shared< include_context >( resolv_filename ) );
-
-      // Get first line from included file.
-      m_priv->get_line();
+      // return EOF token
+      return std::make_shared< token > ( TK_EOF, "E-O-F" );
     }
 
     if ( ! m_priv->m_absorb_eol )
@@ -529,6 +483,74 @@ get_next_token()
   // Although, including empty files will get us here.
   return get_next_token();
 } // lex_processor::get_next_token
+
+
+// ----------------------------------------------------------------------------
+bool
+lex_processor::
+get_next_line()
+{
+  // get new line
+  while ( !m_priv->get_line() )
+  {
+    // EOF encountered
+    LOG_TRACE( m_logger, "End of file on \""
+               << m_priv->m_include_stack.back()->file()
+               << "\"" );
+    m_priv->m_include_stack.pop_back();
+
+    // check for the real end of input
+    if ( m_priv->m_include_stack.empty() )
+    {
+      // return EOF
+      return false;
+    }
+  }   // end while
+
+  // get new line could check for "include" keyword and handle that operation.
+  // Check for include directive - starts with "include " or "!include"
+  if ( *m_priv->m_cur_char == '!' )
+  {
+    m_priv->m_cur_char++;
+  }
+
+  if ( kwiver::vital::starts_with( std::string( m_priv->m_cur_char,
+                                                   m_priv->m_input_line.end() ),
+                                      "include " ) )
+  {
+    // process include directive
+    m_priv->m_cur_char += 8;
+
+    std::string file_name( m_priv->m_cur_char, m_priv->m_input_line.end() );
+    kwiver::vital::string_trim( file_name );
+
+    // Perform macro substitutions first
+    file_name = m_priv->m_token_expander.expand_token( file_name );
+
+    kwiver::vital::config_path_t resolv_filename = m_priv->resolve_file_name(
+      file_name );
+    if ( "" == resolv_filename )   // could not resolve
+    {
+      std::ostringstream sstr;
+      sstr << file_name << " included from " << current_location() <<
+        " could not be found in search path.";
+
+      VITAL_THROW( sprokit::file_no_exist_exception, sstr.str() );
+    }
+
+    LOG_TRACE( m_logger, "Including file: \"" << resolv_filename << "\"" );
+    m_priv->flush_line();
+
+    // Push the current location onto the include stack
+    m_priv->m_include_stack.push_back( std::make_shared< include_context >(
+                                         resolv_filename ) );
+
+    // Get first line from included file.
+    return get_next_line();
+  } // end include
+
+  return true;
+}
 
 
 // ------------------------------------------------------------------
@@ -660,6 +682,7 @@ get_line()
 
   if ( status )
   {
+    kwiver::vital::string_trim( m_input_line );
     m_cur_char = m_input_line.begin();
   }
   return status;

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.h
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -193,6 +193,7 @@ public:
 
 private:
   token_sptr get_next_token();
+  bool get_next_line();
 
   kwiver::vital::logger_handle_t m_logger;
   kwiver::vital::config_path_t m_config_file;


### PR DESCRIPTION
When an include directive was handled, the first line in the included file was not processed. The "include" keyword was still in the current token and as passed to the parser. The first line in the include file needs to be processed when an include directive is encountered.

This addresses issue #708 