### PR TITLE
Promote version.h to vital

### DIFF
--- a/CMake/tools/kwiver-configure-git-helper.cmake
+++ b/CMake/tools/kwiver-configure-git-helper.cmake
@@ -1,0 +1,71 @@
+#
+# Take in a number of arguments and special arguments ``__OUTPUT_PATH__``,
+# ``__SOURCE_PATH__`` and ``__TEMP_PATH__``
+#
+
+message(STATUS "Source Path       : '${__SOURCE_PATH__}'")
+message(STATUS "Intermediate Path : '${__TEMP_PATH__}'")
+message(STATUS "Output Path       : '${__OUTPUT_PATH__}'")
+message(STATUS "Project: '${KWIVER_SOURCE_DIR}'")
+
+if(NOT EXISTS "${__SOURCE_PATH__}")
+  message(FATAL_ERROR "Source file for configuration did not exist! -> ${__SOURCE_PATH__}")
+endif()
+
+find_package(Git)
+if (Git_FOUND AND IS_DIRECTORY "${KWIVER_SOURCE_DIR}/.git")
+  set(KWIVER_BUILT_FROM_GIT TRUE)
+
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}"
+                      rev-parse
+                      HEAD
+    WORKING_DIRECTORY "${KWIVER_SOURCE_DIR}"
+    RESULT_VARIABLE   git_return
+    OUTPUT_VARIABLE   kwiver_git_hash)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}"
+                      rev-parse
+                      --short
+                      HEAD
+    WORKING_DIRECTORY "${KWIVER_SOURCE_DIR}"
+    RESULT_VARIABLE   git_return
+    OUTPUT_VARIABLE   kwiver_git_hash_short)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}"
+                      diff
+                      --no-ext-diff
+                      --quiet
+                      --exit-code
+    WORKING_DIRECTORY "${KWIVER_SOURCE_DIR}"
+    RESULT_VARIABLE   git_return)
+
+  string(STRIP "${kwiver_git_hash}" kwiver_git_hash)
+  string(STRIP "${kwiver_git_hash_short}" kwiver_git_hash_short)
+
+  if (git_return)
+    set(kwiver_git_dirty "dirty")
+  endif ()
+
+  message(STATUS "version: ${KWIVER_VERSION}")
+  message(STATUS "git hash: ${kwiver_git_hash}")
+  message(STATUS "git short hash: ${kwiver_git_hash_short}")
+  message(STATUS "git dirty: ${kwiver_git_dirty}")
+endif ()
+
+# There are TWO configures here on purpose. The second configure containing
+# the COPYONLY flag, only copies the file if the source and dest file are
+# different (equivalent to ``cmake -E copy_if_different``). This helps prevent
+# files from be touched during a forced configuration when none of the
+# contained information changed (prevents rebuilding of dependant targets).
+configure_file(
+  "${__SOURCE_PATH__}"
+  "${__TEMP_PATH__}"
+  @ONLY
+  )
+configure_file(
+  "${__TEMP_PATH__}"
+  "${__OUTPUT_PATH__}"
+  COPYONLY
+  )
+

--- a/CMake/tools/kwiver-configure-git-helper.cmake
+++ b/CMake/tools/kwiver-configure-git-helper.cmake
@@ -6,7 +6,7 @@
 message(STATUS "Source Path       : '${__SOURCE_PATH__}'")
 message(STATUS "Intermediate Path : '${__TEMP_PATH__}'")
 message(STATUS "Output Path       : '${__OUTPUT_PATH__}'")
-message(STATUS "Project: '${KWIVER_SOURCE_DIR}'")
+message(STATUS "Project Root      : '${KWIVER_SOURCE_DIR}'")
 
 if(NOT EXISTS "${__SOURCE_PATH__}")
   message(FATAL_ERROR "Source file for configuration did not exist! -> ${__SOURCE_PATH__}")

--- a/CMake/utils/kwiver-utils-configuration.cmake
+++ b/CMake/utils/kwiver-utils-configuration.cmake
@@ -48,6 +48,12 @@ function(kwiver_configure_file name source dest)
       )
   endforeach()
   set(temp_file "${CMAKE_CURRENT_BINARY_DIR}/configure.${name}.output")
+
+  set(KWIVER_CONFIG_HELPER "kwiver-configure-helper.cmake")
+  if(kwiver_configure_with_git)
+    set(KWIVER_CONFIG_HELPER "kwiver-configure-git-helper.cmake")
+  endif()
+
   add_custom_command(
     OUTPUT  "${dest}"
     COMMAND "${CMAKE_COMMAND}"
@@ -55,7 +61,7 @@ function(kwiver_configure_file name source dest)
             "-D__SOURCE_PATH__:PATH=${source}"
             "-D__TEMP_PATH__:PATH=${temp_file}"
             "-D__OUTPUT_PATH__:PATH=${dest}"
-            -P "${KWIVER_CMAKE_ROOT}/tools/kwiver-configure-helper.cmake"
+            -P "${KWIVER_CMAKE_ROOT}/tools/${KWIVER_CONFIG_HELPER}"
     DEPENDS
             "${source}" ${mcf_DEPENDS}
     WORKING_DIRECTORY

--- a/CMake/utils/kwiver-utils-configuration.cmake
+++ b/CMake/utils/kwiver-utils-configuration.cmake
@@ -52,6 +52,10 @@ function(kwiver_configure_file name source dest)
   set(KWIVER_CONFIG_HELPER "kwiver-configure-helper.cmake")
   if(kwiver_configure_with_git)
     set(KWIVER_CONFIG_HELPER "kwiver-configure-git-helper.cmake")
+    # touch the source file to force this configuration to always run
+    # this is needed so that Git will run and detect repository state
+    # changes
+    file(TOUCH ${source})
   endif()
 
   add_custom_command(

--- a/CMake/utils/kwiver-utils-configuration.cmake
+++ b/CMake/utils/kwiver-utils-configuration.cmake
@@ -52,10 +52,12 @@ function(kwiver_configure_file name source dest)
   set(KWIVER_CONFIG_HELPER "kwiver-configure-helper.cmake")
   if(kwiver_configure_with_git)
     set(KWIVER_CONFIG_HELPER "kwiver-configure-git-helper.cmake")
-    # touch the source file to force this configuration to always run
+    # touch this status file to force the configuration to always run
     # this is needed so that Git will run and detect repository state
     # changes
-    file(TOUCH ${source})
+    set(stat_file "${CMAKE_CURRENT_BINARY_DIR}/configure.${name}.stat")
+    file(WRITE "${stat_file}"
+         "This file is touched to force ${name} to configure.")
   endif()
 
   add_custom_command(
@@ -67,7 +69,7 @@ function(kwiver_configure_file name source dest)
             "-D__OUTPUT_PATH__:PATH=${dest}"
             -P "${KWIVER_CMAKE_ROOT}/tools/${KWIVER_CONFIG_HELPER}"
     DEPENDS
-            "${source}" ${mcf_DEPENDS}
+            "${source}" ${mcf_DEPENDS} ${stat_file}
     WORKING_DIRECTORY
             "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "Configuring ${name} file \"${source}\" -> \"${dest}\""

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -24,6 +24,8 @@ Vital
    header. Added new plugin registrar class framework to simplify the
    registration process.
 
+ * Promoted version.h from sprokit to vital for use across all of KWIVER.
+
 Vital Tools
 
  * Converted tools to use applet plugin approach.

--- a/sprokit/src/bindings/python/sprokit/pipeline/version.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/version.cxx
@@ -32,7 +32,7 @@
 
 #include <sprokit/pipeline/version.h>
 
-#include <sprokit/version.h>
+#include <vital/version.h>
 
 
 /**
@@ -60,19 +60,19 @@ class compile
     static bool check(version_t major_, version_t minor_, version_t patch_);
 };
 
-sprokit::version::version_t const compile::major = SPROKIT_VERSION_MAJOR;
-sprokit::version::version_t const compile::minor = SPROKIT_VERSION_MINOR;
-sprokit::version::version_t const compile::patch = SPROKIT_VERSION_PATCH;
-std::string const compile::version_string = SPROKIT_VERSION;
+sprokit::version::version_t const compile::major = KWIVER_VERSION_MAJOR;
+sprokit::version::version_t const compile::minor = KWIVER_VERSION_MINOR;
+sprokit::version::version_t const compile::patch = KWIVER_VERSION_PATCH;
+std::string const compile::version_string = KWIVER_VERSION;
 bool const compile::git_build =
-#ifdef SPROKIT_BUILT_FROM_GIT
+#ifdef KWIVER_BUILT_FROM_GIT
       true;
 #else
       false;
 #endif
-std::string const compile::git_hash = SPROKIT_GIT_HASH;
-std::string const compile::git_hash_short = SPROKIT_GIT_HASH_SHORT;
-std::string const compile::git_dirty = SPROKIT_GIT_DIRTY;
+std::string const compile::git_hash = KWIVER_GIT_HASH;
+std::string const compile::git_hash_short = KWIVER_GIT_HASH_SHORT;
+std::string const compile::git_dirty = KWIVER_GIT_DIRTY;
 
 class runtime
 {
@@ -122,7 +122,7 @@ bool
 compile
 ::check(version_t major_, version_t minor_, version_t patch_)
 {
-  return SPROKIT_VERSION_CHECK(major_, minor_, patch_);
+  return KWIVER_VERSION_CHECK(major_, minor_, patch_);
 }
 
 #ifdef __GNUC__

--- a/sprokit/src/sprokit/CMakeLists.txt
+++ b/sprokit/src/sprokit/CMakeLists.txt
@@ -1,79 +1,6 @@
 #
 #
 #
-
-set(SPROKIT_BUILT_FROM_GIT)
-
-if ("$Format:$" STREQUAL "")
-  set(sprokit_git_hash       "$Format:%H$")
-  set(sprokit_git_hash_short "$Format:%h$")
-
-  option(SPROKIT_IS_PATCHED "Set to ON if patches are applied on top of a released tarball" OFF)
-  if (SPROKIT_IS_PATCHED)
-    set(sprokit_git_dirty "dirty")
-  endif ()
-elseif (GIT_FOUND)
-  set(configure_code "
-if (IS_DIRECTORY \"${sprokit_source_dir}/.git\")
-  set(SPROKIT_BUILT_FROM_GIT TRUE)
-
-  execute_process(
-    COMMAND           \"${GIT_EXECUTABLE}\"
-                      rev-parse
-                      HEAD
-    WORKING_DIRECTORY \"${sprokit_source_dir}\"
-    RESULT_VARIABLE   git_return
-    OUTPUT_VARIABLE   sprokit_git_hash)
-  execute_process(
-    COMMAND           \"${GIT_EXECUTABLE}\"
-                      rev-parse
-                      --short
-                      HEAD
-    WORKING_DIRECTORY \"${sprokit_source_dir}\"
-    RESULT_VARIABLE   git_return
-    OUTPUT_VARIABLE   sprokit_git_hash_short)
-  execute_process(
-    COMMAND           \"${GIT_EXECUTABLE}\"
-                      diff
-                      --no-ext-diff
-                      --quiet
-                      --exit-code
-    WORKING_DIRECTORY \"${sprokit_source_dir}\"
-    RESULT_VARIABLE   git_return)
-
-  string(STRIP \"\${sprokit_git_hash}\" sprokit_git_hash)
-  string(STRIP \"\${sprokit_git_hash_short}\" sprokit_git_hash_short)
-
-  if (git_return)
-    set(sprokit_git_dirty \"dirty\")
-  endif ()
-
-  message(STATUS \"version: \${sprokit_version}\")
-  message(STATUS \"git hash: \${sprokit_git_hash}\")
-  message(STATUS \"git short hash: \${sprokit_git_hash_short}\")
-  message(STATUS \"git dirty: \${sprokit_git_dirty}\")
-endif ()
-")
-else ()
-  set(sprokit_git_hash       "<unknown>")
-  set(sprokit_git_hash_short "<unknown>")
-  set(sprokit_git_dirty      "<unknown>")
-endif ()
-
-sprokit_configure_file_always(version.h
-  "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/version.h"
-  KWIVER_VERSION_MAJOR
-  KWIVER_VERSION_MINOR
-  KWIVER_VERSION_PATCH
-  KWIVER_VERSION
-  SPROKIT_BUILT_FROM_GIT
-  sprokit_git_hash
-  sprokit_git_hash_short
-  sprokit_git_dirty)
-
-set(configure_code)
-
 if (KWIVER_ENABLE_PYTHON)
   add_subdirectory(python)
 endif ()
@@ -81,8 +8,3 @@ endif ()
 add_subdirectory(pipeline)
 add_subdirectory(pipeline_util)
 add_subdirectory(tools)
-
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/version.h"
-  DESTINATION include/sprokit
-  COMPONENT   development)

--- a/sprokit/src/sprokit/pipeline/version.cxx
+++ b/sprokit/src/sprokit/pipeline/version.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
 
 #include "version.h"
 
-#include <sprokit/version.h>
+#include <vital/version.h>
 
 /**
  * \file version.cxx
@@ -41,21 +41,21 @@
 namespace sprokit
 {
 
-version::version_t const version::major = SPROKIT_VERSION_MAJOR;
-version::version_t const version::minor = SPROKIT_VERSION_MINOR;
-version::version_t const version::patch = SPROKIT_VERSION_PATCH;
-std::string const version::version_string = SPROKIT_VERSION;
+version::version_t const version::major = KWIVER_VERSION_MAJOR;
+version::version_t const version::minor = KWIVER_VERSION_MINOR;
+version::version_t const version::patch = KWIVER_VERSION_PATCH;
+std::string const version::version_string = KWIVER_VERSION;
 
 bool const version::git_build =
-#ifdef SPROKIT_BUILT_FROM_GIT
+#ifdef KWIVER_BUILT_FROM_GIT
   true
 #else
   false
 #endif
   ;
-std::string const version::git_hash = SPROKIT_GIT_HASH;
-std::string const version::git_hash_short = SPROKIT_GIT_HASH_SHORT;
-std::string const version::git_dirty = SPROKIT_GIT_DIRTY;
+std::string const version::git_hash = KWIVER_GIT_HASH;
+std::string const version::git_hash_short = KWIVER_GIT_HASH_SHORT;
+std::string const version::git_dirty = KWIVER_GIT_DIRTY;
 
 // If any of the version components are 0, we get compare warnings. Turn
 // them off here.
@@ -68,7 +68,7 @@ bool
 version
 ::check(version_t major_, version_t minor_, version_t patch_)
 {
-  return SPROKIT_VERSION_CHECK(major_, minor_, patch_);
+  return KWIVER_VERSION_CHECK(major_, minor_, patch_);
 }
 
 #ifdef __GNUC__

--- a/sprokit/src/sprokit/tools/tool_usage.cxx
+++ b/sprokit/src/sprokit/tools/tool_usage.cxx
@@ -31,7 +31,7 @@
 #include "tool_usage.h"
 #include "tool_io.h"
 
-#include <sprokit/version.h>
+#include <vital/version.h>
 
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/value_semantic.hpp>
@@ -56,18 +56,18 @@ tool_usage(int ret, boost::program_options::options_description const& options)
 void
 tool_version_message()
 {
-  std::cout << "sprokit " SPROKIT_VERSION_FULL << std::endl;
-  std::cout << "Built with sprokit: " SPROKIT_VERSION << std::endl;
+  std::cout << "KWIVER " KWIVER_VERSION_FULL << std::endl;
+  std::cout << "Built with KWIVER: " KWIVER_VERSION << std::endl;
   std::cout << "Built from git:     "
-#ifdef SPROKIT_BUILT_FROM_GIT
+#ifdef KWIVER_BUILT_FROM_GIT
     "yes"
 #else
     "no"
 #endif
     << std::endl;
-  std::cout << "Git hash:           " SPROKIT_GIT_HASH << std::endl;
+  std::cout << "Git hash:           " KWIVER_GIT_HASH << std::endl;
 
-  char const* const dirty = SPROKIT_GIT_DIRTY;
+  char const* const dirty = KWIVER_GIT_DIRTY;
   bool const dirty_is_empty = (*dirty == '\0');
   char const* const is_dirty = (dirty_is_empty ? "no" : "yes");
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -4,6 +4,25 @@
 project( vital )
 
 ###
+# Generate verion.h
+#---------------------------------------------------------------------
+#
+
+# Use Git (if available) to add Git hash info to the version header
+set(kwiver_configure_with_git on)
+kwiver_configure_file(version.h
+  "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/version.h"
+  KWIVER_VERSION_MAJOR
+  KWIVER_VERSION_MINOR
+  KWIVER_VERSION_PATCH
+  KWIVER_VERSION
+  KWIVER_SOURCE_DIR
+  )
+set(kwiver_configure_with_git)
+
+
+###
 # KWSys
 #---------------------------------------------------------------------
 # Create the kwsys library for vital.
@@ -199,6 +218,7 @@ kwiver_install_headers(
 kwiver_install_headers(
   ${CMAKE_CURRENT_BINARY_DIR}/vital_export.h
   ${CMAKE_CURRENT_BINARY_DIR}/vital_config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/version.h
   SUBDIR   vital
   NOPATH
   )

--- a/vital/version.h.in
+++ b/vital/version.h.in
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,59 +28,59 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SPROKIT_VERSION_H
-#define SPROKIT_VERSION_H
+#ifndef KWIVER_VERSION_H
+#define KWIVER_VERSION_H
 
 /**
  * \file version.h
  *
- * \brief Version information for sprokit.
+ * \brief Version information for KWIVER.
  */
 
 /// The major version.
-#define SPROKIT_VERSION_MAJOR  @KWIVER_VERSION_MAJOR@
+#define KWIVER_VERSION_MAJOR  @KWIVER_VERSION_MAJOR@
 /// The minor version.
-#define SPROKIT_VERSION_MINOR  @KWIVER_VERSION_MINOR@
+#define KWIVER_VERSION_MINOR  @KWIVER_VERSION_MINOR@
 /// The patch version.
-#define SPROKIT_VERSION_PATCH  @KWIVER_VERSION_PATCH@
+#define KWIVER_VERSION_PATCH  @KWIVER_VERSION_PATCH@
 /// The full version as a string.
-#define SPROKIT_VERSION        "@kwiver_version@"
+#define KWIVER_VERSION        "@KWIVER_VERSION@"
 
 /**
- * \brief Check whether sprokit is built with at least some minimum version.
+ * \brief Check whether KWIVER is built with at least some minimum version.
  *
  * \param major The major version to check.
  * \param minor The minor version to check.
  * \param patch The patch version to check.
  */
-#define SPROKIT_VERSION_CHECK(major, minor, patch) \
-     (((major) <  SPROKIT_VERSION_MAJOR)           \
-  || (((major) == SPROKIT_VERSION_MAJOR)           \
-   && ((minor) <  SPROKIT_VERSION_MINOR))          \
-  || (((major) == SPROKIT_VERSION_MAJOR)           \
-   && ((minor) == SPROKIT_VERSION_MINOR)           \
-   && ((patch) <= SPROKIT_VERSION_PATCH)))
+#define KWIVER_VERSION_CHECK(major, minor, patch) \
+     (((major) <  KWIVER_VERSION_MAJOR)           \
+  || (((major) == KWIVER_VERSION_MAJOR)           \
+   && ((minor) <  KWIVER_VERSION_MINOR))          \
+  || (((major) == KWIVER_VERSION_MAJOR)           \
+   && ((minor) == KWIVER_VERSION_MINOR)           \
+   && ((patch) <= KWIVER_VERSION_PATCH)))
 
-#cmakedefine SPROKIT_BUILT_FROM_GIT
+#cmakedefine KWIVER_BUILT_FROM_GIT
 /// The full git hash of the build.
-#define SPROKIT_GIT_HASH       "@sprokit_git_hash@"
+#define KWIVER_GIT_HASH       "@kwiver_git_hash@"
 /// A short, unique (at the time of creation) hash prefix.
-#define SPROKIT_GIT_HASH_SHORT "@sprokit_git_hash_short@"
+#define KWIVER_GIT_HASH_SHORT "@kwiver_git_hash_short@"
 /// A string describing the 'dirty' state of the build tree.
-#define SPROKIT_GIT_DIRTY      "@sprokit_git_dirty@"
+#define KWIVER_GIT_DIRTY      "@kwiver_git_dirty@"
 /// The git version information.
-#define SPROKIT_GIT_VERSION    SPROKIT_GIT_HASH SPROKIT_GIT_DIRTY
+#define KWIVER_GIT_VERSION    KWIVER_GIT_HASH KWIVER_GIT_DIRTY
 
 /**
- * \def SPROKIT_VERSION_FULL
+ * \def KWIVER_VERSION_FULL
  *
  * \brief The full version string.
  */
 
-#ifdef SPROKIT_BUILT_FROM_GIT
-#define SPROKIT_VERSION_FULL   SPROKIT_VERSION ".git" SPROKIT_GIT_VERSION
+#ifdef KWIVER_BUILT_FROM_GIT
+#define KWIVER_VERSION_FULL   KWIVER_VERSION ".git" KWIVER_GIT_VERSION
 #else
-#define SPROKIT_VERSION_FULL   SPROKIT_VERSION
+#define KWIVER_VERSION_FULL   KWIVER_VERSION
 #endif
 
-#endif // SPROKIT_VERSION_H
+#endif // KWIVER_VERSION_H


### PR DESCRIPTION
This will allow KWIVER code to know it's version.  This was in sprokit, but is being promoted to vital so it can be used everywhere.  The sprokit CMake code for configuring files was a bit different than KWIVER so I had to tweak how the configuration was done.  Also, I had a use a different trick to force this configuration to always run (to pick up Git status changes).  The old method of failing to produce a dummy output file was not working, so I'm writing to a dummy dependent file instead.

One thing that was dropped was the support in Sprokit to set a CMake variable to indicate that the code is patched ("dirty") when no using Git.  How important is this?