### PR TITLE
config_block::get_enum_value with default

### DIFF
--- a/arrows/vxl/estimate_fundamental_matrix.cxx
+++ b/arrows/vxl/estimate_fundamental_matrix.cxx
@@ -127,7 +127,8 @@ estimate_fundamental_matrix
   d_->precondition = config->get_value<bool>("precondition",
                                              d_->precondition);
 
-  d_->method = config->get_enum_value< method_converter >( "method" );
+  d_->method = config->get_enum_value< method_converter >( "method",
+                                                           d_->method );
 }
 
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -17,6 +17,9 @@ Vital
    constructors of feature_track_state and object_track_state still make only
    shallow copies.)
 
+ * Added a variant of config_block::get_enum_value that accepts a default
+   value to fall back on.
+
 Vital Util
 
 Vital Tools

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -179,9 +179,8 @@ public:
   T get_value( config_block_key_t const& key, T const& def ) const noexcept;
 
 
+  /// Convert string to enum value.
   /**
-   * \brief Convert string to enum value.
-   *
    * \param key The index of the configuration value to retrieve.
    * \tparam C Type of the enum converter. Must be derived from
    * enum_converter struct.
@@ -189,6 +188,27 @@ public:
    */
   template < typename C>
   typename C::enum_type get_enum_value( const config_block_key_t& key ) const;
+
+
+  /// Cast the value as an enum, returning a default value in case of an error.
+  /**
+  * Get value from config entry converted to enum type. If
+  * the config entry is not there or the value can not be
+  * converted, the specified default value is
+  * returned. Unfortunately, there is no way to tell what went
+  * wrong.
+  *
+  * \param key The index of the configuration value to retrieve.
+  * \param def The value \p key does not exist or the cast fails.
+  * \tparam C  Type of the enum converter. Must be derived from
+  *            enum_converter struct.
+  * \returns   The enum value stored within the configuration, or
+  *            \p def if something goes wrong.
+  */
+  template < typename C >
+  typename C::enum_type
+  get_enum_value(config_block_key_t const& key,
+                 typename C::enum_type const& def) const noexcept;
 
 
   /**
@@ -692,6 +712,25 @@ config_block
     return get_value< T > ( key );
   }
   catch ( ... )
+  {
+    return def;
+  }
+}
+
+
+// ------------------------------------------------------------------
+// Cast the value as an enum, returning a default value in case of an error.
+template < typename C >
+typename C::enum_type
+config_block
+::get_enum_value(config_block_key_t const& key,
+                 typename C::enum_type const& def) const noexcept
+{
+  try
+  {
+    return get_enum_value< C >(key);
+  }
+  catch (...)
   {
     return def;
   }

--- a/vital/config/tests/test_config_block.cxx
+++ b/vital/config/tests/test_config_block.cxx
@@ -541,6 +541,10 @@ TEST(config_block, enum_conversion)
   EXPECT_THROW(
     config->get_enum_value< my_ec >( config_block_key_t{ "not_a_key" } ),
     no_such_configuration_value_exception );
+
+  EXPECT_EQ(3, config->get_enum_value < my_ec >(keya, 2));
+
+  EXPECT_EQ(2, config->get_enum_value < my_ec >(keyb, 2));
 }
 
 


### PR DESCRIPTION
This branch provides a variant to the get_enum_value function that accepts a default value.  This is analogous to the get_value method that does a similar thing and is used quite heavily.