### PR TITLE
Dev/refactor image python bindings

### DIFF
--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -2,6 +2,26 @@ project(vital_python_types)
 
 include_directories(${pybind11_INCLUDE_DIR})
 
+set( vital_python_headers
+     image.h
+     image_container.h
+  )
+
+set( vital_python_sources
+     image.cxx
+     image_container.cxx
+     types_module.cxx
+   )
+
+kwiver_add_python_library(types
+  vital/types
+  ${vital_python_headers}
+  ${vital_python_sources}
+  )
+
+target_link_libraries(python-vital.types-types
+  PUBLIC ${PYTHON_LIBRARIES}
+         vital)
 kwiver_add_python_library(bounding_box
   vital/types
   bounding_box.cxx)
@@ -100,20 +120,6 @@ target_link_libraries(python-vital.types-homography
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-kwiver_add_python_library(image
-  vital/types
-  image.cxx)
-target_link_libraries(python-vital.types-image
-  PUBLIC ${PYTHON_LIBRARIES}
-         vital)
-
-kwiver_add_python_library(image_container
-  vital/types
-  image_container.cxx)
-target_link_libraries(python-vital.types-image_container
-  PUBLIC ${PYTHON_LIBRARIES}
-         vital)
-
 kwiver_add_python_library(landmark
   vital/types
   landmark.cxx)
@@ -164,6 +170,7 @@ target_link_libraries(python-vital.types-object_track_set
          vital)
 
 kwiver_create_python_init(vital/types
+  types
   bounding_box
   camera
   camera_intrinsics
@@ -172,8 +179,6 @@ kwiver_create_python_init(vital/types
   covariance
   descriptor
   descriptor_set
-  image
-  image_container
   detected_object_type
   detected_object
   detected_object_set

--- a/vital/bindings/python/vital/types/image.cxx
+++ b/vital/bindings/python/vital/types/image.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,25 +29,20 @@
  */
 
 #include <vital/types/image.h>
-
+#include <vital/bindings/python/vital/types/image.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
-namespace py = pybind11;
-
-typedef kwiver::vital::image image_t;
-typedef kwiver::vital::image_pixel_traits pixel_traits;
-
 pixel_traits::pixel_type
-pixel_type(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_type(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   return traits.type;
 }
 
 std::string
-pixel_type_name(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_type_name(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   pixel_traits::pixel_type type = traits.type;
@@ -77,14 +72,15 @@ pixel_type_name(std::shared_ptr<image_t> &self)
 }
 
 size_t
-pixel_num_bytes(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_num_bytes(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   return traits.num_bytes;
 }
 
 py::object
-get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j)
+kwiver::vital::python::image::get_pixel2(std::shared_ptr<image_t> &img,
+                                  unsigned i, unsigned j)
 {
   std::string type = pixel_type_name(img);
 
@@ -115,7 +111,8 @@ get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j)
 }
 
 py::object
-get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k)
+kwiver::vital::python::image::get_pixel3(std::shared_ptr<image_t> &img,
+                                  unsigned i, unsigned j, unsigned k)
 {
   std::string type = pixel_type_name(img);
 
@@ -148,7 +145,8 @@ get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k)
 // __getitem__ has 2 or 3 dimensions, each calling a different function
 // so the index has to be passed in as a vector
 py::object
-get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx)
+kwiver::vital::python::image::get_pixel(std::shared_ptr<image_t> &img,
+                                  std::vector<unsigned> idx)
 {
   if(idx.size() == 2)
   {
@@ -162,21 +160,22 @@ get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx)
 }
 
 void*
-first_pixel(std::shared_ptr<image_t> &img)
+kwiver::vital::python::image::first_pixel(std::shared_ptr<image_t> &img)
 {
   return img->first_pixel();
 }
 
 image_t
-new_image(size_t width, size_t height, size_t depth, bool interleave,
-          pixel_traits::pixel_type &type, size_t bytes)
+kwiver::vital::python::image::new_image(size_t width, size_t height, size_t depth,
+                                bool interleave, pixel_traits::pixel_type &type,
+                                size_t bytes)
 {
   pixel_traits traits(type, bytes);
   return image_t(width, height, depth, interleave, traits);
 }
 
 image_t
-new_image_from_data( char* first_pixel,
+kwiver::vital::python::image::new_image_from_data( char* first_pixel,
                      size_t width, size_t height, size_t depth,
                      int32_t w_step, int32_t h_step, int32_t d_step,
                      pixel_traits::pixel_type pixel_type,
@@ -190,62 +189,14 @@ new_image_from_data( char* first_pixel,
   return new_img;
 }
 
-
-template <typename T>
-image_t
-new_image_from_numpy(py::array_t<T> array)
-{
-
-  // Request a buffer descriptor from Python
-  py::buffer_info info = array.request();
-
-  // Determine if the type has numeric_limits, is integral, and / or is signed
-  // Note: the following function does not handle float16. Should it?
-  pixel_traits traits =  kwiver::vital::image_pixel_traits_of<T>();
-
-  // numpy images are in height x width format by default (row major)
-  size_t height = info.shape[0];
-  size_t width = info.shape[1];
-  size_t depth;
-
-  size_t h_step = info.strides[0] / traits.num_bytes;
-  size_t w_step = info.strides[1] / traits.num_bytes;
-  size_t d_step;
-
-  if (info.ndim == 2)
-  {
-      depth = 1;
-      d_step = 1;
-  }
-  else if (info.ndim == 3)
-  {
-    depth = info.shape[2];
-    d_step = info.strides[2]  / traits.num_bytes;
-  }
-  else
-  {
-    throw std::runtime_error("Incompatible buffer dimension!");
-  }
-
-  char* first_pixel = static_cast<char *>(info.ptr);
-  image_t img = image_t(first_pixel, width, height, depth,
-                        w_step, h_step, d_step, traits);
-
-  // TODO: is is possible to share memory?
-
-  image_t new_img = image_t(); // copy so we can use fresh memory not used elsewhere
-  new_img.copy_from(img);
-  return new_img;
-}
-
-
 /*
  * Get the appropriate python format descriptor string to describe pixel traits
  *
  * References:
  *     https://docs.python.org/3/library/struct.html
  */
-const char* get_trait_format_descriptor(const pixel_traits& traits)
+const char* kwiver::vital::python::image::get_trait_format_descriptor(
+    const pixel_traits& traits)
 {
     const size_t itemsize = traits.num_bytes;
     switch (traits.type)
@@ -311,7 +262,7 @@ const char* get_trait_format_descriptor(const pixel_traits& traits)
 }
 
 
-py::buffer_info get_buffer_info(image_t &img)
+py::buffer_info kwiver::vital::python::image::get_buffer_info(image_t &img)
 {
     const pixel_traits traits = img.pixel_traits();
     const size_t itemsize = traits.num_bytes;
@@ -341,8 +292,7 @@ py::buffer_info get_buffer_info(image_t &img)
     );
 }
 
-
-PYBIND11_MODULE(image, m)
+void image(py::module& m)
 {
   py::class_<image_t, std::shared_ptr<image_t>> img(m, "Image", py::buffer_protocol());
   /*
@@ -373,25 +323,25 @@ PYBIND11_MODULE(image, m)
       "    >>> assert np.all(np_img != vital_img.asarray())\n"
   );
 
-py::enum_<pixel_traits::pixel_type>(img, "Types") .value("PIXEL_UNKNOWN",
-pixel_traits::pixel_type::UNKNOWN) .value("PIXEL_BOOL",
-pixel_traits::pixel_type::BOOL) .value("PIXEL_UNSIGNED",
-pixel_traits::pixel_type::UNSIGNED) .value("PIXEL_SIGNED",
-pixel_traits::pixel_type::SIGNED) .value("PIXEL_FLOAT",
-pixel_traits::pixel_type::FLOAT) .export_values();
+  py::enum_<pixel_traits::pixel_type>(img, "Types") .value("PIXEL_UNKNOWN",
+  pixel_traits::pixel_type::UNKNOWN) .value("PIXEL_BOOL",
+  pixel_traits::pixel_type::BOOL) .value("PIXEL_UNSIGNED",
+  pixel_traits::pixel_type::UNSIGNED) .value("PIXEL_SIGNED",
+  pixel_traits::pixel_type::SIGNED) .value("PIXEL_FLOAT",
+  pixel_traits::pixel_type::FLOAT) .export_values();
 
-  img.def(py::init(&new_image),
+  img.def(py::init(&kwiver::vital::python::image::new_image),
     py::arg("width")=0, py::arg("height")=0, py::arg("depth")=1,
     py::arg("interleave")=false, py::arg("pixel_type")=pixel_traits::pixel_type::UNSIGNED,
     py::arg("bytes")=1)
-  .def(py::init(&new_image_from_data),
+  .def(py::init(&kwiver::vital::python::image::new_image_from_data),
    py::arg("first_pixel"), py::arg("width"), py::arg("height"), py::arg("depth"),
    py::arg("w_step"), py::arg("h_step"), py::arg("d_step"),
    py::arg("pixel_type"), py::arg("bytes"))
 
   // create initializer from typed numpy arrays
   #define init_from_numpy( T ) \
-  .def(py::init(&new_image_from_numpy< T >), py::arg("array"),\
+  .def(py::init(&kwiver::vital::python::image::new_image_from_numpy< T >), py::arg("array"),\
        py::doc("Create (copy) a vital image from a 2D or 3D numpy array"))
   init_from_numpy( uint8_t )
   init_from_numpy( int8_t )
@@ -414,13 +364,12 @@ pixel_traits::pixel_type::FLOAT) .export_values();
   .def("w_step", &image_t::w_step)
   .def("h_step", &image_t::h_step)
   .def("d_step", &image_t::d_step)
-  .def("first_pixel_address", &first_pixel)
-  .def("pixel_type", &pixel_type)
-  .def("pixel_type_name", &pixel_type_name)
-  .def("pixel_num_bytes", &pixel_num_bytes)
-  .def("__getitem__", &get_pixel)
-  .def_buffer(&get_buffer_info)
-
+  .def("first_pixel_address", &kwiver::vital::python::image::first_pixel)
+  .def("pixel_type", &kwiver::vital::python::image::pixel_type)
+  .def("pixel_type_name", &kwiver::vital::python::image::pixel_type_name)
+  .def("pixel_num_bytes", &kwiver::vital::python::image::pixel_num_bytes)
+  .def("__getitem__", &kwiver::vital::python::image::get_pixel)
+  .def_buffer(&kwiver::vital::python::image::get_buffer_info)
   .def("asarray", [](image_t &img){
         // It may be possible to write this method to share memory between
         // vital and numpy using the py::capsule class. For references see:
@@ -428,6 +377,5 @@ pixel_traits::pixel_type::FLOAT) .export_values();
         py::object np = py::module::import("numpy");
         py::object arr = np.attr("array")(img);
         return arr;
-      }, py::doc("Copy the image into a numpy array'"))
-  ;
+      }, py::doc("Copy the image into a numpy array'"));
 }

--- a/vital/bindings/python/vital/types/image.h
+++ b/vital/bindings/python/vital/types/image.h
@@ -1,0 +1,112 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_VITAL_PYTHON_IMAGE_H_
+#define KWIVER_VITAL_PYTHON_IMAGE_H_
+
+#include <vital/types/image.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+typedef kwiver::vital::image image_t;
+typedef kwiver::vital::image_pixel_traits pixel_traits;
+namespace py = pybind11;
+
+void image(py::module &m);
+
+namespace kwiver {
+namespace vital {
+namespace python {
+namespace image {
+  pixel_traits::pixel_type pixel_type(std::shared_ptr<image_t> &self);
+  std::string pixel_type_name(std::shared_ptr<image_t> &self);
+  size_t pixel_num_bytes(std::shared_ptr<image_t> &self);
+  py::object get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j);
+  py::object get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k);
+  py::object get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx);
+  void* first_pixel(std::shared_ptr<image_t> &img);
+  image_t new_image(size_t width, size_t height, size_t depth, bool interleave,
+            pixel_traits::pixel_type &type, size_t bytes);
+  image_t new_image_from_data( char* first_pixel,
+                       size_t width, size_t height, size_t depth,
+                       int32_t w_step, int32_t h_step, int32_t d_step,
+                       pixel_traits::pixel_type pixel_type,
+                       size_t bytes);
+  template <typename T>
+  image_t
+  new_image_from_numpy(py::array_t<T> array)
+  {
+
+    // Request a buffer descriptor from Python
+    py::buffer_info info = array.request();
+
+    // Determine if the type has numeric_limits, is integral, and / or is signed
+    // Note: the following function does not handle float16. Should it?
+    pixel_traits traits =  kwiver::vital::image_pixel_traits_of<T>();
+
+    // numpy images are in height x width format by default (row major)
+    size_t height = info.shape[0];
+    size_t width = info.shape[1];
+    size_t depth;
+
+    size_t h_step = info.strides[0] / traits.num_bytes;
+    size_t w_step = info.strides[1] / traits.num_bytes;
+    size_t d_step;
+
+    if (info.ndim == 2)
+    {
+        depth = 1;
+        d_step = 1;
+    }
+    else if (info.ndim == 3)
+    {
+      depth = info.shape[2];
+      d_step = info.strides[2]  / traits.num_bytes;
+    }
+    else
+    {
+      throw std::runtime_error("Incompatible buffer dimension!");
+    }
+
+    char* first_pixel = static_cast<char *>(info.ptr);
+    image_t img = image_t(first_pixel, width, height, depth,
+                          w_step, h_step, d_step, traits);
+    // TODO: is is possible to share memory?
+    image_t new_img = image_t(); // copy so we can use fresh memory not used elsewhere
+    new_img.copy_from(img);
+    return new_img;
+  }
+  const char* get_trait_format_descriptor(const pixel_traits& traits);
+  py::buffer_info get_buffer_info(image_t &img);
+
+} } } }
+#endif

--- a/vital/bindings/python/vital/types/image_container.h
+++ b/vital/bindings/python/vital/types/image_container.h
@@ -1,0 +1,57 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_VITAL_PYTHON_IMAGE_CONTAINER_H_
+#define KWIVER_VITAL_PYTHON_IMAGE_CONTAINER_H_
+
+#include <pybind11/pybind11.h>
+#include <vital/types/image_container.h>
+#include <vital/bindings/python/vital/types/image.h>
+
+namespace py = pybind11;
+
+typedef kwiver::vital::image_container image_cont_t;
+typedef kwiver::vital::simple_image_container s_image_cont_t;
+
+void image_container(py::module &m);
+
+namespace kwiver {
+namespace vital  {
+namespace python {
+namespace image_container {
+// We need to return a shared pointer--otherwise, pybind11 may lose the subtype
+std::shared_ptr<s_image_cont_t>new_cont(kwiver::vital::image &img);
+
+// We need to do a deep copy instead of just calling get_image, so we can ref track in python
+kwiver::vital::image get_image(std::shared_ptr<image_cont_t> self);
+
+} } } }
+
+#endif

--- a/vital/bindings/python/vital/types/types_module.cxx
+++ b/vital/bindings/python/vital/types/types_module.cxx
@@ -1,0 +1,47 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file algorithm_implementation.cxx
+ *
+ * \brief python bindings for algorithm
+ */
+
+#include <pybind11/pybind11.h>
+#include <vital/bindings/python/vital/types/image.h>
+#include <vital/bindings/python/vital/types/image_container.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(types, m)
+{
+  image(m);
+  image_container(m);
+}


### PR DESCRIPTION
This branch is intended to propose a refactored version of the vital types python bindings. The primary motivation is to be able to reuse code across bindings and is applicable to functions like asarray.

The following changes are proposed
1. Split the binding into header and source
2. Move the custom functions used for the binding in a namespace kwiver::vital::python::vital_type_name
3. Add an additional file type_module.cxx for all the type modules.