### PR TITLE
Fixed a bug in warp_image introduce by addition of OpenMP

### DIFF
--- a/arrows/super3d/warp_image.hxx
+++ b/arrows/super3d/warp_image.hxx
@@ -335,7 +335,7 @@ warp_image( vil_image_view<T> const& src,
   {
 
     // dest_col_ptr now points to the start of the BB region for this row
-    T* dest_col_ptr = row_start + j * dest_j_step;
+    T* dest_col_ptr = row_start + (j - start_j_adj) * dest_j_step;
 
     // Precompute row homography partials for this row
     const vnl_double_3 row_factor = homog_col_2 * static_cast<double>(j);


### PR DESCRIPTION
When switching to OpenMP, the column pointer was computed in the loop
for each row rather than incremented, but the computed pointer did
not account for the starting row, which is not always zero.