### PR TITLE
Fix geo_point bugs

### DIFF
--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -299,7 +299,13 @@ case klv_0104::N:                                         \
     }
     else
     {
-      auto const sensor_location = geo_point{ raw_sensor_location, SRID::lat_lon_WGS84 };
+      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], 0.0);
+      // add altitude, if available, to the sensor location
+      if (auto const& alt = md.find(VITAL_META_SENSOR_ALTITUDE))
+      {
+        sensor_loc[2] = alt.as_double();
+      }
+      auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
       md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
     }
   }

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -79,16 +79,6 @@ is_empty( Eigen::Matrix< double, N, 1, 0, N, 1 > const& vec )
 
 // ----------------------------------------------------------------------------
 bool
-is_valid_lon_lat( vector_3d const& vec )
-{
-  auto const lat = vec[1];
-  auto const lon = vec[0];
-  return ( lat >= -90.0 && lat <= 90.0 ) &&
-         ( lon >= -180.0 && lon <= 360.0 );
-}
-
-// ----------------------------------------------------------------------------
-bool
 is_valid_lon_lat( vector_2d const& vec )
 {
   auto const lat = vec[1];

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -155,8 +155,8 @@ void convert_metadata
   // lat-lon points and image corner points. All geodetic points are assumed to
   // be WGS84 lat-lon.
   //
-  auto raw_sensor_location = empty_vector<3>();
-  auto raw_frame_center = empty_vector<3>();
+  auto raw_sensor_location = empty_vector<2>();
+  auto raw_frame_center = empty_vector<2>();
   auto raw_corner_pt1 = empty_vector<2>(); // offsets relative to frame_center
   auto raw_corner_pt2 = empty_vector<2>();
   auto raw_corner_pt3 = empty_vector<2>();

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -178,13 +178,13 @@ convert_metadata
   // lat-lon points and image corner points. All geodetic points are assumed to
   // be WGS84 lat-lon.
   //
-  auto raw_sensor_location = empty_vector<3>();
-  auto raw_frame_center = empty_vector<3>();
+  auto raw_sensor_location = empty_vector<2>();
+  auto raw_frame_center = empty_vector<2>();
   auto raw_corner_pt1 = empty_vector<2>(); // offsets relative to frame_center
   auto raw_corner_pt2 = empty_vector<2>();
   auto raw_corner_pt3 = empty_vector<2>();
   auto raw_corner_pt4 = empty_vector<2>();
-  auto raw_target_location = empty_vector<3>();
+  auto raw_target_location = empty_vector<2>();
 
   for ( auto itr = lds.begin(); itr != lds.end(); ++itr )
   {

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -422,7 +422,13 @@ convert_metadata
     }
     else
     {
-      auto const sensor_location = geo_point{ raw_sensor_location, SRID::lat_lon_WGS84 };
+      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], 0.0);
+      // add altitude, if available, to the sensor location
+      if (auto const& alt = md.find(VITAL_META_SENSOR_ALTITUDE))
+      {
+        sensor_loc[2] = alt.as_double();
+      }
+      auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
       md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
     }
   }

--- a/vital/types/local_geo_cs.cxx
+++ b/vital/types/local_geo_cs.cxx
@@ -283,6 +283,11 @@ initialize_cameras_with_metadata(std::map<vital::frame_id_t,
         vital::geo_point gloc;
         mdi.data(gloc);
 
+        // set the origin to the ground
+        vital::vector_3d loc = gloc.location();
+        loc[2] = 0.0;
+        gloc.set_location(loc, gloc.crs());
+
         lgcs.set_origin(gloc);
         update_local_origin = true;
         break;


### PR DESCRIPTION
This branch fixes some critical bugs introduced when altitude was added to geo_point.  Most notably, all geo_point metadata fields (like sensor location) are being dropped in the converter because we looking for a 3D vector of data but still only reading 2D values.  Also, the sensor location is given a 2D location at Z=0 when downstream algorithms now expect this geo_point to have a valid Z.  I've addressed these issues on this branch so that TeleSculptor can work as before.  

Note that I'm adding Sensor Altitude to the Sensor Location geo_point, but I'm also still leaving it in it's own metadata tag as it was before.  We may want to deprecate the sensor altitude tag in the future, or maybe not.  It's not clear.