### PR TITLE
Fix use of range adapters on temporaries

### DIFF
--- a/vital/range/filter.h
+++ b/vital/range/filter.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,6 +72,7 @@ public:
   using filter_function_t = Functor;
 
   filter_view( filter_view const& ) = default;
+  filter_view( filter_view&& ) = default;
 
   class iterator
   {
@@ -100,8 +101,8 @@ public:
     filter_function_t m_func;
   };
 
-  filter_view( Range const& range, filter_function_t func )
-    : m_range{ range }, m_func{ func } {}
+  filter_view( Range&& range, filter_function_t func )
+    : m_range( std::forward< Range >( range ) ), m_func( func ) {}
 
   iterator begin() const;
 

--- a/vital/range/indirect.h
+++ b/vital/range/indirect.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,7 @@ public:
   using value_t = range_iterator_t;
 
   indirect_view( indirect_view const& ) = default;
+  indirect_view( indirect_view&& ) = default;
 
   class iterator
   {
@@ -77,13 +78,13 @@ public:
     range_iterator_t m_iter;
   };
 
-  indirect_view( Range& range ) : m_range{ range } {}
+  indirect_view( Range&& range ) : m_range( std::forward< Range >( range ) ) {}
 
   iterator begin() const { return { m_range.begin() }; }
   iterator end() const { return { m_range.end() }; }
 
 protected:
-  range_ref< Range > m_range;
+  range_ref< Range const > m_range;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/vital/range/sliding.h
+++ b/vital/range/sliding.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,6 +77,9 @@ protected:
 public:
   using value_t = std::array< single_value_t, Size >;
 
+  sliding_view( sliding_view const& ) = default;
+  sliding_view( sliding_view&& ) = default;
+
   class iterator
   {
   public:
@@ -108,7 +111,7 @@ public:
     std::array< range_iterator_t, Size > m_iter;
   };
 
-  sliding_view( Range const& range ) : m_range{ range } {}
+  sliding_view( Range&& range ) : m_range( std::forward< Range >( range ) ) {}
 
   iterator begin() const
   { return { m_range.begin(), m_range.end() }; }

--- a/vital/range/tests/test_range_transform.cxx
+++ b/vital/range/tests/test_range_transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,5 +67,76 @@ TEST(range_transform, basic)
     ++counter;
   }
 
+  EXPECT_EQ( 32, counter );
+  EXPECT_EQ( 13.5625, sum );
+}
+
+// ----------------------------------------------------------------------------
+TEST(range_transform, transitive)
+{
+  auto my_transform_1 = []( int x ){
+    return x + 1;
+  };
+  auto my_transform_2 = []( int x ){
+    return static_cast< double >( x ) / 4.0;
+  };
+
+  int counter = 0;
+  auto sum = 0.0;
+  for ( auto x : test_values | range::transform( my_transform_1 )
+                             | range::transform( my_transform_2 ) )
+  {
+    sum += x;
+
+    auto const t = static_cast< double >( test_values[ counter ] );
+    EXPECT_EQ( ( t + 1.0 ) / 4.0, x ) << "At iteration " << counter;
+
+    ++counter;
+  }
+
+  EXPECT_EQ( 32, counter );
+  EXPECT_EQ( 62.25, sum );
+}
+
+// ----------------------------------------------------------------------------
+TEST(range_transform, temporary)
+{
+  class temporary_vector : public std::vector< int >
+  {
+  public:
+    using std::vector< int >::vector;
+    ~temporary_vector()
+    {
+      for ( auto& x : *this )
+      {
+        x = 0;
+      }
+    }
+  };
+
+  auto make_temporary = []{
+    auto out = temporary_vector{};
+    std::copy( std::begin( test_values ), std::end( test_values ),
+               std::back_inserter( out ) );
+    return out;
+  };
+
+  auto my_transform = []( int x ){
+    return static_cast< double >( x ) / 16.0;
+  };
+
+  int counter = 0;
+  auto sum = 0.0;
+  for ( auto x : make_temporary() | range::transform( my_transform ) )
+  {
+    sum += x;
+
+    auto const t = static_cast< double >( test_values[ counter ] );
+    EXPECT_EQ( t / 16.0, x ) << "At iteration " << counter;
+
+    ++counter;
+  }
+
+  EXPECT_EQ( 32, counter );
   EXPECT_EQ( 13.5625, sum );
 }

--- a/vital/range/transform.h
+++ b/vital/range/transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,6 +72,7 @@ public:
   using transform_function_t = Functor;
 
   transform_view( transform_view const& ) = default;
+  transform_view( transform_view&& ) = default;
 
   class iterator
   {
@@ -83,7 +84,7 @@ public:
     bool operator!=( iterator const& other ) const
     { return m_iter != other.m_iter; }
 
-    value_t operator*() const {  return m_func( *m_iter ); }
+    value_t operator*() const { return m_func( *m_iter ); }
 
     iterator& operator++() { ++m_iter; return *this; }
 
@@ -97,8 +98,8 @@ public:
     transform_function_t m_func;
   };
 
-  transform_view( Range const& range, transform_function_t func )
-    : m_range{ range }, m_func{ func } {}
+  transform_view( Range&& range, transform_function_t func )
+    : m_range( std::forward< Range >( range ) ), m_func( func ) {}
 
   iterator begin() const { return { m_range.begin(), m_func }; }
   iterator end() const { return { m_range.end(), m_func }; }

--- a/vital/range/valid.h
+++ b/vital/range/valid.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ public:
   using value_ref_t = typename range_ref< Range >::value_ref_t;
 
   valid_view( valid_view const& ) = default;
+  valid_view( valid_view&& ) = default;
 
   class iterator
   {
@@ -91,8 +92,7 @@ public:
     range_iterator_t m_iter, m_end;
   };
 
-  valid_view( Range& range )
-    : m_range{ range } {}
+  valid_view( Range&& range ) : m_range( std::forward< Range >( range ) ) {}
 
   iterator begin() const;
 


### PR DESCRIPTION
Overhaul a bunch of the range guts to work correctly on temporaries, by having the adapter take a copy of the input. (Note that this means that range adapters can only be used on temporary inputs if the input container type is movable, but with current lifetime rules, there is no other way to lifetime-extend an input temporary.)

Actually getting this to work right, especially on GCC 4.8 (which has some issues with overload resolution in the face of r-value references, as well as the obnoxious bug that uniform initialization syntax can't be used on references) was... interesting. Hint: this, kids, is why `std::forward` exists!

This supersedes #809.