### PR TITLE
Wrap f2f_homography

### DIFF
--- a/sprokit/processes/python/homography_writer.py
+++ b/sprokit/processes/python/homography_writer.py
@@ -50,7 +50,7 @@ class HomographyWriterProcess(sprokit.pipeline.process.PythonProcess):
     # ----------------------------------------------------------------
     def _step(self):
         dat = self.grab_datum_from_port('homography')
-        h = dat.get_datum()
+        h = dat.get_homography_f2f()
 
         for r in [ 0, 1, 2 ]:
             for c in [ 0, 1, 2 ]:

--- a/sprokit/processes/python/homography_writer.py
+++ b/sprokit/processes/python/homography_writer.py
@@ -58,8 +58,8 @@ class HomographyWriterProcess(sprokit.pipeline.process.PythonProcess):
                 print(val, end=' ')
                 self.fout.write( '%.20g ' % val )
 
-        print(h.from_id(), h.to_id())
-        self.fout.write( '%d %d\n' % (h.from_id(), h.to_id()) )
+        print(h.from_id, h.to_id)
+        self.fout.write( '%d %d\n' % (h.from_id, h.to_id) )
         self.fout.flush()
         ## t = h # .transform()
 

--- a/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/datum.cxx
@@ -50,6 +50,7 @@
 #include <vital/types/feature_track_set.h>
 #include <vital/types/timestamp.h>
 #include <vital/types/geo_polygon.h>
+#include <vital/types/homography_f2f.h>
 
 #include <limits>
 #include <string>
@@ -207,6 +208,8 @@ PYBIND11_MODULE(datum, m)
          , "Convert the data to a set of corner points")
     .def("get_string", &datum_get_object<std::string>,
             "Convert the data to a string")
+    .def("get_homography_f2f", &datum_get_object<kwiver::vital::f2f_homography>,
+	 "Convert the data to a f2f_homography")
   ;
 
 } // end module

--- a/vital/bindings/python/vital/types/CMakeLists.txt
+++ b/vital/bindings/python/vital/types/CMakeLists.txt
@@ -120,6 +120,13 @@ target_link_libraries(python-vital.types-homography
   PUBLIC ${PYTHON_LIBRARIES}
          vital)
 
+kwiver_add_python_library(homography_f2f
+  vital/types
+  homography_f2f.cxx)
+target_link_libraries(python-vital.types-homography_f2f
+  PUBLIC ${PYTHON_LIBRARIES}
+         vital)
+
 kwiver_add_python_library(landmark
   vital/types
   landmark.cxx)
@@ -185,6 +192,7 @@ kwiver_create_python_init(vital/types
   eigen
   feature
   homography
+  homography_f2f
   landmark
   rotation
   similarity

--- a/vital/bindings/python/vital/types/homography_f2f.cxx
+++ b/vital/bindings/python/vital/types/homography_f2f.cxx
@@ -1,0 +1,72 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdexcept>
+
+#include <vital/vital_types.h>
+#include <vital/types/homography.h>
+#include <vital/types/homography_f2f.h>
+
+#include <Eigen/Core>
+
+#include <pybind11/pybind11.h>
+
+namespace kv = kwiver::vital;
+namespace py = pybind11;
+
+using f2f_homography = kv::f2f_homography;
+
+PYBIND11_MODULE(homography_f2f, m)
+{
+  // This should wrap all of f2f_homography except for the (templated)
+  // constructor directly from an Eigen::Matrix and the copy
+  // constructor
+  py::class_<f2f_homography, std::shared_ptr<f2f_homography>>(m, "F2FHomography")
+    .def(py::init<kv::homography_sptr const&, kv::frame_id_t, kv::frame_id_t>())
+    .def(py::init<kv::frame_id_t>())
+    .def_property_readonly("homography", &f2f_homography::homography)
+    .def_property_readonly("from_id", &f2f_homography::from_id)
+    .def_property_readonly("to_id", &f2f_homography::to_id)
+    .def("inverse", &f2f_homography::inverse)
+    .def("__mul__", &f2f_homography::operator*)
+    .def("get",
+	 [] (f2f_homography const& self, int r, int c)
+	 {
+	   auto m = self.homography()->matrix();
+	   if(0 <= r && r < m.rows() && 0 <= c && c < m.cols())
+	   {
+	     return m(r, c);
+	   }
+	   throw std::out_of_range("Tried to perform get() out of bounds");
+	 },
+	 "Convenience method that returns the underlying coefficient"
+	 " at the given row and column")
+    ;
+}


### PR DESCRIPTION
The current changes for this PR form a (relatively minimal) Python wrapping of the `f2f_homography` type that I wrote in order to get the `homography_writer` process working, together with some changes for the latter. It suffices for that purpose, but may fall short on other grounds:
- To get the wrapped `f2f_homography` instance out of the wrapped port in `homography_writer`, I added a method to wrapped `datum` type. Is there a better way to do this? (Traits? I'm not very familiar with them.)
- One of the constructors for the wrapped `f2f_homography` class, along with its `homography` attribute, don't work as is (failing with a `TypeError` at run-time) because the `homography` type is wrapped as a separate class. I've started looking at changing the wrapping for `homography`, but I don't know if that's the right way forward.
- There are no tests (related to the unusable constructor).