### PR TITLE
Don't use shared pointer for bounding box

### DIFF
--- a/vital/types/bounding_box.h
+++ b/vital/types/bounding_box.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,7 +72,7 @@ public:
    * @param height Height of box.
    */
   bounding_box( vector_type const& upper_left,
-                T const& width, T const& height )
+                T width, T height )
   {
     vector_type lr( upper_left );
     lr.x() += width;

--- a/vital/types/detected_object.cxx
+++ b/vital/types/detected_object.cxx
@@ -42,7 +42,7 @@ namespace vital {
 detected_object::detected_object( const bounding_box_d& bbox,
                                   double              confidence,
                                   detected_object_type_sptr classifications )
-  : m_bounding_box( std::make_shared< bounding_box_d >( bbox ) )
+  : m_bounding_box( bbox )
   , m_confidence( confidence )
   , m_type( classifications )
   , m_index( 0 )
@@ -62,7 +62,7 @@ detected_object
   }
 
   auto new_obj = std::make_shared<kwiver::vital::detected_object>(
-    *this->m_bounding_box, this->m_confidence, new_type );
+    this->m_bounding_box, this->m_confidence, new_type );
 
   new_obj->m_mask_image = this->m_mask_image; // being cheap - not copying image mask
   new_obj->m_index = this->m_index;
@@ -78,7 +78,7 @@ bounding_box_d
 detected_object
 ::bounding_box() const
 {
-  return *m_bounding_box;
+  return m_bounding_box;
 }
 
 
@@ -87,7 +87,7 @@ void
 detected_object
 ::set_bounding_box( const bounding_box_d& bbox )
 {
-  m_bounding_box = std::make_shared< bounding_box_d >( bbox );
+  m_bounding_box = bbox;
 }
 
 

--- a/vital/types/detected_object.h
+++ b/vital/types/detected_object.h
@@ -79,7 +79,6 @@ public:
   typedef std::vector< detected_object_sptr > vector_t;
   typedef descriptor_dynamic< double > descriptor_t;
   typedef std::shared_ptr< descriptor_t const > descriptor_scptr;
-  typedef std::shared_ptr< bounding_box_d > bounding_box_sptr;
 
   /**
    * @brief Create detected object with bounding box and other attributes.
@@ -250,7 +249,7 @@ public:
   void set_descriptor( descriptor_scptr d );
 
 private:
-  bounding_box_sptr m_bounding_box;
+  bounding_box_d m_bounding_box;
   double m_confidence;
   image_container_scptr m_mask_image;
   descriptor_scptr m_descriptor;


### PR DESCRIPTION
Don't use a shared pointer to store the bounding box in `detected_object`; instead, store it directly in the class. This is almost certainly less expensive, since a `bounding_box_d` is a small, trivially copyable object, and there was no way for the bounding box to not be set.

Also, tweak one of the constructors of `bounding_box` to take the width and height by value, rather than by reference. These are almost certainly scalars, which are trivial to copy by value, and this is consistent with the constructor that takes each of {x,y}{min,max} individually, which was already sensibly taking them by value.