### PR TITLE
Typedef for camera_perspective_map

### DIFF
--- a/arrows/ceres/bundle_adjust.cxx
+++ b/arrows/ceres/bundle_adjust.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -262,7 +262,7 @@ bundle_adjust
   feature_track_set_sptr tracks,
   sfm_constraints_sptr constraints) const
 {
-  camera_map_of_<simple_camera_perspective> cams;
+  simple_camera_perspective_map cams;
   for (auto p : cameras->cameras())
   {
     auto c = std::dynamic_pointer_cast<simple_camera_perspective>(p.second);
@@ -274,7 +274,7 @@ bundle_adjust
   auto lms = landmarks->landmarks();
   this->optimize(cams, lms, tracks, {}, {}, constraints);
   landmarks = std::make_shared<simple_landmark_map>(lms);
-  cameras = std::make_shared<camera_map_of_<simple_camera_perspective>>(cams);
+  cameras = std::make_shared<simple_camera_perspective_map>(cams);
 }
 
 
@@ -282,7 +282,7 @@ bundle_adjust
 // Optimize the camera and landmark parameters given a set of tracks
 void
 bundle_adjust
-::optimize(kwiver::vital::camera_map_of_<simple_camera_perspective> &cameras,
+::optimize(kwiver::vital::simple_camera_perspective_map &cameras,
            kwiver::vital::landmark_map::map_landmark_t &landmarks,
            vital::feature_track_set_sptr tracks,
            const std::set<vital::frame_id_t>& to_fix_cameras_in,

--- a/arrows/ceres/bundle_adjust.h
+++ b/arrows/ceres/bundle_adjust.h
@@ -89,7 +89,7 @@ public:
   */
   virtual void
   optimize(
-    kwiver::vital::camera_map_of_<kwiver::vital::simple_camera_perspective> &cameras,
+    kwiver::vital::simple_camera_perspective_map &cameras,
     kwiver::vital::landmark_map::map_landmark_t &landmarks,
     vital::feature_track_set_sptr tracks,
     const std::set<vital::frame_id_t>& fixed_cameras,

--- a/arrows/core/initialize_cameras_landmarks_keyframe.cxx
+++ b/arrows/core/initialize_cameras_landmarks_keyframe.cxx
@@ -71,8 +71,6 @@ namespace core {
 typedef std::map< frame_id_t, simple_camera_perspective_sptr >               map_cam_t;
 typedef std::map<frame_id_t, simple_camera_perspective_sptr>::iterator       cam_map_itr_t;
 typedef std::map<frame_id_t, simple_camera_perspective_sptr>::const_iterator const_cam_map_itr_t;
-typedef camera_map_of_<simple_camera_perspective>                            simple_camera_perspective_map;
-typedef std::shared_ptr<simple_camera_perspective_map>                       simple_camera_perspective_map_sptr;
 
 typedef vital::landmark_map::map_landmark_t map_landmark_t;
 

--- a/arrows/core/sfm_utils.cxx
+++ b/arrows/core/sfm_utils.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2018 by Kitware, Inc.
+* Copyright 2018-2019 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ frame_coverage_vec
 image_coverages(
   std::vector<track_sptr> const& trks,
   vital::landmark_map::map_landmark_t const& lms,
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams )
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams )
 {
   const int mask_w(16);
   const int mask_h(16);
@@ -166,7 +166,7 @@ remove_landmarks(const std::set<track_id_t>& to_remove,
 /// find connected components of cameras
 camera_components
 connected_camera_components(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   landmark_map::map_landmark_t const& lms,
   feature_track_set_sptr tracks)
 {
@@ -263,7 +263,7 @@ connected_camera_components(
 /// Detect underconstrained landmarks.
 std::set<landmark_id_t>
 detect_bad_landmarks(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   landmark_map::map_landmark_t const& lms,
   feature_track_set_sptr tracks,
   double triang_cos_ang_thresh,
@@ -452,7 +452,7 @@ detect_bad_landmarks(
 /// detect bad cameras in sfm solution
 std::set<frame_id_t>
 detect_bad_cameras(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   landmark_map::map_landmark_t const& lms,
   feature_track_set_sptr tracks,
   float coverage_thresh)
@@ -474,7 +474,7 @@ detect_bad_cameras(
 /// clean structure from motion solution
 void
 clean_cameras_and_landmarks(
-  vital::camera_map_of_<vital::simple_camera_perspective>& cams_persp,
+  vital::simple_camera_perspective_map& cams_persp,
   landmark_map::map_landmark_t& lms,
   feature_track_set_sptr tracks,
   double triang_cos_ang_thresh,
@@ -506,7 +506,7 @@ clean_cameras_and_landmarks(
     }
   }
 
-  camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map det_cams;
+  simple_camera_perspective_map::frame_to_T_sptr_map det_cams;
   if (active_cams.empty())
   {
     det_cams = cams;

--- a/arrows/core/sfm_utils.h
+++ b/arrows/core/sfm_utils.h
@@ -1,5 +1,5 @@
 /*ckwg +29
-* Copyright 2018 by Kitware, Inc.
+* Copyright 2018-2019 by Kitware, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,7 @@
 #include <vital/types/landmark_map.h>
 #include <vital/types/camera_map.h>
 #include <vital/types/camera_perspective.h>
+#include <vital/types/camera_perspective_map.h>
 #include <vital/types/feature_track_set.h>
 
 namespace kwiver {
@@ -73,7 +74,7 @@ frame_coverage_vec
 image_coverages(
   std::vector<vital::track_sptr> const& trks,
   vital::landmark_map::map_landmark_t const& lms,
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams);
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams);
 
 typedef std::vector<std::unordered_set<vital::frame_id_t>> camera_components;
 
@@ -90,7 +91,7 @@ typedef std::vector<std::unordered_set<vital::frame_id_t>> camera_components;
 KWIVER_ALGO_CORE_EXPORT
 camera_components
 connected_camera_components(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   vital::landmark_map::map_landmark_t const& lms,
   vital::feature_track_set_sptr tracks);
 
@@ -115,7 +116,7 @@ connected_camera_components(
 KWIVER_ALGO_CORE_EXPORT
 std::set<vital::landmark_id_t>
 detect_bad_landmarks(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   vital::landmark_map::map_landmark_t const& lms,
   vital::feature_track_set_sptr tracks,
   double triang_cos_ang_thresh,
@@ -147,7 +148,7 @@ remove_landmarks(const std::set<vital::track_id_t>& to_remove,
 KWIVER_ALGO_CORE_EXPORT
 std::set<vital::frame_id_t>
 detect_bad_cameras(
-  vital::camera_map_of_<vital::simple_camera_perspective>::frame_to_T_sptr_map const& cams,
+  vital::simple_camera_perspective_map::frame_to_T_sptr_map const& cams,
   vital::landmark_map::map_landmark_t const& lms,
   vital::feature_track_set_sptr tracks,
   float coverage_thresh);
@@ -175,7 +176,7 @@ detect_bad_cameras(
 KWIVER_ALGO_CORE_EXPORT
 void
 clean_cameras_and_landmarks(
-  vital::camera_map_of_<vital::simple_camera_perspective>& cams,
+  vital::simple_camera_perspective_map& cams,
   vital::landmark_map::map_landmark_t& lms,
   vital::feature_track_set_sptr tracks,
   double triang_cos_ang_thresh,

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -86,6 +86,7 @@ set( vital_public_headers
   types/camera.h
   types/camera_intrinsics.h
   types/camera_perspective.h
+  types/camera_perspective_map.h
   types/camera_rpc.h
   types/camera_map.h
   types/category_hierarchy.h

--- a/vital/algo/bundle_adjust.cxx
+++ b/vital/algo/bundle_adjust.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,7 +59,7 @@ bundle_adjust
 void
 bundle_adjust
 ::optimize(
-  kwiver::vital::camera_map_of_<kwiver::vital::simple_camera_perspective> &cameras,
+  kwiver::vital::simple_camera_perspective_map &cameras,
   kwiver::vital::landmark_map::map_landmark_t &landmarks,
   vital::feature_track_set_sptr tracks,
   const std::set<vital::frame_id_t>& fixed_cameras,

--- a/vital/algo/bundle_adjust.h
+++ b/vital/algo/bundle_adjust.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2017 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,7 @@
 #include <vital/algo/algorithm.h>
 #include <vital/types/feature_track_set.h>
 #include <vital/types/camera_map.h>
+#include <vital/types/camera_perspective_map.h>
 #include <vital/types/landmark_map.h>
 #include <vital/types/sfm_constraints.h>
 
@@ -86,7 +87,7 @@ public:
    * \param [in] metadata the frame metadata to use as constraints
    */
   virtual void
-  optimize(kwiver::vital::camera_map_of_<kwiver::vital::simple_camera_perspective> &cameras,
+  optimize(kwiver::vital::simple_camera_perspective_map &cameras,
            kwiver::vital::landmark_map::map_landmark_t &landmarks,
            vital::feature_track_set_sptr tracks,
            const std::set<vital::frame_id_t>& fixed_cameras,

--- a/vital/types/camera_perspective_map.h
+++ b/vital/types/camera_perspective_map.h
@@ -1,0 +1,57 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Typedefs for camera_perspective camera_maps
+ */
+
+#ifndef VITAL_CAMERA_PERSPECTIVE_MAP_H_
+#define VITAL_CAMERA_PERSPECTVIE_MAP_H_
+
+#include "camera_map.h"
+#include "camera_perspective.h"
+
+
+namespace kwiver {
+namespace vital {
+
+/// Typedefs that combine camera_map_of_ and camera_perspective
+typedef vital::camera_map_of_<vital::camera_perspective> camera_perspective_map;
+typedef std::shared_ptr<camera_perspective_map> camera_perspective_map_sptr;
+
+/// Typedefs that combine camera_map_of_ and simple_camera_perspective
+typedef vital::camera_map_of_<vital::simple_camera_perspective> simple_camera_perspective_map;
+typedef std::shared_ptr<simple_camera_perspective_map> simple_camera_perspective_map_sptr;
+
+} // end namespace vital
+} // end namespace kwiver
+
+#endif

--- a/vital/types/camera_perspective_map.h
+++ b/vital/types/camera_perspective_map.h
@@ -43,13 +43,17 @@
 namespace kwiver {
 namespace vital {
 
-/// Typedefs that combine camera_map_of_ and camera_perspective
-typedef vital::camera_map_of_<vital::camera_perspective> camera_perspective_map;
-typedef std::shared_ptr<camera_perspective_map> camera_perspective_map_sptr;
+/// Type aliases that combine camera_map_of_ and camera_perspective
+using camera_perspective_map =
+        vital::camera_map_of_<vital::camera_perspective>;
+using camera_perspective_map_sptr =
+        std::shared_ptr<camera_perspective_map>;
 
-/// Typedefs that combine camera_map_of_ and simple_camera_perspective
-typedef vital::camera_map_of_<vital::simple_camera_perspective> simple_camera_perspective_map;
-typedef std::shared_ptr<simple_camera_perspective_map> simple_camera_perspective_map_sptr;
+/// Type aliases that combine camera_map_of_ and simple_camera_perspective
+using simple_camera_perspective_map =
+        vital::camera_map_of_<vital::simple_camera_perspective>;
+using simple_camera_perspective_map_sptr =
+        std::shared_ptr<simple_camera_perspective_map>;
 
 } // end namespace vital
 } // end namespace kwiver


### PR DESCRIPTION
Formalized some commonly used typedefs by making a vital types header that defines these typedefs for use in all of kwiver.