### PR TITLE
Make track_state::clone() fully deep copy

### DIFF
--- a/arrows/core/compute_association_matrix_from_features.cxx
+++ b/arrows/core/compute_association_matrix_from_features.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -168,8 +168,8 @@ compute_association_matrix_from_features
         track_sptr trk = filtered_tracks[t];
         detected_object_sptr det = filtered_dets->begin()[d];
 
-        detected_object::descriptor_sptr det_features = det->descriptor();
-        detected_object::descriptor_sptr trk_features;
+        auto det_features = det->descriptor();
+        auto trk_features = decltype(det_features){};
 
         if( !trk->empty() )
         {
@@ -206,9 +206,9 @@ compute_association_matrix_from_features
 
           double sum_sqr = 0.0;
 
-          for( double *pos1 = det_features->raw_data(),
-                      *pos2 = trk_features->raw_data(),
-                      *end = pos1 + det_features->size();
+          for( auto pos1 = det_features->raw_data(),
+                    pos2 = trk_features->raw_data(),
+                    end = pos1 + det_features->size();
                pos1 != end; ++pos1, ++pos2 )
           {
             sum_sqr += ( ( *pos1 - *pos2 ) * ( *pos1 - *pos2 ) );

--- a/arrows/core/track_set_impl.cxx
+++ b/arrows/core/track_set_impl.cxx
@@ -540,27 +540,28 @@ frame_index_track_set_impl
 
 track_set_implementation_uptr
 frame_index_track_set_impl
-::clone() const
+::clone( vital::clone_type ct ) const
 {
   std::unique_ptr<frame_index_track_set_impl> the_clone =
     std::unique_ptr<frame_index_track_set_impl>(new frame_index_track_set_impl());
 
   // clone the track data
-  for (auto trk : all_tracks_)
+  for ( auto const& trk : all_tracks_ )
   {
-    the_clone->all_tracks_.insert(std::make_pair(trk.first,trk.second->clone()));
+    the_clone->all_tracks_.emplace( trk.first, trk.second->clone( ct ) );
   }
 
   // clone the frame data
-  for (auto fd : frame_data_)
+  for ( auto const& fd : frame_data_ )
   {
-    if (fd.second)
-    {
-      the_clone->frame_data_[fd.first] = fd.second->clone();
-    }
+    the_clone->frame_data_.emplace( fd.first, fd.second->clone() );
   }
 
-  return std::unique_ptr<track_set_implementation>(static_cast<track_set_implementation*>(the_clone.release()));
+#if __GNUC__ > 4 || __clang_major__ > 3
+  return the_clone;
+#else
+  return std::move( the_clone );
+#endif
 }
 
 

--- a/arrows/core/track_set_impl.h
+++ b/arrows/core/track_set_impl.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -159,7 +159,8 @@ public:
   virtual bool set_frame_data( vital::track_set_frame_data_sptr data,
                                vital::frame_id_t offset = -1 );
 
-  virtual vital::track_set_implementation_uptr clone() const;
+  vital::track_set_implementation_uptr clone(
+    vital::clone_type = vital::clone_type::DEEP ) const override;
 
 protected:
   /// Populate frame_map_ with data from all_tracks_

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -9,6 +9,14 @@ Updates since v1.4.0
 
 Vital
 
+ * Added a parameter to the clone() methods of the track_state, track and
+   track_set types controlling whether to make an actual deep copy (default) or
+   to make a shallow copy (previous behavior) where elements of the derived
+   feature_track_state or object_track_state would still be shared. (This
+   change also affects track_set::merge_in_other_track_set(). However, the copy
+   constructors of feature_track_state and object_track_state still make only
+   shallow copies.)
+
 Vital Util
 
 Vital Tools

--- a/sprokit/processes/core/compute_track_descriptors_process.cxx
+++ b/sprokit/processes/core/compute_track_descriptors_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -243,7 +243,7 @@ compute_track_descriptors_process
         // Reset all descriptors stored in detections
         for( vital::detected_object_sptr det : *detections )
         {
-          det->set_descriptor( vital::detected_object::descriptor_sptr() );
+          det->set_descriptor( nullptr );
         }
 
         // Inject computed descriptors

--- a/vital/types/detected_object.cxx
+++ b/vital/types/detected_object.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -110,7 +110,7 @@ detected_object
 
 
 // ------------------------------------------------------------------
-image_container_sptr
+image_container_scptr
 detected_object
 ::mask()
 {
@@ -121,7 +121,7 @@ detected_object
 // ------------------------------------------------------------------
 void
 detected_object
-::set_mask( image_container_sptr m )
+::set_mask( image_container_scptr m )
 {
   m_mask_image = m;
 }
@@ -182,7 +182,7 @@ detected_object
 
 
 // ------------------------------------------------------------------
-detected_object::descriptor_sptr
+detected_object::descriptor_scptr
 detected_object
 ::descriptor() const
 {
@@ -193,7 +193,7 @@ detected_object
 // ------------------------------------------------------------------
 void
 detected_object
-::set_descriptor( descriptor_sptr d )
+::set_descriptor( descriptor_scptr d )
 {
   m_descriptor = d;
 }

--- a/vital/types/detected_object.h
+++ b/vital/types/detected_object.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,9 +78,8 @@ public:
 
   typedef std::vector< detected_object_sptr > vector_t;
   typedef descriptor_dynamic< double > descriptor_t;
-  typedef std::shared_ptr< descriptor_t > descriptor_sptr;
+  typedef std::shared_ptr< descriptor_t const > descriptor_scptr;
   typedef std::shared_ptr< bounding_box_d > bounding_box_sptr;
-
 
   /**
    * @brief Create detected object with bounding box and other attributes.
@@ -218,7 +217,7 @@ public:
    *
    * @return Pointer to the mask image.
    */
-  image_container_sptr mask();
+  image_container_scptr mask();
 
   /**
    * @brief Set mask image for this detection.
@@ -227,7 +226,7 @@ public:
    *
    * @param m Mask image
    */
-  void set_mask( image_container_sptr m );
+  void set_mask( image_container_scptr m );
 
   /**
    * @brief Get descriptor vector.
@@ -238,7 +237,7 @@ public:
    *
    * @return Pointer to the descriptor vector.
    */
-  descriptor_sptr descriptor() const;
+  descriptor_scptr descriptor() const;
 
   /**
    * @brief Set descriptor for this detection.
@@ -248,13 +247,13 @@ public:
    *
    * @param d Descriptor vector
    */
-  void set_descriptor( descriptor_sptr d );
+  void set_descriptor( descriptor_scptr d );
 
 private:
   bounding_box_sptr m_bounding_box;
   double m_confidence;
-  image_container_sptr m_mask_image;
-  descriptor_sptr m_descriptor;
+  image_container_scptr m_mask_image;
+  descriptor_scptr m_descriptor;
 
   // The detection type is an optional list of possible object types.
   detected_object_type_sptr m_type;

--- a/vital/types/feature_track_set.cxx
+++ b/vital/types/feature_track_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,10 +70,10 @@ feature_track_set
 
 track_set_sptr
 feature_track_set
-::clone() const
+::clone( clone_type ct ) const
 {
   track_set_implementation_uptr new_imp =
-    this->impl_->clone();
+    this->impl_->clone( ct );
   feature_track_set_sptr new_fts =
     std::make_shared<feature_track_set>(std::move(new_imp));
   return std::dynamic_pointer_cast<track_set>(new_fts);

--- a/vital/types/image_container.h
+++ b/vital/types/image_container.h
@@ -100,8 +100,8 @@ protected:
 
 
 /// Shared pointer for base image_container type
-typedef std::shared_ptr<image_container> image_container_sptr;
-
+using image_container_sptr = std::shared_ptr< image_container >;
+using image_container_scptr = std::shared_ptr< image_container const >;
 
 /// List of image_container shared pointers
 typedef std::vector<image_container_sptr> image_container_sptr_list;

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014 by Kitware, Inc.
+ * Copyright 2014, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,15 +88,15 @@ track
 /// Clone
 track_sptr
 track
-::clone() const
+::clone( clone_type ct ) const
 {
   track_sptr t( new track( *this ) );
-  t->history_.resize(this->history_.size());
-  size_t i = 0;
+  t->history_.reserve( this->history_.size() );
   for( auto const& ts : this->history_ )
   {
-    t->history_[i] =  ts->clone();
-    t->history_[i++]->track_ = t->shared_from_this();
+    auto new_state = ts->clone( ct );
+    new_state->track_ = t;
+    t->history_.emplace_back( std::move( new_state ) );
   }
   return t;
 }

--- a/vital/types/track_set.h
+++ b/vital/types/track_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2018 by Kitware, Inc.
+ * Copyright 2013-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -430,7 +430,8 @@ public:
   virtual frame_id_t offset_to_frame( frame_id_t offset ) const;
 
   /// Clone this track set implementation
-  virtual track_set_implementation_uptr clone() const = 0;
+  virtual track_set_implementation_uptr clone(
+    clone_type = clone_type::DEEP ) const = 0;
 };
 
 
@@ -646,17 +647,21 @@ public:
     return impl_->offset_to_frame(offset);
   }
 
-  virtual track_set_sptr clone() const;
+  virtual track_set_sptr clone( clone_type = clone_type::DEEP ) const;
 
   /// Merges the other feature track set into this feature track set.
   /**
-  * \param [in] other  the other feature track set to merge into this one
-  * \param [in] do_not_append_tracks if true, the other tracks are cloned and assigned a new track id.
-  *  if false, if the same track id is found in other and in the current feature track set, then
-  *  track states from other are cloned and appended to this object's track.
+  * \param other The other feature track set to merge into this one.
+  * \param clone_method How to clone track states, if needed.
+  * \param do_not_append_tracks
+  *   If \c true, the other tracks are cloned and assigned a new track id. If
+  *   \c false, if the same track id is found in other and in the current
+  *   track set, then track states from other are cloned and appended to this
+  *   object's track.
   */
   virtual void merge_in_other_track_set(
-    track_set_sptr other,
+    track_set_sptr const& other,
+    clone_type clone_method = clone_type::SHALLOW,
     bool do_not_append_tracks = false);
 
 protected:
@@ -723,7 +728,8 @@ public:
   virtual bool set_frame_data( track_set_frame_data_sptr data,
                                frame_id_t offset = -1 );
 
-  virtual track_set_implementation_uptr clone() const;
+  track_set_implementation_uptr clone(
+    clone_type = clone_type::DEEP ) const override;
 
 protected:
   /// The vector of tracks

--- a/vital/vital_types.h
+++ b/vital/vital_types.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,6 +69,12 @@ typedef double gsd_t;
 
 // a short name for unsigned char
 typedef unsigned char byte;
+
+enum class clone_type
+{
+  SHALLOW,
+  DEEP,
+};
 
 } } // end namespace
 


### PR DESCRIPTION
Modify `clone()` of classes derived from `track_state` (`object_track_state`, `feature_track_state`) to make a full deep copy, rather than continuing to share pointers with the original state. This is necessary in order to e.g. make a copy of a `track`[`_state`] that can safely be used by another thread. This also affects `track::clone()`. (The copy constructors still make only a shallow copy.)

This patch also incorporates several related improvements:

- Introduce a new helper class to keep references to the `track_state`'s owning track. This primarily has the behavior that it is non-assignable and that copies don't actually copy anything. This allows more operations on `track_state` itself to be defaulted.

- Improve the efficiency of `track::clone()` by reserving space in the new history vector, rather than resizing. This avoids an extra initialization of the history pointers.

- Constructors which take r-value references to pointers to associated objects are added to `object_track_state` and `feature_track_state`. (These are used by the implementations of `clone()`, and save a reference counting operation compared to the old constructors.)