### PR TITLE
Update the KPF YAML parser to allow embedded YAML in metadata.

### DIFF
--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -217,8 +217,23 @@ parse_packet( const YAML::const_iterator& it, KPF::packet_t& p )
       break;
 
     case KPF::packet_style::META:
-      new (&p.meta) KPFC::meta_t( it->second.as<string>() );
-      p.header.domain = KPF::packet_header_t::NO_DOMAIN;
+      {
+        string metadata_line = "";
+        // first try it as a simple string
+        try
+        {
+          metadata_line = it->second.as<string>();
+        }
+        catch (const YAML::Exception& e )
+        {
+          // hmm, it may have embedded yaml, try that
+          YAML::Emitter meta_rewrite;
+          meta_rewrite << it->second;
+          metadata_line = string( meta_rewrite.c_str() );
+        }
+        new (&p.meta) KPFC::meta_t( metadata_line );
+        p.header.domain = KPF::packet_header_t::NO_DOMAIN;
+      }
       break;
 
     case KPF::packet_style::POLY:


### PR DESCRIPTION
Some of the KPF coming out of the annotation toolchain contains
embedded YAML in the metadata, e.g.

   - { meta: { team: "Kitware" } }

...previously, the parser attempted to render the metadata as a
string via the as<string>() method. This fails for YAML objects, which
require a YAML::Emitter. So we first try the as<string>() approach; if
this fails, we use an emitter, which renders the above as

    meta '{team: !<!> Kitware}'

This parses to itself if used as input.