### PR TITLE
Added default plugin search paths relative to the kwiver executable

### DIFF
--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/plugin_loader/plugin_factory.h>
 #include <vital/exceptions/base.h>
+#include <vital/util/get_paths.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -162,6 +163,10 @@ int main(int argc, char *argv[])
   applet_context_t tool_context = std::make_shared< kwiver::tools::applet_context >();
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
+  const std::string exec_path = kwiver::vital::get_executable_path();
+  vpm.add_search_path(exec_path + "/../lib/kwiver/modules");
+  vpm.add_search_path(exec_path + "/../lib/kwiver/modules/applets");
+  vpm.add_search_path(exec_path + "/../lib/kwiver/processes");
   vpm.load_all_plugins();
 
 


### PR DESCRIPTION
When installed, you should be able to run the kwiver tool without
needing to set any environment variables.

Ultimately we should only need to set the path to `lib/kwiver/modules` but the plugin loading does not yet automatically look in `applets` and `processes`.