### PR TITLE
Dev/frame offset detected object set

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -53,6 +53,13 @@ Sprokit
 
 Sprokit: Processes
 
+ * Added a core sprokit process to shift a stream of detected object
+   sets by a specified offset.  When a negative offset is specified,
+   detected object sets are initially consumed from the stream until
+   the offset is satisfied.  When a positive offset is specified,
+   empty detected object sets are prepended to the stream until the
+   offset is satisfied.
+
 Tools
 
 Unit Tests

--- a/sprokit/processes/core/CMakeLists.txt
+++ b/sprokit/processes/core/CMakeLists.txt
@@ -41,6 +41,7 @@ set( sources
   serializer_base.cxx
   serializer_process.cxx
   deserializer_process.cxx
+  shift_detected_object_set_frames_process.cxx
   split_image_process.cxx
   stabilize_image_process.cxx
   track_features_process.cxx
@@ -85,6 +86,7 @@ set( private_headers
   serializer_base.h
   serializer_process.h
   deserializer_process.h
+  shift_detected_object_set_frames_process.h
   split_image_process.h
   stabilize_image_process.h
   track_features_process.h

--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -68,6 +68,7 @@
 #include "refine_detections_process.h"
 #include "serializer_process.h"
 #include "deserializer_process.h"
+#include "shift_detected_object_set_frames_process.h"
 #include "split_image_process.h"
 #include "stabilize_image_process.h"
 #include "track_features_process.h"
@@ -135,6 +136,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< compute_track_descriptors_process >();
   reg.register_process< perform_query_process >();
   reg.register_process< detect_motion_process >();
+  reg.register_process< shift_detected_object_set_frames_process >();
 
   mark_process_module_as_loaded( vpm, reg.module_name() );
 } // register_process

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2018 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
@@ -113,24 +113,25 @@ void
 shift_detected_object_set_frames_process
 ::_step()
 {
-  while (d->remaining_offset != 0)
+  while (d->remaining_offset > 0)
   {
-    // Source or sink data until the remaining offset is 0.
-    if (d->remaining_offset > 0)
-    {
-      push_to_port_using_trait( detected_object_set,
-				d->empty_detected_object_set_sptr);
-      --d->remaining_offset;
-    }
-    else if (d->remaining_offset < 0)
-    {
-      (void)grab_from_port_using_trait( detected_object_set );
-      ++d->remaining_offset;
-    }
+    // Source data until the remaining offset is 0.
+    push_to_port_using_trait( detected_object_set,
+			      d->empty_detected_object_set_sptr);
+    --d->remaining_offset;
   }
 
-  push_to_port_using_trait( detected_object_set,
-			    grab_from_port_using_trait( detected_object_set ) );
+  if (d->remaining_offset < 0)
+  {
+    // Sink data util the remaining offset is 0.
+    (void)grab_from_port_using_trait( detected_object_set );
+    ++d->remaining_offset;
+  }
+  else
+  {
+    push_to_port_using_trait( detected_object_set,
+			      grab_from_port_using_trait( detected_object_set ) );
+  }
 }
 
 shift_detected_object_set_frames_process::priv

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
@@ -43,14 +43,15 @@
 namespace kwiver
 {
 
+create_config_trait( offset, int, "0", "The offset to shift the input by." );
+
 class shift_detected_object_set_frames_process::priv
 {
   public:
-    typedef int32_t number_t;
-    priv(number_t offset);
+    priv(int offset);
     ~priv();
 
-    number_t remaining_offset;
+    int remaining_offset;
 
     static vital::config_block_key_t const config_value;
     static vital::config_block_value_t const default_value;
@@ -58,15 +59,8 @@ class shift_detected_object_set_frames_process::priv
     static vital::detected_object_set_sptr const empty_detected_object_set_sptr;
 };
 
-vital::config_block_key_t const
-shift_detected_object_set_frames_process::priv::config_value =\
-  vital::config_block_key_t("offset");
-vital::config_block_value_t const
-shift_detected_object_set_frames_process::priv::default_value =\
-  vital::config_block_value_t("0");
-
 vital::detected_object_set_sptr const
-shift_detected_object_set_frames_process::priv::empty_detected_object_set_sptr =\
+shift_detected_object_set_frames_process::priv::empty_detected_object_set_sptr =
   std::make_shared<vital::detected_object_set>();
 
 
@@ -88,10 +82,7 @@ void
 shift_detected_object_set_frames_process
 ::make_config()
 {
-  declare_configuration_key(
-    priv::config_value,
-    priv::default_value,
-    vital::config_block_description_t("The offset to shift the input by."));
+  declare_config_using_trait( offset );
 }
 
 void
@@ -115,7 +106,7 @@ shift_detected_object_set_frames_process
 {
   // Configure the process.
   {
-    priv::number_t offset = config_value<priv::number_t>(priv::config_value);
+    int offset = config_value_using_trait( offset );
 
     d.reset(new priv(offset));
   }
@@ -150,7 +141,7 @@ shift_detected_object_set_frames_process
 }
 
 shift_detected_object_set_frames_process::priv
-::priv(number_t offset)
+::priv(int offset)
   : remaining_offset(offset)
 {
 }

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
@@ -49,12 +49,9 @@ class shift_detected_object_set_frames_process::priv
 {
   public:
     priv(int offset);
-    ~priv();
+    ~priv() = default;
 
     int remaining_offset;
-
-    static vital::config_block_key_t const config_value;
-    static vital::config_block_value_t const default_value;
 
     static vital::detected_object_set_sptr const empty_detected_object_set_sptr;
 };
@@ -110,8 +107,6 @@ shift_detected_object_set_frames_process
 
     d.reset(new priv(offset));
   }
-
-  process::_configure();
 }
 
 void
@@ -136,18 +131,11 @@ shift_detected_object_set_frames_process
 
   push_to_port_using_trait( detected_object_set,
 			    grab_from_port_using_trait( detected_object_set ) );
-
-  process::_step();
 }
 
 shift_detected_object_set_frames_process::priv
 ::priv(int offset)
   : remaining_offset(offset)
-{
-}
-
-shift_detected_object_set_frames_process::priv
-::~priv()
 {
 }
 

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.cxx
@@ -1,0 +1,163 @@
+/*ckwg +29
+ * Copyright 2011-2018 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "shift_detected_object_set_frames_process.h"
+
+#include <vital/config/config_block.h>
+#include <sprokit/processes/kwiver_type_traits.h>
+#include <sprokit/pipeline/process_exception.h>
+
+/**
+ * \file shift_detected_object_set_frames_process.cxx
+ *
+ * \brief Implementation of the detected object set frame shift process
+ */
+
+namespace kwiver
+{
+
+class shift_detected_object_set_frames_process::priv
+{
+  public:
+    typedef int32_t number_t;
+    priv(number_t offset);
+    ~priv();
+
+    number_t remaining_offset;
+
+    static vital::config_block_key_t const config_value;
+    static vital::config_block_value_t const default_value;
+
+    static vital::detected_object_set_sptr const empty_detected_object_set_sptr;
+};
+
+vital::config_block_key_t const
+shift_detected_object_set_frames_process::priv::config_value =\
+  vital::config_block_key_t("offset");
+vital::config_block_value_t const
+shift_detected_object_set_frames_process::priv::default_value =\
+  vital::config_block_value_t("0");
+
+vital::detected_object_set_sptr const
+shift_detected_object_set_frames_process::priv::empty_detected_object_set_sptr =\
+  std::make_shared<vital::detected_object_set>();
+
+
+shift_detected_object_set_frames_process
+::shift_detected_object_set_frames_process(vital::config_block_sptr const& config)
+  : process(config)
+  , d()
+{
+  make_ports();
+  make_config();
+}
+
+shift_detected_object_set_frames_process
+::~shift_detected_object_set_frames_process()
+{
+}
+
+void
+shift_detected_object_set_frames_process
+::make_config()
+{
+  declare_configuration_key(
+    priv::config_value,
+    priv::default_value,
+    vital::config_block_description_t("The offset to shift the input by."));
+}
+
+void
+shift_detected_object_set_frames_process
+::make_ports()
+{
+  sprokit::process::port_flags_t required;
+
+  required.insert( flag_required );
+
+  // -- input --
+  declare_input_port_using_trait( detected_object_set, required );
+
+  // -- output --
+  declare_output_port_using_trait( detected_object_set, required );
+}
+
+void
+shift_detected_object_set_frames_process
+::_configure()
+{
+  // Configure the process.
+  {
+    priv::number_t offset = config_value<priv::number_t>(priv::config_value);
+
+    d.reset(new priv(offset));
+  }
+
+  process::_configure();
+}
+
+void
+shift_detected_object_set_frames_process
+::_step()
+{
+  while (d->remaining_offset != 0)
+  {
+    // Source or sink data until the remaining offset is 0.
+    if (d->remaining_offset > 0)
+    {
+      push_to_port_using_trait( detected_object_set,
+				d->empty_detected_object_set_sptr);
+      --d->remaining_offset;
+    }
+    else if (d->remaining_offset < 0)
+    {
+      (void)grab_from_port_using_trait( detected_object_set );
+      ++d->remaining_offset;
+    }
+  }
+
+  push_to_port_using_trait( detected_object_set,
+			    grab_from_port_using_trait( detected_object_set ) );
+
+  process::_step();
+}
+
+shift_detected_object_set_frames_process::priv
+::priv(number_t offset)
+  : remaining_offset(offset)
+{
+}
+
+shift_detected_object_set_frames_process::priv
+::~priv()
+{
+}
+
+}

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.h
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.h
@@ -1,0 +1,109 @@
+/*ckwg +29
+ * Copyright 2011-2012 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPROKIT_PROCESSES_SHIFT_DETECTED_OBJECT_SET_FRAMES_PROCESS_H
+#define SPROKIT_PROCESSES_SHIFT_DETECTED_OBJECT_SET_FRAMES_PROCESS_H
+
+#include <sprokit/pipeline/process.h>
+
+#include "kwiver_processes_export.h"
+
+/**
+ * \file shift_process.h
+ *
+ * \brief Declaration of the detected object set frame shift process
+ */
+
+namespace kwiver
+{
+
+/**
+ * \class shift_detected_object_set_frames_process
+ *
+ * \brief Shifts input stream of detected object sets
+ *
+ * \process Either
+ *
+ * \iports
+ *
+ * \iports{any} The input detected object set
+ *
+ * \oports
+ *
+ * \oport{any} The ith - offset detected object set from the input stream.
+ *             Any items outside the input stream bounds are provided as empty
+ *             detected object sets
+ * *
+ * \reqs
+ *
+ * \req The \port{any} input must be connected.
+ * \req The \port{any} output must be connected.
+ *
+ * \ingroup examples
+ */
+class KWIVER_PROCESSES_NO_EXPORT shift_detected_object_set_frames_process
+  : public sprokit::process
+{
+  public:
+    PLUGIN_INFO( "shift_detected_object_set",
+                 "Shift an input stream of detected objects "
+		 "by a certain number of frames")
+    /**
+     * \brief Constructor.
+     *
+     * \param config The configuration for the process.
+     */
+    shift_detected_object_set_frames_process
+      (kwiver::vital::config_block_sptr const& config);
+    /**
+     * \brief Destructor.
+     */
+    ~shift_detected_object_set_frames_process();
+  protected:
+    /**
+     * \brief Configure the process.
+     */
+    void _configure();
+
+    /**
+     * \brief Step the process.
+     */
+    void _step();
+  private:
+    void make_ports();
+    void make_config();
+
+    class priv;
+    std::unique_ptr<priv> d;
+};
+
+}
+
+#endif // SPROKIT_PROCESSES_SHIFT_DETECTED_OBJECT_SET_FRAMES_PROCESS_H

--- a/sprokit/processes/core/shift_detected_object_set_frames_process.h
+++ b/sprokit/processes/core/shift_detected_object_set_frames_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Added a core sprokit process to shift a stream of detected object sets by a specified offset.  When a negative offset is specified, detected object sets are initially consumed from the stream until the offset is satisfied.  When a positive offset is specified, empty detected object sets are prepended to the stream until the offset is satisfied.

This process is useful in conjunction with the recent PR for camera-to-camera transfer of detected object sets (#838), where the cameras might not align temporally.

In my limited understanding of Kwiver / Sprokit, this approach seemed the least invasive.  Otherwise it my be necessary to add a parameter to several output processes to ensure that the offset is considered before writing out.