### PR TITLE
Downgrade the clang version to 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,14 @@ language: cpp
 
 matrix:
   include:
-    addons:
-      apt:
-        sources:
-                - ubuntu-toolchain-r-test
-        packages:
-                - g++-4.8
-                - libproj-dev
-                - libgl1-mesa-dev
-                - libxt-dev
-                - libatlas-base-dev
-                - python2.7-dev
-                - clang-3.5
-                - compiler: gcc
+    - compiler: gcc
       env:
         - C_COMPILER=gcc-4.8
         - CXX_COMPILER=g++-4.8
     - compiler: clang
-      env: # default clang is version 3.7 but we want 3.5 to avoid link errors
-        - C_COMPILER=clang-3.5
-        - CXX_COMPILER=clang++-3.5
+      env: # default clang is version 3.4
+        - C_COMPILER=clang
+        - CXX_COMPILER=clang++
 
 cache:
   directories:
@@ -35,6 +23,18 @@ cache:
 
 before_script:
   - bash .travis/install-deps.sh
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - libproj-dev
+    - libgl1-mesa-dev
+    - libxt-dev
+    - libatlas-base-dev
+    - python2.7-dev
 
 script:
   - export PATH=$HOME/deps/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,26 @@ language: cpp
 
 matrix:
   include:
-    - compiler: gcc
+    addons:
+      apt:
+        sources:
+                - ubuntu-toolchain-r-test
+        packages:
+                - g++-4.8
+                - libproj-dev
+                - libgl1-mesa-dev
+                - libxt-dev
+                - libatlas-base-dev
+                - python2.7-dev
+                - clang-3.5
+                - compiler: gcc
       env:
         - C_COMPILER=gcc-4.8
         - CXX_COMPILER=g++-4.8
     - compiler: clang
-      env: # default clang is version 3.4
-        - C_COMPILER=clang
-        - CXX_COMPILER=clang++
+      env: # default clang is version 3.7 but we want 3.5 to avoid link errors
+        - C_COMPILER=clang-3.5
+        - CXX_COMPILER=clang++-3.5
 
 cache:
   directories:
@@ -23,18 +35,6 @@ cache:
 
 before_script:
   - bash .travis/install-deps.sh
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-    - libproj-dev
-    - libgl1-mesa-dev
-    - libxt-dev
-    - libatlas-base-dev
-    - python2.7-dev
 
 script:
   - export PATH=$HOME/deps/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
         - C_COMPILER=gcc-4.8
         - CXX_COMPILER=g++-4.8
     - compiler: clang
-      env: # default clang is version 3.4
+      env: # default clang is version 3.7 but we need 3.5 to prevent link errors
         - C_COMPILER=clang
-        - CXX_COMPILER=clang++
+        - CXX_COMPILER=clang++-3.5
 
 cache:
   directories:
@@ -35,6 +35,8 @@ addons:
     - libxt-dev
     - libatlas-base-dev
     - python2.7-dev
+    - clang-3.5
+
 
 script:
   - export PATH=$HOME/deps/bin:$PATH


### PR DESCRIPTION
Travis recently moved their clang version from 3.5 to 3.7 which is causing a lot of link errors on the Ubuntu platform. I have tested 3.7 on other platforms, e.g.  Fedora and CentOS with clang 3.7 and had no issues which leads me to believe it has something to do with the underlying libraries on Ubuntu 16.04 and not the kwiver code itself. That said, I will still investigate to see if there is a valid 'fix' for the errors on a test machine, but at least this patch will allow the current kwiver master to build successfully on Travis clang.