### PR TITLE
Dev/kpf direct packet write

### DIFF
--- a/arrows/kpf/yaml/kpf_canonical_io.h
+++ b/arrows/kpf/yaml/kpf_canonical_io.h
@@ -96,6 +96,8 @@ template <>
 struct KPF_YAML_EXPORT writer< canonical::id_t >
 {
   writer( size_t i, int d ): id(i), domain(d) {}
+  writer( const canonical::id_t& i, int d )
+    : id( i ), domain( d ) {}
   explicit writer( const canonical::scoped< canonical::id_t >& s )
     : id( s.t ), domain( s.domain ) {}
   canonical::id_t id;
@@ -106,6 +108,8 @@ template <>
 struct KPF_YAML_EXPORT writer< canonical::timestamp_t >
 {
   writer( double t, int d ): ts(t), domain(d) {}
+  writer( const canonical::timestamp_t& t, int d )
+    : ts( t ), domain( d ) {}
   explicit writer( const canonical::scoped< canonical::timestamp_t >& s )
     : ts( s.t ), domain( s.domain ) {}
   canonical::timestamp_t ts;
@@ -116,7 +120,7 @@ template<>
 struct KPF_YAML_EXPORT writer< canonical::kv_t >
 {
   writer( const std::string& k, const std::string& v ): kv(k,v) {}
-  explicit writer( const canonical::kv_t kv_in ): kv( kv_in ) {}
+  explicit writer( const canonical::kv_t& kv_in ): kv( kv_in ) {}
   canonical::kv_t kv;
   // key/value has no domain, thus no scoped version
 };
@@ -125,6 +129,8 @@ template<>
 struct KPF_YAML_EXPORT writer< canonical::conf_t >
 {
   writer( double c, int d ): conf(c), domain(d) {}
+  writer( const canonical::conf_t& c, int d )
+    : conf( c ), domain( d ) {}
   explicit writer( const canonical::scoped< canonical::conf_t >& s )
     : conf( s.t ), domain( s.domain ) {}
   canonical::conf_t conf;
@@ -134,7 +140,7 @@ struct KPF_YAML_EXPORT writer< canonical::conf_t >
 template<>
 struct KPF_YAML_EXPORT writer< canonical::cset_t >
 {
-  writer( canonical::cset_t& c, int d ): cset(c), domain(d) {}
+  writer( const canonical::cset_t& c, int d ): cset(c), domain(d) {}
   explicit writer( const canonical::scoped< canonical::cset_t >& s )
     : cset( s.t ), domain( s.domain ) {}
   canonical::cset_t cset;
@@ -145,6 +151,8 @@ template<>
 struct KPF_YAML_EXPORT writer< canonical::eval_t >
 {
   writer( double c, int d ): eval(c), domain(d) {}
+  writer( const canonical::eval_t& e, int d )
+    : eval( e ), domain( d ) {}
   explicit writer( const canonical::scoped< canonical::eval_t >& s )
     : eval( s.t ), domain( s.domain ) {}
   canonical::eval_t eval;
@@ -163,6 +171,8 @@ template<>
 struct KPF_YAML_EXPORT writer< canonical::timestamp_range_t >
 {
   writer( double start, double stop ): tsr(start, stop) {}
+  writer( const canonical::timestamp_range_t& t, int d )
+    : tsr( t ), domain( d ) {}
   explicit writer( const canonical::scoped< canonical::timestamp_range_t >& s )
     : tsr( s.t ), domain( s.domain ) {}
   canonical::timestamp_range_t tsr;

--- a/arrows/kpf/yaml/kpf_parser_base.h
+++ b/arrows/kpf/yaml/kpf_parser_base.h
@@ -41,6 +41,7 @@
 #define KWIVER_VITAL_KPF_PARSER_BASE_
 
 #include <arrows/kpf/yaml/kpf_parse_utils.h>
+#include <arrows/kpf/yaml/kpf_yaml_schemas.h>
 
 namespace kwiver {
 namespace vital {
@@ -54,6 +55,7 @@ public:
 
   virtual bool get_status() const = 0;
   virtual bool parse_next_record( packet_buffer_t& ) = 0;
+  virtual schema_style get_current_record_schema() const = 0;
   virtual bool eof() const = 0;
 };
 

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -519,6 +519,7 @@ namespace kpf {
 
 kpf_yaml_parser_t
 ::kpf_yaml_parser_t( istream& is )
+  : current_record_schema( schema_style::INVALID )
 {
   try
   {
@@ -546,6 +547,13 @@ kpf_yaml_parser_t
 ::eof() const
 {
   return this->current_record == this->root.end();
+}
+
+schema_style
+kpf_yaml_parser_t
+::get_current_record_schema() const
+{
+  return this->current_record_schema;
 }
 
 /**
@@ -612,6 +620,8 @@ kpf_yaml_parser_t
   bool okay = false;
   auto check = kpf_v3_check( n );
   auto n_sub = n.begin();
+
+  this->current_record_schema = check;
 
   // special case for meta
   if ((check == schema_style::INVALID) && ( str2style( n_sub->first.as<string>()) == packet_style::META ))

--- a/arrows/kpf/yaml/kpf_yaml_parser.h
+++ b/arrows/kpf/yaml/kpf_yaml_parser.h
@@ -57,12 +57,13 @@ public:
 
   virtual bool get_status() const;
   virtual bool parse_next_record( packet_buffer_t& pb );
+  virtual schema_style get_current_record_schema() const;
   virtual bool eof() const;
 
 private:
   YAML::Node root;
   YAML::const_iterator current_record;
-
+  schema_style current_record_schema;
 };
 
 } // ...kpf

--- a/arrows/kpf/yaml/kpf_yaml_schemas.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_schemas.cxx
@@ -104,6 +104,7 @@ validation_data
   switch (s)
   {
   case schema_style::INVALID:     return "invalid";
+  case schema_style::META:        return "meta";
   case schema_style::GEOM:        return "geom";
   case schema_style::ACT:         return "act";
   case schema_style::TYPES:       return "types";
@@ -117,7 +118,7 @@ schema_style
 validation_data
 ::str_to_schema_style( const string& s )
 {
-  for (auto style: { schema_style::INVALID, schema_style::GEOM, schema_style::ACT,
+  for (auto style: { schema_style::INVALID, schema_style::META, schema_style::GEOM, schema_style::ACT,
         schema_style::TYPES, schema_style::REGIONS, schema_style::UNSPECIFIED } )
   {
     if (s == schema_style_to_str( style ))

--- a/arrows/kpf/yaml/kpf_yaml_schemas.h
+++ b/arrows/kpf/yaml/kpf_yaml_schemas.h
@@ -51,6 +51,7 @@ namespace kpf {
 
 enum class schema_style {
   INVALID,     // invalid
+  META,        // metadata
   GEOM,        // geometry
   ACT,         // activity
   TYPES,       // object types

--- a/arrows/kpf/yaml/kpf_yaml_writer.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_writer.cxx
@@ -228,6 +228,27 @@ operator<<( record_yaml_writer& w, const writer< canonical::activity_t >& io )
   return w;
 }
 
+record_yaml_writer&
+operator<<( record_yaml_writer& w, const packet_t& p )
+{
+  auto d = p.header.domain;
+  switch (p.header.style)
+  {
+  case packet_style::META:   w << writer< canonical::meta_t>( p.meta.txt ); break;
+  case packet_style::ID:     w << writer< canonical::id_t>( p.id, d ); break;
+  case packet_style::TS:     w << writer< canonical::timestamp_t>( p.timestamp, d );  break;
+  case packet_style::TSR:    w << writer< canonical::timestamp_range_t>( p.timestamp_range, d); break;
+  case packet_style::GEOM:   w << writer< canonical::bbox_t>( p.bbox, d ); break;
+  case packet_style::POLY:   w << writer< canonical::poly_t>( p.poly, d ); break;
+  case packet_style::CONF:   w << writer< canonical::conf_t>( p.conf, d ); break;
+  case packet_style::CSET:   w << writer< canonical::cset_t>( *p.cset, d ); break;
+  case packet_style::ACT:    w << writer< canonical::activity_t>( p.activity, d ); break;
+  case packet_style::EVAL:   w << writer< canonical::eval_t>( p.eval, d ); break;
+  case packet_style::KV:     w << writer< canonical::kv_t>( p.kv ); break;
+  default:
+    LOG_ERROR( main_logger, "No KPF packet writer for " << p );
+    break;
+  }
   return w;
 }
 

--- a/arrows/kpf/yaml/kpf_yaml_writer.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_writer.cxx
@@ -210,9 +210,10 @@ operator<<( record_yaml_writer& w, const writer< canonical::activity_t >& io )
     w << writer< canonical::eval_t>( e );
   }
 
-  w.oss << "actors: [{ ";
+  w.oss << "actors: [ ";
   for (auto a: act.actors)
   {
+    w.oss << "{ ";
     w.oss << "id" << a.actor_id.domain << ": " << a.actor_id.t.d << ", ";
     w.oss << "timespan: [{ ";
     for (auto t: a.actor_timespan )
@@ -220,8 +221,12 @@ operator<<( record_yaml_writer& w, const writer< canonical::activity_t >& io )
       w.oss << "tsr" << t.domain << ": [" << t.t.start << " , " << t.t.stop << "], ";
     }
     w.oss << " }], ";
+    w.oss << " }, ";
   }
-  w.oss << "}], ";
+  w.oss << "], ";
+
+  return w;
+}
 
   return w;
 }

--- a/arrows/kpf/yaml/kpf_yaml_writer.h
+++ b/arrows/kpf/yaml/kpf_yaml_writer.h
@@ -55,6 +55,7 @@ class KPF_YAML_EXPORT record_yaml_writer
 public:
   explicit record_yaml_writer( std::ostream& os ) : s( os ), line_started(false), schema( schema_style::UNSPECIFIED ), has_meta( false ) {}
 
+  friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const packet_t& p );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::id_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::bbox_t >& io );
   friend KPF_YAML_EXPORT record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::timestamp_t >& io );
@@ -81,6 +82,9 @@ private:
   schema_style schema;
   bool has_meta;
 };
+
+KPF_YAML_EXPORT
+record_yaml_writer& operator<<( record_yaml_writer& w, const packet_t& p );
 
 KPF_YAML_EXPORT
 record_yaml_writer& operator<<( record_yaml_writer& w, const writer< canonical::id_t >& io );

--- a/examples/cpp/kpf/CMakeLists.txt
+++ b/examples/cpp/kpf/CMakeLists.txt
@@ -56,10 +56,18 @@ target_include_directories( yaml_parser PRIVATE ${YAML_CPP_INCLUDE_DIR})
 target_link_libraries( yaml_parser
   ${YAML_CPP_LIBRARIES} )
 
+add_executable( kpf_yaml_copy kpf_yaml_copy.cxx )
+target_include_directories( kpf_yaml_copy PRIVATE ${YAML_CPP_INCLUDE_DIR})
+target_link_libraries( kpf_yaml_copy
+  kwiver_algo_kpf
+  kpf_yaml
+  ${YAML_CPP_LIBRARIES} )
+
 if(WIN32)
   target_compile_definitions(kpf_example_simple PRIVATE YAML_CPP_DLL)
   target_compile_definitions(kpf_example_complex PRIVATE YAML_CPP_DLL)
   target_compile_definitions(kpf_example_activity PRIVATE YAML_CPP_DLL)
   target_compile_definitions(kpf_yaml_reader PRIVATE YAML_CPP_DLL)
+  target_compile_definitions(kpf_yaml_copy PRIVATE YAML_CPP_DLL)
   target_compile_definitions(yaml_parser PRIVATE YAML_CPP_DLL)
 endif()

--- a/examples/cpp/kpf/kpf_yaml_copy.cxx
+++ b/examples/cpp/kpf/kpf_yaml_copy.cxx
@@ -1,0 +1,84 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief A simple demonstration that reads a yaml KPF file and writes it back out.
+ *
+ */
+
+#include <arrows/kpf/yaml/kpf_reader.h>
+#include <arrows/kpf/yaml/kpf_yaml_parser.h>
+#include <arrows/kpf/yaml/kpf_yaml_writer.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+
+namespace KPF=kwiver::vital::kpf;
+
+
+int main( int argc, char* argv[] )
+{
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " file.kpf\n";
+    return EXIT_FAILURE;
+  }
+
+  std::ifstream is( argv[1] );
+  if (!is)
+  {
+    std::cerr << "Couldn't open '" << argv[1] << "' for reading\n";
+    return EXIT_FAILURE;
+  }
+
+  KPF::kpf_yaml_parser_t parser( is );
+  KPF::kpf_reader_t reader( parser );
+  KPF::record_yaml_writer writer( std::cout );
+  while (reader.next())
+  {
+    const KPF::packet_buffer_t& packets = reader.get_packet_buffer();
+
+    std::vector< std::string > meta = reader.get_meta_packets();
+    writer.set_schema( KPF::schema_style::META );
+    for (auto m: meta)
+    {
+      writer << m << KPF::record_yaml_writer::endl;
+    }
+    writer.set_schema( parser.get_current_record_schema() );
+    for (auto p: packets )
+    {
+      writer << p.second;
+    }
+    writer << KPF::record_yaml_writer::endl;
+    reader.flush();
+  }
+}


### PR DESCRIPTION
For some upcoming DIVA tools, it's useful to be able to load a KPF file, tweak some individual packets, and write the whole thing back out without worrying about what the file's particular schema or ever looking at the other packets.

However, the KPF library didn't support directly writing out a packet_t object. This commit adds the ability to directly write out a packet.

It also adds a short example which copies a KPF file, just reading it in and writing it back out.

