### PR TITLE
Make the sprokit_pipeline target depend on the version.h target in vital

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,25 @@ endif ()
 
 # =============================================================================================
 
+###
+# Generate vital/verion.h. This file is needed by sprokit so much be generated here, before sprokit is included
+#---------------------------------------------------------------------
+#
+
+# Use Git (if available) to add Git hash info to the version header
+set(kwiver_configure_with_git on)
+kwiver_configure_file(version.h
+  "${CMAKE_CURRENT_SOURCE_DIR}/vital/version.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/vital/version.h"
+  KWIVER_VERSION_MAJOR
+  KWIVER_VERSION_MINOR
+  KWIVER_VERSION_PATCH
+  KWIVER_VERSION
+  KWIVER_SOURCE_DIR
+  )
+set(kwiver_configure_with_git)
+
+
 set( LIB_SUFFIX "" CACHE STRING
   "Library directory suffix. e.g. suffix=\"kwiver\" will install libraries in \"libkwiver\" rather than \"lib\"")
 mark_as_advanced( LIB_SUFFIX )

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -1,5 +1,13 @@
 project(sprokit_pipeline)
 
+set(VITAL_VERSION_H "${vital_BINARY_DIR}/version.h")
+
+set_source_files_properties(
+  ${VITAL_VERSION_H}
+  PROPERTIES
+  GENERATED TRUE
+  )
+
 set(pipeline_srcs
   datum.cxx
   edge.cxx
@@ -44,6 +52,7 @@ set(pipeline_headers
   types.h
   utils.h
   version.h
+  ${VITAL_VERSION_H}
   )
 
 set(pipeline_private_headers)
@@ -103,6 +112,8 @@ kwiver_add_library(sprokit_pipeline
   ${pipeline_headers}
   ${pipeline_private_headers}
   )
+
+add_dependencies(sprokit_pipeline configure-version.h)
 
 target_link_libraries(sprokit_pipeline
   PUBLIC              vital_config

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -4,25 +4,6 @@
 project( vital )
 
 ###
-# Generate verion.h
-#---------------------------------------------------------------------
-#
-
-# Use Git (if available) to add Git hash info to the version header
-set(kwiver_configure_with_git on)
-kwiver_configure_file(version.h
-  "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/version.h"
-  KWIVER_VERSION_MAJOR
-  KWIVER_VERSION_MINOR
-  KWIVER_VERSION_PATCH
-  KWIVER_VERSION
-  KWIVER_SOURCE_DIR
-  )
-set(kwiver_configure_with_git)
-
-
-###
 # KWSys
 #---------------------------------------------------------------------
 # Create the kwsys library for vital.


### PR DESCRIPTION
The sprokit_pipeline target is sometimes built before the configure-version.h target that produces vital/version.h. Since sprokit_pipeline's version.cxx includes vital/version.h, set the appropriate dependency.