### PR TITLE
Fix finding FFMPEG

### DIFF
--- a/CMake/FindFFMPEG.cmake
+++ b/CMake/FindFFMPEG.cmake
@@ -14,7 +14,9 @@ find_path( FFMPEG_INCLUDE1_DIR ffmpeg/avcodec.h
 )
 find_path( FFMPEG_INCLUDE2_DIR libavcodec/avcodec.h
   /usr/include
+  /usr/include/ffmpeg
   /usr/local/include
+  /usr/local/include/ffmpeg
 )
 if( FFMPEG_INCLUDE1_DIR)
   set(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE1_DIR} )


### PR DESCRIPTION
Tweak `FindFFMPEG.cmake` so that it is able to find FFMPEG provided by Fedora (and possibly other distros).