### PR TITLE
Refactor transform functions

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -35,6 +35,7 @@ set( plugin_core_headers
   match_features_homography.h
   match_tracks.h
   mesh_operations.h
+  necker_reverse.h
   read_object_track_set_kw18.h
   read_track_descriptor_set_csv.h
   render_mesh_depth_map.h
@@ -111,6 +112,7 @@ set( plugin_core_sources
   match_features_fundamental_matrix.cxx
   match_features_homography.cxx
   match_tracks.cxx
+  necker_reverse.cxx
   mesh_operations.cxx
   read_object_track_set_kw18.cxx
   read_track_descriptor_set_csv.cxx

--- a/arrows/core/initialize_cameras_landmarks.cxx
+++ b/arrows/core/initialize_cameras_landmarks.cxx
@@ -51,6 +51,7 @@
 #include <arrows/core/epipolar_geometry.h>
 #include <arrows/core/metrics.h>
 #include <arrows/core/match_matrix.h>
+#include <arrows/core/necker_reverse.h>
 #include <arrows/core/triangulate.h>
 #include <arrows/core/transform.h>
 

--- a/arrows/core/initialize_cameras_landmarks_keyframe.cxx
+++ b/arrows/core/initialize_cameras_landmarks_keyframe.cxx
@@ -57,6 +57,7 @@
 #include <arrows/core/epipolar_geometry.h>
 #include <arrows/core/metrics.h>
 #include <arrows/core/match_matrix.h>
+#include <arrows/core/necker_reverse.h>
 #include <arrows/core/triangulate.h>
 #include <arrows/core/transform.h>
 #include <vital/algo/estimate_pnp.h>

--- a/arrows/core/necker_reverse.cxx
+++ b/arrows/core/necker_reverse.cxx
@@ -1,0 +1,166 @@
+/*ckwg +29
+ * Copyright 2014-2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Implementation of Necker reversal functions
+ */
+
+#include "necker_reverse.h"
+#include <Eigen/Geometry>
+#include <Eigen/SVD>
+
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+
+/// Compute a plane passing through the landmarks
+vital::vector_4d
+landmark_plane(const vital::landmark_map::map_landmark_t& landmarks)
+{
+  using namespace kwiver::vital;
+  // compute the landmark location mean and covariance
+  vector_3d lc(0.0, 0.0, 0.0);
+  matrix_3x3d covar = matrix_3x3d::Zero();
+  for (auto const& p : landmarks)
+  {
+    vector_3d pt = p.second->loc();
+    lc += pt;
+    covar += pt * pt.transpose();
+  }
+  const double num_lm = static_cast<double>(landmarks.size());
+  lc /= num_lm;
+  covar /= num_lm;
+  covar -= lc * lc.transpose();
+
+  // the plane will pass through the landmark centeroid (lc)
+  // and have a normal vector aligned with the smallest eigenvector of covar
+  Eigen::JacobiSVD<matrix_3x3d> svd(covar, Eigen::ComputeFullV);
+  vector_3d axis = svd.matrixV().col(2);
+  return vector_4d(axis.x(), axis.y(), axis.z(), -(lc.dot(axis)));
+}
+
+
+/// Mirror landmarks about the specified plane
+vital::landmark_map_sptr
+mirror_landmarks(vital::landmark_map const& landmarks,
+                 vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  landmark_map::map_landmark_t new_lms;
+  const vector_3d axis(plane.x(), plane.y(), plane.z());
+  const double d = plane[3];
+  // mirror landmark locations about the mirroring plane
+  for (auto const& p : landmarks.landmarks())
+  {
+    vector_3d v = p.second->loc();
+    v -= 2.0 * (v.dot(axis) + d) * axis;
+    auto new_lm = std::make_shared<vital::landmark_d>(*p.second);
+    new_lm->set_loc(v);
+    new_lms[p.first] = new_lm;
+  }
+  return std::make_shared<simple_landmark_map>(new_lms);
+}
+
+
+/// Compute the Necker reversal of a camera in place
+void
+necker_reverse_inplace(vital::simple_camera_perspective& camera,
+                       vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  const vector_3d axis(plane.x(), plane.y(), plane.z());
+  const double d = plane[3];
+  const rotation_d Ra180(vector_4d(axis.x(), axis.y(), axis.z(), 0.0));
+  static const rotation_d Rz180(vector_4d(0.0, 0.0, 1.0, 0.0));
+
+  // extract the camera center
+  const vital::vector_3d cc = camera.center();
+  // extract the camera principal axis
+  const vital::vector_3d pa = camera.rotation().matrix().row(2);
+  // compute the distance from cc along pa until intersection with
+  // the mirroring plane of the points
+  const double dist = -(cc.dot(axis) + d) / pa.dot(axis);
+  // compute the ground point where the principal axis
+  // intersects the mirroring plane
+  const vital::vector_3d gp = cc + dist * pa;
+  // rotate the camera center 180 degrees about the mirroring plane normal
+  // axis centered at gp, also rotate the camera 180 about its principal axis
+  camera.set_center(Ra180 * (cc - gp) + gp);
+  camera.set_rotation(Rz180 * camera.rotation() * Ra180);
+}
+
+
+/// Compute the Necker reversal of the cameras
+vital::camera_map_sptr
+necker_reverse(vital::camera_map const& cameras,
+               vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  camera_map::map_camera_t cams;
+  // flip cameras around
+  for (auto & p : cameras.cameras())
+  {
+    // make a clone of this camera as a simple_camera_perspective
+    auto flipped = std::make_shared<vital::simple_camera_perspective>(
+      dynamic_cast<vital::simple_camera_perspective&>(*p.second));
+
+    necker_reverse_inplace(*flipped, plane);
+    cams[p.first] = flipped;
+  }
+  return std::make_shared<simple_camera_map>(cams);
+}
+
+
+/// Compute an approximate Necker reversal of cameras and landmarks
+void
+necker_reverse(vital::camera_map_sptr& cameras,
+               vital::landmark_map_sptr& landmarks,
+               bool reverse_landmarks)
+{
+  using namespace kwiver::vital;
+  const vector_4d plane = landmark_plane(landmarks->landmarks());
+
+  // reverse the cameras
+  cameras = necker_reverse(*cameras, plane);
+
+  if (reverse_landmarks)
+  {
+    // mirror the landmarks
+    landmarks = mirror_landmarks(*landmarks, plane);
+  }
+}
+
+
+} // end namespace core
+} // end namespace arrows
+} // end namespace kwiver

--- a/arrows/core/necker_reverse.h
+++ b/arrows/core/necker_reverse.h
@@ -1,0 +1,126 @@
+/*ckwg +29
+ * Copyright 2014-2016, 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Header for Necker reverse functions
+ */
+
+#ifndef KWIVER_ARROWS_CORE_NECKER_REVERSE_H_
+#define KWIVER_ARROWS_CORE_NECKER_REVERSE_H_
+
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/types/camera_perspective.h>
+#include <vital/types/camera_map.h>
+#include <vital/types/landmark_map.h>
+
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+
+/// Compute a plane passing through the landmarks
+/**
+ * Returns the parameters of the best fit plan passing through
+ * the centroid of the landmarks.  The plane is [nx, ny, nz, d] where
+ * [nx, ny, nz] is a unit normal and d is the offset.
+ */
+KWIVER_ALGO_CORE_EXPORT
+vital::vector_4d
+landmark_plane(const vital::landmark_map::map_landmark_t& landmarks);
+
+
+/// Mirror landmarks about the specified plane
+KWIVER_ALGO_CORE_EXPORT
+vital::landmark_map_sptr
+mirror_landmarks(vital::landmark_map const& landmarks,
+                 vital::vector_4d const& plane);
+
+
+/// Compute the Necker reversal of a camera in place
+/**
+ * Using the specified landmark plane, apply a Necker reversal
+ * transformation to the camera in place.  The camera rotates 180 degrees
+ * about the normal vector of the plane at the point where the principal
+ * ray intersects the plane.  The camera also rotates 180 degrees about its
+ * principal.  The resulting camera provides a similar projection of points
+ * near the specified plane, espcially for very long focal lengths.
+ */
+KWIVER_ALGO_CORE_EXPORT
+void
+necker_reverse_inplace(vital::simple_camera_perspective& camera,
+                       vital::vector_4d const& plane);
+
+
+/// Compute the Necker reversal of the cameras
+/**
+* Using the specified landmark plane, apply a Necker reversal
+* transformation to each camera.  The camera rotates 180 degrees
+* about the normal vector of the plane at the point where the principal
+* ray intersects the plane.  The camera also rotates 180 degrees about its
+* principal.  The resulting camera provides a similar projection of points
+* near the specified plane, espcially for very long focal lengths.
+*/
+KWIVER_ALGO_CORE_EXPORT
+vital::camera_map_sptr
+necker_reverse(vital::camera_map const& cameras,
+               vital::vector_4d const& plane);
+
+
+/// Compute an approximate Necker reversal of cameras and landmarks
+/**
+ * This operation help restart bundle adjustment after falling into
+ * a common local minima that with depth reversal that is illustrated
+ * by the Necker cube phenomena.
+ *
+ * The functions finds the axis, A, connecting the mean of the camera centers
+ * and mean of the landmark locations.  It then rotates each camera 180 degrees
+ * about this axis and also 180 degrees about each cameras own principal axis.
+ * The landmarks are mirrored about the plane passing through the
+ * mean landmark location and with a normal aligning with axis A.
+ * Setting reverse_landmarks to false, prevents this mirroring of the landmarks,
+ * leaving them where they originally were.  Only the cameras are modified
+ * in this case.
+ *
+ */
+KWIVER_ALGO_CORE_EXPORT
+void
+necker_reverse(vital::camera_map_sptr& cameras,
+               vital::landmark_map_sptr& landmarks,
+               bool reverse_landmarks = true);
+
+} // end namespace core
+} // end namespace arrows
+} // end namespace kwiver
+
+#endif

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -151,6 +151,11 @@ vital::camera_map_sptr transform(vital::camera_map_sptr cameras,
   for(vital::camera_map::map_camera_t::value_type& p : cam_map)
   {
     auto cam_ptr = std::dynamic_pointer_cast<vital::camera_perspective>(p.second);
+    if (!cam_ptr)
+    {
+      p.second = nullptr;
+      continue;
+    }
     p.second = transform(cam_ptr, xform);
   }
   return vital::camera_map_sptr(new vital::simple_camera_map(cam_map));

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -45,8 +45,8 @@ namespace arrows {
 
 /// Transform the camera by applying a similarity transformation in place
 void
-transform_inplace(const vital::similarity_d& xform,
-                  vital::simple_camera_perspective& cam)
+transform_inplace(vital::simple_camera_perspective& cam,
+                  const vital::similarity_d& xform)
 {
   cam.set_center( xform * cam.get_center() );
   cam.set_rotation( cam.get_rotation() * xform.rotation().inverse() );
@@ -57,8 +57,8 @@ transform_inplace(const vital::similarity_d& xform,
 /// Transform the landmark by applying a similarity transformation in place
 template <typename T>
 void
-transform_inplace(const vital::similarity_<T>& xform,
-                  vital::landmark_<T>& lm)
+transform_inplace(vital::landmark_<T>& lm,
+                  const vital::similarity_<T>& xform)
 {
   lm.set_loc( xform * lm.get_loc() );
   lm.set_scale( lm.get_scale() * xform.scale() );
@@ -89,7 +89,7 @@ vital::camera_perspective_sptr transform(vital::camera_perspective_sptr cam,
   if( vital::simple_camera_perspective* vcam =
       dynamic_cast<vital::simple_camera_perspective*>(cam.get()) )
   {
-    transform_inplace(xform, *vcam);
+    transform_inplace(*vcam, xform);
   }
   else
   {
@@ -129,11 +129,11 @@ vital::landmark_sptr transform(vital::landmark_sptr lm,
   lm = lm->clone();
   if( vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(lm.get()) )
   {
-    transform_inplace(xform, *vlm);
+    transform_inplace(*vlm, xform);
   }
   else if( vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(lm.get()) )
   {
-    transform_inplace(vital::similarity_f(xform), *vlm);
+    transform_inplace(*vlm, vital::similarity_f(xform));
   }
   else
   {
@@ -239,8 +239,8 @@ template KWIVER_ALGO_CORE_EXPORT vital::covariance_<3,T> \
 transform(const vital::covariance_<3,T>& covar, \
           const vital::similarity_<T>& xform); \
 template KWIVER_ALGO_CORE_EXPORT void \
-transform_inplace(const vital::similarity_<T>& xform, \
-                  vital::landmark_<T>& cam);
+transform_inplace(vital::landmark_<T>& cam, \
+                  const vital::similarity_<T>& xform);
 
 INSTANTIATE_TRANSFORM(double);
 INSTANTIATE_TRANSFORM(float);

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -54,6 +54,18 @@ transform_inplace(vital::simple_camera_perspective& cam,
 }
 
 
+/// Transform the camera map by applying a similarity transformation in place
+void transform_inplace(vital::simple_camera_perspective_map& cameras,
+                       const vital::similarity_d& xform)
+{
+  auto cam_map = cameras.T_cameras();
+  for (auto& p : cam_map)
+  {
+    transform_inplace(*p.second, xform);
+  }
+}
+
+
 /// Transform the landmark by applying a similarity transformation in place
 template <typename T>
 void

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -78,6 +78,33 @@ transform_inplace(vital::landmark_<T>& lm,
 }
 
 
+/// Transform the landmark map by applying a similarity transformation in place
+void transform_inplace(vital::landmark_map& landmarks,
+                       const vital::similarity_d& xform)
+{
+  vital::landmark_map::map_landmark_t lm_map = landmarks.landmarks();
+  transform_inplace(lm_map, xform);
+}
+
+
+/// Transform the landmark map by applying a similarity transformation in place
+void transform_inplace(vital::landmark_map::map_landmark_t& landmarks,
+                       const vital::similarity_d& xform)
+{
+  for (vital::landmark_map::map_landmark_t::value_type& p : landmarks)
+  {
+    if (vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(p.second.get()))
+    {
+      transform_inplace(*vlm, xform);
+    }
+    else if (vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(p.second.get()))
+    {
+      transform_inplace(*vlm, vital::similarity_f(xform));
+    }
+  }
+}
+
+
 /// Transform a 3D covariance matrix with a similarity transformation
 template <typename T>
 vital::covariance_<3,T> transform(const vital::covariance_<3,T>& covar,

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2016 by Kitware, Inc.
+ * Copyright 2014-2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,17 +30,17 @@
 
 /**
  * \file
- * \brief Implementation of kwiver::arrows::transform functions to apply
+ * \brief Implementation of kwiver::arrows::core::transform functions to apply
  * similarity transformations
  */
 
 #include "transform.h"
 #include <Eigen/Geometry>
-#include <Eigen/SVD>
 
 
 namespace kwiver {
 namespace arrows {
+namespace core {
 
 
 /// Transform the camera by applying a similarity transformation in place
@@ -218,124 +218,6 @@ vital::landmark_map_sptr transform(vital::landmark_map_sptr landmarks,
 }
 
 
-/// Compute a plane passing through the landmarks
-vital::vector_4d
-landmark_plane(const vital::landmark_map::map_landmark_t& landmarks)
-{
-  using namespace kwiver::vital;
-  // compute the landmark location mean and covariance
-  vector_3d lc(0.0, 0.0, 0.0);
-  matrix_3x3d covar = matrix_3x3d::Zero();
-  for (auto const& p : landmarks)
-  {
-    vector_3d pt = p.second->loc();
-    lc += pt;
-    covar += pt * pt.transpose();
-  }
-  const double num_lm = static_cast<double>(landmarks.size());
-  lc /= num_lm;
-  covar /= num_lm;
-  covar -= lc * lc.transpose();
-
-  // the plane will pass through the landmark centeroid (lc)
-  // and have a normal vector aligned with the smallest eigenvector of covar
-  Eigen::JacobiSVD<matrix_3x3d> svd(covar, Eigen::ComputeFullV);
-  vector_3d axis = svd.matrixV().col(2);
-  return vector_4d(axis.x(), axis.y(), axis.z(), -(lc.dot(axis)));
-}
-
-
-/// Mirror landmarks about the specified plane
-vital::landmark_map_sptr
-mirror_landmarks(vital::landmark_map const& landmarks,
-                 vital::vector_4d const& plane)
-{
-  using namespace kwiver::vital;
-  landmark_map::map_landmark_t new_lms;
-  const vector_3d axis(plane.x(), plane.y(), plane.z());
-  const double d = plane[3];
-  // mirror landmark locations about the mirroring plane
-  for (auto const& p : landmarks.landmarks())
-  {
-    vector_3d v = p.second->loc();
-    v -= 2.0 * (v.dot(axis) + d) * axis;
-    auto new_lm = std::make_shared<vital::landmark_d>(*p.second);
-    new_lm->set_loc(v);
-    new_lms[p.first] = new_lm;
-  }
-  return std::make_shared<simple_landmark_map>(new_lms);
-}
-
-
-/// Compute the Necker reversal of a camera in place
-void
-necker_reverse_inplace(vital::simple_camera_perspective& camera,
-                       vital::vector_4d const& plane)
-{
-  using namespace kwiver::vital;
-  const vector_3d axis(plane.x(), plane.y(), plane.z());
-  const double d = plane[3];
-  const rotation_d Ra180(vector_4d(axis.x(), axis.y(), axis.z(), 0.0));
-  static const rotation_d Rz180(vector_4d(0.0, 0.0, 1.0, 0.0));
-
-  // extract the camera center
-  const vital::vector_3d cc = camera.center();
-  // extract the camera principal axis
-  const vital::vector_3d pa = camera.rotation().matrix().row(2);
-  // compute the distance from cc along pa until intersection with
-  // the mirroring plane of the points
-  const double dist = -(cc.dot(axis) + d) / pa.dot(axis);
-  // compute the ground point where the principal axis
-  // intersects the mirroring plane
-  const vital::vector_3d gp = cc + dist * pa;
-  // rotate the camera center 180 degrees about the mirroring plane normal
-  // axis centered at gp, also rotate the camera 180 about its principal axis
-  camera.set_center(Ra180 * (cc - gp) + gp);
-  camera.set_rotation(Rz180 * camera.rotation() * Ra180);
-}
-
-
-/// Compute the Necker reversal of the cameras
-vital::camera_map_sptr
-necker_reverse(vital::camera_map const& cameras,
-               vital::vector_4d const& plane)
-{
-  using namespace kwiver::vital;
-  camera_map::map_camera_t cams;
-  // flip cameras around
-  for (auto & p : cameras.cameras())
-  {
-    // make a clone of this camera as a simple_camera_perspective
-    auto flipped = std::make_shared<vital::simple_camera_perspective>(
-      dynamic_cast<vital::simple_camera_perspective&>(*p.second));
-
-    necker_reverse_inplace(*flipped, plane);
-    cams[p.first] = flipped;
-  }
-  return std::make_shared<simple_camera_map>(cams);
-}
-
-
-/// Compute an approximate Necker reversal of cameras and landmarks
-void
-necker_reverse(vital::camera_map_sptr& cameras,
-               vital::landmark_map_sptr& landmarks,
-               bool reverse_landmarks)
-{
-  using namespace kwiver::vital;
-  const vector_4d plane = landmark_plane(landmarks->landmarks());
-
-  // reverse the cameras
-  cameras = necker_reverse(*cameras, plane);
-
-  if (reverse_landmarks)
-  {
-    // mirror the landmarks
-    landmarks = mirror_landmarks(*landmarks, plane);
-  }
-}
-
-
 /// \cond DoxygenSuppress
 #define INSTANTIATE_TRANSFORM(T) \
 template KWIVER_ALGO_CORE_EXPORT vital::covariance_<3,T> \
@@ -352,5 +234,6 @@ INSTANTIATE_TRANSFORM(float);
 /// \endcond
 
 
+} // end namespace core
 } // end namespace arrows
 } // end namespace kwiver

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -162,6 +162,20 @@ vital::camera_map_sptr transform(vital::camera_map_sptr cameras,
 }
 
 
+/// construct a transformed map of cameras by applying a similarity transformation
+vital::camera_perspective_map_sptr
+transform(vital::camera_perspective_map_sptr cameras,
+          const vital::similarity_d& xform)
+{
+  auto cam_map = cameras->T_cameras();
+  for (auto& p : cam_map)
+  {
+    p.second = transform(p.second, xform);
+  }
+  return std::make_shared<vital::camera_perspective_map>(cam_map);
+}
+
+
 /// construct a transformed landmark by applying a similarity transformation
 vital::landmark_sptr transform(vital::landmark_sptr lm,
                                const vital::similarity_d& xform)

--- a/arrows/core/transform.cxx
+++ b/arrows/core/transform.cxx
@@ -218,76 +218,121 @@ vital::landmark_map_sptr transform(vital::landmark_map_sptr landmarks,
 }
 
 
+/// Compute a plane passing through the landmarks
+vital::vector_4d
+landmark_plane(const vital::landmark_map::map_landmark_t& landmarks)
+{
+  using namespace kwiver::vital;
+  // compute the landmark location mean and covariance
+  vector_3d lc(0.0, 0.0, 0.0);
+  matrix_3x3d covar = matrix_3x3d::Zero();
+  for (auto const& p : landmarks)
+  {
+    vector_3d pt = p.second->loc();
+    lc += pt;
+    covar += pt * pt.transpose();
+  }
+  const double num_lm = static_cast<double>(landmarks.size());
+  lc /= num_lm;
+  covar /= num_lm;
+  covar -= lc * lc.transpose();
+
+  // the plane will pass through the landmark centeroid (lc)
+  // and have a normal vector aligned with the smallest eigenvector of covar
+  Eigen::JacobiSVD<matrix_3x3d> svd(covar, Eigen::ComputeFullV);
+  vector_3d axis = svd.matrixV().col(2);
+  return vector_4d(axis.x(), axis.y(), axis.z(), -(lc.dot(axis)));
+}
+
+
+/// Mirror landmarks about the specified plane
+vital::landmark_map_sptr
+mirror_landmarks(vital::landmark_map const& landmarks,
+                 vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  landmark_map::map_landmark_t new_lms;
+  const vector_3d axis(plane.x(), plane.y(), plane.z());
+  const double d = plane[3];
+  // mirror landmark locations about the mirroring plane
+  for (auto const& p : landmarks.landmarks())
+  {
+    vector_3d v = p.second->loc();
+    v -= 2.0 * (v.dot(axis) + d) * axis;
+    auto new_lm = std::make_shared<vital::landmark_d>(*p.second);
+    new_lm->set_loc(v);
+    new_lms[p.first] = new_lm;
+  }
+  return std::make_shared<simple_landmark_map>(new_lms);
+}
+
+
+/// Compute the Necker reversal of a camera in place
+void
+necker_reverse_inplace(vital::simple_camera_perspective& camera,
+                       vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  const vector_3d axis(plane.x(), plane.y(), plane.z());
+  const double d = plane[3];
+  const rotation_d Ra180(vector_4d(axis.x(), axis.y(), axis.z(), 0.0));
+  static const rotation_d Rz180(vector_4d(0.0, 0.0, 1.0, 0.0));
+
+  // extract the camera center
+  const vital::vector_3d cc = camera.center();
+  // extract the camera principal axis
+  const vital::vector_3d pa = camera.rotation().matrix().row(2);
+  // compute the distance from cc along pa until intersection with
+  // the mirroring plane of the points
+  const double dist = -(cc.dot(axis) + d) / pa.dot(axis);
+  // compute the ground point where the principal axis
+  // intersects the mirroring plane
+  const vital::vector_3d gp = cc + dist * pa;
+  // rotate the camera center 180 degrees about the mirroring plane normal
+  // axis centered at gp, also rotate the camera 180 about its principal axis
+  camera.set_center(Ra180 * (cc - gp) + gp);
+  camera.set_rotation(Rz180 * camera.rotation() * Ra180);
+}
+
+
+/// Compute the Necker reversal of the cameras
+vital::camera_map_sptr
+necker_reverse(vital::camera_map const& cameras,
+               vital::vector_4d const& plane)
+{
+  using namespace kwiver::vital;
+  camera_map::map_camera_t cams;
+  // flip cameras around
+  for (auto & p : cameras.cameras())
+  {
+    // make a clone of this camera as a simple_camera_perspective
+    auto flipped = std::make_shared<vital::simple_camera_perspective>(
+      dynamic_cast<vital::simple_camera_perspective&>(*p.second));
+
+    necker_reverse_inplace(*flipped, plane);
+    cams[p.first] = flipped;
+  }
+  return std::make_shared<simple_camera_map>(cams);
+}
+
+
 /// Compute an approximate Necker reversal of cameras and landmarks
 void
 necker_reverse(vital::camera_map_sptr& cameras,
                vital::landmark_map_sptr& landmarks,
                bool reverse_landmarks)
 {
-  typedef vital::landmark_map::map_landmark_t lm_map_t;
-  typedef vital::camera_map::map_camera_t cam_map_t;
+  using namespace kwiver::vital;
+  const vector_4d plane = landmark_plane(landmarks->landmarks());
 
-  cam_map_t cams = cameras->cameras();
-  lm_map_t lms = landmarks->landmarks();
-
-  // compute the landmark location mean and covariance
-  vital::vector_3d lc(0.0, 0.0, 0.0);
-  vital::matrix_3x3d covar = vital::matrix_3x3d::Zero();
-  for (const lm_map_t::value_type& p : lms)
-  {
-    vital::vector_3d pt = p.second->loc();
-    lc += pt;
-    covar += pt * pt.transpose();
-  }
-  const double num_lm = static_cast<double>(lms.size());
-  lc /= num_lm;
-  covar /= num_lm;
-  covar -= lc * lc.transpose();
-
-  // the mirroring plane will pass through the landmark centeroid (lc)
-  // and have a normal vector aligned with the smallest eigenvector of covar
-  Eigen::JacobiSVD<vital::matrix_3x3d> svd(covar, Eigen::ComputeFullV);
-  vital::vector_3d axis = svd.matrixV().col(2);
-
-  // flip cameras around
-  vital::rotation_d Ra180(vital::vector_4d(axis.x(), axis.y(), axis.z(), 0.0));
-  vital::rotation_d Rz180(vital::vector_4d(0.0, 0.0, 1.0, 0.0));
-  for (cam_map_t::value_type& p : cams)
-  {
-    auto flipped = std::make_shared<vital::simple_camera_perspective>(
-      dynamic_cast<vital::simple_camera_perspective&>(*p.second));
-    // extract the camera center
-    const vital::vector_3d cc = flipped->center();
-    // extract the camera principal axis
-    vital::vector_3d pa = flipped->rotation().matrix().row(2);
-    // compute the distance from cc along pa until intersection with
-    // the mirroring plane of the points
-    const double dist = (lc - cc).dot(axis) / pa.dot(axis);
-    // compute the ground point where the principal axis
-    // intersects the mirroring plane
-    vital::vector_3d gp = cc + dist * pa;
-    // rotate the camera center 180 degrees about the mirroring plane normal
-    // axis centered at gp, also rotate the camera 180 about its principal axis
-    flipped->set_center(Ra180 * (flipped->center() - gp) + gp);
-    flipped->set_rotation(Rz180 * flipped->rotation() * Ra180);
-    p.second = vital::camera_perspective_sptr(flipped);
-  }
+  // reverse the cameras
+  cameras = necker_reverse(*cameras, plane);
 
   if (reverse_landmarks)
   {
-    // mirror landmark locations about the mirroring plane
-    for (lm_map_t::value_type& p : lms)
-    {
-      vital::vector_3d v = p.second->loc();
-      v -= 2.0 * (v - lc).dot(axis) * axis;
-      auto new_lm = std::make_shared<vital::landmark_d>(*p.second);
-      new_lm->set_loc(v);
-      p.second = new_lm;
-    }
+    // mirror the landmarks
+    landmarks = mirror_landmarks(*landmarks, plane);
   }
-
-  cameras = vital::camera_map_sptr(new vital::simple_camera_map(cams));
-  landmarks = vital::landmark_map_sptr(new vital::simple_landmark_map(lms));
 }
 
 

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -113,6 +113,13 @@ vital::camera_map_sptr transform(vital::camera_map_sptr cameras,
                                  const vital::similarity_d& xform);
 
 
+/// construct a transformed map of cameras by applying a similarity transformation
+KWIVER_ALGO_CORE_EXPORT
+vital::camera_perspective_map_sptr
+transform(vital::camera_perspective_map_sptr cameras,
+          const vital::similarity_d& xform);
+
+
 /// construct a transformed landmark by applying a similarity transformation
 KWIVER_ALGO_CORE_EXPORT
 vital::landmark_sptr transform(vital::landmark_sptr lm,

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -72,15 +72,15 @@ vital::covariance_<3,T> transform(const vital::covariance_<3,T>& covar,
 
 /// Transform the camera by applying a similarity transformation in place
 KWIVER_ALGO_CORE_EXPORT
-void transform_inplace(const vital::similarity_d& xform,
-                       vital::simple_camera_perspective& cam);
+void transform_inplace(vital::simple_camera_perspective& cam,
+                       const vital::similarity_d& xform);
 
 
 /// Transform the landmark by applying a similarity transformation in place
 template <typename T>
 KWIVER_ALGO_CORE_EXPORT
-void transform_inplace(const vital::similarity_<T>& xform,
-                       vital::landmark_<T>& lm);
+void transform_inplace(vital::landmark_<T>& lm,
+                       const vital::similarity_<T>& xform);
 
 
 /// construct a transformed camera by applying a similarity transformation

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -132,6 +132,54 @@ vital::landmark_map_sptr transform(vital::landmark_map_sptr landmarks,
                                    const vital::similarity_d& xform);
 
 
+/// Compute a plane passing through the landmarks
+/**
+ * Returns the parameters of the best fit plan passing through
+ * the centroid of the landmarks.  The plane is [nx, ny, nz, d] where
+ * [nx, ny, nz] is a unit normal and d is the offset.
+ */
+KWIVER_ALGO_CORE_EXPORT
+vital::vector_4d
+landmark_plane(const vital::landmark_map::map_landmark_t& landmarks);
+
+
+/// Mirror landmarks about the specified plane
+KWIVER_ALGO_CORE_EXPORT
+vital::landmark_map_sptr
+mirror_landmarks(vital::landmark_map const& landmarks,
+                 vital::vector_4d const& plane);
+
+
+/// Compute the Necker reversal of a camera in place
+/**
+ * Using the specified landmark plane, apply a Necker reversal
+ * transformation to the camera in place.  The camera rotates 180 degrees
+ * about the normal vector of the plane at the point where the principal
+ * ray intersects the plane.  The camera also rotates 180 degrees about its
+ * principal.  The resulting camera provides a similar projection of points
+ * near the specified plane, espcially for very long focal lengths.
+ */
+KWIVER_ALGO_CORE_EXPORT
+void
+necker_reverse_inplace(vital::simple_camera_perspective& camera,
+                       vital::vector_4d const& plane);
+
+
+/// Compute the Necker reversal of the cameras
+/**
+* Using the specified landmark plane, apply a Necker reversal
+* transformation to each camera.  The camera rotates 180 degrees
+* about the normal vector of the plane at the point where the principal
+* ray intersects the plane.  The camera also rotates 180 degrees about its
+* principal.  The resulting camera provides a similar projection of points
+* near the specified plane, espcially for very long focal lengths.
+*/
+KWIVER_ALGO_CORE_EXPORT
+vital::camera_map_sptr
+necker_reverse(vital::camera_map const& cameras,
+               vital::vector_4d const& plane);
+
+
 /// Compute an approximate Necker reversal of cameras and landmarks
 /**
  * This operation help restart bundle adjustment after falling into

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -40,7 +40,7 @@
 #include <vital/vital_config.h>
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <vital/types/camera_perspective.h>
+#include <vital/types/camera_perspective_map.h>
 #include <vital/types/similarity.h>
 #include <vital/types/covariance.h>
 #include <vital/types/camera_map.h>
@@ -73,6 +73,12 @@ vital::covariance_<3,T> transform(const vital::covariance_<3,T>& covar,
 /// Transform the camera by applying a similarity transformation in place
 KWIVER_ALGO_CORE_EXPORT
 void transform_inplace(vital::simple_camera_perspective& cam,
+                       const vital::similarity_d& xform);
+
+
+/// Transform the camera map by applying a similarity transformation in place
+KWIVER_ALGO_CORE_EXPORT
+void transform_inplace(vital::simple_camera_perspective_map& cameras,
                        const vital::similarity_d& xform);
 
 

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -89,6 +89,18 @@ void transform_inplace(vital::landmark_<T>& lm,
                        const vital::similarity_<T>& xform);
 
 
+/// Transform the landmark map by applying a similarity transformation in place
+KWIVER_ALGO_CORE_EXPORT
+void transform_inplace(vital::landmark_map& landmarks,
+                       const vital::similarity_d& xform);
+
+
+/// Transform the landmark map by applying a similarity transformation in place
+KWIVER_ALGO_CORE_EXPORT
+void transform_inplace(vital::landmark_map::map_landmark_t& landmarks,
+                       const vital::similarity_d& xform);
+
+
 /// construct a transformed camera by applying a similarity transformation
 KWIVER_ALGO_CORE_EXPORT
 vital::camera_perspective_sptr transform(vital::camera_perspective_sptr cam,

--- a/arrows/core/transform.h
+++ b/arrows/core/transform.h
@@ -30,7 +30,7 @@
 
 /**
  * \file
- * \brief Header for kwiver::arrows::transform functions
+ * \brief Header for kwiver::arrows::core::transform functions
  */
 
 #ifndef KWIVER_ARROWS_CORE_TRANSFORM_H_
@@ -49,6 +49,7 @@
 
 namespace kwiver {
 namespace arrows {
+namespace core {
 
 
 /// Transform a 3D covariance matrix with a similarity transformation
@@ -131,77 +132,7 @@ KWIVER_ALGO_CORE_EXPORT
 vital::landmark_map_sptr transform(vital::landmark_map_sptr landmarks,
                                    const vital::similarity_d& xform);
 
-
-/// Compute a plane passing through the landmarks
-/**
- * Returns the parameters of the best fit plan passing through
- * the centroid of the landmarks.  The plane is [nx, ny, nz, d] where
- * [nx, ny, nz] is a unit normal and d is the offset.
- */
-KWIVER_ALGO_CORE_EXPORT
-vital::vector_4d
-landmark_plane(const vital::landmark_map::map_landmark_t& landmarks);
-
-
-/// Mirror landmarks about the specified plane
-KWIVER_ALGO_CORE_EXPORT
-vital::landmark_map_sptr
-mirror_landmarks(vital::landmark_map const& landmarks,
-                 vital::vector_4d const& plane);
-
-
-/// Compute the Necker reversal of a camera in place
-/**
- * Using the specified landmark plane, apply a Necker reversal
- * transformation to the camera in place.  The camera rotates 180 degrees
- * about the normal vector of the plane at the point where the principal
- * ray intersects the plane.  The camera also rotates 180 degrees about its
- * principal.  The resulting camera provides a similar projection of points
- * near the specified plane, espcially for very long focal lengths.
- */
-KWIVER_ALGO_CORE_EXPORT
-void
-necker_reverse_inplace(vital::simple_camera_perspective& camera,
-                       vital::vector_4d const& plane);
-
-
-/// Compute the Necker reversal of the cameras
-/**
-* Using the specified landmark plane, apply a Necker reversal
-* transformation to each camera.  The camera rotates 180 degrees
-* about the normal vector of the plane at the point where the principal
-* ray intersects the plane.  The camera also rotates 180 degrees about its
-* principal.  The resulting camera provides a similar projection of points
-* near the specified plane, espcially for very long focal lengths.
-*/
-KWIVER_ALGO_CORE_EXPORT
-vital::camera_map_sptr
-necker_reverse(vital::camera_map const& cameras,
-               vital::vector_4d const& plane);
-
-
-/// Compute an approximate Necker reversal of cameras and landmarks
-/**
- * This operation help restart bundle adjustment after falling into
- * a common local minima that with depth reversal that is illustrated
- * by the Necker cube phenomena.
- *
- * The functions finds the axis, A, connecting the mean of the camera centers
- * and mean of the landmark locations.  It then rotates each camera 180 degrees
- * about this axis and also 180 degrees about each cameras own principal axis.
- * The landmarks are mirrored about the plane passing through the
- * mean landmark location and with a normal aligning with axis A.
- * Setting reverse_landmarks to false, prevents this mirroring of the landmarks,
- * leaving them where they originally were.  Only the cameras are modified
- * in this case.
- *
- */
-KWIVER_ALGO_CORE_EXPORT
-void
-necker_reverse(vital::camera_map_sptr& cameras,
-               vital::landmark_map_sptr& landmarks,
-               bool reverse_landmarks = true);
-
+} // end namespace core
 } // end namespace arrows
 } // end namespace kwiver
 

--- a/arrows/vxl/tests/test_initialize_cameras_landmarks.cxx
+++ b/arrows/vxl/tests/test_initialize_cameras_landmarks.cxx
@@ -111,7 +111,7 @@ evaluate_initialization(const kwiver::vital::camera_map_sptr true_cams,
     auto new_cam =
       std::dynamic_pointer_cast<vital::camera_perspective>(new_cams[p.first]);
     vital::camera_perspective_sptr new_cam_t =
-      arrows::transform(new_cam, global_sim);
+      arrows::core::transform(new_cam, global_sim);
     vital::rotation_d dR = new_cam_t->rotation().inverse() * orig_cam->rotation();
     EXPECT_NEAR(0.0, dR.angle(), tol) << "Rotation difference magnitude";
 
@@ -123,7 +123,8 @@ evaluate_initialization(const kwiver::vital::camera_map_sptr true_cams,
   vital::landmark_map::map_landmark_t new_lms = est_landmarks->landmarks();
   for (auto const& p : orig_lms)
   {
-    vital::landmark_sptr new_lm_tr = arrows::transform(new_lms[p.first], global_sim);
+    vital::landmark_sptr new_lm_tr =
+      arrows::core::transform(new_lms[p.first], global_sim);
 
     double dt = (p.second->loc() - new_lm_tr->loc()).norm();
     EXPECT_NEAR(0.0, dt, tol) << "Landmark location difference";

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -86,6 +86,7 @@ set( vital_public_headers
   types/camera.h
   types/camera_intrinsics.h
   types/camera_perspective.h
+  types/camera_perspective_map.h
   types/camera_rpc.h
   types/camera_map.h
   types/category_hierarchy.h

--- a/vital/types/camera_perspective_map.h
+++ b/vital/types/camera_perspective_map.h
@@ -1,0 +1,57 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Typedefs for camera_perspective camera_maps
+ */
+
+#ifndef VITAL_CAMERA_PERSPECTIVE_MAP_H_
+#define VITAL_CAMERA_PERSPECTVIE_MAP_H_
+
+#include "camera_map.h"
+#include "camera_perspective.h"
+
+
+namespace kwiver {
+namespace vital {
+
+/// Typedefs that combine camera_map_of_ and camera_perspective
+typedef vital::camera_map_of_<vital::camera_perspective> camera_perspective_map;
+typedef std::shared_ptr<camera_perspective_map> camera_perspective_map_sptr;
+
+/// Typedefs that combine camera_map_of_ and simple_camera_perspective
+typedef vital::camera_map_of_<vital::simple_camera_perspective> simple_camera_perspective_map;
+typedef std::shared_ptr<simple_camera_perspective_map> simple_camera_perspective_map_sptr;
+
+} // end namespace vital
+} // end namespace kwiver
+
+#endif


### PR DESCRIPTION
This branch refactors the `core` transform functions with the following changes
- Make the order of transform arguments consistent (xform always last)
- Add a few more helper transform functions for more specific data types
- Fix the namespace of these functions. Moved from `arrows` into `arrows::core`
- Move the Necker reverse function into a new `necker_reverse.h` header.
- Refactored the Necker reverse function into its components so that each can be called directly

There are no changes to any algorithms on this branch, just moving code around and exposing more APIs.