### PR TITLE
Include imgproc header in convert_color_space

### DIFF
--- a/arrows/ocv/convert_color_space.cxx
+++ b/arrows/ocv/convert_color_space.cxx
@@ -11,8 +11,8 @@
 
 #include <arrows/ocv/image_container.h>
 
-#include <opencv/cxcore.h>
-#include <opencv/cv.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 
 namespace kwiver {
 namespace arrows {


### PR DESCRIPTION
Also include .hpp files from the opencv2 directory, not .h files from
the opencv directory.

This allows the call to cv::cvtColor to work, at least under OpenCV
3.4.0.