### PR TITLE
Don't crash merging into empty track set

### DIFF
--- a/vital/tests/test_track_set.cxx
+++ b/vital/tests/test_track_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,5 +63,13 @@ TEST(track_set, merge_functions)
   auto test_set_1 = make_simple_track_set(1);
   auto test_set_2 = make_simple_track_set(2);
   test_track_set_merge(test_set_1, test_set_2);
+
+  auto test_set_3 = std::make_shared< kwiver::vital::track_set >();
+  ASSERT_TRUE( test_set_3->empty() );
+
+  test_set_3->merge_in_other_track_set( test_set_2 );
+
+  EXPECT_FALSE( test_set_3->empty() );
+  ASSERT_EQ( 4, test_set_3->size() );
 }
 

--- a/vital/types/track_set.cxx
+++ b/vital/types/track_set.cxx
@@ -49,11 +49,16 @@ track_set
   track_set_sptr const& other, clone_type clone_method,
   bool do_not_append_tracks)
 {
-  auto ot = other->tracks();
+  auto const& ot = other->tracks();
+
+  if (this->empty())
+  {
+    this->set_tracks(ot);
+  }
 
   track_id_t next_track_id = (*this->all_track_ids().crbegin()) + 1;
 
-  for (auto &t : ot)
+  for (auto const& t : ot)
   {
     auto ct = this->get_track(t->id());
     if (!ct)
@@ -70,7 +75,7 @@ track_set
       }
       else
       {
-        for (auto ts : *t)
+        for (auto const& ts : *t)
         {
           auto ts_clone = ts->clone( clone_method );
           if (ct->back()->frame() < ts_clone->frame())


### PR DESCRIPTION
Fix a bug in `track_set::merge_in_other_track_set` that would cause a crash if the track set being merged into is empty. Also add `const` to some locals that aren't modified, and avoid some unnecessary copies.