### PR TITLE
Probes for missing KPF packets no longer invalidate the stream.

### DIFF
--- a/arrows/kpf/yaml/kpf_reader.h
+++ b/arrows/kpf/yaml/kpf_reader.h
@@ -95,11 +95,11 @@ public:
   // look for a packet matching the header; if found,
   // return true, remove from buffer, return the packet
   // if not found, return false
-  std::pair< bool, packet_t > transfer_packet_from_buffer( const packet_header_t& h );
+  std::pair< bool, packet_t > transfer_packet_from_buffer( const packet_header_t& h, bool set_bad_if_missing = false );
 
   // like above, but specifically for kv (key/value) packets with a
   // particular key
-  std::pair< bool, packet_t > transfer_kv_packet_from_buffer( const std::string& key );
+  std::pair< bool, packet_t > transfer_kv_packet_from_buffer( const std::string& key, bool set_bad_if_missing = false );
 
   // return any meta packets
   std::vector< std::string > get_meta_packets() const;


### PR DESCRIPTION
When the user calls reader.transfer_packet_from_buffer(), if it fails,
the reader should still be good. The catch is that the reader
also internally calls TPFB(); if called indirectly from the reader,
it should set the reader state to bad.

This commit adds a test case and adds an extra bool parameter to
TPFB (and the sibling transfer_kv_packet_from_buffer) which
defaults to false (don't change reader state) but is true
when called internally.