### PR TITLE
Allow "downsampler" to work on input with missing frames

### DIFF
--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -59,7 +59,6 @@ public:
   unsigned burst_frame_break_;
   bool renumber_frames_;
 
-  double ds_factor_;
   double ds_counter_;
   unsigned burst_counter_;
   bool burst_skip_mode_;
@@ -201,12 +200,12 @@ void downsample_process
 bool downsample_process::priv
 ::skip_frame( vital::timestamp const& ts, double frame_rate )
 {
-  ds_factor_ = frame_rate / target_frame_rate_;
+  double ds_factor = frame_rate / target_frame_rate_;
 
   if( is_first_ )
   {
     // Triggers always sending the first frame
-    ds_counter_ = ds_factor_;
+    ds_counter_ = ds_factor;
     is_first_ = false;
   }
   else
@@ -214,13 +213,13 @@ bool downsample_process::priv
     ds_counter_ += 1.0;
   }
 
-  if( ds_counter_ < ds_factor_ )
+  if( ds_counter_ < ds_factor )
   {
     return true;
   }
   else
   {
-    ds_counter_ = std::fmod( ds_counter_, ds_factor_ );
+    ds_counter_ = std::fmod( ds_counter_, ds_factor );
   }
 
   if( burst_frame_count_ != 0 && burst_frame_break_ != 0 )

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -237,7 +237,7 @@ bool downsample_process::priv
 
   if( burst_frame_count_ != 0 && burst_frame_break_ != 0 )
   {
-    burst_counter_++;
+    burst_counter_ += elapsed_frames;
     burst_counter_ %= burst_frame_count_ + burst_frame_break_;
 
     // If burst_counter_ is in [1..burst_frame_count_], we're in

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -59,13 +59,21 @@ public:
   unsigned burst_frame_break_;
   bool renumber_frames_;
 
-  double ds_counter_;
+  // Time of the current frame (seconds)
+  double ds_frame_time_;
+  // Time of the last sent frame (ignoring burst filtering)
+  double last_sent_frame_time_;
   unsigned burst_counter_;
   unsigned output_counter_;
   bool is_first_;
 
   static port_t const port_inputs[5];
   static port_t const port_outputs[5];
+
+private:
+  // Compute the frame number corresponding to time_seconds assuming a
+  // frame rate of target_frame_rate_
+  int target_frame_count( double time_seconds );
 };
 
 
@@ -117,7 +125,8 @@ void downsample_process
 void downsample_process
 ::_init()
 {
-  d->ds_counter_ = 0.0;
+  d->ds_frame_time_ = 0.0;
+  d->last_sent_frame_time_ = 0.0;
   d->burst_counter_ = 0;
   d->output_counter_ = 0;
   d->is_first_ = true;
@@ -195,29 +204,35 @@ void downsample_process
 }
 
 
+int downsample_process::priv
+::target_frame_count( double time_seconds )
+{
+  return static_cast< int >( std::floor( time_seconds * target_frame_rate_ ) );
+}
+
+
 bool downsample_process::priv
 ::skip_frame( vital::timestamp const& ts, double frame_rate )
 {
-  double ds_factor = frame_rate / target_frame_rate_;
+  ds_frame_time_ = ts.has_valid_time() ?
+    ts.get_time_seconds() : ds_frame_time_ + 1 / frame_rate;
 
   if( is_first_ )
   {
     // Triggers always sending the first frame
-    ds_counter_ = ds_factor;
+    last_sent_frame_time_ = ( target_frame_count( ds_frame_time_ ) - 0.5 ) / target_frame_rate_;
     is_first_ = false;
   }
-  else
-  {
-    ds_counter_ += 1.0;
-  }
 
-  if( ds_counter_ < ds_factor )
+  int elapsed_frames = target_frame_count( ds_frame_time_ )
+    - target_frame_count( last_sent_frame_time_ );
+  if( elapsed_frames <= 0 )
   {
     return true;
   }
   else
   {
-    ds_counter_ = std::fmod( ds_counter_, ds_factor );
+    last_sent_frame_time_ = ds_frame_time_;
   }
 
   if( burst_frame_count_ != 0 && burst_frame_break_ != 0 )

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -61,7 +61,6 @@ public:
 
   double ds_counter_;
   unsigned burst_counter_;
-  bool burst_skip_mode_;
   unsigned output_counter_;
   bool is_first_;
 
@@ -120,7 +119,6 @@ void downsample_process
 {
   d->ds_counter_ = 0.0;
   d->burst_counter_ = 0;
-  d->burst_skip_mode_ = false;
   d->output_counter_ = 0;
   d->is_first_ = true;
 }
@@ -225,21 +223,13 @@ bool downsample_process::priv
   if( burst_frame_count_ != 0 && burst_frame_break_ != 0 )
   {
     burst_counter_++;
+    burst_counter_ %= burst_frame_count_ + burst_frame_break_;
 
-    if( burst_skip_mode_ )
+    // If burst_counter_ is in [1..burst_frame_count_], we're in
+    // pass-through mode; otherwise we're in skip mode.
+    if( burst_counter_ > burst_frame_count_ || burst_counter_ == 0)
     {
-      if( burst_counter_ >= burst_frame_break_ )
-      {
-        burst_counter_ = 0;
-        burst_skip_mode_ = false;
-      }
-
       return true;
-    }
-    else if( burst_counter_ >= burst_frame_count_ )
-    {
-      burst_counter_ = 0;
-      burst_skip_mode_ = true;
     }
   }
 


### PR DESCRIPTION
This PR contains changes to allow `downsampler_process` to work on input that's missing frames by using the provided timestamp to determine the elapsed time. For cases when a timestamp is missing, the code assumes the provided frame rate. It doesn't use it otherwise.

I wasn't sure how to have this interact with the burst mode when there's such a large gap that a down-sampled output would be missed. I chose to have it count the missed output as well. (Normally, at say 5Hz output and a 3/2 cycle, you'd have outputs at 0s, 0.2s, 0.4s, 1s, 1.2s, 1.4s, etc. I've implemented it such that if there is no input around e.g. 1.2s, that output is missed but continues as normal, thus 1s, ~1.2s~, 1.4s, 2s, 2.2s, 2.4s, etc.)

Let me know if this should be against another branch. Once it's finalized, I can update #690 and add this to it.

Here is an extract from a log I made of output time stamps from a test video from @mattdawkins with a nominal ~30Hz frame rate but with many single missing frames and down-sampled to 5Hz:
```
ts(f: 13570, t: 770633333 (Wed Dec 31 19:12:50 1969), d: 0)
ts(f: 13573, t: 770800000 (Wed Dec 31 19:12:50 1969), d: 0)
ts(f: 13576, t: 771000000 (Wed Dec 31 19:12:51 1969), d: 0)
ts(f: 13581, t: 771266666 (Wed Dec 31 19:12:51 1969), d: 0)
ts(f: 13583, t: 771400000 (Wed Dec 31 19:12:51 1969), d: 0)
ts(f: 13587, t: 771633333 (Wed Dec 31 19:12:51 1969), d: 0)
ts(f: 13590, t: 771800000 (Wed Dec 31 19:12:51 1969), d: 0)
ts(f: 13594, t: 772000000 (Wed Dec 31 19:12:52 1969), d: 0)
ts(f: 13599, t: 772266666 (Wed Dec 31 19:12:52 1969), d: 0)
ts(f: 13601, t: 772400000 (Wed Dec 31 19:12:52 1969), d: 0)
ts(f: 13606, t: 772633333 (Wed Dec 31 19:12:52 1969), d: 0)
ts(f: 13609, t: 772800000 (Wed Dec 31 19:12:52 1969), d: 0)
ts(f: 13613, t: 773000000 (Wed Dec 31 19:12:53 1969), d: 0)
ts(f: 13617, t: 773233333 (Wed Dec 31 19:12:53 1969), d: 0)
```