### PR TITLE
Rename geo_raw_point_t to geo_3d_point_t

### DIFF
--- a/arrows/serialize/json/load_save.cxx
+++ b/arrows/serialize/json/load_save.cxx
@@ -454,7 +454,7 @@ void load( ::cereal::JSONInputArchive& archive, kwiver::vital::geo_point& point 
              CEREAL_NVP( z )
       );
 
-    const kwiver::vital::geo_point::geo_raw_point_t raw( x, y, z );
+    const kwiver::vital::geo_point::geo_3d_point_t raw( x, y, z );
     point.set_location( raw, crs );
   }
 }

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -152,7 +152,7 @@ TEST( load_save, geo_point_2d )
 // ----------------------------------------------------------------------------
 TEST( load_save, geo_point_raw )
 {
-  kwiver::vital::geo_point::geo_raw_point_t geo( 42.50, 73.54, 16.33 );
+  kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
   kwiver::vital::geo_point obj( geo, kwiver::vital::SRID::lat_lon_WGS84 );
 
   std::stringstream msg;
@@ -245,7 +245,7 @@ kwiver::vital::metadata create_meta_collection()
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_FRAME_CENTER );
-    kwiver::vital::geo_point::geo_raw_point_t geo( 42.50, 73.54, 16.33 );
+    kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
     kwiver::vital::geo_point pt ( geo, kwiver::vital::SRID::lat_lon_WGS84 );
     auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
     meta.add( item );

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -553,7 +553,7 @@ void convert_protobuf( const kwiver::protobuf::geo_point&  proto_point,
 {
   if ( proto_point.has_crs() )
   {
-    kwiver::vital::geo_point::geo_raw_point_t pt;
+    kwiver::vital::geo_point::geo_3d_point_t pt;
     pt[0] = proto_point.x();
     pt[1] = proto_point.y();
     pt[2] = proto_point.z();

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -316,11 +316,11 @@ TEST( convert_protobuf, geo_point_2d )
 TEST( convert_protobuf, geo_point_raw )
 {
   // --- 3d variant ---
-  kwiver::vital::geo_point::geo_raw_point_t geo( 42.50, 73.54, 16.33 );
+  kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
   kwiver::vital::geo_point obj( geo, kwiver::vital::SRID::lat_lon_WGS84 );
 
   kwiver::protobuf::geo_point obj_proto;
-  kwiver::vital::geo_point::geo_raw_point_t geo_dser( 0, 0, 0 );
+  kwiver::vital::geo_point::geo_3d_point_t geo_dser( 0, 0, 0 );
   kwiver::vital::geo_point obj_dser( geo_dser, 0 );
 
   kasp::convert_protobuf( obj, obj_proto );
@@ -392,7 +392,7 @@ TEST( convert_protobuf, metadata )
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_FRAME_CENTER );
 
-    kwiver::vital::geo_point::geo_raw_point_t geo( 42.50, 73.54, 16.33 );
+    kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
     kwiver::vital::geo_point pt ( geo, kwiver::vital::SRID::lat_lon_WGS84 );
     auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
     meta.add( item );

--- a/vital/types/geo_covariance.cxx
+++ b/vital/types/geo_covariance.cxx
@@ -57,7 +57,7 @@ geo_covariance( geo_2d_point_t const& point, int crs )
 
 // ----------------------------------------------------------------------------
 geo_covariance::
-geo_covariance( geo_raw_point_t const& point, int crs )
+geo_covariance( geo_3d_point_t const& point, int crs )
   : geo_point(point, crs)
 {
 

--- a/vital/types/geo_covariance.h
+++ b/vital/types/geo_covariance.h
@@ -53,7 +53,7 @@ public:
 
   geo_covariance();
   geo_covariance( geo_2d_point_t const&, int crs );
-  geo_covariance( geo_raw_point_t const& pt, int crs );
+  geo_covariance( geo_3d_point_t const& pt, int crs );
 
   virtual ~geo_covariance() = default;
 

--- a/vital/types/geo_point.cxx
+++ b/vital/types/geo_point.cxx
@@ -42,7 +42,7 @@
 namespace kwiver {
 namespace vital {
 
-using geo_raw_point_t = geo_point::geo_raw_point_t;
+using geo_3d_point_t = geo_point::geo_3d_point_t;
 
 // ----------------------------------------------------------------------------
 geo_point::
@@ -55,14 +55,14 @@ geo_point::
 geo_point( geo_2d_point_t const& point, int crs )
   : m_original_crs( crs )
 {
-  m_loc.insert( std::make_pair( crs, geo_raw_point_t{ point[0],
+  m_loc.insert( std::make_pair( crs, geo_3d_point_t{ point[0],
                                                       point[1],
                                                       0 } ));
 }
 
 // ----------------------------------------------------------------------------
 geo_point::
-geo_point( geo_raw_point_t const& point, int crs )
+geo_point( geo_3d_point_t const& point, int crs )
   : m_original_crs( crs )
 {
   m_loc.insert( std::make_pair( crs, point ) );
@@ -76,7 +76,7 @@ bool geo_point
 }
 
 // ----------------------------------------------------------------------------
-geo_raw_point_t geo_point
+geo_3d_point_t geo_point
 ::location() const
 {
   return m_loc.at( m_original_crs );
@@ -90,7 +90,7 @@ int geo_point
 }
 
 // ----------------------------------------------------------------------------
-geo_raw_point_t geo_point
+geo_3d_point_t geo_point
 ::location( int crs ) const
 {
   auto const i = m_loc.find( crs );
@@ -110,12 +110,12 @@ void geo_point
 {
   m_original_crs = crs;
   m_loc.clear();
-  m_loc.insert( std::make_pair( crs, geo_raw_point_t { loc[0], loc[1], 0 } ) );
+  m_loc.insert( std::make_pair( crs, geo_3d_point_t { loc[0], loc[1], 0 } ) );
 }
 
 // ----------------------------------------------------------------------------
 void geo_point
-::set_location( geo_raw_point_t const& loc, int crs )
+::set_location( geo_3d_point_t const& loc, int crs )
 {
   m_original_crs = crs;
   m_loc.clear();

--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -68,12 +68,12 @@ namespace vital {
 class VITAL_EXPORT geo_point
 {
 public:
-  using geo_raw_point_t = kwiver::vital::vector_3d;
+  using geo_3d_point_t = kwiver::vital::vector_3d;
   using geo_2d_point_t = kwiver::vital::vector_2d;
 
   geo_point();
   geo_point( geo_2d_point_t const&, int crs );
-  geo_point( geo_raw_point_t const&, int crs );
+  geo_point( geo_3d_point_t const&, int crs );
 
   virtual ~geo_point() = default;
 
@@ -85,7 +85,7 @@ public:
    *
    * \see crs()
    */
-  geo_raw_point_t location() const;
+  geo_3d_point_t location() const;
 
   /**
    * \brief Accessor for original CRS.
@@ -102,7 +102,7 @@ public:
    * \returns The location in the requested CRS.
    * \throws std::runtime_error if the conversion fails.
    */
-  geo_raw_point_t location( int crs ) const;
+  geo_3d_point_t location( int crs ) const;
 
   //@{
   /**
@@ -112,7 +112,7 @@ public:
    * by the raw location and specified CRS.
    */
   void set_location( geo_2d_point_t const&, int crs );
-  void set_location( geo_raw_point_t const&, int crs );
+  void set_location( geo_3d_point_t const&, int crs );
   //@}
 
   /**
@@ -127,7 +127,7 @@ public:
 protected:
 
   int m_original_crs;
-  mutable std::unordered_map< int, geo_raw_point_t > m_loc;
+  mutable std::unordered_map< int, geo_3d_point_t > m_loc;
 };
 
 VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, geo_point const& obj );


### PR DESCRIPTION
Rename the geo_raw_point_t type to geo_3d_point_t to conform to the current patter and already available geo_2d_point_t.
