### PR TITLE
Prefer unix-style dependencies over Frameworks on macOS

### DIFF
--- a/CMake/kwiver-depends.cmake
+++ b/CMake/kwiver-depends.cmake
@@ -1,5 +1,9 @@
 # Central location for KWIVER external dependency declaration and resolution
 
+# On macOS, prefer unix-style packages (e.g. from Fletch) over Frameworks
+# when looking for dependencies
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 # Required for Vital
 include( kwiver-depends-Eigen )
 


### PR DESCRIPTION
Sometimes a build on macOS will find incompatible system Frameworks
versions of dependencies before those provided by Fletch.  This setting
gives unix-style packages, like those in Fletch, priority.