### PR TITLE
Fixed a bug in the Ceres bundle adjuster callback.

### DIFF
--- a/arrows/ceres/bundle_adjust.cxx
+++ b/arrows/ceres/bundle_adjust.cxx
@@ -618,10 +618,8 @@ bundle_adjust
     typedef std::map<track_id_t, std::vector<double> > lm_param_map_t;
     for(const lm_param_map_t::value_type& lmp : d_->landmark_params)
     {
-      auto& lmi = d_->lms[lmp.first];
-      auto updated_lm = std::make_shared<landmark_d>(*lmi);
-      updated_lm->set_loc(Eigen::Map<const vector_3d>(&lmp.second[0]));
-      lmi = updated_lm;
+      auto lmi = std::static_pointer_cast<landmark_d>(d_->lms[lmp.first]);
+      lmi->set_loc(Eigen::Map<const vector_3d>(&lmp.second[0]));
     }
     landmark_map_sptr landmarks = std::make_shared<simple_landmark_map>(d_->lms);
 


### PR DESCRIPTION
The main optimize function was previously updated to modify landmarks in place
for speed. This was fine, but the callback was not updated similarly.  As a
result, when the callback was used it would overwrite the landmarks with new
copies, but the main optimize function was not returning these changes since
it was returning the original memory.  This change updates the callback to
update in the same way as the main optimize function to fix this bug.