### PR TITLE
fix unwrap mesh test

### DIFF
--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -68,12 +68,12 @@
 #include <arrows/core/keyframe_selector_basic.h>
 #include <arrows/core/match_features_fundamental_matrix.h>
 #include <arrows/core/match_features_homography.h>
-#include <arrows/core/uv_unwrap_mesh.h>
 #include <arrows/core/read_object_track_set_kw18.h>
 #include <arrows/core/read_track_descriptor_set_csv.h>
 #include <arrows/core/track_features_augment_keyframes.h>
 #include <arrows/core/track_features_core.h>
 #include <arrows/core/triangulate_landmarks.h>
+#include <arrows/core/uv_unwrap_mesh.h>
 #include <arrows/core/video_input_filter.h>
 #include <arrows/core/video_input_image_list.h>
 #include <arrows/core/video_input_pos.h>
@@ -135,6 +135,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_algorithm< track_features_augment_keyframes >();
   reg.register_algorithm< track_features_core >();
   reg.register_algorithm< triangulate_landmarks >();
+  reg.register_algorithm< uv_unwrap_mesh >();
   reg.register_algorithm< video_input_filter >();
   reg.register_algorithm< video_input_image_list >();
   reg.register_algorithm< video_input_pos >();

--- a/arrows/core/tests/test_uv_unwrap_mesh.cxx
+++ b/arrows/core/tests/test_uv_unwrap_mesh.cxx
@@ -85,6 +85,15 @@ public:
   mesh_sptr mesh;
 };
 
+// ----------------------------------------------------------------------------
+TEST(uv_unwrap_mesh, create)
+{
+  using namespace kwiver::vital;
+
+  plugin_manager::instance().load_all_plugins();
+
+  EXPECT_NE(nullptr, algo::uv_unwrap_mesh::create("core"));
+}
 
 // ----------------------------------------------------------------------------
 TEST_F(uv_unwrap_mesh_test, check_texture_coordinates)

--- a/arrows/core/tests/test_uv_unwrap_mesh.cxx
+++ b/arrows/core/tests/test_uv_unwrap_mesh.cxx
@@ -43,7 +43,6 @@ using namespace kwiver::arrows::core;
 // ----------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-  plugin_manager::instance().load_all_plugins();
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
 }

--- a/arrows/core/tests/test_uv_unwrap_mesh.cxx
+++ b/arrows/core/tests/test_uv_unwrap_mesh.cxx
@@ -33,7 +33,6 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/types/mesh.h>
 
-#include <Eigen/Dense>
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/arrows/core/uv_unwrap_mesh.h
+++ b/arrows/core/uv_unwrap_mesh.h
@@ -52,11 +52,8 @@ class KWIVER_ALGO_CORE_EXPORT uv_unwrap_mesh
     : public vital::algorithm_impl<uv_unwrap_mesh, vital::algo::uv_unwrap_mesh>
 {
 public:
-  /// Name of the algorithm
-  static constexpr char const* name = "core";
-
-  /// Description of the algorithm
-  static constexpr char const* description = "Unwrap a mesh and generate texture coordinates";
+  PLUGIN_INFO( "core",
+               "Unwrap a mesh and generate texture coordinates" )
 
   /// Get configuration
   virtual vital::config_block_sptr get_configuration() const;


### PR DESCRIPTION
This fixes and issue where test_uv_unwrap_mesh would segfault at build time during test discovery because it was loading plugins in the main function.  The main function is also called for test discovery at build time, and is run in an environment that does not yet have plugins available. 

It also adds a proper test for loading this algorithm from the plugin, which initially failed, and then fixes this failure by registering the algorithm with the core plugin.