### PR TITLE
update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 #Travis CI configuration for KWIVER
 # See http://travis-ci.org/Kitware/kwiver/
 
-sudo: false
-
+dist: bionic
 language: cpp
 
 matrix:
   include:
     - compiler: gcc
       env:
-        - C_COMPILER=gcc-4.8
-        - CXX_COMPILER=g++-4.8
+        - C_COMPILER=gcc
+        - CXX_COMPILER=g++
     - compiler: clang
-      env: # default clang is version 3.4
+      env: # default clang is version 7.0.0
         - C_COMPILER=clang
         - CXX_COMPILER=clang++
 
@@ -22,19 +21,8 @@ cache:
   - /opt/kitware
 
 before_script:
+  - sudo apt-get install -y libproj-dev libgl1-mesa-dev libxt-dev libatlas-base-dev
   - bash .travis/install-deps.sh
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-    - libproj-dev
-    - libgl1-mesa-dev
-    - libxt-dev
-    - libatlas-base-dev
-    - python2.7-dev
 
 script:
   - export PATH=$HOME/deps/bin:$PATH
@@ -42,6 +30,7 @@ script:
   - cd build
   # Travis needs help finding libomp (OpenMP) with Clang builds
   - export LD_LIBRARY_PATH=$(if [[ $CXX == "clang++" ]]; then echo -n '/usr/local/clang/lib'; fi)
+  - export LD_LIBRARY_PATH=/opt/kitware/fletch/lib:$LD_LIBRARY_PATH
   - cmake -DCMAKE_C_COMPILER=$C_COMPILER
           -DCMAKE_CXX_COMPILER=$CXX_COMPILER
           -DCMAKE_INSTALL_PREFIX=$HOME/install

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -12,21 +12,11 @@ mkdir -p $INSTALL_DIR
 # Make a directory to test installation of KWIVER into
 mkdir -p $HOME/install
 
-# check if directory is cached
-if [ ! -f "$INSTALL_DIR/bin/cmake" ]; then
-  cd /tmp
-  wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.sh
-  bash cmake-3.4.0-Linux-x86_64.sh --skip-license --prefix="$INSTALL_DIR/"
-else
-  echo 'Using cached CMake directory.';
-fi
-
-
 # download and unpack Fletch
 HASH_FILE="$HASH_DIR/fletch.sha512"
 cd /tmp
 if [ -f $TRAVIS_BUILD_DIR/doc/release-notes/master.txt ]; then
-  TAR_FILE_ID=599c39468d777f7d33e9cbe5
+  TAR_FILE_ID=5d3a2d40877dfcc9022ec9f5
   echo "Using master branch of Fletch"
 else
   TAR_FILE_ID=599f2db18d777f7d33e9cc9e


### PR DESCRIPTION
- Updates Travis target OS from Ubuntu Trusty to Bionic
- Updates gcc version from 4.8 to 7.0 (default)
- Updates clang version from 3.4 to 3.7 (also default)
- Uses the CMake that travis CI has by default (3.12.X) rather than installing from source
- Changes to use a Fletch binary that is generated on Ubuntu Bionic 18.04 rather than Ubuntu Trusty 14.04
