### PR TITLE
Improve vital::point construction

### DIFF
--- a/vital/types/point.h
+++ b/vital/types/point.h
@@ -49,19 +49,21 @@ namespace kwiver {
 namespace vital {
 
 template < unsigned N, typename T >
-class VITAL_EXPORT point
+class VITAL_EXPORT point : protected Eigen::Matrix< T, N, 1 >
 {
 public:
   using vector_type = Eigen::Matrix< T, N, 1 >;
   using covariance_type = covariance_<N, float>;
 
-  point() { }
-  point(vector_type const& v) : m_value(v) { }
-
+  point() : vector_type{ vector_type::Zero() } {}
+  point( vector_type v, covariance_type c )
+    : vector_type{ v }, m_covariance{ c } {}
   virtual ~point() = default;
 
-  vector_type value() const { return m_value; }
-  void set_value(vector_type v) { m_value = v; }
+  using vector_type::vector_type;
+
+  vector_type value() const { return *this; }
+  void set_value(vector_type v) { *this = v; }
 
   covariance_type covariance() const { return m_covariance; }
   void set_covariance(covariance_type v)
@@ -70,7 +72,6 @@ public:
   }
 
 protected:
-  vector_type m_value = vector_type::Zero();
   covariance_type m_covariance;
 };
 


### PR DESCRIPTION
Modify `vital::point` to subclass (via protected inheritance) its corresponding `Eigen` vector value, in order to also inherit the constructors for the same. This allows more convenient construction of a `vital::point`, e.g. by passing a set of coordinate scalars.