### PR TITLE
Treat empty detected_object_type like NULL d_o_t

### DIFF
--- a/arrows/ocv/draw_detected_object_set.cxx
+++ b/arrows/ocv/draw_detected_object_set.cxx
@@ -227,7 +227,7 @@ public:
     for ( auto det = in_set->cbegin(); det != ie; ++det )
     {
       auto det_type = (*det)->type();
-      if ( ! det_type )
+      if ( ! det_type || det_type->size() == 0 )
       {
         // No type has been assigned. Just filter on threshold
         if ((*det)->confidence() < m_threshold )


### PR DESCRIPTION
Some processes, especially readers, create an new detected_object
with an empty, rather than NULL detected_object_type which prevents
them from being drawn by this process.  This change extends the
current behavior for a NULL d_o_t (essentially "just" a detection)
to include empty detected_object_types.