### PR TITLE
Remove include guard comments

### DIFF
--- a/arrows/ceres/bundle_adjust.h
+++ b/arrows/ceres/bundle_adjust.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -112,4 +112,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_BUNDLE_ADJUST_H_
+#endif

--- a/arrows/ceres/camera_position.h
+++ b/arrows/ceres/camera_position.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,4 +91,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_CAMERA_SMOOTHNESS_H_
+#endif

--- a/arrows/ceres/camera_smoothness.h
+++ b/arrows/ceres/camera_smoothness.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,4 +163,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_CAMERA_SMOOTHNESS_H_
+#endif

--- a/arrows/ceres/lens_distortion.h
+++ b/arrows/ceres/lens_distortion.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -170,4 +170,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_LENS_DISTORTION_H_
+#endif

--- a/arrows/ceres/optimize_cameras.h
+++ b/arrows/ceres/optimize_cameras.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -118,4 +118,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_OPTIMIZE_CAMERAS_H_
+#endif

--- a/arrows/ceres/options.h
+++ b/arrows/ceres/options.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -250,4 +250,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_CAMERA_OPTIONS_H_
+#endif

--- a/arrows/ceres/reprojection_error.h
+++ b/arrows/ceres/reprojection_error.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,4 +58,4 @@ create_cost_func(LensDistortionType ldt, double x, double y);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CERES_REPROJECTION_ERROR_H_
+#endif

--- a/arrows/ceres/types.h
+++ b/arrows/ceres/types.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -162,4 +162,4 @@ CERES_ENUM_HELPERS(kwiver::arrows::ceres, CameraIntrinsicShareType)
 #undef CERES_ENUM_HELPERS
 
 
-#endif // KWIVER_ARROWS_CERES_TYPES_H_
+#endif

--- a/arrows/core/associate_detections_to_tracks_threshold.h
+++ b/arrows/core/associate_detections_to_tracks_threshold.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -121,4 +121,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_ASSOCIATE_DETECTIONS_TO_TRACKS_THRESHOLD_H_
+#endif

--- a/arrows/core/class_probablity_filter.h
+++ b/arrows/core/class_probablity_filter.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,4 +92,4 @@ private:
 }}} //End namespace
 
 
-#endif // KWIVER_ARROWS_CLASS_PROBABLITY_FILTER_H_
+#endif

--- a/arrows/core/close_loops_appearance_indexed.h
+++ b/arrows/core/close_loops_appearance_indexed.h
@@ -122,4 +122,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_CORE_CLOSE_LOOPS_APPEARANCE_INDEXED_H_
+#endif

--- a/arrows/core/close_loops_bad_frames_only.h
+++ b/arrows/core/close_loops_bad_frames_only.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -144,4 +144,4 @@ protected:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_CORE_CLOSE_LOOPS_BAD_FRAMES_ONLY_H_
+#endif

--- a/arrows/core/close_loops_exhaustive.h
+++ b/arrows/core/close_loops_exhaustive.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,4 +129,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS__CLOSE_LOOPS_EXHAUSTIVE_H_
+#endif

--- a/arrows/core/close_loops_keyframe.h
+++ b/arrows/core/close_loops_keyframe.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -123,4 +123,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_CLOSE_LOOPS_KEYFRAME_H_
+#endif

--- a/arrows/core/close_loops_multi_method.h
+++ b/arrows/core/close_loops_multi_method.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,4 +133,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_CLOSE_LOOPS_MULTI_METHOD_H_
+#endif

--- a/arrows/core/compute_association_matrix_from_features.h
+++ b/arrows/core/compute_association_matrix_from_features.h
@@ -118,4 +118,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_COMPUTE_ASSOCIATION_MATRIX_FROM_FEATURES_H_
+#endif

--- a/arrows/core/compute_ref_homography_core.h
+++ b/arrows/core/compute_ref_homography_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -135,4 +135,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_CORE_COMPUTE_REF_HOMOGRAPHY_CORE_H_
+#endif

--- a/arrows/core/convert_image_bypass.h
+++ b/arrows/core/convert_image_bypass.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,4 +67,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_CONVERT_IMAGE_BYPASS_H_
+#endif

--- a/arrows/core/create_detection_grid.h
+++ b/arrows/core/create_detection_grid.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -113,4 +113,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_CREATE_DETECTION_GRID_H_
+#endif

--- a/arrows/core/epipolar_geometry.h
+++ b/arrows/core/epipolar_geometry.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -111,4 +111,4 @@ essential_matrix_to_fundamental(kwiver::vital::essential_matrix const& E,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_EPIPOLAR_GEOMETRY_H_
+#endif

--- a/arrows/core/estimate_canonical_transform.h
+++ b/arrows/core/estimate_canonical_transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -109,4 +109,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS__ESTIMATE_CANONICAL_TRANSFORM_H_
+#endif

--- a/arrows/core/feature_descriptor_io.h
+++ b/arrows/core/feature_descriptor_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -103,4 +103,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_FEATURE_DESCRIPTOR_IO_H_
+#endif

--- a/arrows/core/filter_features_magnitude.h
+++ b/arrows/core/filter_features_magnitude.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,4 +88,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_FILTER_FEATURES_MAGNITUDE_H_
+#endif

--- a/arrows/core/filter_features_scale.h
+++ b/arrows/core/filter_features_scale.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -87,4 +87,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_FILTER_FEATURES_SCALE_H_
+#endif

--- a/arrows/core/filter_tracks.h
+++ b/arrows/core/filter_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,4 +83,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_FILTER_TRACKS_H_
+#endif

--- a/arrows/core/handle_descriptor_request_core.h
+++ b/arrows/core/handle_descriptor_request_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -115,4 +115,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_FORMULATE_QUERY_CORE_H_
+#endif

--- a/arrows/core/hierarchical_bundle_adjust.h
+++ b/arrows/core/hierarchical_bundle_adjust.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,4 +90,4 @@ typedef std::shared_ptr<hierarchical_bundle_adjust> hierarchical_bundle_adjust_s
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_HIERARCHICAL_BUNDLE_ADJUST_H_
+#endif

--- a/arrows/core/initialize_cameras_landmarks.h
+++ b/arrows/core/initialize_cameras_landmarks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -110,4 +110,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_INITIALIZE_CAMERAS_LANDMARKS_H_
+#endif

--- a/arrows/core/initialize_cameras_landmarks_keyframe.h
+++ b/arrows/core/initialize_cameras_landmarks_keyframe.h
@@ -97,4 +97,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_INITIALIZE_CAMERAS_LANDMARKS_KEYFRAME_H_
+#endif

--- a/arrows/core/initialize_object_tracks_threshold.h
+++ b/arrows/core/initialize_object_tracks_threshold.h
@@ -112,4 +112,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_INITIALIZE_OBJECT_TRACKS_THRESHOLD_H_
+#endif

--- a/arrows/core/interpolate_track_spline.h
+++ b/arrows/core/interpolate_track_spline.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,4 +85,4 @@ protected:
 
 } } } // end namespace
 
-#endif /* KWIVER_ARROWS_CORE_INTERPOLATE_TRACK_SPLINE_H_ */
+#endif

--- a/arrows/core/match_features_fundamental_matrix.h
+++ b/arrows/core/match_features_fundamental_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -104,4 +104,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS__MATCH_FEATURES_FUNDMENTAL_MATRIX_H_
+#endif

--- a/arrows/core/match_features_homography.h
+++ b/arrows/core/match_features_homography.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2018 by Kitware, Inc.
+ * Copyright 2013-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -150,4 +150,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_MATCH_FEATURES_HOMOGRAPHY_H_
+#endif

--- a/arrows/core/match_matrix.h
+++ b/arrows/core/match_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,4 +88,4 @@ match_matrix_track_importance(vital::track_set_sptr tracks,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_MATCH_MATRIX_H_
+#endif

--- a/arrows/core/match_tracks.h
+++ b/arrows/core/match_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -137,4 +137,4 @@ track_pairs_t match_tracks( vital::algo::match_features_sptr matcher,
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_CORE_MATCH_TRACKS_H_
+#endif

--- a/arrows/core/track_features_augment_keyframes.h
+++ b/arrows/core/track_features_augment_keyframes.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -147,4 +147,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_TRACK_FEATURES_AUGMENT_KEYFRAMES_H_
+#endif

--- a/arrows/core/track_features_core.h
+++ b/arrows/core/track_features_core.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2018 by Kitware, Inc.
+ * Copyright 2013-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,4 +129,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_TRACK_FEATURES_CORE_H_
+#endif

--- a/arrows/core/track_set_impl.h
+++ b/arrows/core/track_set_impl.h
@@ -186,4 +186,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_TRACK_SET_IMPL_H_
+#endif

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,4 +132,4 @@ necker_reverse(vital::camera_map_sptr& cameras,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_TRANSFORM_H_
+#endif

--- a/arrows/core/triangulate_landmarks.h
+++ b/arrows/core/triangulate_landmarks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -117,4 +117,4 @@ typedef std::shared_ptr<triangulate_landmarks> triangulate_landmarks_sptr;
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CORE_TRIANGULATE_LANDMARKS_H_
+#endif

--- a/arrows/cuda/cuda_error_check.h
+++ b/arrows/cuda/cuda_error_check.h
@@ -54,4 +54,4 @@ void cuda_throw(cudaError_t code, const char *file, int line);
 }  // end namespace arrows
 }  // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CUDA_CUDA_ERROR_CHECK_H_
+#endif

--- a/arrows/cuda/cuda_memory.h
+++ b/arrows/cuda/cuda_memory.h
@@ -76,4 +76,4 @@ make_cuda_mem(size_t size)
 }  // end namespace arrows
 }  // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CUDA_CUDA_MEMORY_H_
+#endif

--- a/arrows/cuda/integrate_depth_maps.h
+++ b/arrows/cuda/integrate_depth_maps.h
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2018 by Kitware, Inc.
+* Copyright 2018-2019 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -97,4 +97,4 @@ private:
 }  // end namespace arrows
 }  // end namespace kwiver
 
-#endif // KWIVER_ARROWS_CUDA_INTEGRATE_DEPTH_MAPS_H_
+#endif

--- a/arrows/gdal/image_container.h
+++ b/arrows/gdal/image_container.h
@@ -92,4 +92,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_GDAL_IMAGE_CONTAINER_H_
+#endif

--- a/arrows/gdal/image_io.h
+++ b/arrows/gdal/image_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,4 +76,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_GDAL_IMAGE_IO_H_
+#endif

--- a/arrows/matlab/matlab_detection_output.h
+++ b/arrows/matlab/matlab_detection_output.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,4 +63,4 @@ private:
 
 } } } // end namespace
 
-#endif /* KWIVER_VITAL_BINDINGS_MATLAB_DETECTION_OUTPUT_H_ */
+#endif

--- a/arrows/ocv/analyze_tracks.h
+++ b/arrows/ocv/analyze_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,4 +85,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_ANALYZE_TRACKS_H_
+#endif

--- a/arrows/ocv/camera_intrinsics.h
+++ b/arrows/ocv/camera_intrinsics.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,4 +61,4 @@ dist_coeffs_to_ocv(std::vector<double> const& vital_dist_coeffs);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_CAMERA_INTRINSICS_H_
+#endif

--- a/arrows/ocv/descriptor_set.h
+++ b/arrows/ocv/descriptor_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -87,4 +87,4 @@ descriptors_to_ocv_matrix(const vital::descriptor_set& desc_set);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_DESCRIPTOR_SET_H_
+#endif

--- a/arrows/ocv/detect_features.h
+++ b/arrows/ocv/detect_features.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,4 +80,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_DETECT_FEATURES_H_
+#endif

--- a/arrows/ocv/detect_heat_map.h
+++ b/arrows/ocv/detect_heat_map.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -117,4 +117,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif /* KWIVER_ARROWS_OCV_HEAT_MAP_BOUNDING_BOXES_H_ */
+#endif

--- a/arrows/ocv/detect_motion_3frame_differencing.h
+++ b/arrows/ocv/detect_motion_3frame_differencing.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -104,4 +104,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif /* KWIVER_ARROWS_OCV_THREE_FRAME_DIFFERENCING_H_ */
+#endif

--- a/arrows/ocv/detect_motion_mog2.h
+++ b/arrows/ocv/detect_motion_mog2.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -107,4 +107,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif /* KWIVER_ARROWS_OCV_DETECT_MOTION_MOG2_H_ */
+#endif

--- a/arrows/ocv/draw_tracks.h
+++ b/arrows/ocv/draw_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -95,4 +95,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_DRAW_TRACKS_H_
+#endif

--- a/arrows/ocv/estimate_fundamental_matrix.h
+++ b/arrows/ocv/estimate_fundamental_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -96,4 +96,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_OCV_ESTIMATE_FUNDAMENTAL_MATRIX_H_
+#endif

--- a/arrows/ocv/estimate_homography.h
+++ b/arrows/ocv/estimate_homography.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -81,4 +81,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_ESTIMATE_HOMOGRAPHY_H_
+#endif

--- a/arrows/ocv/estimate_pnp.h
+++ b/arrows/ocv/estimate_pnp.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,4 +98,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_OCV_ESTIMATE_PNP_H_
+#endif

--- a/arrows/ocv/extract_descriptors.h
+++ b/arrows/ocv/extract_descriptors.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,4 +75,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_EXTRACT_DESCRIPTORS_H_
+#endif

--- a/arrows/ocv/feature_detect_extract_BRISK.h
+++ b/arrows/ocv/feature_detect_extract_BRISK.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -106,4 +106,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_BRISK_H_
+#endif

--- a/arrows/ocv/feature_detect_extract_ORB.h
+++ b/arrows/ocv/feature_detect_extract_ORB.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -107,4 +107,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_ORB_H_
+#endif

--- a/arrows/ocv/feature_detect_extract_SIFT.h
+++ b/arrows/ocv/feature_detect_extract_SIFT.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -114,4 +114,4 @@ private:
 
 #endif //defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
-#endif // KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_SIFT_H_
+#endif

--- a/arrows/ocv/feature_detect_extract_SURF.h
+++ b/arrows/ocv/feature_detect_extract_SURF.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -115,4 +115,4 @@ private:
 
 #endif //defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
-#endif // KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_SURF_H_
+#endif

--- a/arrows/ocv/feature_set.h
+++ b/arrows/ocv/feature_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,4 +84,4 @@ features_to_ocv_keypoints(const vital::feature_set& features);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_FEATURE_SET_H_
+#endif

--- a/arrows/ocv/image_container.h
+++ b/arrows/ocv/image_container.h
@@ -150,4 +150,4 @@ KWIVER_ALGO_OCV_EXPORT cv::Mat image_container_to_ocv_matrix(const vital::image_
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_IMAGE_CONTAINER_H_
+#endif

--- a/arrows/ocv/image_io.h
+++ b/arrows/ocv/image_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -86,4 +86,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_IMAGE_IO_H_
+#endif

--- a/arrows/ocv/mat_image_memory.h
+++ b/arrows/ocv/mat_image_memory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,4 +85,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_MAT_IMAGE_MEMORY_H_
+#endif

--- a/arrows/ocv/match_features.h
+++ b/arrows/ocv/match_features.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -86,4 +86,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_MATCH_FEATURES_H_
+#endif

--- a/arrows/ocv/match_set.h
+++ b/arrows/ocv/match_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,4 +84,4 @@ matches_to_ocv_dmatch(const vital::match_set& match_set);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_MATCH_SET_H_
+#endif

--- a/arrows/ocv/refine_detections_write_to_disk.h
+++ b/arrows/ocv/refine_detections_write_to_disk.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,4 +90,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_REFINE_DETECTIONS_WRITE_TO_DISK_H_
+#endif

--- a/arrows/ocv/split_image.h
+++ b/arrows/ocv/split_image.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -71,4 +71,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_SPLIT_IMAGE_H_
+#endif

--- a/arrows/ocv/track_features_klt.h
+++ b/arrows/ocv/track_features_klt.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,4 +129,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_OCV_TRACK_FEATURES_KLT_H_
+#endif

--- a/arrows/proj/geo_conv.h
+++ b/arrows/proj/geo_conv.h
@@ -76,4 +76,4 @@ private:
 
 } } } // end namespace
 
-#endif // KWIVER_ARROWS_PROJ_GEO_CONV_H_
+#endif

--- a/arrows/super3d/compute_depth.h
+++ b/arrows/super3d/compute_depth.h
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2017-2018 by Kitware, Inc.
+* Copyright 2017-2019 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -100,4 +100,4 @@ private:
 }  // end namespace arrows
 }  // end namespace kwiver
 
-#endif // KWIVER_ARROWS_SUPER3D_COMPUTE_SUPER3D_H_
+#endif

--- a/arrows/super3d/cost_volume.h
+++ b/arrows/super3d/cost_volume.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2018 by Kitware, Inc.
+ * Copyright 2012-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,4 +76,4 @@ void load_cost_volume(vil_image_view<double> &cost_volume,
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_SUPER3D_COST_VOLUME_H_
+#endif

--- a/arrows/super3d/tv_refine_search.h
+++ b/arrows/super3d/tv_refine_search.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2018 by Kitware, Inc.
+ * Copyright 2012-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -113,4 +113,4 @@ min_search_bound(vil_image_view<double> &a,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_SUPER3D_TV_REFINE_SEARCH_H_
+#endif

--- a/arrows/super3d/util.h
+++ b/arrows/super3d/util.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2018 by Kitware, Inc.
+ * Copyright 2012-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,4 +83,4 @@ void height_map_to_depth_map(const vpgl_perspective_camera<double>& camera,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_SUPER3D_UTIL_H_
+#endif

--- a/arrows/super3d/warp_image.h
+++ b/arrows/super3d/warp_image.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2010-2018 by Kitware, Inc.
+ * Copyright 2010-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,4 +163,4 @@ warp_image( vil_image_view<T> const& src,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_SUPER3D_WARP_IMAGE_H_
+#endif

--- a/arrows/super3d/world_angled_frustum.h
+++ b/arrows/super3d/world_angled_frustum.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2018 by Kitware, Inc.
+ * Copyright 2012-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -109,4 +109,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_SUPER3D_WORLD_ANGLED_FRUSTUM_H_
+#endif

--- a/arrows/super3d/world_space.h
+++ b/arrows/super3d/world_space.h
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2012-2018 by Kitware, Inc.
+* Copyright 2012-2019 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -121,4 +121,4 @@ compute_offset_range(const std::vector<vnl_double_3> &landmarks,
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_SUPER3D_WORLD_SPACE_H_
+#endif

--- a/arrows/viscl/convert_image.h
+++ b/arrows/viscl/convert_image.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,4 +62,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_CONVERT_IMAGE_H_
+#endif

--- a/arrows/viscl/descriptor_set.h
+++ b/arrows/viscl/descriptor_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,4 +85,4 @@ descriptors_to_viscl(const vital::descriptor_set& desc_set);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_DESCRIPTOR_SET_H_
+#endif

--- a/arrows/viscl/detect_features.h
+++ b/arrows/viscl/detect_features.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,4 +78,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_DETECT_FEATURES_H_
+#endif

--- a/arrows/viscl/extract_descriptors.h
+++ b/arrows/viscl/extract_descriptors.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -74,4 +74,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_EXTRACT_DESCRIPTORS_H_
+#endif

--- a/arrows/viscl/feature_set.h
+++ b/arrows/viscl/feature_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -101,4 +101,4 @@ features_to_viscl(const vital::feature_set& features);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_FEATURE_SET_H_
+#endif

--- a/arrows/viscl/image_container.h
+++ b/arrows/viscl/image_container.h
@@ -116,4 +116,4 @@ KWIVER_ALGO_VISCL_EXPORT viscl::image image_container_to_viscl(const vital::imag
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_IMAGE_CONTAINER_H_
+#endif

--- a/arrows/viscl/match_features.h
+++ b/arrows/viscl/match_features.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -82,4 +82,4 @@ private:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_VISCL_MATCH_FEATURES_H_
+#endif

--- a/arrows/viscl/match_set.h
+++ b/arrows/viscl/match_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,4 +89,4 @@ matches_to_viscl(const vital::match_set& match_set);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_MATCH_SET_H_
+#endif

--- a/arrows/viscl/utils.h
+++ b/arrows/viscl/utils.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2014-2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,4 +45,4 @@ void min_image_dimensions(const vital::feature_set &feat, unsigned int &width, u
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VISCL_UTILS_H_
+#endif

--- a/arrows/vxl/bundle_adjust.h
+++ b/arrows/vxl/bundle_adjust.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,4 +91,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_BUNDLE_ADJUST_H_
+#endif

--- a/arrows/vxl/camera.h
+++ b/arrows/vxl/camera.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,4 +85,4 @@ void vital_to_vpgl_calibration(const vital::camera_intrinsics& mcal,
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_CAMERA_H_
+#endif

--- a/arrows/vxl/camera_map.h
+++ b/arrows/vxl/camera_map.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,4 +90,4 @@ camera_map_to_vpgl(const vital::camera_map& cam_map);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_CAMERA_MAP_H_
+#endif

--- a/arrows/vxl/close_loops_homography_guided.h
+++ b/arrows/vxl/close_loops_homography_guided.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -135,4 +135,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_CLOSE_LOOPS_HOMOGRAPHY_GUIDED_H_
+#endif

--- a/arrows/vxl/compute_homography_overlap.h
+++ b/arrows/vxl/compute_homography_overlap.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,4 +59,4 @@ overlap( const vnl_double_3x3& h, const unsigned ni, const unsigned nj );
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_COMPUTE_HOMOGRAPHY_OVERLAP_H_
+#endif

--- a/arrows/vxl/estimate_canonical_transform.h
+++ b/arrows/vxl/estimate_canonical_transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -102,4 +102,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_ESTIMATE_CANONICAL_TRANSFORM_H_
+#endif

--- a/arrows/vxl/estimate_essential_matrix.h
+++ b/arrows/vxl/estimate_essential_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,4 +98,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_ESTIMATE_ESSENTIAL_MATRIX_H_
+#endif

--- a/arrows/vxl/estimate_fundamental_matrix.h
+++ b/arrows/vxl/estimate_fundamental_matrix.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -109,4 +109,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_ESTIMATE_FUNDAMENTAL_MATRIX_H_
+#endif

--- a/arrows/vxl/estimate_homography.h
+++ b/arrows/vxl/estimate_homography.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,4 +83,4 @@ public:
 } // end namespace kwiver
 
 
-#endif // KWIVER_ARROWS_VXL_ESTIMATE_HOMOGRAPHY_H_
+#endif

--- a/arrows/vxl/estimate_similarity_transform.h
+++ b/arrows/vxl/estimate_similarity_transform.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,4 +83,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_ESTIMATE_SIMILARITY_TRANSFORM_H_
+#endif

--- a/arrows/vxl/image_container.h
+++ b/arrows/vxl/image_container.h
@@ -116,4 +116,4 @@ protected:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_IMAGE_CONTAINER_H_
+#endif

--- a/arrows/vxl/image_io.h
+++ b/arrows/vxl/image_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -100,4 +100,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_IMAGE_IO_H_
+#endif

--- a/arrows/vxl/match_features_constrained.h
+++ b/arrows/vxl/match_features_constrained.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2016 by Kitware, Inc.
+ * Copyright 2015-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -100,4 +100,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_MATCH_FEATURES_CONSTRAINED_H_
+#endif

--- a/arrows/vxl/optimize_cameras.h
+++ b/arrows/vxl/optimize_cameras.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,4 +89,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_OPTIMIZE_CAMERAS_H_
+#endif

--- a/arrows/vxl/split_image.h
+++ b/arrows/vxl/split_image.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,4 +70,4 @@ public:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_SPLIT_IMAGE_H_
+#endif

--- a/arrows/vxl/triangulate_landmarks.h
+++ b/arrows/vxl/triangulate_landmarks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,4 +92,4 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_TRIANGULATE_LANDMARKS_H_
+#endif

--- a/arrows/vxl/vil_image_memory.h
+++ b/arrows/vxl/vil_image_memory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,4 +129,4 @@ vil_memory_chunk_sptr vital_to_vxl(const vital::image_memory_sptr mem);
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif // KWIVER_ARROWS_VXL_VIL_IMAGE_MEMORY_H_
+#endif

--- a/sprokit/processes/core/split_image_process.h
+++ b/sprokit/processes/core/split_image_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -79,4 +79,4 @@ private:
 
 } // end namespace
 
-#endif /* KWIVER_SPLIT_IMAGE_PROCESS_H_ */
+#endif

--- a/sprokit/processes/matlab/matlab_process.h
+++ b/sprokit/processes/matlab/matlab_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,4 +73,4 @@ private:
 
 } } // end namespace
 
-#endif // KWIVER_MATLAB_PROCESS_H_
+#endif

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2015 by Kitware, Inc.
+ * Copyright 2011-2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -373,4 +373,4 @@ test_bound( char const* name, ValueType const& value,
 } //end namespace testing
 } //end namespace kwiver
 
-#endif // KWIVER_TEST_TEST_COMMON_H_
+#endif

--- a/tests/test_eigen.h
+++ b/tests/test_eigen.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -173,4 +173,4 @@ static auto compare_similar_matrices = similar_matrix_comparator{};
 } // end namespace testing
 } // end namespace kwiver
 
-#endif // KWIVER_TEST_TEST_EIGEN_H_
+#endif

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2015 by Kitware, Inc.
+ * Copyright 2011-2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,4 +72,4 @@ is_almost( Eigen::Matrix< T, M, N > const& a,
 }
 }
 
-#endif // KWIVER_TEST_MATH_H_
+#endif

--- a/tests/test_tracks.h
+++ b/tests/test_tracks.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -121,4 +121,4 @@ generate_tracks( unsigned frames=100,
 } // end namespace testing
 } // end namespace kwiver
 
-#endif // KWIVER_TEST_TEST_SCENE_H_
+#endif

--- a/vital/algorithm_plugin_manager_paths.h.in
+++ b/vital/algorithm_plugin_manager_paths.h.in
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2015 by Kitware, Inc.
+ * Copyright 2011-2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,4 +35,4 @@
 #define SHARED_LIB_SUFFIX    "@CMAKE_SHARED_MODULE_SUFFIX@"
 #define PATH_SEPARATOR_CHAR  '@path_sep@'
 
-#endif /* KWIVER_VITAL_PLUGIN_MODULE_PATHS_H_H_*/
+#endif

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -905,4 +905,4 @@ config_block
 
 } }
 
-#endif // KWIVER_CONFIG_BLOCK_H_
+#endif

--- a/vital/config/config_block_io.h
+++ b/vital/config/config_block_io.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2014 by Kitware, Inc.
+ * Copyright 2013-2014, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -249,4 +249,4 @@ application_config_file_paths(std::string const& application_name,
 
 } }
 
-#endif // KWIVER_CONFIG_BLOCK_IO_H_
+#endif

--- a/vital/config/config_block_types.h
+++ b/vital/config/config_block_types.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2014 by Kitware, Inc.
+ * Copyright 2013-2014, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,4 +67,4 @@ typedef std::vector< std::string > config_path_list_t;
 
 } }
 
-#endif /* KWIVER_CONFIG_BLOCK_TYPES_H_ */
+#endif

--- a/vital/klv/convert_metadata.h
+++ b/vital/klv/convert_metadata.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -119,4 +119,4 @@ private:
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_KLV_CONVERT_METADATA_H_ */
+#endif

--- a/vital/logger/default_logger.h
+++ b/vital/logger/default_logger.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,4 +88,4 @@ private:
 
 } } } // end namespace
 
-#endif /* KWIVER_DEFAULT_LOGGER_H_ */
+#endif

--- a/vital/logger/kwiver_logger.h
+++ b/vital/logger/kwiver_logger.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -326,4 +326,4 @@ typedef std::shared_ptr< kwiver_logger > logger_handle_t;
 
 } } // end namespace
 
-#endif /* KWIVER_KWIVER_LOGGER_H_ */
+#endif

--- a/vital/logger/kwiver_logger_factory.h
+++ b/vital/logger/kwiver_logger_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -93,4 +93,4 @@ private:
 } } } // end namespace
 
 
-#endif /* KWIVER_KWIVER_LOGGER_FACTORY_H_ */
+#endif

--- a/vital/logger/kwiver_logger_manager.h
+++ b/vital/logger/kwiver_logger_manager.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,4 +98,4 @@ private:
 
 } } // end namespace kwiver
 
-#endif /* KWIVER_KWIVER_LOGGER_MANAGER_H_ */
+#endif

--- a/vital/logger/location_info.h
+++ b/vital/logger/location_info.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -146,4 +146,4 @@ private:
            __KWIVER_LOGGER_FUNC__,                                       \
            __LINE__)
 
-#endif /* KWIVER_LOGGER_LOCATION_INFO_H_ */
+#endif

--- a/vital/logger/logger.h
+++ b/vital/logger/logger.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -258,4 +258,4 @@ logger_handle_t VITAL_LOGGER_EXPORT get_logger( std::string const& name );
 
 } } // end namespace
 
-#endif /* KWIVER_CORE_LOGGER_H_ */
+#endif

--- a/vital/plugin_loader/plugin_loader.h
+++ b/vital/plugin_loader/plugin_loader.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -298,4 +298,4 @@ private:
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_PLUGIN_LOADER_H_ */
+#endif

--- a/vital/tests/test_track_set.h
+++ b/vital/tests/test_track_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -288,4 +288,4 @@ test_track_set_modifiers( track_set_sptr test_set )
 } // end namespace vital
 } // end namespace kwiver
 
-#endif // KWIVER_VITAL_TEST_TEST_TRACK_SET_H_
+#endif

--- a/vital/types/geo_MGRS.h
+++ b/vital/types/geo_MGRS.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,4 +83,4 @@ std::ostream & operator<< (std::ostream & str, const kwiver::vital::geo_MGRS & o
 
 } } // end namespace
 
-#endif // KWIVER_VITAL_GEO_MGRS_H_
+#endif

--- a/vital/types/geo_covariance.h
+++ b/vital/types/geo_covariance.h
@@ -73,4 +73,4 @@ VITAL_EXPORT::std::ostream& operator<< ( ::std::ostream& str, geo_covariance con
 }
 } // end namespace
 
-#endif /* KWIVER_VITAL_GEO_POINT_W_COV_H_ */
+#endif

--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -134,4 +134,4 @@ VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, geo_point const& 
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_GEO_POINT_H_ */
+#endif

--- a/vital/types/geo_polygon.h
+++ b/vital/types/geo_polygon.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -123,4 +123,4 @@ VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, geo_polygon const
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_GEO_POLYGON_H_ */
+#endif

--- a/vital/types/geodesy.h
+++ b/vital/types/geodesy.h
@@ -160,4 +160,4 @@ VITAL_EXPORT utm_ups_zone_t utm_ups_zone( vector_3d const& lon_lat_alt );
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_GEODESY_H_ */
+#endif

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -505,4 +505,4 @@ VITAL_EXPORT bool test_equal_content( const kwiver::vital::metadata& one,
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_METADATA_H_ */
+#endif

--- a/vital/types/metadata_map.h
+++ b/vital/types/metadata_map.h
@@ -228,4 +228,4 @@ protected:
 } // end namespace vital
 } // end namespace kwiver
 
-#endif // KWIVER_VITAL_METADATA_MAP_H_
+#endif

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -172,4 +172,4 @@ enum vital_metadata_tag {
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_METADATA_TAGS_H_ */
+#endif

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -177,4 +177,4 @@ private:
   new kwiver::vital::typed_metadata< TAG, kwiver::vital::vital_meta_trait<TAG>::type > \
   ( kwiver::vital::vital_meta_trait<TAG>::name(), DATA )
 
-#endif /* KWIVER_VITAL_METADATA_TRAITS_H_ */
+#endif

--- a/vital/types/point.h
+++ b/vital/types/point.h
@@ -93,4 +93,4 @@ VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_4f const& o
 
 } } // end namespace
 
-#endif /* KWIVER_VITAL_POINT_H_ */
+#endif

--- a/vital/util/bounded_buffer.h
+++ b/vital/util/bounded_buffer.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -175,4 +175,4 @@ private:
 
 } } // end namespace
 
-#endif // KWIVER_VITAL_UTIL_BOUNDED_BUFFER_H_
+#endif

--- a/vital/util/thread_pool.h
+++ b/vital/util/thread_pool.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -176,4 +176,4 @@ auto thread_pool::enqueue(F&& f, Args&&... args)
 
 } }   // end namespace
 
-#endif // KWIVER_VITAL_THREAD_POOL_H_
+#endif

--- a/vital/util/thread_pool_builtin_backend.h
+++ b/vital/util/thread_pool_builtin_backend.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -160,4 +160,4 @@ void thread_pool_builtin_backend::enqueue_task(std::function<void()> func)
 
 } }   // end namespace
 
-#endif // KWIVER_VITAL_THREAD_POOL_BUILTIN_BACKEND_H_
+#endif

--- a/vital/util/thread_pool_gcd_backend.h
+++ b/vital/util/thread_pool_gcd_backend.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -87,6 +87,6 @@ public:
 
 } }   // end namespace
 
-#endif // KWIVER_VITAL_THREAD_POOL_SYNC_BACKEND_H_
+#endif
 
 #endif // __APPLE__

--- a/vital/util/thread_pool_sync_backend.h
+++ b/vital/util/thread_pool_sync_backend.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,4 +72,4 @@ public:
 
 } }   // end namespace
 
-#endif // KWIVER_VITAL_THREAD_POOL_SYNC_BACKEND_H_
+#endif


### PR DESCRIPTION
Remove comments repeating the include guard symbol after the terminal `#endif`. Per recent updates to our style guide (4ed769b2c7e5 / #847), these are not very useful and have a tendency to become incorrect.