### PR TITLE
Provide default image_container::get_image(<crop>)

### DIFF
--- a/arrows/ocv/image_container.h
+++ b/arrows/ocv/image_container.h
@@ -88,13 +88,7 @@ public:
 
   /// Get an in-memory image class to access the data
   virtual vital::image get_image() const { return ocv_to_vital(data_, RGB_COLOR); }
-
-  /// Get an in-memory image class to access the data
-  virtual vital::image get_image(unsigned x_offset, unsigned y_offset,
-                                 unsigned width, unsigned height) const
-  {
-    return ocv_to_vital(data_, RGB_COLOR).crop(x_offset, y_offset, width, height);
-  }
+  using vital::image_container::get_image;
 
   /// Access the underlying cv::Mat data structure
   cv::Mat get_Mat() const { return data_; }

--- a/arrows/viscl/image_container.h
+++ b/arrows/viscl/image_container.h
@@ -86,13 +86,7 @@ public:
 
   /// Get an in-memory image class to access the data
   virtual vital::image get_image() const { return viscl_to_vital(data_); }
-
-  /// Get an in-memory image class to access the data
-  virtual vital::image get_image(unsigned x_offset, unsigned y_offset,
-                                 unsigned width, unsigned height) const
-  {
-     return viscl_to_vital(data_).crop(x_offset, y_offset, width, height);
-  }
+  using vital::image_container::get_image;
 
   /// Access the underlying VisCL data structure
   viscl::image get_viscl_image() const { return data_; }

--- a/arrows/vxl/image_container.h
+++ b/arrows/vxl/image_container.h
@@ -95,13 +95,7 @@ public:
 
   /// Get an in-memory image class to access the data
   virtual vital::image get_image() const { return vxl_to_vital(*data_); }
-
-  /// Get an in-memory image class to access the data
-  virtual vital::image get_image(unsigned x_offset, unsigned y_offset,
-                                 unsigned width, unsigned height) const
-  {
-    return vxl_to_vital(*data_).crop(x_offset, y_offset, width, height);
-  }
+  using vital::image_container::get_image;
 
   /// Get image data in this container.
   vil_image_view_base_sptr get_vil_image_view() const { return data_; }

--- a/vital/types/image_container.h
+++ b/vital/types/image_container.h
@@ -82,7 +82,10 @@ public:
 
   /// Get an in-memory image class to access a sub-image of the data
   virtual image get_image(unsigned x_offset, unsigned y_offset,
-                          unsigned width, unsigned height) const = 0;
+                          unsigned width, unsigned height) const
+  {
+    return get_image().crop(x_offset, y_offset, width, height);
+  };
 
   /// Get metadata associated with this image
   virtual metadata_sptr get_metadata() const { return md_; }


### PR DESCRIPTION
Provide a default implementation of the `image_container::get_image` overload that returns a crop of the full image. Most implementations just do a full image conversion and then crop the result, which the default implementation can do just fine without requiring everyone to duplicate said code.