### PR TITLE
Fix returned value type for search path.

### DIFF
--- a/vital/config/config_block_io.cxx
+++ b/vital/config/config_block_io.cxx
@@ -268,7 +268,7 @@ read_config_file( std::string const& file_name,
 
   auto result = config_block_sptr{};
 
-  auto const& search_paths =
+  auto const search_paths =
     application_config_file_paths( application_name, application_version,
                                    install_prefix );
 


### PR DESCRIPTION
The application_config_file_paths() method returned a reference to a
stack based local variable. This kept the reference to a stale data area.