### PR TITLE
Add adapter_data_set::empty

### DIFF
--- a/sprokit/processes/adapters/adapter_data_set.cxx
+++ b/sprokit/processes/adapters/adapter_data_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@ void
 adapter_data_set
 ::add_datum( sprokit::process::port_t const& port, sprokit::datum_t const& datum )
 {
-  m_port_datum_set.insert( std::pair<std::string, sprokit::datum_t> (port, datum ) );
+  m_port_datum_set.emplace( port, datum );
 }
 
 

--- a/sprokit/processes/adapters/adapter_data_set.cxx
+++ b/sprokit/processes/adapters/adapter_data_set.cxx
@@ -80,6 +80,15 @@ adapter_data_set
 
 
 // ------------------------------------------------------------------
+bool
+adapter_data_set
+::empty() const
+{
+  return m_port_datum_set.empty();
+}
+
+
+// ------------------------------------------------------------------
 kwiver::adapter::adapter_data_set::datum_map_t::iterator
 adapter_data_set
 ::begin()

--- a/sprokit/processes/adapters/adapter_data_set.h
+++ b/sprokit/processes/adapters/adapter_data_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -154,8 +154,7 @@ public:
   template <typename T>
   void add_value( sprokit::process::port_t const& port, T const& val )
   {
-    m_port_datum_set.insert(
-      std::pair<std::string, sprokit::datum_t> (port, sprokit::datum::new_datum<T>( val ) ) );
+    m_port_datum_set.emplace( port, sprokit::datum::new_datum<T>( val ) );
   }
 
   //@{

--- a/sprokit/processes/adapters/adapter_data_set.h
+++ b/sprokit/processes/adapters/adapter_data_set.h
@@ -157,6 +157,16 @@ public:
     m_port_datum_set.emplace( port, sprokit::datum::new_datum<T>( val ) );
   }
 
+  /**
+   * @brief Query if data set is empty.
+   *
+   * This method tests if the data set is empty.
+   *
+   * @return \c true if the data set is empty (contains no values), otherwise
+   * \c false.
+   */
+  bool empty() const;
+
   //@{
   /**
    * @brief Get begin iterator for items in this data set.


### PR DESCRIPTION
Tweak some `adapter_data_set` code to use `map::emplace` rather than the much more verbose manual construction of a `pair` to be inserted. Add a new method to `adapter_data_set` to query if there are any values in the data set. (This can be done in a less efficient, more round-about manner anyway by comparing the `begin` and `end` iterators, but having a dedicated method is much more convenient, and probably more efficient.)