### PR TITLE
Add CMAKE_BINARY_DIR to BUILD_INTERFACE include directories

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -196,7 +196,7 @@ function(kwiver_add_library     name)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}${library_subdir_suffix}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin${library_subdir}${library_subdir_suffix}"
     INSTALL_RPATH            "\$ORIGIN/../lib:\$ORIGIN/"
-    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"
+    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR};${CMAKE_BINARY_DIR}>$<INSTALL_INTERFACE:include>"
     ${props}
     )
 


### PR DESCRIPTION
This is a follow-up to my previous change to INTERFACE_INCLUDE_DIRECTORIES - it now works from in the build directory as well as the install directory.