### PR TITLE
Fix MSVC_ENV value override and trailing semicolon

### DIFF
--- a/CMake/utils/kwiver-utils-msvc.cmake
+++ b/CMake/utils/kwiver-utils-msvc.cmake
@@ -99,6 +99,8 @@ function(kwiver_setup_msvc_env)
     endforeach()
     set(MSVC_ENV "${MSVC_ENV}\n")
   endforeach()
+  # Remove semi-colons at the end of lines
+  string(REPLACE ";\n" "\n" MSVC_ENV "${MSVC_ENV}")
   #message(STATUS "Setting MSVC environment to ${MSVC_ENV}")
 
   # Now loop over all the executable we made and provide a vcxproj file for them

--- a/CMake/utils/kwiver-utils-msvc.cmake
+++ b/CMake/utils/kwiver-utils-msvc.cmake
@@ -72,15 +72,22 @@ function(kwiver_setup_msvc_env)
       # replace batch terms with msvc terms
       string(REPLACE "%config%" "$(Configuration)" _val "${_val}")
       string(REPLACE "%~dp0" "${batch_dir}" _val "${_val}")
-      # remove any recursive sets
+      # check for any recursive sets
       # such as PATH=%something%;%PATH% <-- remove the %PATH%
+      string(FIND "${_val}" "%${_var}%" idx)
+      # remove recursive sets
       string(REPLACE "%${_var}%" "" _val "${_val}")
       #message(STATUS "I am setting ${_var} to ${_val}")
       # Keep track of setting the same variable over and over
       if(NOT ${_var} IN_LIST _env_variables)
         list(APPEND _env_variables "${_var}")
       endif()
-      list(APPEND "_env_${_var}" "${_val}")
+      # if a recursive variable was found append values, else replace
+      if("${idx}" GREATER -1)
+        list(APPEND "_env_${_var}" "${_val}")
+      else()
+        set("_env_${_var}" "${_val}")
+      endif()
     endforeach()
   endforeach()
   # Consolidate setting env variables into one line

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -1,4 +1,4 @@
-KWIVER v1.4.0 Release Notes
+KWIVER v1.3.1 Release Notes
 ===========================
 
 This is a minor release of KWIVER that provides both new functionality and
@@ -12,3 +12,9 @@ Bug Fixes since v1.3.0
 
  * Fixed issue where ffmpeg_video_input does not set the depth step for
    frame images correctly.
+
+ * Fixed an issue in the MSVC environment in which and extra ";" was
+   appended to each variable
+
+ * Fixed an issue in the MSVC environment in which redefining variables
+   from setup_KWIVER.bat would append to the old value instead of replacing.


### PR DESCRIPTION
fixes #740 