### PR TITLE
Remove references to boost python. All documentation for consistency

### DIFF
--- a/CMake/kwiver-setup-python.cmake
+++ b/CMake/kwiver-setup-python.cmake
@@ -56,9 +56,6 @@
 #      python output paths. This may be removed in the future.
 #      (e.g. build/lib)
 #
-#    boost_python_library_var
-#      Set to either Boost_PYTHON_LIBRARY or Boost_PYTHON3_LIBRARY.
-
 
 ###
 # Private helper function to execute `python -c "<cmd>"`

--- a/sprokit/doc/running-notes.md
+++ b/sprokit/doc/running-notes.md
@@ -1,10 +1,5 @@
 # general notes on running a pipeline
 
-## Building boost for Python support
-
-Boost can not be built with debug mode because it activates asserts
-that prevent modules from loading.
-
 ## General module loading
 
 ### Modules/Processes
@@ -123,6 +118,3 @@ Improvement: Make any converters a class, not just two unbound
 functions. The class provides a more functor like environment where
 there can be state and better debugging. Specifically each converter
 can make its target type visible.
-
-A major problem with this conversion stuff is (in addition to the
-boost::python magic) that it is opaque.


### PR DESCRIPTION
Removing documented references to Boost python for consistency. This branch is in preparation to remove the default build of Boost python from fletch