### PR TITLE
Fix bug on CentOS where the pointer couild be NULL.

### DIFF
--- a/vital/kwiversys/SystemInformation.cxx
+++ b/vital/kwiversys/SystemInformation.cxx
@@ -1798,8 +1798,9 @@ int SystemInformationImplementation::GetFullyQualifiedDomainName(
 
   for(p = info; p != NULL; p = p->ai_next)
     {
-    std::string candidate = p->ai_canonname;
-    if ((candidate.find(base)!=std::string::npos) && baseSize<candidate.size())
+      if ( ! p->ai_canonname ) continue;
+      const std::string candidate{ p->ai_canonname };
+      if ((candidate.find(base) != std::string::npos) && baseSize < candidate.size())
       {
       // success, stop now.
       fqdn=candidate;


### PR DESCRIPTION
There is a case on CentOS where the pointer to the
cannonname is null. Test for null and skip entry.