### PR TITLE
 Improve API for metadata collections

### DIFF
--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -100,9 +100,9 @@ public:
     ts.set_frame( frame );
     if ( metadata )
     {
-      if ( metadata->has( vital::VITAL_META_GPS_SEC ) )
+      if ( auto& item = metadata->find( vital::VITAL_META_GPS_SEC ) )
       {
-        double gps_sec = metadata->find( vital::VITAL_META_GPS_SEC ).as_double();
+        double gps_sec = item.as_double();
         // TODO: also use gps_week and convert to UTC to get abosolute time
         // or subtract off first frame time to get time relative to start
         ts.set_time_seconds( gps_sec );
@@ -386,9 +386,9 @@ video_input_pos
   ts.set_frame( d->d_frame_number );
   if ( d->d_metadata )
   {
-    if ( d->d_metadata->has( vital::VITAL_META_GPS_SEC ) )
+    if ( auto& item = d->d_metadata->find( vital::VITAL_META_GPS_SEC ) )
     {
-      double gps_sec = d->d_metadata->find( vital::VITAL_META_GPS_SEC ).as_double();
+      double gps_sec = item.as_double();
       // TODO: also use gps_week and convert to UTC to get abosolute time
       // or subtract off first frame time to get time relative to start
       ts.set_time_seconds( gps_sec );

--- a/arrows/gdal/tests/test_image.cxx
+++ b/arrows/gdal/tests/test_image.cxx
@@ -168,19 +168,16 @@ TEST_F(image_io, load_geotiff)
   test_rpc_metadata(md);
 
   // Test corner points
-  EXPECT_TRUE( md->has( kwiver::vital::VITAL_META_CORNER_POINTS ) )
+  ASSERT_TRUE( md->has( kwiver::vital::VITAL_META_CORNER_POINTS ) )
     << "Metadata should include corner points.";
 
-  if ( md->has( kwiver::vital::VITAL_META_CORNER_POINTS ) )
-  {
-    kwiver::vital::geo_polygon corner_pts;
-    md->find( kwiver::vital::VITAL_META_CORNER_POINTS ).data( corner_pts );
-    EXPECT_EQ( corner_pts.crs(), 4326);
-    EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( -16.0, 0.0) );
-    EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 0.0, 32.0) );
-    EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 0.0, -32.0) );
-    EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 16.0, 0.0) );
-  }
+  kwiver::vital::geo_polygon corner_pts;
+  md->find( kwiver::vital::VITAL_META_CORNER_POINTS ).data( corner_pts );
+  EXPECT_EQ( corner_pts.crs(), 4326);
+  EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( -16.0, 0.0) );
+  EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 0.0, 32.0) );
+  EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 0.0, -32.0) );
+  EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 16.0, 0.0) );
 }
 
 TEST_F(image_io, load_nitf)

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -154,10 +154,13 @@ refine_detections_write_to_disk
   // Get input filename if it's in the vital_metadata
   std::string filename;
   auto md = image_data->get_metadata();
-  if( md && md->has(VITAL_META_IMAGE_URI) )
+  if( md )
   {
-    // Get the full path, and then extract just the filename proper
-    filename = ST::GetFilenameName( md->find(VITAL_META_IMAGE_URI).as_string() );
+    if ( auto& mdi = md->find( VITAL_META_IMAGE_URI ) )
+    {
+      // Get the full path, and then extract just the filename proper
+      filename = ST::GetFilenameName( mdi.as_string() );
+    }
   }
 
   for( auto det : *detections )

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -273,7 +273,7 @@ public:
   {
     bool retval( true );
 
-    meta_ts = 0.0;
+    meta_ts = 0;
     if ( ! this->d_video_stream.advance() )
     {
       return false;
@@ -413,20 +413,17 @@ public:
       {
         // A metadata collection was created
         // check to see if it is of the desired type.
-        std::string collection_type;
         for( auto meta : klv_metadata )
         {
           // Test to see if the collection is from the specified standard (0104/0601)
-          if (meta->has( VITAL_META_METADATA_ORIGIN ) )
+          if ( auto& origin = meta->find( VITAL_META_METADATA_ORIGIN ) )
           {
-            collection_type = meta->find( VITAL_META_METADATA_ORIGIN ).as_string();
-
-            if (type == collection_type)
+            if (type == origin.as_string())
             {
-              if (meta->has( VITAL_META_UNIX_TIMESTAMP ) )
+              if ( auto& ts = meta->find( VITAL_META_UNIX_TIMESTAMP ) )
               {
                 // Get unix timestamp as usec
-                meta_ts = meta->find( VITAL_META_UNIX_TIMESTAMP ).as_uint64();
+                meta_ts = static_cast< time_usec_t >( ts.as_uint64() );
 
                 LOG_DEBUG( this->d_logger, "Found initial " << type <<
                            " timestamp: " << meta_ts );

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,9 +51,9 @@ tags_to_vector( metadata_sptr const& md, std::vector<vital_metadata_tag> tags )
 
   for (unsigned int i=0; i<vec_length; ++i)
   {
-   if (md->has(tags[i]))
+   if (auto& mdi = md->find(tags[i]))
     {
-      rslt[i] = md->find(tags[i]).as_double();
+      rslt[i] = mdi.as_double();
     }
     else
     {
@@ -79,9 +79,9 @@ tags_to_matrix( metadata_sptr const& md, std::vector<vital_metadata_tag> tags )
 
   for (int i=0; i<4; ++i)
   {
-   if (md->has(tags[i]))
+   if (auto& mdi = md->find(tags[i]))
     {
-      rslt.row(i) = string_to_vector(md->find(tags[i]).as_string());
+      rslt.row(i) = string_to_vector(mdi.as_string());
     }
     else
     {

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,22 +56,26 @@ basename_from_metadata(metadata_sptr md,
   typedef kwiversys::SystemTools  ST;
 
   std::string basename = "frame";
-  if( md && md->has( kwiver::vital::VITAL_META_IMAGE_URI ) )
+  if( md )
   {
-    std::string img_name = md->find( VITAL_META_IMAGE_URI ).as_string();
-    basename = ST::GetFilenameWithoutLastExtension( img_name );
-  }
-  else
-  {
-    if ( md && md->has( kwiver::vital::VITAL_META_VIDEO_URI ) )
+    if ( auto& mdi = md->find( kwiver::vital::VITAL_META_IMAGE_URI ) )
     {
-      std::string vid_name = md->find( VITAL_META_VIDEO_URI ).as_string();
-      basename = ST::GetFilenameWithoutLastExtension( vid_name );
+      return ST::GetFilenameWithoutLastExtension( mdi.as_string() );
     }
-    char frame_str[6];
-    std::snprintf(frame_str, 6, "%05d", static_cast<int>(frame));
-    basename += "-" + std::string(frame_str);
   }
+
+  if( md )
+  {
+    if ( auto& mdi = md->find( kwiver::vital::VITAL_META_VIDEO_URI ) )
+    {
+      basename = ST::GetFilenameWithoutLastExtension( mdi.as_string() );
+    }
+  }
+
+  char frame_str[6];
+  std::snprintf(frame_str, 6, "%05d", static_cast<int>(frame));
+  basename += "-" + std::string(frame_str);
+
   return basename;
 }
 
@@ -193,9 +197,9 @@ write_pos_file( metadata const& md,
                               vital_metadata_tag const& tag,
                               std::string const& dflt) -> std::ostream&
   {
-    if ( md.has(tag) )
+    if ( auto& mdi = md.find(tag) )
     {
-      md.find(tag).print_value(os);
+      mdi.print_value(os);
     }
     else
     {
@@ -212,10 +216,10 @@ write_pos_file( metadata const& md,
   print_default( ofile, VITAL_META_SENSOR_PITCH_ANGLE,  "0" ) << ", ";
   print_default( ofile, VITAL_META_SENSOR_ROLL_ANGLE,   "0" ) << ", ";
 
-  if ( md.has( VITAL_META_SENSOR_LOCATION ) )
+  if ( auto& mdi = md.find( VITAL_META_SENSOR_LOCATION ) )
   {
     kwiver::vital::geo_point latlon;
-    md.find( VITAL_META_SENSOR_LOCATION ).data( latlon );
+    mdi.data( latlon );
     auto const& raw_latlon = latlon.location( SRID::lat_lon_WGS84 );
     ofile << raw_latlon[1] << ", " << raw_latlon[0] << ", ";
   }
@@ -227,9 +231,9 @@ write_pos_file( metadata const& md,
   // altitude is in feet in a POS file and needs to be converted to feet
   constexpr double feet2meters = 0.3048;
   double altitude = 0.0;
-  if ( md.has( VITAL_META_SENSOR_ALTITUDE ) )
+  if ( auto& mdi = md.find( VITAL_META_SENSOR_ALTITUDE ) )
   {
-    altitude = md.find( VITAL_META_SENSOR_ALTITUDE ).as_double() / feet2meters;
+    altitude = mdi.as_double() / feet2meters;
   }
   ofile << altitude << ", ";
   print_default( ofile, VITAL_META_GPS_SEC,       "0" ) << ", ";

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,7 @@ namespace vital {
     { }
 
     virtual ~unknown_metadata_item() {}
+    virtual bool is_valid() const { return false; }
     virtual vital_metadata_tag tag() const { return static_cast< vital_metadata_tag >(0); }
     virtual std::type_info const& type() const { return typeid( void ); }
     virtual std::string as_string() const { return "--Unknown metadata item--"; }
@@ -85,6 +86,14 @@ metadata_item
 metadata_item
 ::~metadata_item()
 { }
+
+
+bool
+metadata_item
+::is_valid() const
+{
+  return true;
+}
 
 
 std::string const&

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -354,9 +354,8 @@ bool test_equal_content( const kwiver::vital::metadata& one,
     const auto tag = mi.first;
     const auto metap = mi.second;
 
-    if ( ! other.has( tag ) ) { return false; }
-
-    const auto& omi = other.find( tag );
+    auto& omi = other.find( tag );
+    if ( ! omi ) { return false; }
 
     // It is simpler to just do a string comparison than to try to do
     // a type specific comparison.

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,6 +73,18 @@ class VITAL_EXPORT metadata_item
 public:
   virtual ~metadata_item();
 
+  /// Test if metadata item is valid.
+  /**
+   * This method tests if this metadata item is valid.
+   *
+   * @return \c true if the item is valid, otherwise \c false.
+   *
+   * @sa metadata::find
+   */
+  virtual bool is_valid() const;
+
+  /// @copydoc is_valid
+  operator bool() const { return this->is_valid(); }
 
   /// Get name of metadata item.
   /**
@@ -370,9 +382,10 @@ public:
 
   /// Find metadata entry for specified tag.
   /**
-   * This method looks for the metadata entrty corresponding to the
-   * supplied tag. If the tag is not present in the collection, the
-   * results are undefined.
+   * This method looks for the metadata entrty corresponding to the supplied
+   * tag. If the tag is not present in the collection, the result will be a
+   * instance for which metadata_item::is_valid returns \c false and whose
+   * behavior otherwise is unspecified.
    *
    * @param tag Look for this tag in collection of metadata.
    *

--- a/vital/types/metadata_map.h
+++ b/vital/types/metadata_map.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -169,9 +169,9 @@ public:
     auto &mdv = d_it->second;
     for (auto md : mdv)
     {
-      if (md->has(tag))
+      if (auto const& item = md->find(tag))
       {
-        return md->find(tag);
+        return item;
       }
     }
 


### PR DESCRIPTION
Add a new method to `metadata` to retrieve an item if present, or clearly indicate (by returning a null pointer) if no such item is present. This saves having to perform two lookups to avoid the "undefined result" of the old look-up method. Also update users to use the new method, and remove the no-longer-needed `find`.