### PR TITLE
Add check for file open error and other config file issues

### DIFF
--- a/sprokit/processes/adapters/epx_test.cxx
+++ b/sprokit/processes/adapters/epx_test.cxx
@@ -32,6 +32,7 @@
 
 #include <vital/plugin_loader/plugin_loader.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/config/config_block_formatter.h>
 
 #include <sstream>
 #include <iostream>
@@ -53,7 +54,8 @@ pre_setup( context& ctxt )
   // print config
   std::stringstream str;
 
-  ctxt.pipe_config()->print( str );
+  vital::config_block_formatter fmt( ctxt.pipe_config() );
+  fmt.print( str );
 
   std::cout <<  "exp_test: pipe config:\n" << str.str() <<std::endl;
 }
@@ -71,7 +73,9 @@ void epx_test::configure( kwiver::vital::config_block_sptr const conf )
 {
   // print config
   std::stringstream str;
-  conf->print( str );
+  vital::config_block_formatter fmt( conf);
+  fmt.print( str );
+
    std::cout <<  "exp_test: configure called with config:\n" << str.str() <<std::endl;
 }
 

--- a/vital/config/config_block.cxx
+++ b/vital/config/config_block.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2018 by Kitware, Inc.
+ * Copyright 2011-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -595,40 +595,5 @@ strip_block_name( config_block_key_t const& subblock, config_block_key_t const& 
 
   return key.substr( subblock.size() + config_block::block_sep.size() );
 }
-
-
-// ------------------------------------------------------------------
-/// Format config block in a printable stream
-void
-config_block::
-print( std::ostream& str )
-{
-  kwiver::vital::config_block_keys_t all_keys = this->available_values();
-
-  for( kwiver::vital::config_block_key_t key : all_keys )
-  {
-    std::string ro;
-
-    auto const val = this->get_value< kwiver::vital::config_block_value_t > ( key );
-
-    if ( this->is_read_only( key ) )
-    {
-      ro = "[RO]";
-    }
-
-    str << key << ro << " = " << val;
-
-    // Add location information if available
-    std::string file;
-    int line(0);
-    if ( get_location( key, file, line ) )
-    {
-      str << "  (" << file << ":" << line << ")";
-    }
-
-    str << std::endl;
-  }
-}
-
 
 } }   // end namespace

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2018 by Kitware, Inc.
+ * Copyright 2011-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -375,17 +375,6 @@ public:
 
   /// The magic group for global parameters.
   static config_block_key_t const global_value;
-
-
-  /// Format config in printable form
-  /**
-   * This method formats the config entries onto the supplied stream.
-   *
-   * \param str Stream to accept formated text.
-   */
-  VITAL_CONFIG_DEPRECATED
-  void print( std::ostream & str );
-
 
   /// Set source file location where entry is defined.
   /**

--- a/vital/config/config_block_formatter.cxx
+++ b/vital/config/config_block_formatter.cxx
@@ -99,11 +99,13 @@ print( std::ostream& str )
 void config_block_formatter::
 print( std::ostream& str, const std::string& fmt )
 {
-  using plugin_factory_t =  kwiver::vital::implementation_factory_by_name< kwiver::vital::format_config_block > ;
+  using plugin_factory_t =  kwiver::vital::implementation_factory_by_name< kwiver::vital::format_config_block >;
 
   plugin_factory_t fact;
 
   format_config_block_sptr formatter( fact.create( fmt ) );
+
+  // Pass along current formatting options
   formatter->m_config = this->m_config;
   formatter->opt_gen_source_loc = this->m_gen_source_loc;
   formatter->opt_prefix = this->m_prefix;

--- a/vital/config/config_block_formatter.h
+++ b/vital/config/config_block_formatter.h
@@ -44,7 +44,7 @@ namespace vital {
 /**
  * @brief Generates formatted versions of a config block.
  *
- * This class encapsulates weveral different formatting options for
+ * This class encapsulates several different formatting options for
  * a config block.
  */
 class VITAL_CONFIG_EXPORT config_block_formatter

--- a/vital/config/config_block_io.cxx
+++ b/vital/config/config_block_io.cxx
@@ -95,27 +95,6 @@ application_paths( config_path_list_t const& paths,
 
 
 // ------------------------------------------------------------------
-// Helper method to write out a comment to a configuration file ostream
-/**
- * Makes sure there is no trailing white-space printed to file.
- */
-void
-write_cb_comment( std::ostream& ofile, config_block_description_t const& comment )
-{
-  kwiver::vital::wrap_text_block wtb;
-  wtb.set_indent_string( "# " );
-  wtb.set_line_length( 80 );
-
-  // Add a leading new-line to separate comment block from previous config
-  // entry.
-  ofile << "\n";
-
-  const auto formatted = wtb.wrap_text( comment );
-  ofile << formatted;
-}
-
-
-// ------------------------------------------------------------------
 /// Add paths in the KWIVER_CONFIG_PATH env variable to the given path vector
 /**
  * Appends the current working directory (".") and then the contents of the
@@ -389,6 +368,9 @@ void write_config( config_block_sptr const& config,
   config_block_keys_t avail_keys = config->available_values();
   std::sort( avail_keys.begin(), avail_keys.end() );
 
+  kwiver::vital::wrap_text_block wtb;
+  wtb.set_indent_string( "# " );
+  wtb.set_line_length( 80 );
 
   bool prev_had_descr = false;  // for additional spacing
   for( config_block_key_t key : avail_keys )
@@ -403,7 +385,10 @@ void write_config( config_block_sptr const& config,
 
     if ( descr != config_block_description_t() )
     {
-      write_cb_comment( ofile, descr );
+      // Add a leading new-line to separate comment block from previous config
+      // entry.
+      ofile << "\n" << wtb.wrap_text( descr );
+
       prev_had_descr = true;
     }
     else if ( prev_had_descr )

--- a/vital/config/config_block_io.cxx
+++ b/vital/config/config_block_io.cxx
@@ -352,7 +352,6 @@ write_config_file( config_block_sptr const& config,
     kwiversys::SystemTools::CollapseFullPath( file_path ) );
   if ( ! kwiversys::SystemTools::FileIsDirectory( parent_dir ) )
   {
-    //std::cerr << "at least one containing directory not found, creating them..." << std::endl;
     if ( ! kwiversys::SystemTools::MakeDirectory( parent_dir ) )
     {
       VITAL_THROW( config_file_write_exception, parent_dir,
@@ -362,6 +361,12 @@ write_config_file( config_block_sptr const& config,
 
   // open output file and write each key/value to a line.
   std::ofstream ofile( file_path.c_str() );
+
+  if ( ! ofile )
+  {
+    VITAL_THROW( config_file_write_exception, file_path,
+                 "Could not open config file for writing" );
+  }
 
   write_config( config, ofile );
   ofile.close();
@@ -398,7 +403,6 @@ void write_config( config_block_sptr const& config,
 
     if ( descr != config_block_description_t() )
     {
-      //std::cerr << "[write_config_file] Writing comment for '" << key << "'." << std::endl;
       write_cb_comment( ofile, descr );
       prev_had_descr = true;
     }
@@ -417,7 +421,8 @@ void write_config( config_block_sptr const& config,
     {
       ofile << "# defined - " << file << ":" << line << "\n";
     }
-  }
+  } // end for
+
   ofile.flush();
 } // write_config_file
 

--- a/vital/config/config_block_io.cxx
+++ b/vital/config/config_block_io.cxx
@@ -413,14 +413,14 @@ void write_config( config_block_sptr const& config,
       prev_had_descr = false;
     }
 
-    ofile << key << " = " << config->get_value< config_block_value_t > ( key ) << "\n";
-
-    std::string file;
-    int line;
-    if ( config->get_location( key, file, line ) )
+    std::string ro;
+    if ( config->is_read_only( key ) )
     {
-      ofile << "# defined - " << file << ":" << line << "\n";
+      ro = "[RO]";
     }
+
+    ofile << key << ro << " = " << config->get_value< config_block_value_t > ( key ) << "\n";
+
   } // end for
 
   ofile.flush();


### PR DESCRIPTION
This patch adds a check to make sure the output file has been actually opened.

Additional config formatting cleanup has been applied.
- Remove deprecated method config_block::print()
- config:block::write_config() did not handle the "RO" attribute
