### PR TITLE
Dev/camera to camera detection transform

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -41,6 +41,7 @@ set( plugin_core_headers
   track_features_augment_keyframes.h
   track_features_core.h
   transform.h
+  transform_detected_object_set.h
   triangle_scan_iterator.h
   triangulate_landmarks.h
   uv_unwrap_mesh.h
@@ -118,6 +119,7 @@ set( plugin_core_sources
   track_features_augment_keyframes.cxx
   track_features_core.cxx
   transform.cxx
+  transform_detected_object_set.cxx
   triangle_scan_iterator.cxx
   triangulate_landmarks.cxx
   uv_unwrap_mesh.cxx

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -73,6 +73,7 @@
 #include <arrows/core/read_track_descriptor_set_csv.h>
 #include <arrows/core/track_features_augment_keyframes.h>
 #include <arrows/core/track_features_core.h>
+#include <arrows/core/transform_detected_object_set.h>
 #include <arrows/core/triangulate_landmarks.h>
 #include <arrows/core/uv_unwrap_mesh.h>
 #include <arrows/core/video_input_filter.h>
@@ -138,6 +139,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_algorithm< read_track_descriptor_set_csv >();
   reg.register_algorithm< track_features_augment_keyframes >();
   reg.register_algorithm< track_features_core >();
+  reg.register_algorithm< transform_detected_object_set >();
   reg.register_algorithm< triangulate_landmarks >();
   reg.register_algorithm< uv_unwrap_mesh >();
   reg.register_algorithm< video_input_filter >();

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -30,10 +30,12 @@
 
 #include "transform_detected_object_set.h"
 
+#include <iostream>
 #include <vital/io/camera_io.h>
 #include <vital/config/config_difference.h>
 #include <vital/util/string.h>
 #include <vital/types/bounding_box.h>
+#include <Eigen/Core>
 
 namespace kwiver {
 namespace arrows {
@@ -97,13 +99,153 @@ check_configuration( vital::config_block_sptr config ) const
   return true;
 }
 
+
+// ------------------------------------------------------------------
+Eigen::Vector3d
+transform_detected_object_set::
+backproject_to_height( const kwiver::vital::camera_perspective_sptr camera,
+		       const Eigen::Vector2d img_pt ) const
+{
+  // Back an image point to a specified world height
+  double height = 0.0;
+
+  Eigen::Vector3d img_pt_3;
+  img_pt_3 << img_pt, 1.0;
+
+  Eigen::Vector3d npt = camera->intrinsics()->as_matrix().colPivHouseholderQr().solve( img_pt_3 );
+  Eigen::Matrix3d M = camera->rotation().matrix();
+  Eigen::Vector3d t = camera->translation();
+
+  M(0,2) = height * M(0,2) + t(0);
+  M(1,2) = height * M(1,2) + t(1);
+  M(2,2) = height * M(2,2) + t(2);
+
+  Eigen::Vector3d wpt = M.colPivHouseholderQr().solve( npt );
+  auto output = Eigen::Vector3d(wpt(0) / wpt(2), wpt(1) / wpt(2), height);
+
+  return output;
+}
+
+// ------------------------------------------------------------------
+Eigen::Vector3d
+transform_detected_object_set::
+backproject_to_plane( const kwiver::vital::camera_perspective_sptr camera,
+		      const Eigen::Vector2d img_pt,
+		      const Eigen::Vector4d plane ) const
+{
+  // Back an image point to a specified world plane
+  Eigen::Vector3d img_pt_3;
+  img_pt_3 << img_pt, 1.0;
+
+  Eigen::Vector3d npt = camera->intrinsics()->as_matrix().colPivHouseholderQr().solve( img_pt_3 );
+  Eigen::Matrix3d M = camera->rotation().matrix().transpose();
+
+  auto n = Eigen::Vector3d(plane(0), plane(1), plane(2));
+  double d = plane(3);
+
+  Eigen::Vector3d Mt = M * camera->translation();
+  Eigen::Vector3d Mp = M * npt;
+
+  return Mp * (n.dot( Mt ) - d) / n.dot( Mp ) - Mt;
+}
+
+// ------------------------------------------------------------------
+Eigen::Matrix<double, 8, 3>
+transform_detected_object_set::
+backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
+		  const Eigen::Vector4d box ) const
+{
+  // project base of the box to the ground
+  auto base_pt = Eigen::Vector2d((box(0) + box(2)) / 2, box(3));
+  Eigen::Vector3d pc = this->backproject_to_height( camera, base_pt );
+  Eigen::Vector3d ray = pc - (-camera->rotation().matrix().transpose() * camera->translation());
+  ray(2) = 0.0;
+  ray.normalize();
+
+  Eigen::Vector3d p1 = this->backproject_to_height( camera, Eigen::Vector2d(box(0), box(3)) );
+  Eigen::Vector3d p2 = this->backproject_to_height( camera, Eigen::Vector2d(box(2), box(3)) );
+
+  Eigen::Vector3d vh = p2 - p1;
+  Eigen::Vector3d vd = ray * vh.norm();
+  vh = Eigen::Vector3d(-vd(1), vd(0), 0);
+  p1 = pc - vh / 2;
+  p2 = pc + vh / 2;
+  Eigen::Vector3d p3 = p2 + vd;
+  Eigen::Vector3d p4 = p1 + vd;
+
+  // TODO: Check that norm of vd is not equal to 0.0?
+
+  Eigen::Vector3d n = vd.normalized();
+  double d = -(n.transpose() * p3)(0);
+
+  Eigen::Vector4d back_plane;
+  back_plane << n, d;
+  Eigen::Vector3d p5 = this->backproject_to_plane( camera, Eigen::Vector2d(box(0), box(1)), back_plane );
+  double height = p5(2);
+
+  Eigen::Matrix<double, 8, 3> box3d;
+  box3d << p1.transpose(),
+    p2.transpose(),
+    p3.transpose(),
+    p4.transpose(),
+    p1(0), p1(1), height,
+    p2(0), p2(1), height,
+    p3(0), p3(1), height,
+    p4(0), p4(1), height;
+
+  return box3d;
+}
+
+// ------------------------------------------------------------------
+Eigen::Vector4d
+transform_detected_object_set::
+box_around_box3d( const kwiver::vital::camera_perspective_sptr camera,
+		  const Eigen::Matrix<double, 8, 3> box3d ) const
+{
+  Eigen::Matrix<double, 8, 2> projected_points;
+
+  // project the points
+  for (int i=0; i<8; i++) {
+    projected_points.row(i) = camera->project(box3d.row(i)).transpose();
+  }
+
+  Eigen::Vector4d out_box;
+  out_box << (Eigen::Vector2d)projected_points.colwise().minCoeff(),
+    (Eigen::Vector2d)projected_points.colwise().maxCoeff();
+
+  return out_box;
+}
+
+// ------------------------------------------------------------------
+Eigen::Vector4d
+transform_detected_object_set::
+view_to_view( const kwiver::vital::camera_perspective_sptr src_camera,
+	      const kwiver::vital::camera_perspective_sptr dest_camera,
+	      const Eigen::Vector4d bounds ) const
+{
+  Eigen::Matrix<double, 8, 3> box3d = this->backproject_bbox( src_camera, bounds );
+  Eigen::Vector4d tgt_box = this->box_around_box3d( dest_camera, box3d );
+
+  return tgt_box;
+}
+
 // ------------------------------------------------------------------
 vital::bounding_box<double>
 transform_detected_object_set::
 transform_bounding_box( vital::bounding_box<double>& bbox ) const
 {
-  // TODO
-  return bbox;
+  Eigen::Vector4d bbox_bounds;
+  bbox_bounds << bbox.min_x(), bbox.min_y(),
+    bbox.max_x(), bbox.max_y();
+
+  Eigen::Vector4d out_bounds = this->view_to_view( this->src_camera,
+						   this->dest_camera,
+						   bbox_bounds );
+
+  return vital::bounding_box<double>(out_bounds(0),
+				     out_bounds(1),
+				     out_bounds(2),
+				     out_bounds(3));
 }
 
 // ------------------------------------------------------------------
@@ -119,8 +261,8 @@ filter( const vital::detected_object_set_sptr input_set ) const
   {
     auto out_det = (*det)->clone();
     auto out_box = out_det->bounding_box();
-    this->transform_bounding_box(out_box);
-    out_det->set_bounding_box( out_box );
+    auto new_out_box = this->transform_bounding_box(out_box);
+    out_det->set_bounding_box( new_out_box );
     ret_set->add( out_det );
   } // end foreach detection
 

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -37,6 +37,8 @@
 #include <vital/types/bounding_box.h>
 #include <Eigen/Core>
 
+using namespace kwiver::vital;
+
 namespace kwiver {
 namespace arrows {
 namespace core {
@@ -108,50 +110,33 @@ check_configuration( vital::config_block_sptr config ) const
 
 
 // ------------------------------------------------------------------
-Eigen::Vector3d
+vector_3d
 transform_detected_object_set::
-backproject_to_height( const kwiver::vital::camera_perspective_sptr camera,
-		       const Eigen::Vector2d img_pt ) const
+backproject_to_ground( const kwiver::vital::camera_perspective_sptr camera,
+		       const vector_2d img_pt ) const
 {
-  // Back an image point to a specified world height
-  double height = 0.0;
-
-  Eigen::Vector3d img_pt_3;
-  img_pt_3 << img_pt, 1.0;
-
-  Eigen::Vector3d npt = camera->intrinsics()->as_matrix().colPivHouseholderQr().solve( img_pt_3 );
-  Eigen::Matrix3d M = camera->rotation().matrix();
-  Eigen::Vector3d t = camera->translation();
-
-  M(0,2) = height * M(0,2) + t(0);
-  M(1,2) = height * M(1,2) + t(1);
-  M(2,2) = height * M(2,2) + t(2);
-
-  Eigen::Vector3d wpt = M.colPivHouseholderQr().solve( npt );
-  auto output = Eigen::Vector3d(wpt(0) / wpt(2), wpt(1) / wpt(2), height);
-
-  return output;
+  auto ground_plane = vector_4d(0, 0, 1, 0);
+  return this->backproject_to_plane( camera, img_pt, ground_plane );
 }
 
 // ------------------------------------------------------------------
-Eigen::Vector3d
+vector_3d
 transform_detected_object_set::
 backproject_to_plane( const kwiver::vital::camera_perspective_sptr camera,
-		      const Eigen::Vector2d img_pt,
-		      const Eigen::Vector4d plane ) const
+		      const vector_2d img_pt,
+		      const vector_4d plane ) const
 {
   // Back an image point to a specified world plane
-  Eigen::Vector3d img_pt_3;
-  img_pt_3 << img_pt, 1.0;
+  vector_2d npt_ = camera->intrinsics()->unmap(img_pt);
+  auto npt = vector_3d(npt_(0), npt_(1), 1.0);
 
-  Eigen::Vector3d npt = camera->intrinsics()->as_matrix().colPivHouseholderQr().solve( img_pt_3 );
-  Eigen::Matrix3d M = camera->rotation().matrix().transpose();
+  matrix_3x3d M = camera->rotation().matrix().transpose();
 
-  auto n = Eigen::Vector3d(plane(0), plane(1), plane(2));
+  auto n = vector_3d(plane(0), plane(1), plane(2));
   double d = plane(3);
 
-  Eigen::Vector3d Mt = M * camera->translation();
-  Eigen::Vector3d Mp = M * npt;
+  vector_3d Mt = M * camera->translation();
+  vector_3d Mp = M * npt;
 
   return Mp * (n.dot( Mt ) - d) / n.dot( Mp ) - Mt;
 }
@@ -160,34 +145,34 @@ backproject_to_plane( const kwiver::vital::camera_perspective_sptr camera,
 Eigen::Matrix<double, 8, 3>
 transform_detected_object_set::
 backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
-		  const Eigen::Vector4d box ) const
+		  const vector_4d box ) const
 {
   // project base of the box to the ground
-  auto base_pt = Eigen::Vector2d((box(0) + box(2)) / 2, box(3));
-  Eigen::Vector3d pc = this->backproject_to_height( camera, base_pt );
-  Eigen::Vector3d ray = pc - (-camera->rotation().matrix().transpose() * camera->translation());
+  auto base_pt = vector_2d((box(0) + box(2)) / 2, box(3));
+  vector_3d pc = this->backproject_to_ground( camera, base_pt );
+  vector_3d ray = pc - (-camera->rotation().matrix().transpose() * camera->translation());
   ray(2) = 0.0;
   ray.normalize();
 
-  Eigen::Vector3d p1 = this->backproject_to_height( camera, Eigen::Vector2d(box(0), box(3)) );
-  Eigen::Vector3d p2 = this->backproject_to_height( camera, Eigen::Vector2d(box(2), box(3)) );
+  vector_3d p1 = this->backproject_to_ground( camera, vector_2d(box(0), box(3)) );
+  vector_3d p2 = this->backproject_to_ground( camera, vector_2d(box(2), box(3)) );
 
-  Eigen::Vector3d vh = p2 - p1;
-  Eigen::Vector3d vd = ray * vh.norm();
-  vh = Eigen::Vector3d(-vd(1), vd(0), 0);
+  vector_3d vh = p2 - p1;
+  vector_3d vd = ray * vh.norm();
+  vh = vector_3d(-vd(1), vd(0), 0);
   p1 = pc - vh / 2;
   p2 = pc + vh / 2;
-  Eigen::Vector3d p3 = p2 + vd;
-  Eigen::Vector3d p4 = p1 + vd;
+  vector_3d p3 = p2 + vd;
+  vector_3d p4 = p1 + vd;
 
   // TODO: Check that norm of vd is not equal to 0.0?
 
-  Eigen::Vector3d n = vd.normalized();
+  vector_3d n = vd.normalized();
   double d = -(n.transpose() * p3)(0);
 
-  Eigen::Vector4d back_plane;
+  vector_4d back_plane;
   back_plane << n, d;
-  Eigen::Vector3d p5 = this->backproject_to_plane( camera, Eigen::Vector2d(box(0), box(1)), back_plane );
+  vector_3d p5 = this->backproject_to_plane( camera, vector_2d(box(0), box(1)), back_plane );
   double height = p5(2);
 
   Eigen::Matrix<double, 8, 3> box3d;
@@ -204,7 +189,7 @@ backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
 }
 
 // ------------------------------------------------------------------
-Eigen::Vector4d
+vector_4d
 transform_detected_object_set::
 box_around_box3d( const kwiver::vital::camera_perspective_sptr camera,
 		  const Eigen::Matrix<double, 8, 3> box3d ) const
@@ -216,22 +201,22 @@ box_around_box3d( const kwiver::vital::camera_perspective_sptr camera,
     projected_points.row(i) = camera->project(box3d.row(i)).transpose();
   }
 
-  Eigen::Vector4d out_box;
-  out_box << (Eigen::Vector2d)projected_points.colwise().minCoeff(),
-    (Eigen::Vector2d)projected_points.colwise().maxCoeff();
+  vector_4d out_box;
+  out_box << (vector_2d)projected_points.colwise().minCoeff(),
+    (vector_2d)projected_points.colwise().maxCoeff();
 
   return out_box;
 }
 
 // ------------------------------------------------------------------
-Eigen::Vector4d
+vector_4d
 transform_detected_object_set::
 view_to_view( const kwiver::vital::camera_perspective_sptr src_camera,
 	      const kwiver::vital::camera_perspective_sptr dest_camera,
-	      const Eigen::Vector4d bounds ) const
+	      const vector_4d bounds ) const
 {
   Eigen::Matrix<double, 8, 3> box3d = this->backproject_bbox( src_camera, bounds );
-  Eigen::Vector4d tgt_box = this->box_around_box3d( dest_camera, box3d );
+  vector_4d tgt_box = this->box_around_box3d( dest_camera, box3d );
 
   return tgt_box;
 }
@@ -241,11 +226,11 @@ vital::bounding_box<double>
 transform_detected_object_set::
 transform_bounding_box( vital::bounding_box<double>& bbox ) const
 {
-  Eigen::Vector4d bbox_bounds;
+  vector_4d bbox_bounds;
   bbox_bounds << bbox.min_x(), bbox.min_y(),
     bbox.max_x(), bbox.max_y();
 
-  Eigen::Vector4d out_bounds = this->view_to_view( this->src_camera,
+  vector_4d out_bounds = this->view_to_view( this->src_camera,
 						   this->dest_camera,
 						   bbox_bounds );
 

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -43,7 +43,7 @@ namespace kwiver {
 namespace arrows {
 namespace core {
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 transform_detected_object_set::
 transform_detected_object_set()
   : src_camera_krtd_file_name( "" )
@@ -51,18 +51,19 @@ transform_detected_object_set()
 {
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 transform_detected_object_set::
 transform_detected_object_set(kwiver::vital::camera_perspective_sptr src_cam,
-			      kwiver::vital::camera_perspective_sptr dest_cam)
+                              kwiver::vital::camera_perspective_sptr dest_cam)
   : src_camera( src_cam )
   , dest_camera( dest_cam )
 {
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vital::config_block_sptr
-transform_detected_object_set::get_configuration() const
+transform_detected_object_set::
+get_configuration() const
 {
   // Get base config from base class
   vital::config_block_sptr config = vital::algorithm::get_configuration();
@@ -77,7 +78,7 @@ transform_detected_object_set::get_configuration() const
 }
 
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 void
 transform_detected_object_set::
 set_configuration( vital::config_block_sptr config_in )
@@ -85,19 +86,19 @@ set_configuration( vital::config_block_sptr config_in )
   vital::config_block_sptr config = this->get_configuration();
 
   config->merge_config( config_in );
-  this->src_camera_krtd_file_name =\
+  this->src_camera_krtd_file_name =
     config->get_value< std::string > ( "src_camera_krtd_file_name" );
-  this->dest_camera_krtd_file_name =\
+  this->dest_camera_krtd_file_name =
     config->get_value< std::string > ( "dest_camera_krtd_file_name" );
 
-  this->src_camera =\
+  this->src_camera =
     kwiver::vital::read_krtd_file( this->src_camera_krtd_file_name );
-  this->dest_camera =\
+  this->dest_camera =
     kwiver::vital::read_krtd_file( this->dest_camera_krtd_file_name );
 }
 
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 bool
 transform_detected_object_set::
 check_configuration( vital::config_block_sptr config ) const
@@ -108,30 +109,30 @@ check_configuration( vital::config_block_sptr config ) const
   if ( ! key_list.empty() )
   {
     LOG_WARN( logger(), "Additional parameters found in config block that are "
-	      "not required or desired: "
-              << kwiver::vital::join( key_list, ", " ) );
+                        "not required or desired: "
+                        << kwiver::vital::join( key_list, ", " ) );
   }
 
   return true;
 }
 
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vector_3d
 transform_detected_object_set::
 backproject_to_ground( const kwiver::vital::camera_perspective_sptr camera,
-		       const vector_2d img_pt ) const
+                       const vector_2d img_pt ) const
 {
   auto ground_plane = vector_4d(0, 0, 1, 0);
   return this->backproject_to_plane( camera, img_pt, ground_plane );
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vector_3d
 transform_detected_object_set::
 backproject_to_plane( const kwiver::vital::camera_perspective_sptr camera,
-		      const vector_2d img_pt,
-		      const vector_4d plane ) const
+                      const vector_2d img_pt,
+                      const vector_4d plane ) const
 {
   // Back an image point to a specified world plane
   vector_2d npt_ = camera->intrinsics()->unmap(img_pt);
@@ -148,11 +149,11 @@ backproject_to_plane( const kwiver::vital::camera_perspective_sptr camera,
   return Mp * (n.dot( Mt ) - d) / n.dot( Mp ) - Mt;
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 Eigen::Matrix<double, 8, 3>
 transform_detected_object_set::
 backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
-		  const vector_4d box ) const
+                  const vector_4d box ) const
 {
   // project base of the box to the ground
   auto base_pt = vector_2d((box(0) + box(2)) / 2, box(3));
@@ -161,9 +162,9 @@ backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
   ray(2) = 0.0;
   ray.normalize();
 
-  vector_3d p1 =\
+  vector_3d p1 =
     this->backproject_to_ground( camera, vector_2d(box(0), box(3)) );
-  vector_3d p2 =\
+  vector_3d p2 =
     this->backproject_to_ground( camera, vector_2d(box(2), box(3)) );
 
   vector_3d vh = p2 - p1;
@@ -181,28 +182,28 @@ backproject_bbox( const kwiver::vital::camera_perspective_sptr camera,
 
   vector_4d back_plane;
   back_plane << n, d;
-  vector_3d p5 =\
+  vector_3d p5 =
     this->backproject_to_plane( camera, vector_2d(box(0), box(1)), back_plane );
   double height = p5(2);
 
   Eigen::Matrix<double, 8, 3> box3d;
   box3d << p1.transpose(),
-    p2.transpose(),
-    p3.transpose(),
-    p4.transpose(),
-    p1(0), p1(1), height,
-    p2(0), p2(1), height,
-    p3(0), p3(1), height,
-    p4(0), p4(1), height;
+           p2.transpose(),
+           p3.transpose(),
+           p4.transpose(),
+           p1(0), p1(1), height,
+           p2(0), p2(1), height,
+           p3(0), p3(1), height,
+           p4(0), p4(1), height;
 
   return box3d;
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vector_4d
 transform_detected_object_set::
 box_around_box3d( const kwiver::vital::camera_perspective_sptr camera,
-		  const Eigen::Matrix<double, 8, 3> box3d ) const
+                  const Eigen::Matrix<double, 8, 3> box3d ) const
 {
   Eigen::Matrix<double, 8, 2> projected_points;
 
@@ -214,45 +215,45 @@ box_around_box3d( const kwiver::vital::camera_perspective_sptr camera,
 
   vector_4d out_box;
   out_box << (vector_2d)projected_points.colwise().minCoeff(),
-    (vector_2d)projected_points.colwise().maxCoeff();
+             (vector_2d)projected_points.colwise().maxCoeff();
 
   return out_box;
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vector_4d
 transform_detected_object_set::
 view_to_view( const kwiver::vital::camera_perspective_sptr src_camera,
-	      const kwiver::vital::camera_perspective_sptr dest_camera,
-	      const vector_4d bounds ) const
+              const kwiver::vital::camera_perspective_sptr dest_camera,
+              const vector_4d bounds ) const
 {
-  Eigen::Matrix<double, 8, 3> box3d =\
+  Eigen::Matrix<double, 8, 3> box3d =
     this->backproject_bbox( src_camera, bounds );
   vector_4d tgt_box = this->box_around_box3d( dest_camera, box3d );
 
   return tgt_box;
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vital::bounding_box<double>
 transform_detected_object_set::
 transform_bounding_box( vital::bounding_box<double>& bbox ) const
 {
   vector_4d bbox_bounds;
   bbox_bounds << bbox.min_x(), bbox.min_y(),
-    bbox.max_x(), bbox.max_y();
+                 bbox.max_x(), bbox.max_y();
 
   vector_4d out_bounds = this->view_to_view( this->src_camera,
-					     this->dest_camera,
-					     bbox_bounds );
+                                             this->dest_camera,
+                                             bbox_bounds );
 
   return vital::bounding_box<double>(out_bounds(0),
-				     out_bounds(1),
-				     out_bounds(2),
-				     out_bounds(3));
+                                     out_bounds(1),
+                                     out_bounds(2),
+                                     out_bounds(3));
 }
 
-// ------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 vital::detected_object_set_sptr
 transform_detected_object_set::
 filter( const vital::detected_object_set_sptr input_set ) const

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -48,6 +48,13 @@ transform_detected_object_set::transform_detected_object_set()
 {
 }
 
+// ------------------------------------------------------------------
+transform_detected_object_set::transform_detected_object_set(kwiver::vital::camera_perspective_sptr src_cam,
+							     kwiver::vital::camera_perspective_sptr dest_cam)
+  : src_camera( src_cam )
+  , dest_camera( dest_cam )
+{
+}
 
 // ------------------------------------------------------------------
 vital::config_block_sptr

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -1,0 +1,130 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "transform_detected_object_set.h"
+
+#include <vital/io/camera_io.h>
+#include <vital/config/config_difference.h>
+#include <vital/util/string.h>
+#include <vital/types/bounding_box.h>
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+// ------------------------------------------------------------------
+transform_detected_object_set::transform_detected_object_set()
+  : src_camera_krtd_file_name( "" )
+  , dest_camera_krtd_file_name( "" )
+{
+}
+
+
+// ------------------------------------------------------------------
+vital::config_block_sptr
+transform_detected_object_set::get_configuration() const
+{
+  // Get base config from base class
+  vital::config_block_sptr config = vital::algorithm::get_configuration();
+
+  config->set_value( "src_camera_krtd_file_name", src_camera_krtd_file_name,
+                     "Source camera KRTD file name path" );
+
+  config->set_value( "dest_camera_krtd_file_name", dest_camera_krtd_file_name,
+                     "Destination camera KRTD file name path" );
+
+  return config;
+}
+
+
+// ------------------------------------------------------------------
+void
+transform_detected_object_set::
+set_configuration( vital::config_block_sptr config_in )
+{
+  vital::config_block_sptr config = this->get_configuration();
+
+  config->merge_config( config_in );
+  this->src_camera_krtd_file_name = config->get_value< std::string > ( "src_camera_krtd_file_name" );
+  this->dest_camera_krtd_file_name = config->get_value< std::string > ( "dest_camera_krtd_file_name" );
+
+  this->src_camera = kwiver::vital::read_krtd_file( this->src_camera_krtd_file_name );
+  this->dest_camera = kwiver::vital::read_krtd_file( this->dest_camera_krtd_file_name );
+}
+
+
+// ------------------------------------------------------------------
+bool
+transform_detected_object_set::
+check_configuration( vital::config_block_sptr config ) const
+{
+  kwiver::vital::config_difference cd( this->get_configuration(), config );
+  const auto key_list = cd.extra_keys();
+
+  if ( ! key_list.empty() )
+  {
+    LOG_WARN( logger(), "Additional parameters found in config block that are not required or desired: "
+              << kwiver::vital::join( key_list, ", " ) );
+  }
+
+  return true;
+}
+
+// ------------------------------------------------------------------
+vital::bounding_box<double>
+transform_detected_object_set::
+transform_bounding_box( vital::bounding_box<double>& bbox ) const
+{
+  // TODO
+  return bbox;
+}
+
+// ------------------------------------------------------------------
+vital::detected_object_set_sptr
+transform_detected_object_set::
+filter( const vital::detected_object_set_sptr input_set ) const
+{
+  auto ret_set = std::make_shared<vital::detected_object_set>();
+
+  // loop over all detections
+  auto ie = input_set->cend();
+  for ( auto det = input_set->cbegin(); det != ie; ++det )
+  {
+    auto out_det = (*det)->clone();
+    auto out_box = out_det->bounding_box();
+    this->transform_bounding_box(out_box);
+    out_det->set_bounding_box( out_box );
+    ret_set->add( out_det );
+  } // end foreach detection
+
+  return ret_set;
+} // transform_detected_object_set::filter
+
+} } }     // end namespace

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -96,16 +96,16 @@ private:
 
   virtual Eigen::Matrix<double, 8, 3>
     backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
-                     const vector_4d box) const;
+                     const vital::bounding_box<double> bbox) const;
 
-  virtual vector_4d
+  virtual vital::bounding_box<double>
     box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
                      const Eigen::Matrix<double, 8, 3> box3d) const;
 
-  virtual vector_4d
+  virtual vital::bounding_box<double>
     view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
                  const kwiver::vital::camera_perspective_sptr dest_camera,
-                 const vector_4d bounds) const;
+                 const vital::bounding_box<double> bbox) const;
 };
 
 }}} //End namespace

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -70,6 +70,23 @@ private:
   kwiver::vital::camera_perspective_sptr dest_camera;
 
   virtual vital::bounding_box<double> transform_bounding_box(vital::bounding_box<double>& bbox) const;
+
+  virtual Eigen::Vector3d backproject_to_height(const kwiver::vital::camera_perspective_sptr camera,
+						const Eigen::Vector2d img_pt) const;
+
+  virtual Eigen::Vector3d backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,
+					       const Eigen::Vector2d img_pt,
+					       const Eigen::Vector4d plane) const;
+
+  virtual Eigen::Matrix<double, 8, 3> backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
+						       const Eigen::Vector4d box) const;
+
+  virtual Eigen::Vector4d box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
+					   const Eigen::Matrix<double, 8, 3> box3d) const;
+
+  virtual Eigen::Vector4d view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
+				       const kwiver::vital::camera_perspective_sptr dest_camera,
+				       const Eigen::Vector4d bounds) const;
 };
 
 }}} //End namespace

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -75,7 +75,7 @@ private:
 
   virtual vital::bounding_box<double> transform_bounding_box(vital::bounding_box<double>& bbox) const;
 
-  virtual Eigen::Vector3d backproject_to_height(const kwiver::vital::camera_perspective_sptr camera,
+  virtual Eigen::Vector3d backproject_to_ground(const kwiver::vital::camera_perspective_sptr camera,
 						const Eigen::Vector2d img_pt) const;
 
   virtual Eigen::Vector3d backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -42,32 +42,36 @@ namespace kwiver {
 namespace arrows {
 namespace core {
 
-// ----------------------------------------------------------------
-/**
- * @brief Transforms detections based on source and destination cameras.
- *
- */
-
+/// @brief Transforms detections based on source and destination cameras.
 class KWIVER_ALGO_CORE_EXPORT transform_detected_object_set
   : public vital::algorithm_impl<transform_detected_object_set,
-				 vital::algo::detected_object_filter>
+                                 vital::algo::detected_object_filter>
 {
 public:
   PLUGIN_INFO( "transform_detected_object_set",
                "Transforms a detected object set based on source and "
-	       "destination cameras.\n\n" )
+               "destination cameras.\n\n" )
 
+  /// @brief Default constructor
   transform_detected_object_set();
 
+  /// @brief Constructor taking source and destination cameras directly
   transform_detected_object_set(kwiver::vital::camera_perspective_sptr src_cam,
-				kwiver::vital::camera_perspective_sptr dest_cam);
+                                kwiver::vital::camera_perspective_sptr dest_cam);
 
+  /// @brief Default destructor
   virtual ~transform_detected_object_set() = default;
 
+  /// @brief Get this algorithm's configuration block
   virtual vital::config_block_sptr get_configuration() const;
+
+  /// @brief Set this algorithm's properties via a config block
   virtual void set_configuration(vital::config_block_sptr config);
+
+  /// @brief Check that the algorithm's currently configuration is valid
   virtual bool check_configuration(vital::config_block_sptr config) const;
 
+  /// @brief Apply the transformation
   virtual vital::detected_object_set_sptr
     filter( const vital::detected_object_set_sptr input_set) const;
 
@@ -83,25 +87,25 @@ private:
 
   virtual vector_3d
     backproject_to_ground(const kwiver::vital::camera_perspective_sptr camera,
-			  const vector_2d img_pt) const;
+                          const vector_2d img_pt) const;
 
   virtual vector_3d
     backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,
-			 const vector_2d img_pt,
-			 const vector_4d plane) const;
+                         const vector_2d img_pt,
+                         const vector_4d plane) const;
 
   virtual Eigen::Matrix<double, 8, 3>
     backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
-		     const vector_4d box) const;
+                     const vector_4d box) const;
 
   virtual vector_4d
     box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
-		     const Eigen::Matrix<double, 8, 3> box3d) const;
+                     const Eigen::Matrix<double, 8, 3> box3d) const;
 
   virtual vector_4d
     view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
-		 const kwiver::vital::camera_perspective_sptr dest_camera,
-		 const vector_4d bounds) const;
+                 const kwiver::vital::camera_perspective_sptr dest_camera,
+                 const vector_4d bounds) const;
 };
 
 }}} //End namespace

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -54,6 +54,10 @@ public:
                "Transforms a detected object set based on source and destination cameras.\n\n" )
 
   transform_detected_object_set();
+
+  transform_detected_object_set(kwiver::vital::camera_perspective_sptr src_cam,
+				kwiver::vital::camera_perspective_sptr dest_cam);
+
   virtual ~transform_detected_object_set() = default;
 
   virtual vital::config_block_sptr get_configuration() const;

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -42,7 +42,7 @@ namespace kwiver {
 namespace arrows {
 namespace core {
 
-/// @brief Transforms detections based on source and destination cameras.
+/// Transforms detections based on source and destination cameras.
 class KWIVER_ALGO_CORE_EXPORT transform_detected_object_set
   : public vital::algorithm_impl<transform_detected_object_set,
                                  vital::algo::detected_object_filter>
@@ -52,26 +52,26 @@ public:
                "Transforms a detected object set based on source and "
                "destination cameras.\n\n" )
 
-  /// @brief Default constructor
+  /// Default constructor
   transform_detected_object_set();
 
-  /// @brief Constructor taking source and destination cameras directly
+  /// Constructor taking source and destination cameras directly
   transform_detected_object_set(kwiver::vital::camera_perspective_sptr src_cam,
                                 kwiver::vital::camera_perspective_sptr dest_cam);
 
-  /// @brief Default destructor
+  /// Default destructor
   virtual ~transform_detected_object_set() = default;
 
-  /// @brief Get this algorithm's configuration block
+  /// Get this algorithm's configuration block
   virtual vital::config_block_sptr get_configuration() const;
 
-  /// @brief Set this algorithm's properties via a config block
+  /// Set this algorithm's properties via a config block
   virtual void set_configuration(vital::config_block_sptr config);
 
-  /// @brief Check that the algorithm's currently configuration is valid
+  /// Check that the algorithm's currently configuration is valid
   virtual bool check_configuration(vital::config_block_sptr config) const;
 
-  /// @brief Apply the transformation
+  /// Apply the transformation
   virtual vital::detected_object_set_sptr
     filter( const vital::detected_object_set_sptr input_set) const;
 

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -73,7 +73,7 @@ public:
 
   /// Apply the transformation
   virtual vital::detected_object_set_sptr
-    filter( const vital::detected_object_set_sptr input_set) const;
+    filter( vital::detected_object_set_sptr const input_set) const;
 
 private:
   std::string src_camera_krtd_file_name;
@@ -83,29 +83,29 @@ private:
   kwiver::vital::camera_perspective_sptr dest_camera;
 
   virtual vital::bounding_box<double>
-    transform_bounding_box(vital::bounding_box<double>& bbox) const;
+    transform_bounding_box(vital::bounding_box<double> const& bbox) const;
 
   virtual vector_3d
-    backproject_to_ground(const kwiver::vital::camera_perspective_sptr camera,
-                          const vector_2d img_pt) const;
+    backproject_to_ground(kwiver::vital::camera_perspective_sptr const camera,
+                          vector_2d const& img_pt) const;
 
   virtual vector_3d
-    backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,
-                         const vector_2d img_pt,
-                         const vector_4d plane) const;
+    backproject_to_plane(kwiver::vital::camera_perspective_sptr const camera,
+                         vector_2d const& img_pt,
+                         vector_4d const& plane) const;
 
   virtual Eigen::Matrix<double, 8, 3>
-    backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
-                     const vital::bounding_box<double> bbox) const;
+    backproject_bbox(kwiver::vital::camera_perspective_sptr const camera,
+                     vital::bounding_box<double> const& bbox) const;
 
   virtual vital::bounding_box<double>
-    box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
-                     const Eigen::Matrix<double, 8, 3> box3d) const;
+    box_around_box3d(kwiver::vital::camera_perspective_sptr const camera,
+                     Eigen::Matrix<double, 8, 3> const& box3d) const;
 
   virtual vital::bounding_box<double>
-    view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
-                 const kwiver::vital::camera_perspective_sptr dest_camera,
-                 const vital::bounding_box<double> bbox) const;
+    view_to_view(kwiver::vital::camera_perspective_sptr const src_camera,
+                 kwiver::vital::camera_perspective_sptr const dest_camera,
+                 vital::bounding_box<double> const& bbox) const;
 };
 
 }}} //End namespace

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -1,0 +1,78 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_ARROWS_TRANSFORM_DETECTED_OBJECT_SET_H_
+#define KWIVER_ARROWS_TRANSFORM_DETECTED_OBJECT_SET_H_
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/algo/detected_object_filter.h>
+#include <vital/io/camera_io.h>
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+// ----------------------------------------------------------------
+/**
+ * @brief Transforms detections based on source and destination cameras.
+ *
+ */
+
+class KWIVER_ALGO_CORE_EXPORT transform_detected_object_set
+  : public vital::algorithm_impl<transform_detected_object_set, vital::algo::detected_object_filter>
+{
+public:
+  PLUGIN_INFO( "transform_detected_object_set",
+               "Transforms a detected object set based on source and destination cameras.\n\n" )
+
+  transform_detected_object_set();
+  virtual ~transform_detected_object_set() = default;
+
+  virtual vital::config_block_sptr get_configuration() const;
+  virtual void set_configuration(vital::config_block_sptr config);
+  virtual bool check_configuration(vital::config_block_sptr config) const;
+
+  virtual vital::detected_object_set_sptr filter( const vital::detected_object_set_sptr input_set) const;
+
+private:
+  std::string src_camera_krtd_file_name;
+  std::string dest_camera_krtd_file_name;
+
+  kwiver::vital::camera_perspective_sptr src_camera;
+  kwiver::vital::camera_perspective_sptr dest_camera;
+
+  virtual vital::bounding_box<double> transform_bounding_box(vital::bounding_box<double>& bbox) const;
+};
+
+}}} //End namespace
+
+
+#endif // KWIVER_ARROWS_TRANSFORM_DETECTED_OBJECT_SET_H_

--- a/arrows/core/transform_detected_object_set.h
+++ b/arrows/core/transform_detected_object_set.h
@@ -36,6 +36,8 @@
 #include <vital/algo/detected_object_filter.h>
 #include <vital/io/camera_io.h>
 
+using namespace kwiver::vital;
+
 namespace kwiver {
 namespace arrows {
 namespace core {
@@ -47,11 +49,13 @@ namespace core {
  */
 
 class KWIVER_ALGO_CORE_EXPORT transform_detected_object_set
-  : public vital::algorithm_impl<transform_detected_object_set, vital::algo::detected_object_filter>
+  : public vital::algorithm_impl<transform_detected_object_set,
+				 vital::algo::detected_object_filter>
 {
 public:
   PLUGIN_INFO( "transform_detected_object_set",
-               "Transforms a detected object set based on source and destination cameras.\n\n" )
+               "Transforms a detected object set based on source and "
+	       "destination cameras.\n\n" )
 
   transform_detected_object_set();
 
@@ -64,7 +68,8 @@ public:
   virtual void set_configuration(vital::config_block_sptr config);
   virtual bool check_configuration(vital::config_block_sptr config) const;
 
-  virtual vital::detected_object_set_sptr filter( const vital::detected_object_set_sptr input_set) const;
+  virtual vital::detected_object_set_sptr
+    filter( const vital::detected_object_set_sptr input_set) const;
 
 private:
   std::string src_camera_krtd_file_name;
@@ -73,24 +78,30 @@ private:
   kwiver::vital::camera_perspective_sptr src_camera;
   kwiver::vital::camera_perspective_sptr dest_camera;
 
-  virtual vital::bounding_box<double> transform_bounding_box(vital::bounding_box<double>& bbox) const;
+  virtual vital::bounding_box<double>
+    transform_bounding_box(vital::bounding_box<double>& bbox) const;
 
-  virtual Eigen::Vector3d backproject_to_ground(const kwiver::vital::camera_perspective_sptr camera,
-						const Eigen::Vector2d img_pt) const;
+  virtual vector_3d
+    backproject_to_ground(const kwiver::vital::camera_perspective_sptr camera,
+			  const vector_2d img_pt) const;
 
-  virtual Eigen::Vector3d backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,
-					       const Eigen::Vector2d img_pt,
-					       const Eigen::Vector4d plane) const;
+  virtual vector_3d
+    backproject_to_plane(const kwiver::vital::camera_perspective_sptr camera,
+			 const vector_2d img_pt,
+			 const vector_4d plane) const;
 
-  virtual Eigen::Matrix<double, 8, 3> backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
-						       const Eigen::Vector4d box) const;
+  virtual Eigen::Matrix<double, 8, 3>
+    backproject_bbox(const kwiver::vital::camera_perspective_sptr camera,
+		     const vector_4d box) const;
 
-  virtual Eigen::Vector4d box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
-					   const Eigen::Matrix<double, 8, 3> box3d) const;
+  virtual vector_4d
+    box_around_box3d(const kwiver::vital::camera_perspective_sptr camera,
+		     const Eigen::Matrix<double, 8, 3> box3d) const;
 
-  virtual Eigen::Vector4d view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
-				       const kwiver::vital::camera_perspective_sptr dest_camera,
-				       const Eigen::Vector4d bounds) const;
+  virtual vector_4d
+    view_to_view(const kwiver::vital::camera_perspective_sptr src_camera,
+		 const kwiver::vital::camera_perspective_sptr dest_camera,
+		 const vector_4d bounds) const;
 };
 
 }}} //End namespace

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -29,9 +29,9 @@ Arrows
 
 Arrows: Core
 
- * Added an arrow (transform_detected_object_set) for transforming detected
-   object sets from one camera perspective to another.  This arrow is an
-   implementation of vital::algo::detected_object_filter.
+ * Added an algorithm implementation (transform_detected_object_set) for
+   transforming detected object sets from one camera perspective to another.
+   Implements vital::algo::detected_object_filter.
 
 Arrows: Ceres
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -29,6 +29,10 @@ Arrows
 
 Arrows: Core
 
+ * Added an arrow (transform_detected_object_set) for transforming detected
+   object sets from one camera perspective to another.  This arrow is an
+   implementation of vital::algo::detected_object_filter.
+
 Arrows: Ceres
 
 Arrows: CUDA


### PR DESCRIPTION
This pull request adds an arrow for transforming detected object sets from one camera view to another (as an implementation of detected_object_set_filter).  The arrow name should probably be a bit more descriptive.