### PR TITLE
Fix KPF build

### DIFF
--- a/arrows/kpf/CMakeLists.txt
+++ b/arrows/kpf/CMakeLists.txt
@@ -1,9 +1,4 @@
-if(fletch_ENABLED_YAMLCPP)
-  find_package( yaml-cpp REQUIRED )
-else()
-  message(STATUS "To enable the kpf arrow, please build or locate yaml libraries in fletch")
-  return()
-endif()
+find_package( yaml-cpp REQUIRED )
 
 add_subdirectory(yaml)
 

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ set(kwiver_examples_libraries vital_algo
                               kwiver_algo_vxl
                               kwiversys )
 
-if(fletch_ENABLED_YAMLCPP)
+if(KWIVER_ENABLE_KPF)
   add_subdirectory( kpf )
 
   list(APPEND kwiver_examples_libraries kwiver_algo_kpf kpf_yaml ${YAML_CPP_LIBRARIES})

--- a/track_oracle/file_formats/kpf_utils/CMakeLists.txt
+++ b/track_oracle/file_formats/kpf_utils/CMakeLists.txt
@@ -1,9 +1,4 @@
-if(fletch_ENABLED_YAMLCPP)
-  find_package( yaml-cpp REQUIRED )
-else()
-  message(STATUS "Cannot build track_oracle KPF support without YAML in Fletch")
-  return()
-endif()
+find_package( yaml-cpp REQUIRED )
 
 #
 # KPF track_oracle utilities

--- a/track_oracle/file_formats/track_filter_kpf_activity/CMakeLists.txt
+++ b/track_oracle/file_formats/track_filter_kpf_activity/CMakeLists.txt
@@ -1,9 +1,5 @@
-if(fletch_ENABLED_YAMLCPP)
-  find_package( yaml-cpp REQUIRED )
-else()
-  message(STATUS "Cannot build track_oracle KPF support without YAML in Fletch")
-  return()
-endif()
+find_package( yaml-cpp REQUIRED )
+
 #
 # KPF activities
 #

--- a/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.cxx
+++ b/track_oracle/file_formats/track_filter_kpf_activity/track_filter_kpf_activity.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,7 @@ static kwiver::vital::logger_handle_t main_logger( kwiver::vital::get_logger( __
 
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
+++ b/track_oracle/file_formats/track_kpf_geom/CMakeLists.txt
@@ -1,9 +1,5 @@
-if(fletch_ENABLED_YAMLCPP)
-  find_package( yaml-cpp REQUIRED )
-else()
-  message(STATUS "Cannot build track_oracle KPF support without YAML in Fletch")
-  return()
-endif()
+find_package( yaml-cpp REQUIRED )
+
 #
 # KPF geometry
 #


### PR DESCRIPTION
Modify the CMake logic when potentially building KPF stuff to just require yaml-cpp, rather than requiring a fletch that provides yaml-cpp. This allows yaml-cpp from other sources (e.g. distro packages) to be used.

Also add `#include <algorithm>` to `track_filter_kpf_activity.cxx`, which needs it in order to use `std::find_if`.