### PR TITLE
Explicitly require Qt ≥ 5.10

### DIFF
--- a/CMake/kwiver-depends-Qt.cmake
+++ b/CMake/kwiver-depends-Qt.cmake
@@ -12,5 +12,5 @@ option( KWIVER_ENABLE_QT
   )
 
 if( KWIVER_ENABLE_QT )
-  find_package( Qt5 REQUIRED COMPONENTS Core Gui )
+  find_package( Qt5 5.10 REQUIRED COMPONENTS Core Gui )
 endif( KWIVER_ENABLE_QT )


### PR DESCRIPTION
Modify finding Qt (when we use it) to explicitly require Qt ≥ 5.10. We actually require this already, due to use of [QImage::sizeInBytes](https://doc.qt.io/qt-5/qimage.html#sizeInBytes) that was added in 5.10; this just arranges to get an explicit version-mismatch error at configure time rather than a 'no such method' build error. (It would be possible to work around this, at the cost of not supporting images over 2 GiB, but at least one of our consumers also requires Qt ≥ 5.10, and [fletch](https://github.com/kitware/fletch) provides at least 5.11.)