### PR TITLE
Fix interface include dirs for sprokit libraries

### DIFF
--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -113,6 +113,11 @@ kwiver_add_library(sprokit_pipeline
   ${VITAL_VERSION_H}
   )
 
+target_include_directories(sprokit_pipeline INTERFACE
+  $<BUILD_INTERFACE:${sprokit_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${sprokit_BINARY_DIR}/src>
+  )
+
 add_dependencies(sprokit_pipeline configure-version.h)
 
 target_link_libraries(sprokit_pipeline


### PR DESCRIPTION
Sprokit libraries need `<root>/sprokit/src` in their interface include directories, as well as `<root>`, or consumers not using the (legacy) `${KWIVER_INCLUDE_DIRS}` will fail to compile if they use sprokit. Fix by adding the necessary interface include directories to `sprokit_pipeline` (expecting the other sprokit libraries to pick them up transitively).