### PR TITLE
Add track::front()

### DIFF
--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -245,6 +245,9 @@ public:
 
   /// Access a const iterator to the end of the history
   history_const_itr end() const { return history_.end(); }
+
+  /// Access the first entry of the history
+  track_state_sptr front() const { return history_.front(); }
 
   /// Access the last entry of the history
   track_state_sptr back() const { return history_.back(); }


### PR DESCRIPTION
Add a new method to track to access the first history state, for consistency with the existing `track::back()`.