### PR TITLE
Move the not WIN32 guard to python folder

### DIFF
--- a/sprokit/src/sprokit/CMakeLists.txt
+++ b/sprokit/src/sprokit/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 #
 #
-if (KWIVER_ENABLE_PYTHON)
+if ( KWIVER_ENABLE_PYTHON AND NOT WIN32 )
   add_subdirectory(python)
 endif ()
 

--- a/sprokit/src/sprokit/python/util/CMakeLists.txt
+++ b/sprokit/src/sprokit/python/util/CMakeLists.txt
@@ -1,14 +1,12 @@
 project(sprokit_python_util)
 
-if( NOT WIN32 )
-  set(python_util_srcs
-      ${python_util_srcs}
-      pystream.cxx)
+set(python_util_srcs
+    ${python_util_srcs}
+    pystream.cxx)
 
-  set(python_util_headers
-      ${python_util_headers}
-      pystream.h)
-endif()
+set(python_util_headers
+    ${python_util_headers}
+    pystream.h)
 
 kwiver_add_library(sprokit_python_util
   ${python_util_srcs}


### PR DESCRIPTION
Since custom pybind11 header have been moved into vital, there is not need to build the python directory in windows.