### PR TITLE
Perform Imports Alphabetically

### DIFF
--- a/vital/bindings/python/vital/modules/loaders.py
+++ b/vital/bindings/python/vital/modules/loaders.py
@@ -143,7 +143,13 @@ class ModuleLoader(Loader):
                             break
 
     def _findPluginModules(self, namespace):
-        for filepath in self._findPluginFilePaths(namespace):
+
+        filepaths = [ p for p in self._findPluginFilePaths(namespace) ]
+
+        if len( filepaths ) > 0:
+            filepaths.sort( reverse=True )
+
+        for filepath in filepaths:
             path_segments = list(filepath.split(os.path.sep))
             path_segments = [p for p in path_segments if p]
             path_segments[-1] = os.path.splitext(path_segments[-1])[0]

--- a/vital/bindings/python/vital/modules/module_loader.py
+++ b/vital/bindings/python/vital/modules/module_loader.py
@@ -78,6 +78,8 @@ def load_python_modules():
         'Preparing to load sprokit python plugin modules: '
         '[\n    {}\n]'.format(',\n    '.join(list(map(repr, packages)))))
 
+    packages.sort( reverse=True )
+
     loader = loaders.ModuleLoader()
     all_modules = []
 

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -36,6 +36,8 @@
 #include <vital/util/demangle.h>
 #include <vital/util/string.h>
 
+#include <algorithm>
+#include <vector>
 #include <sstream>
 
 #include <kwiversys/SystemTools.hxx>
@@ -331,10 +333,19 @@ plugin_loader_impl
   dir.Load( dir_path );
   unsigned long num_files = dir.GetNumberOfFiles();
 
-  for (unsigned long i = 0; i < num_files; ++i )
+  std::vector< std::string > file_list;
+
+  for ( unsigned long i = 0; i < num_files; ++i )
+  {
+    file_list.push_back( std::string( dir.GetFile( i ) ) );
+  }
+
+  std::sort( file_list.begin(), file_list.end() );
+
+  for ( auto file_no_path : file_list )
   {
     std::string file = dir.GetPath();
-    file += "/" + std::string( dir.GetFile( i ) );
+    file += "/" + file_no_path;
 
     // Accept this file as a module to check if it has the correct library
     // suffix and matches a provided module name if one was provided.


### PR DESCRIPTION
This makes the log prettier.

But the real reason is this fixes an obscure tensorflow->opencv->pytorch import error when dealing with builds on all of the above, but only on some OS.