### PR TITLE
Added check for missing metadata tag

### DIFF
--- a/vital/types/metadata_map.h
+++ b/vital/types/metadata_map.h
@@ -194,7 +194,10 @@ public:
     auto &mdv = d_it->second;
     for (auto md : mdv)
     {
-      return true;
+      if (md->has(tag))
+      {
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
metadata_map has_item checked that the map contained a given
frame's data but not that the tag that we want is there too.
Added a check for the particular tag.