### PR TITLE
Visual Studio requires include algorithm for min max

### DIFF
--- a/vital/util/simple_stats.h
+++ b/vital/util/simple_stats.h
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <string>
 #include <cmath>
+#include <algorithm>
 
 namespace kwiver {
 namespace vital {


### PR DESCRIPTION
BUG: The omission of include algorithm causes a build failure on Windows.