### PR TITLE
Dev/reuse image binding code

### DIFF
--- a/examples/pipelines/images_to_python.pipe.in
+++ b/examples/pipelines/images_to_python.pipe.in
@@ -1,6 +1,6 @@
 # ================================================================
 process input
-  :: frame_list_input
+  :: frame_list_process
 # Input file containing new-line separated paths to sequential image
 # files.
   image_list_file = @EXAMPLE_DIR@/pipelines/image_list.txt
@@ -14,7 +14,7 @@ process input
 
 # ================================================================
 # Python process to accept an image.
-process process
+process p
   :: ProcessImage
 
 # ================================================================
@@ -37,16 +37,18 @@ process writer
 #
 config _pipeline:_edge
        capacity = 10
+config _scheduler
+       type = pythread_per_process
 
 # ================================================================
 # connections
 connect from input.image
-        to   process.image
+        to   p.image
 
-connect from process.out_image
+connect from p.out_image
         to disp.image
 
-connect from process.out_image
+connect from p.out_image
         to writer.image
 
 # -- end of file --

--- a/vital/bindings/python/vital/tests/helpers.py
+++ b/vital/bindings/python/vital/tests/helpers.py
@@ -1,6 +1,6 @@
 """
 ckwg +31
-Copyright 2016 by Kitware, Inc.
+Copyright 2016-2019 by Kitware, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -175,3 +175,39 @@ def reprojection_error_sqr(cam, lm, feat):
     return (reprojection_error_vec(cam, lm, feat) ** 2).sum()
 
 
+def create_numpy_image(dtype_name, nchannels, order='c'):
+    if nchannels is None:
+        shape = (5, 4)
+    else:
+        shape = (5, 4, nchannels)
+    size = numpy.prod(shape)
+
+    dtype = numpy.dtype(dtype_name)
+
+    if dtype_name == 'bool':
+        np_img = numpy.zeros(size, dtype=dtype).reshape(shape)
+        np_img[0::2] = 1
+    else:
+        np_img = numpy.arange(size, dtype=dtype).reshape(shape)
+
+    if order.startswith('c'):
+        np_img = numpy.ascontiguousarray(np_img)
+    elif order.startswith('fortran'):
+        np_img = numpy.asfortranarray(np_img)
+    else:
+        raise KeyError(order)
+    if order.endswith('-reverse'):
+        np_img = np_img[::-1, ::-1]
+
+    return np_img
+
+def map_dtype_name_to_pixel_type(dtype_name):
+    if dtype_name == 'float16':
+        want = 'float16'
+    if dtype_name == 'float32':
+        want = 'float'
+    elif dtype_name == 'float64':
+        want = 'double'
+    else:
+        want = dtype_name
+    return want

--- a/vital/bindings/python/vital/tests/test_image.py
+++ b/vital/bindings/python/vital/tests/test_image.py
@@ -107,10 +107,8 @@ class TestVitalImage (object):
             np_img = create_numpy_image(dtype_name, nchannels, order)
             vital_img = Image(np_img)
             recast = vital_img.asarray()
-
-            if nchannels is None:
-                # asarray always returns 3 channels
-                np_img = np_img[..., None]
+            # asarray always returns 3 channels
+            np_img = np.atleast_3d(np_img)
             pixel_type_name = vital_img.pixel_type_name()
             want = map_dtype_name_to_pixel_type(dtype_name)
 

--- a/vital/bindings/python/vital/tests/test_image.py
+++ b/vital/bindings/python/vital/tests/test_image.py
@@ -38,7 +38,7 @@ import nose.tools
 
 from vital.types import Image
 import numpy as np
-
+from vital.tests.helpers import create_numpy_image, map_dtype_name_to_pixel_type
 
 class TestVitalImage (object):
 
@@ -104,46 +104,15 @@ class TestVitalImage (object):
                        'float64']
 
         def _test_numpy(dtype_name, nchannels, order='c'):
-            if nchannels is None:
-                shape = (5, 4)
-            else:
-                shape = (5, 4, nchannels)
-            size = np.prod(shape)
-
-            dtype = np.dtype(dtype_name)
-
-            if dtype_name == 'bool':
-                np_img = np.zeros(size, dtype=dtype).reshape(shape)
-                np_img[0::2] = 1
-            else:
-                np_img = np.arange(size, dtype=dtype).reshape(shape)
-
-            if order.startswith('c'):
-                np_img = np.ascontiguousarray(np_img)
-            elif order.startswith('fortran'):
-                np_img = np.asfortranarray(np_img)
-            else:
-                raise KeyError(order)
-            if order.endswith('-reverse'):
-                np_img = np_img[::-1, ::-1]
-
+            np_img = create_numpy_image(dtype_name, nchannels, order)
             vital_img = Image(np_img)
             recast = vital_img.asarray()
 
             if nchannels is None:
                 # asarray always returns 3 channels
                 np_img = np_img[..., None]
-
             pixel_type_name = vital_img.pixel_type_name()
-
-            if dtype_name == 'float16':
-                want = 'float16'
-            if dtype_name == 'float32':
-                want = 'float'
-            elif dtype_name == 'float64':
-                want = 'double'
-            else:
-                want = dtype_name
+            want = map_dtype_name_to_pixel_type(dtype_name)
 
             assert pixel_type_name == want, 'want={} but got={}'.format(
                 want, pixel_type_name)

--- a/vital/bindings/python/vital/tests/test_image_container.py
+++ b/vital/bindings/python/vital/tests/test_image_container.py
@@ -82,9 +82,8 @@ class TestVitalImageContainer (object):
             img_container = ImageContainer.fromarray(np_img)
             recast = img_container.asarray()
 
-            if nchannels is None:
-                # asarray always returns 3 channels
-                np_img = np_img[..., None]
+            # asarray always returns 3 channels
+            np_img = np.atleast_3d(np_img)
 
             vital_img = img_container.image()
             pixel_type_name = vital_img.pixel_type_name()
@@ -120,9 +119,8 @@ class TestVitalImageContainer (object):
             img_container = ImageContainer(Image(np_img))
             recast = img_container.asarray()
 
-            if nchannels is None:
-                # asarray always returns 3 channels
-                np_img = np_img[..., None]
+            # asarray always returns 3 channels
+            np_img = np.atleast_3d(np_img)
 
             vital_img = img_container.image()
             pixel_type_name = vital_img.pixel_type_name()

--- a/vital/bindings/python/vital/tests/test_image_container.py
+++ b/vital/bindings/python/vital/tests/test_image_container.py
@@ -1,6 +1,6 @@
 """
 ckwg +31
-Copyright 2015-2016 by Kitware, Inc.
+Copyright 2015-2019 by Kitware, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@ from vital.types import (
 )
 
 import nose.tools
+import numpy as np
+from vital.tests.helpers import create_numpy_image, map_dtype_name_to_pixel_type
 
 
 class TestVitalImageContainer (object):
@@ -66,3 +68,79 @@ class TestVitalImageContainer (object):
         i = Image(720, 480)
         ic = ImageContainer(i)
         nose.tools.assert_equal(ic.height(), 480)
+
+    def test_fromarray(self):
+        dtype_names = ['bool',
+                       'int8', 'int16', 'int32',
+                       'uint8', 'uint16', 'uint32',
+                       # 'float16',  # currently not supported
+                       'float32',
+                       'float64']
+
+        def _test_numpy(dtype_name, nchannels, order='c'):
+            np_img = create_numpy_image(dtype_name, nchannels, order)
+            img_container = ImageContainer.fromarray(np_img)
+            recast = img_container.asarray()
+
+            if nchannels is None:
+                # asarray always returns 3 channels
+                np_img = np_img[..., None]
+
+            vital_img = img_container.image()
+            pixel_type_name = vital_img.pixel_type_name()
+
+            pixel_type_name = vital_img.pixel_type_name()
+            want = map_dtype_name_to_pixel_type(dtype_name)
+
+            assert pixel_type_name == want, 'want={} but got={}'.format(
+                want, pixel_type_name)
+
+            if not np.all(np_img == recast):
+                raise AssertionError(
+                    'Failed dtype={}, nchannels={}, order={}'.format(
+                        dtype_name, nchannels, order))
+
+        n_pass = 0
+        for order in ['c', 'fortran', 'c-reverse', 'fortran-reverse']:
+            for nchannels in [None, 1, 3, 4]:
+                for dtype_name in dtype_names:
+                    _test_numpy(dtype_name, nchannels)
+                    n_pass += 1
+
+    def test_asarray(self):
+        dtype_names = ['bool',
+                       'int8', 'int16', 'int32',
+                       'uint8', 'uint16', 'uint32',
+                       # 'float16',  # currently not supported
+                       'float32',
+                       'float64']
+
+        def _test_numpy(dtype_name, nchannels, order='c'):
+            np_img = create_numpy_image(dtype_name, nchannels, order)
+            img_container = ImageContainer(Image(np_img))
+            recast = img_container.asarray()
+
+            if nchannels is None:
+                # asarray always returns 3 channels
+                np_img = np_img[..., None]
+
+            vital_img = img_container.image()
+            pixel_type_name = vital_img.pixel_type_name()
+
+            pixel_type_name = vital_img.pixel_type_name()
+            want = map_dtype_name_to_pixel_type(dtype_name)
+
+            assert pixel_type_name == want, 'want={} but got={}'.format(
+                want, pixel_type_name)
+
+            if not np.all(np_img == recast):
+                raise AssertionError(
+                    'Failed dtype={}, nchannels={}, order={}'.format(
+                        dtype_name, nchannels, order))
+
+        n_pass = 0
+        for order in ['c', 'fortran', 'c-reverse', 'fortran-reverse']:
+            for nchannels in [None, 1, 3, 4]:
+                for dtype_name in dtype_names:
+                    _test_numpy(dtype_name, nchannels)
+                    n_pass += 1

--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -2,6 +2,26 @@ project(vital_python_types)
 
 include_directories(${pybind11_INCLUDE_DIR})
 
+set( vital_python_headers
+     image.h
+     image_container.h
+  )
+
+set( vital_python_sources
+     image.cxx
+     image_container.cxx
+     types_module.cxx
+   )
+
+kwiver_add_python_library(types
+  vital/types
+  ${vital_python_headers}
+  ${vital_python_sources}
+  )
+
+target_link_libraries(python-vital.types-types
+  PUBLIC ${PYTHON_LIBRARIES}
+         vital)
 kwiver_add_python_library(bounding_box
   vital/types
   bounding_box.cxx)
@@ -100,20 +120,6 @@ target_link_libraries(python-vital.types-homography
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
-kwiver_add_python_library(image
-  vital/types
-  image.cxx)
-target_link_libraries(python-vital.types-image
-  PUBLIC ${PYTHON_LIBRARIES}
-         vital)
-
-kwiver_add_python_library(image_container
-  vital/types
-  image_container.cxx)
-target_link_libraries(python-vital.types-image_container
-  PUBLIC ${PYTHON_LIBRARIES}
-         vital)
-
 kwiver_add_python_library(landmark
   vital/types
   landmark.cxx)
@@ -164,6 +170,7 @@ target_link_libraries(python-vital.types-object_track_set
          vital)
 
 kwiver_create_python_init(vital/types
+  types
   bounding_box
   camera
   camera_intrinsics
@@ -172,8 +179,6 @@ kwiver_create_python_init(vital/types
   covariance
   descriptor
   descriptor_set
-  image
-  image_container
   detected_object_type
   detected_object
   detected_object_set

--- a/vital/bindings/python/vital/types/image.cxx
+++ b/vital/bindings/python/vital/types/image.cxx
@@ -292,6 +292,244 @@ py::buffer_info kwiver::vital::python::image::get_buffer_info(image_t &img)
     );
 }
 
+py::object kwiver::vital::python::image::asarray(image_t img)
+{
+  const pixel_traits traits = img.pixel_traits();
+  const size_t num_bytes = traits.num_bytes;
+  const pixel_traits::pixel_type pixel_type = traits.type;
+  py::object np = py::module::import("numpy");
+  //py::object np_arr = np.attr("array")(img);
+  //return np_arr;
+  switch(pixel_type)
+  {
+    case pixel_traits::pixel_type::BOOL:
+    {
+        switch (num_bytes)
+        {
+            case 1:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::BOOL, 1>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::BOOL, 1 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            default:
+                throw std::runtime_error(
+                    "Boolean image supports single byte pixels. "
+                    + std::to_string(num_bytes)  + " provided." );
+        }
+    }
+    case pixel_traits::pixel_type::UNSIGNED:
+    {
+        switch (traits.num_bytes)
+        {
+            case 1:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 1>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 1 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 2:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 2>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 2 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 4:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 4>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 4>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 8:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 8>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::UNSIGNED, 8>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            default:
+                throw std::runtime_error(
+                    "Unsigned Integer image supports 1, 2, 4, 8 byte pixels. "
+                    + std::to_string(num_bytes)  + " provided." );
+        }
+    }
+    case pixel_traits::pixel_type::SIGNED:
+    {
+        switch (traits.num_bytes)
+        {
+            case 1:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 1>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 1 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 2:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 2>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 2 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 4:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 4>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 4>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 8:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 8>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::SIGNED, 8>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            default:
+                throw std::runtime_error(
+                    "Signed Integer image supports 1, 2, 4, 8 byte pixels. "
+                    + std::to_string(num_bytes)  + " provided." );
+        }
+    }
+    case pixel_traits::pixel_type::FLOAT:
+    {
+        switch (traits.num_bytes)
+        {
+            case 2:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 2>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 2 >::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 4:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 4>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 4>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            case 8:
+            {
+              auto first_pixel = static_cast< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 8>::type* >
+                                             ( img.first_pixel() );
+              auto arr = py::array_t< kwiver::vital::image_pixel_from_traits
+                                             < pixel_traits::pixel_type::FLOAT, 8>::type >
+                                         ( { img.height(), img.width(), img.depth() },
+                                           { img.h_step()*num_bytes,
+                                             img.w_step()*num_bytes,
+                                             img.d_step()*num_bytes },
+                                           first_pixel );
+              py::object np_arr = np.attr("array")(arr);
+              return np_arr;
+            }
+            default:
+                throw std::runtime_error(
+                    "Float image supports 2, 4, 8 byte pixels. "
+                    + std::to_string(num_bytes)  + " provided." );
+        }
+    }
+    case pixel_traits::pixel_type::UNKNOWN:
+        throw std::runtime_error(
+                "Cannot handle traits with unknown pixel type ");
+    default:
+        throw std::runtime_error("Unidentified pixel trait and number of bytes encoutered");
+  }
+}
+
 void image(py::module& m)
 {
   py::class_<image_t, std::shared_ptr<image_t>> img(m, "Image", py::buffer_protocol());
@@ -374,8 +612,7 @@ void image(py::module& m)
         // It may be possible to write this method to share memory between
         // vital and numpy using the py::capsule class. For references see:
         // https://stackoverflow.com/questions/44659924/ret-nparrays-pybind11
-        py::object np = py::module::import("numpy");
-        py::object arr = np.attr("array")(img);
-        return arr;
+        py::object np_arr = kwiver::vital::python::image::asarray(img);
+        return np_arr;
       }, py::doc("Copy the image into a numpy array'"));
 }

--- a/vital/bindings/python/vital/types/image.cxx
+++ b/vital/bindings/python/vital/types/image.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,25 +29,20 @@
  */
 
 #include <vital/types/image.h>
-
+#include <vital/bindings/python/vital/types/image.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
-namespace py = pybind11;
-
-typedef kwiver::vital::image image_t;
-typedef kwiver::vital::image_pixel_traits pixel_traits;
-
 pixel_traits::pixel_type
-pixel_type(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_type(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   return traits.type;
 }
 
 std::string
-pixel_type_name(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_type_name(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   pixel_traits::pixel_type type = traits.type;
@@ -77,14 +72,15 @@ pixel_type_name(std::shared_ptr<image_t> &self)
 }
 
 size_t
-pixel_num_bytes(std::shared_ptr<image_t> &self)
+kwiver::vital::python::image::pixel_num_bytes(std::shared_ptr<image_t> &self)
 {
   auto traits = self->pixel_traits();
   return traits.num_bytes;
 }
 
 py::object
-get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j)
+kwiver::vital::python::image::get_pixel2(std::shared_ptr<image_t> &img,
+                                  unsigned i, unsigned j)
 {
   std::string type = pixel_type_name(img);
 
@@ -115,7 +111,8 @@ get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j)
 }
 
 py::object
-get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k)
+kwiver::vital::python::image::get_pixel3(std::shared_ptr<image_t> &img,
+                                  unsigned i, unsigned j, unsigned k)
 {
   std::string type = pixel_type_name(img);
 
@@ -148,7 +145,8 @@ get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k)
 // __getitem__ has 2 or 3 dimensions, each calling a different function
 // so the index has to be passed in as a vector
 py::object
-get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx)
+kwiver::vital::python::image::get_pixel(std::shared_ptr<image_t> &img,
+                                  std::vector<unsigned> idx)
 {
   if(idx.size() == 2)
   {
@@ -162,21 +160,22 @@ get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx)
 }
 
 void*
-first_pixel(std::shared_ptr<image_t> &img)
+kwiver::vital::python::image::first_pixel(std::shared_ptr<image_t> &img)
 {
   return img->first_pixel();
 }
 
 image_t
-new_image(size_t width, size_t height, size_t depth, bool interleave,
-          pixel_traits::pixel_type &type, size_t bytes)
+kwiver::vital::python::image::new_image(size_t width, size_t height, size_t depth,
+                                bool interleave, pixel_traits::pixel_type &type,
+                                size_t bytes)
 {
   pixel_traits traits(type, bytes);
   return image_t(width, height, depth, interleave, traits);
 }
 
 image_t
-new_image_from_data( char* first_pixel,
+kwiver::vital::python::image::new_image_from_data( char* first_pixel,
                      size_t width, size_t height, size_t depth,
                      int32_t w_step, int32_t h_step, int32_t d_step,
                      pixel_traits::pixel_type pixel_type,
@@ -190,62 +189,14 @@ new_image_from_data( char* first_pixel,
   return new_img;
 }
 
-
-template <typename T>
-image_t
-new_image_from_numpy(py::array_t<T> array)
-{
-
-  // Request a buffer descriptor from Python
-  py::buffer_info info = array.request();
-
-  // Determine if the type has numeric_limits, is integral, and / or is signed
-  // Note: the following function does not handle float16. Should it?
-  pixel_traits traits =  kwiver::vital::image_pixel_traits_of<T>();
-
-  // numpy images are in height x width format by default (row major)
-  size_t height = info.shape[0];
-  size_t width = info.shape[1];
-  size_t depth;
-
-  size_t h_step = info.strides[0] / traits.num_bytes;
-  size_t w_step = info.strides[1] / traits.num_bytes;
-  size_t d_step;
-
-  if (info.ndim == 2)
-  {
-      depth = 1;
-      d_step = 1;
-  }
-  else if (info.ndim == 3)
-  {
-    depth = info.shape[2];
-    d_step = info.strides[2]  / traits.num_bytes;
-  }
-  else
-  {
-    throw std::runtime_error("Incompatible buffer dimension!");
-  }
-
-  char* first_pixel = static_cast<char *>(info.ptr);
-  image_t img = image_t(first_pixel, width, height, depth,
-                        w_step, h_step, d_step, traits);
-
-  // TODO: is is possible to share memory?
-
-  image_t new_img = image_t(); // copy so we can use fresh memory not used elsewhere
-  new_img.copy_from(img);
-  return new_img;
-}
-
-
 /*
  * Get the appropriate python format descriptor string to describe pixel traits
  *
  * References:
  *     https://docs.python.org/3/library/struct.html
  */
-const char* get_trait_format_descriptor(const pixel_traits& traits)
+const char* kwiver::vital::python::image::get_trait_format_descriptor(
+    const pixel_traits& traits)
 {
     const size_t itemsize = traits.num_bytes;
     switch (traits.type)
@@ -311,7 +262,7 @@ const char* get_trait_format_descriptor(const pixel_traits& traits)
 }
 
 
-py::buffer_info get_buffer_info(image_t &img)
+py::buffer_info kwiver::vital::python::image::get_buffer_info(image_t &img)
 {
     const pixel_traits traits = img.pixel_traits();
     const size_t itemsize = traits.num_bytes;
@@ -341,8 +292,7 @@ py::buffer_info get_buffer_info(image_t &img)
     );
 }
 
-
-PYBIND11_MODULE(image, m)
+void image(py::module& m)
 {
   py::class_<image_t, std::shared_ptr<image_t>> img(m, "Image", py::buffer_protocol());
   /*
@@ -373,25 +323,25 @@ PYBIND11_MODULE(image, m)
       "    >>> assert np.all(np_img != vital_img.asarray())\n"
   );
 
-py::enum_<pixel_traits::pixel_type>(img, "Types") .value("PIXEL_UNKNOWN",
-pixel_traits::pixel_type::UNKNOWN) .value("PIXEL_BOOL",
-pixel_traits::pixel_type::BOOL) .value("PIXEL_UNSIGNED",
-pixel_traits::pixel_type::UNSIGNED) .value("PIXEL_SIGNED",
-pixel_traits::pixel_type::SIGNED) .value("PIXEL_FLOAT",
-pixel_traits::pixel_type::FLOAT) .export_values();
+  py::enum_<pixel_traits::pixel_type>(img, "Types") .value("PIXEL_UNKNOWN",
+  pixel_traits::pixel_type::UNKNOWN) .value("PIXEL_BOOL",
+  pixel_traits::pixel_type::BOOL) .value("PIXEL_UNSIGNED",
+  pixel_traits::pixel_type::UNSIGNED) .value("PIXEL_SIGNED",
+  pixel_traits::pixel_type::SIGNED) .value("PIXEL_FLOAT",
+  pixel_traits::pixel_type::FLOAT) .export_values();
 
-  img.def(py::init(&new_image),
+  img.def(py::init(&kwiver::vital::python::image::new_image),
     py::arg("width")=0, py::arg("height")=0, py::arg("depth")=1,
     py::arg("interleave")=false, py::arg("pixel_type")=pixel_traits::pixel_type::UNSIGNED,
     py::arg("bytes")=1)
-  .def(py::init(&new_image_from_data),
+  .def(py::init(&kwiver::vital::python::image::new_image_from_data),
    py::arg("first_pixel"), py::arg("width"), py::arg("height"), py::arg("depth"),
    py::arg("w_step"), py::arg("h_step"), py::arg("d_step"),
    py::arg("pixel_type"), py::arg("bytes"))
 
   // create initializer from typed numpy arrays
   #define init_from_numpy( T ) \
-  .def(py::init(&new_image_from_numpy< T >), py::arg("array"),\
+  .def(py::init(&kwiver::vital::python::image::new_image_from_numpy< T >), py::arg("array"),\
        py::doc("Create (copy) a vital image from a 2D or 3D numpy array"))
   init_from_numpy( uint8_t )
   init_from_numpy( int8_t )
@@ -414,13 +364,12 @@ pixel_traits::pixel_type::FLOAT) .export_values();
   .def("w_step", &image_t::w_step)
   .def("h_step", &image_t::h_step)
   .def("d_step", &image_t::d_step)
-  .def("first_pixel_address", &first_pixel)
-  .def("pixel_type", &pixel_type)
-  .def("pixel_type_name", &pixel_type_name)
-  .def("pixel_num_bytes", &pixel_num_bytes)
-  .def("__getitem__", &get_pixel)
-  .def_buffer(&get_buffer_info)
-
+  .def("first_pixel_address", &kwiver::vital::python::image::first_pixel)
+  .def("pixel_type", &kwiver::vital::python::image::pixel_type)
+  .def("pixel_type_name", &kwiver::vital::python::image::pixel_type_name)
+  .def("pixel_num_bytes", &kwiver::vital::python::image::pixel_num_bytes)
+  .def("__getitem__", &kwiver::vital::python::image::get_pixel)
+  .def_buffer(&kwiver::vital::python::image::get_buffer_info)
   .def("asarray", [](image_t &img){
         // It may be possible to write this method to share memory between
         // vital and numpy using the py::capsule class. For references see:
@@ -428,6 +377,5 @@ pixel_traits::pixel_type::FLOAT) .export_values();
         py::object np = py::module::import("numpy");
         py::object arr = np.attr("array")(img);
         return arr;
-      }, py::doc("Copy the image into a numpy array'"))
-  ;
+      }, py::doc("Copy the image into a numpy array'"));
 }

--- a/vital/bindings/python/vital/types/image.h
+++ b/vital/bindings/python/vital/types/image.h
@@ -107,6 +107,7 @@ namespace image {
   }
   const char* get_trait_format_descriptor(const pixel_traits& traits);
   py::buffer_info get_buffer_info(image_t &img);
+  py::object asarray(image_t img);
 
 } } } }
 #endif

--- a/vital/bindings/python/vital/types/image.h
+++ b/vital/bindings/python/vital/types/image.h
@@ -1,0 +1,112 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_VITAL_PYTHON_IMAGE_H_
+#define KWIVER_VITAL_PYTHON_IMAGE_H_
+
+#include <vital/types/image.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+typedef kwiver::vital::image image_t;
+typedef kwiver::vital::image_pixel_traits pixel_traits;
+namespace py = pybind11;
+
+void image(py::module &m);
+
+namespace kwiver {
+namespace vital {
+namespace python {
+namespace image {
+  pixel_traits::pixel_type pixel_type(std::shared_ptr<image_t> &self);
+  std::string pixel_type_name(std::shared_ptr<image_t> &self);
+  size_t pixel_num_bytes(std::shared_ptr<image_t> &self);
+  py::object get_pixel2(std::shared_ptr<image_t> &img, unsigned i, unsigned j);
+  py::object get_pixel3(std::shared_ptr<image_t> &img, unsigned i, unsigned j, unsigned k);
+  py::object get_pixel(std::shared_ptr<image_t> &img, std::vector<unsigned> idx);
+  void* first_pixel(std::shared_ptr<image_t> &img);
+  image_t new_image(size_t width, size_t height, size_t depth, bool interleave,
+            pixel_traits::pixel_type &type, size_t bytes);
+  image_t new_image_from_data( char* first_pixel,
+                       size_t width, size_t height, size_t depth,
+                       int32_t w_step, int32_t h_step, int32_t d_step,
+                       pixel_traits::pixel_type pixel_type,
+                       size_t bytes);
+  template <typename T>
+  image_t
+  new_image_from_numpy(py::array_t<T> array)
+  {
+
+    // Request a buffer descriptor from Python
+    py::buffer_info info = array.request();
+
+    // Determine if the type has numeric_limits, is integral, and / or is signed
+    // Note: the following function does not handle float16. Should it?
+    pixel_traits traits =  kwiver::vital::image_pixel_traits_of<T>();
+
+    // numpy images are in height x width format by default (row major)
+    size_t height = info.shape[0];
+    size_t width = info.shape[1];
+    size_t depth;
+
+    size_t h_step = info.strides[0] / traits.num_bytes;
+    size_t w_step = info.strides[1] / traits.num_bytes;
+    size_t d_step;
+
+    if (info.ndim == 2)
+    {
+        depth = 1;
+        d_step = 1;
+    }
+    else if (info.ndim == 3)
+    {
+      depth = info.shape[2];
+      d_step = info.strides[2]  / traits.num_bytes;
+    }
+    else
+    {
+      throw std::runtime_error("Incompatible buffer dimension!");
+    }
+
+    char* first_pixel = static_cast<char *>(info.ptr);
+    image_t img = image_t(first_pixel, width, height, depth,
+                          w_step, h_step, d_step, traits);
+    // TODO: is is possible to share memory?
+    image_t new_img = image_t(); // copy so we can use fresh memory not used elsewhere
+    new_img.copy_from(img);
+    return new_img;
+  }
+  const char* get_trait_format_descriptor(const pixel_traits& traits);
+  py::buffer_info get_buffer_info(image_t &img);
+
+} } } }
+#endif

--- a/vital/bindings/python/vital/types/image_container.cxx
+++ b/vital/bindings/python/vital/types/image_container.cxx
@@ -134,21 +134,22 @@ void image_container(py::module& m)
 
   .def(py::init(&kwiver::vital::python::image_container::new_cont), py::arg("image"))
 
-  // Create initialzer based on numpy array type
-  #define fromarray( T ) \
+  // Create initializer based on numpy array type
+  #define def_fromarray( T ) \
   .def_static("fromarray", \
               &kwiver::vital::python::image_container::new_image_container_from_numpy<T>, \
               py::arg("array"),\
       py::doc("Create an ImageContainer from a numpy array"))
-  fromarray( uint8_t )
-  fromarray( int8_t )
-  fromarray( uint16_t )
-  fromarray( int16_t )
-  fromarray( uint32_t )
-  fromarray( int32_t )
-  fromarray( uint64_t )
-  fromarray( int64_t )
-  fromarray( float )
-  fromarray( double )
-  fromarray( bool );
+  def_fromarray( uint8_t )
+  def_fromarray( int8_t )
+  def_fromarray( uint16_t )
+  def_fromarray( int16_t )
+  def_fromarray( uint32_t )
+  def_fromarray( int32_t )
+  def_fromarray( uint64_t )
+  def_fromarray( int64_t )
+  def_fromarray( float )
+  def_fromarray( double )
+  def_fromarray( bool );
+  #undef def_fromarray
 }

--- a/vital/bindings/python/vital/types/image_container.h
+++ b/vital/bindings/python/vital/types/image_container.h
@@ -1,0 +1,57 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_VITAL_PYTHON_IMAGE_CONTAINER_H_
+#define KWIVER_VITAL_PYTHON_IMAGE_CONTAINER_H_
+
+#include <pybind11/pybind11.h>
+#include <vital/types/image_container.h>
+#include <vital/bindings/python/vital/types/image.h>
+
+namespace py = pybind11;
+
+typedef kwiver::vital::image_container image_cont_t;
+typedef kwiver::vital::simple_image_container s_image_cont_t;
+
+void image_container(py::module &m);
+
+namespace kwiver {
+namespace vital  {
+namespace python {
+namespace image_container {
+// We need to return a shared pointer--otherwise, pybind11 may lose the subtype
+std::shared_ptr<s_image_cont_t>new_cont(kwiver::vital::image &img);
+
+// We need to do a deep copy instead of just calling get_image, so we can ref track in python
+kwiver::vital::image get_image(std::shared_ptr<image_cont_t> self);
+
+} } } }
+
+#endif

--- a/vital/bindings/python/vital/types/image_container.h
+++ b/vital/bindings/python/vital/types/image_container.h
@@ -52,6 +52,13 @@ std::shared_ptr<s_image_cont_t>new_cont(kwiver::vital::image &img);
 // We need to do a deep copy instead of just calling get_image, so we can ref track in python
 kwiver::vital::image get_image(std::shared_ptr<image_cont_t> self);
 
+template <typename T>
+s_image_cont_t new_image_container_from_numpy(py::array_t<T> array)
+{
+  kwiver::vital::image img = kwiver::vital::python::image::new_image_from_numpy(array);
+  return s_image_cont_t(img);
+}
+
 } } } }
 
 #endif

--- a/vital/bindings/python/vital/types/types_module.cxx
+++ b/vital/bindings/python/vital/types/types_module.cxx
@@ -1,0 +1,47 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file algorithm_implementation.cxx
+ *
+ * \brief python bindings for algorithm
+ */
+
+#include <pybind11/pybind11.h>
+#include <vital/bindings/python/vital/types/image.h>
+#include <vital/bindings/python/vital/types/image_container.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(types, m)
+{
+  image(m);
+  image_container(m);
+}


### PR DESCRIPTION
Depends on #817 
1. Reuse asarray logic from image bindings inside image container bindings.
2. The vital image in fromarray is created using new_image_from_numpy in image binding.
3. numpy array in asarray is created by checking the attributes of pixel trait. Creating a py::object from the image sometimes returns a numpy array with data type int8 rather than uint8. This occurs when asarray is called on an image in the image container obtained from another process in the pipeline. In this case, the asarray function of the ImageContainer returns a numpy array with the correct data type.
