### PR TITLE
Clean-up for dev/add-pytorch-arrow

### DIFF
--- a/arrows/pytorch/grid.py
+++ b/arrows/pytorch/grid.py
@@ -44,6 +44,9 @@ class Grid(object):
         r"""
             The output of the function is a grid feature list for
             each corresponding bbox of current frame/image
+
+            A grid feature records which cells in the configured
+            neighborhood have at least one bonuding box in them.
         """
         self.img_w, self.img_h = im_size
 
@@ -54,9 +57,9 @@ class Grid(object):
         # initial all gridcell to 0
         grid = torch.FloatTensor(self._grid_rows, self._grid_cols).zero_()
 
-        bbox_id_centerIDX = {}
+        bbox_id_centerIDX = []
         # build the grid for current image
-        for idx, item in enumerate(bbox_list):
+        for item in bbox_list:
             bb = item if mot_flag else item.bounding_box()
 
             x = int(bb.min_x())
@@ -72,7 +75,7 @@ class Grid(object):
             row_idx = int(c_h // cell_h)
             col_idx = int(c_w // cell_w)
 
-            bbox_id_centerIDX[idx] = row_idx, col_idx
+            bbox_id_centerIDX.append((row_idx, col_idx))
 
             # Assertion for corner cases
             assert row_idx < grid.shape[0]
@@ -81,10 +84,10 @@ class Grid(object):
 
         grid_feature_list = []
         # obtain grid feature for each bbox
-        for idx in range(len(bbox_id_centerIDX)):
+        for row_idx, col_idx in bbox_id_centerIDX:
             # top left corner's the neighborhood grid
-            neighborhood_grid_top = bbox_id_centerIDX[idx][0] - self._half_cell_w
-            neighborhood_grid_left = bbox_id_centerIDX[idx][1] - self._half_cell_w
+            neighborhood_grid_top = row_idx - self._half_cell_w
+            neighborhood_grid_left = col_idx - self._half_cell_w
 
             neighborhood_grid = torch.FloatTensor(self._target_neighborhood_w,
                                             self._target_neighborhood_w).zero_()

--- a/arrows/pytorch/grid.py
+++ b/arrows/pytorch/grid.py
@@ -39,10 +39,10 @@ class Grid(object):
 
     def __call__(self, im_size, bbox_list, mot_flag=False):
         return self.obtain_grid_feature_list(im_size, bbox_list, mot_flag)
-    
+
     def obtain_grid_feature_list(self, im_size, bbox_list, mot_flag):
         r"""
-            The output of the function is a grid feature list for 
+            The output of the function is a grid feature list for
             each corresponding bbox of current frame/image
         """
         self.img_w, self.img_h = im_size
@@ -73,7 +73,7 @@ class Grid(object):
             col_idx = int(c_w // cell_w)
 
             bbox_id_centerIDX[idx] = row_idx, col_idx
-            
+
             # Assertion for corner cases
             assert row_idx < grid.shape[0]
             assert col_idx < grid.shape[1]
@@ -86,17 +86,16 @@ class Grid(object):
             neighborhood_grid_top = bbox_id_centerIDX[idx][0] - self._half_cell_w
             neighborhood_grid_left = bbox_id_centerIDX[idx][1] - self._half_cell_w
 
-            neighborhood_grid = torch.FloatTensor(self._target_neighborhood_w, 
+            neighborhood_grid = torch.FloatTensor(self._target_neighborhood_w,
                                             self._target_neighborhood_w).zero_()
 
             for r in range(self._target_neighborhood_w):
                 for c in range(self._target_neighborhood_w):
-                    if 0 <= neighborhood_grid_top + r < grid.size(0) and \
-                            0 <= neighborhood_grid_left + c < grid.size(1):
-                        neighborhood_grid[r, c] = grid[neighborhood_grid_top + r, \
+                    if (0 <= neighborhood_grid_top + r < grid.size(0)
+                        and 0 <= neighborhood_grid_left + c < grid.size(1)):
+                        neighborhood_grid[r, c] = grid[neighborhood_grid_top + r,
                                                     neighborhood_grid_left + c]
 
             grid_feature_list.append(neighborhood_grid.view(neighborhood_grid.numel()))
 
         return grid_feature_list
-

--- a/arrows/pytorch/iou_tracker.py
+++ b/arrows/pytorch/iou_tracker.py
@@ -40,17 +40,17 @@ class IOUTracker(object):
         if track_state_list:
             for track in track_set.iter_active():
                 # get det with highest iou
-                best_match = max(track_state_list, \
+                best_match = max(track_state_list,
                         key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
                 # sort the track state list in order to check whether multiple bboxes overlap with the current track
-                sorted_ts_list = sorted(track_state_list, \
+                sorted_ts_list = sorted(track_state_list,
                         key=lambda x: self._iou_score(track[-1].bbox, x.bbox))
                 best_iou_score = self._iou_score(track[-1].bbox, best_match.bbox)
                 if best_iou_score >= self._iou_accept_threshold:
                     # if no other bbox with overlap larger than iou_reject_threshold
-                    if len(sorted_ts_list) >= 2 and \
-                            self._iou_score(track[-1].bbox, sorted_ts_list[1].bbox) < \
-                            self._iou_reject_threshold:
+                    if (len(sorted_ts_list) >= 2 and
+                        (self._iou_score(track[-1].bbox, sorted_ts_list[1].bbox)
+                         < self._iou_reject_threshold)):
                         track.updated_flag = True
                         track_set.update_track(track.track_id, best_match)
                         # remove best matching detection from detections

--- a/arrows/pytorch/srnn_matching.py
+++ b/arrows/pytorch/srnn_matching.py
@@ -41,9 +41,9 @@ class TargetRNNDataLoader(data.Dataset):
                         bbox_area_ratio = 1.0 / bbox_area_ratio
 
                     # in the search area, we prepare data and calculate the similarity score
-                    if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and                      # track dis constraint
-                        dis < self._track_search_threshold * track_state.bbox[2] and         # track_state dis constraint
-                        bbox_area_ratio < self._track_search_threshold):                                    # bbox area constraint
+                    if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and         # track dis constraint
+                        dis < self._track_search_threshold * track_state.bbox[2] and           # track_state dis constraint
+                        bbox_area_ratio < self._track_search_threshold):                       # bbox area constraint
                         cur_data_item = []
 
                         #app feature and app target

--- a/arrows/pytorch/srnn_matching.py
+++ b/arrows/pytorch/srnn_matching.py
@@ -47,26 +47,26 @@ class TargetRNNDataLoader(data.Dataset):
                         cur_data_item = []
 
                         #app feature and app target
-                        app_f_tensor = torch.stack([cur_track[i].app_feature \
+                        app_f_tensor = torch.stack([cur_track[i].app_feature
                                                 for i in range(-g_config.timeStep, 0)])
                         cur_data_item += app_f_tensor, track_state.app_feature
 
                         #motion feature and motion target
-                        motion_f_tensor = torch.stack([cur_track[i].motion_feature \
+                        motion_f_tensor = torch.stack([cur_track[i].motion_feature
                                                 for i in range(-g_config.timeStep, 0)])
-                        motion_target_f = (np.asarray(track_state.bbox_center, \
-                                            dtype=np.float32).reshape(g_config.M_F_num) - \
-                                           np.asarray(cur_track[-1].bbox_center, 
+                        motion_target_f = (np.asarray(track_state.bbox_center,
+                                            dtype=np.float32).reshape(g_config.M_F_num) -
+                                           np.asarray(cur_track[-1].bbox_center,
                                                dtype=np.float32).reshape(g_config.M_F_num))
                         cur_data_item += motion_f_tensor, torch.from_numpy(motion_target_f)
 
                         #interaction feature and interaction target
-                        interaction_f_tensor = torch.stack([cur_track[i].interaction_feature \
+                        interaction_f_tensor = torch.stack([cur_track[i].interaction_feature
                                                 for i in range(-g_config.timeStep, 0)])
                         cur_data_item += interaction_f_tensor, track_state.interaction_feature
 
                         #bbar feature and bbar target
-                        bbar_f_tensor = torch.stack([cur_track[i].bbar_feature \
+                        bbar_f_tensor = torch.stack([cur_track[i].bbar_feature
                                                 for i in range(-g_config.timeStep, 0)])
                         cur_data_item += bbar_f_tensor, track_state.bbar_feature
 
@@ -84,14 +84,14 @@ class TargetRNNDataLoader(data.Dataset):
 
 
 class SRNNMatching(object):
-    def __init__(self, targetRNN_full_model_path, targetRNN_AIM_V_model_path, 
+    def __init__(self, targetRNN_full_model_path, targetRNN_AIM_V_model_path,
                     batch_size, gpu_list=None):
         self._device, self._use_gpu_flag = get_device(gpu_list)
         self._batch_size = batch_size
 
         # load target AIM model, trained with fixed variable timestep
         full_model_list = (RnnType.Appearance, RnnType.Motion, RnnType.Interaction)
-        self._targetRNN_full_model = TargetLSTM(model_list=full_model_list, 
+        self._targetRNN_full_model = TargetLSTM(model_list=full_model_list,
                                                 use_gpu_flag=self._use_gpu_flag)
         self._targetRNN_full_model = self._targetRNN_full_model.to(self._device)
 
@@ -105,12 +105,12 @@ class SRNNMatching(object):
 
         if self._use_gpu_flag:
             # DataParallel also understands device_ids=None to mean "all devices", so we're good.
-            self._targetRNN_full_model = torch.nn.DataParallel(self._targetRNN_full_model, 
+            self._targetRNN_full_model = torch.nn.DataParallel(self._targetRNN_full_model,
                                                                     device_ids=gpu_list)
 
         # load  target AIM_V model, but trained with variable timestep
         V_model_list = (RnnType.Appearance, RnnType.Motion, RnnType.Interaction)
-        self._targetRNN_AIM_V_model = TargetLSTM(model_list=V_model_list, 
+        self._targetRNN_AIM_V_model = TargetLSTM(model_list=V_model_list,
                             use_gpu_flag=self._use_gpu_flag).to(self._device)
 
         if self._use_gpu_flag:
@@ -122,7 +122,7 @@ class SRNNMatching(object):
         self._targetRNN_AIM_V_model.eval()
 
         if self._use_gpu_flag:
-            self._targetRNN_AIM_V_model = torch.nn.DataParallel(self._targetRNN_AIM_V_model, 
+            self._targetRNN_AIM_V_model = torch.nn.DataParallel(self._targetRNN_AIM_V_model,
                                                             device_ids=gpu_list)
 
     def __call__(self, track_set, track_state_list, track_search_threshold):
@@ -157,8 +157,8 @@ class SRNNMatching(object):
 
 
     def _est_similarity(self, loader, rnnType):
-        for (app_f_list, app_target_f, motion_f_list, motion_target_f, 
-                interaction_f_list, interaction_target_f, bbar_f_list, 
+        for (app_f_list, app_target_f, motion_f_list, motion_target_f,
+                interaction_f_list, interaction_target_f, bbar_f_list,
                 bbar_target_f, t, ts) in loader:
             v_app_seq = app_f_list.to(self._device)
             v_app_target =  app_target_f.to(self._device)
@@ -169,12 +169,12 @@ class SRNNMatching(object):
             v_bbar_seq = bbar_f_list.to(self._device)
             v_bbar_target = bbar_target_f.to(self._device)
             if rnnType is RnnType.Target_RNN_AIM:
-                output = self._targetRNN_full_model(v_app_seq, v_app_target, v_motion_seq, 
-                                        v_motion_target, v_interaction_seq, 
+                output = self._targetRNN_full_model(v_app_seq, v_app_target, v_motion_seq,
+                                        v_motion_target, v_interaction_seq,
                                         v_interaction_target, v_bbar_seq, v_bbar_target)
             elif rnnType is RnnType.Target_RNN_AIM_V:
-                output = self._targetRNN_AIM_V_model(v_app_seq, v_app_target, v_motion_seq, 
-                                        v_motion_target, v_interaction_seq, 
+                output = self._targetRNN_AIM_V_model(v_app_seq, v_app_target, v_motion_seq,
+                                        v_motion_target, v_interaction_seq,
                                         v_interaction_target)
 
             F_softmax = nn.Softmax()

--- a/arrows/pytorch/srnn_tracker.py
+++ b/arrows/pytorch/srnn_tracker.py
@@ -83,121 +83,7 @@ class SRNNTracker(KwiverProcess):
     def __init__(self, conf):
         KwiverProcess.__init__(self, conf)
 
-        #GPU list
-        self.add_config_trait("gpu_list", "gpu_list", 'all',
-                              gpu_list_desc(use_for='SRNN tracking'))
-        self.declare_config_using_trait('gpu_list')
-
-        # siamese
-        #----------------------------------------------------------------------------------
-        self.add_config_trait("siamese_model_path", "siamese_model_path",
-                              'siamese/snapshot_epoch_6.pt',
-                              'Trained PyTorch model.')
-        self.declare_config_using_trait('siamese_model_path')
-
-        self.add_config_trait("siamese_model_input_size", "siamese_model_input_size", '224',
-                              'Model input image size')
-        self.declare_config_using_trait('siamese_model_input_size')
-
-        self.add_config_trait("siamese_batch_size", "siamese_batch_size", '128',
-                              'siamese model processing batch size')
-        self.declare_config_using_trait('siamese_batch_size')
-        #----------------------------------------------------------------------------------
-
-        # detection select threshold
-        self.add_config_trait("detection_select_threshold", "detection_select_threshold", '0.0',
-                              'detection select threshold')
-        self.declare_config_using_trait('detection_select_threshold')
-        self.add_config_trait("track_initialization_threshold", "track_initialization_threshold", '0.0',
-                              'track_initialization_threshold')
-        self.declare_config_using_trait('track_initialization_threshold')
-
-        # SRNN
-        #----------------------------------------------------------------------------------
-        # target RNN full model
-        self.add_config_trait("targetRNN_AIM_model_path", "targetRNN_AIM_model_path",
-                              'targetRNN_snapshot/App_LSTM_epoch_51.pt',
-                              'Trained targetRNN PyTorch model.')
-        self.declare_config_using_trait('targetRNN_AIM_model_path')
-
-        # target RNN AI model
-        self.add_config_trait("targetRNN_AIM_V_model_path", "targetRNN_AIM_V_model_path",
-                              'targetRNN_AI/App_LSTM_epoch_51.pt',
-                              'Trained targetRNN AIM with variable input size PyTorch model.')
-        self.declare_config_using_trait('targetRNN_AIM_V_model_path')
-
-        # target RNN batch size
-        self.add_config_trait("targetRNN_batch_size", "targetRNN_batch_size", '256',
-                              'targetRNN model processing batch size')
-        self.declare_config_using_trait('targetRNN_batch_size')
-
-        # matching similarity threshold
-        self.add_config_trait("similarity_threshold", "similarity_threshold", '0.5',
-                              'similarity threshold.')
-        self.declare_config_using_trait('similarity_threshold')
-        #----------------------------------------------------------------------------------
-
-        # IOU
-        #----------------------------------------------------------------------------------
-        # IOU tracker flag
-        self.add_config_trait("IOU_tracker_flag", "IOU_tracker_flag", 'True', 'IOU tracker flag.')
-        self.declare_config_using_trait('IOU_tracker_flag')
-
-        # IOU accept threshold
-        self.add_config_trait("IOU_accept_threshold", "IOU_accept_threshold", '0.5',
-                              'IOU accept threshold.')
-        self.declare_config_using_trait('IOU_accept_threshold')
-
-        # IOU reject threshold
-        self.add_config_trait("IOU_reject_threshold", "IOU_reject_threshold", '0.1',
-                              'IOU reject threshold.')
-        self.declare_config_using_trait('IOU_reject_threshold')
-        #----------------------------------------------------------------------------------
-
-        # search threshold
-        self.add_config_trait("track_search_threshold", "track_search_threshold", '0.1',
-                              'track search threshold.')
-        self.declare_config_using_trait('track_search_threshold')
-
-        # matching active track threshold
-        self.add_config_trait("terminate_track_threshold", "terminate_track_threshold", '15',
-                              'terminate the tracking if the target has been lost for more than '
-                              'terminate_track_threshold read-in frames.')
-        self.declare_config_using_trait('terminate_track_threshold')
-
-        # matching active track threshold
-        self.add_config_trait("sys_terminate_track_threshold", "sys_terminate_track_threshold", '50',
-                              'terminate the tracking if the target has been lost for more than '
-                              'terminate_track_threshold system (original) frames.')
-        self.declare_config_using_trait('sys_terminate_track_threshold')
-
-        # MOT gt detection
-        #-------------------------------------------------------------------
-        self.add_config_trait("MOT_GTbbox_flag", "MOT_GTbbox_flag", 'False', 'MOT GT bbox flag')
-        self.declare_config_using_trait('MOT_GTbbox_flag')
-        #-------------------------------------------------------------------
-
-        # AFRL gt detection
-        #-------------------------------------------------------------------
-        self.add_config_trait("AFRL_GTbbox_flag", "AFRL_GTbbox_flag", 'False', 'AFRL GT bbox flag')
-        self.declare_config_using_trait('AFRL_GTbbox_flag')
-
-        #-------------------------------------------------------------------
-
-        # GT bbox file
-        #-------------------------------------------------------------------
-        self.add_config_trait("GT_bbox_file_path", "GT_bbox_file_path",
-                             '', 'ground truth detection file for testing')
-        self.declare_config_using_trait('GT_bbox_file_path')
-        #-------------------------------------------------------------------
-
-        # Add features to detections
-        #-------------------------------------------------------------------
-        self.add_config_trait("add_features_to_detections",
-                              "add_features_to_detections", 'True',
-                              'Should we add internally computed features to detections?')
-        self.declare_config_using_trait('add_features_to_detections')
-        #-------------------------------------------------------------------
+        self.__declare_config_traits()
 
         self._track_flag = False
 
@@ -220,6 +106,105 @@ class SRNNTracker(KwiverProcess):
         #  output port ( port-name,flags)
         self.declare_output_port_using_trait('object_track_set', optional)
         self.declare_output_port_using_trait('detected_object_set', optional)
+
+    def __declare_config_traits(self):
+        def add_declare_config_trait(name, default, desc):
+            self.add_config_trait(name, name, default, desc)
+            self.declare_config_using_trait(name)
+
+        #GPU list
+        add_declare_config_trait('gpu_list', 'all',
+                                 gpu_list_desc(use_for='SRNN tracking'))
+
+        # siamese
+        #----------------------------------------------------------------------------------
+        add_declare_config_trait('siamese_model_path',
+                                 'siamese/snapshot_epoch_6.pt',
+                                 'Trained PyTorch model.')
+
+        add_declare_config_trait('siamese_model_input_size', '224',
+                                 'Model input image size')
+
+        add_declare_config_trait('siamese_batch_size', '128',
+                                 'siamese model processing batch size')
+        #----------------------------------------------------------------------------------
+
+        # detection select threshold
+        add_declare_config_trait('detection_select_threshold', '0.0',
+                                 'detection select threshold')
+        add_declare_config_trait('track_initialization_threshold', '0.0',
+                                 'track initialization threshold')
+
+        # SRNN
+        #----------------------------------------------------------------------------------
+        # target RNN full model
+        add_declare_config_trait("targetRNN_AIM_model_path",
+                                 'targetRNN_snapshot/App_LSTM_epoch_51.pt',
+                                 'Trained targetRNN PyTorch model.')
+
+        # target RNN AI model
+        add_declare_config_trait("targetRNN_AIM_V_model_path",
+                                 'targetRNN_AI/App_LSTM_epoch_51.pt',
+                                 'Trained targetRNN AIM with variable input size PyTorch model.')
+
+        # target RNN batch size
+        add_declare_config_trait("targetRNN_batch_size", '256',
+                                 'targetRNN model processing batch size')
+
+        # matching similarity threshold
+        add_declare_config_trait("similarity_threshold", '0.5',
+                                 'similarity threshold.')
+        #----------------------------------------------------------------------------------
+
+        # IOU
+        #----------------------------------------------------------------------------------
+        # IOU tracker flag
+        add_declare_config_trait("IOU_tracker_flag", 'True', 'IOU tracker flag.')
+
+        # IOU accept threshold
+        add_declare_config_trait("IOU_accept_threshold", '0.5',
+                                 'IOU accept threshold.')
+
+        # IOU reject threshold
+        add_declare_config_trait("IOU_reject_threshold", '0.1',
+                                 'IOU reject threshold.')
+        #----------------------------------------------------------------------------------
+
+        # search threshold
+        add_declare_config_trait("track_search_threshold", '0.1',
+                                 'track search threshold.')
+
+        # matching active track threshold
+        add_declare_config_trait("terminate_track_threshold", '15',
+                                 'terminate the tracking if the target has been lost for more than '
+                                 'terminate_track_threshold read-in frames.')
+
+        # matching active track threshold
+        add_declare_config_trait("sys_terminate_track_threshold", '50',
+                                 'terminate the tracking if the target has been lost for more than '
+                                 'terminate_track_threshold system (original) frames.')
+
+        # MOT gt detection
+        #-------------------------------------------------------------------
+        add_declare_config_trait("MOT_GTbbox_flag", 'False', 'MOT GT bbox flag')
+        #-------------------------------------------------------------------
+
+        # AFRL gt detection
+        #-------------------------------------------------------------------
+        add_declare_config_trait("AFRL_GTbbox_flag", 'False', 'AFRL GT bbox flag')
+        #-------------------------------------------------------------------
+
+        # GT bbox file
+        #-------------------------------------------------------------------
+        add_declare_config_trait("GT_bbox_file_path", '',
+                                 'ground truth detection file for testing')
+        #-------------------------------------------------------------------
+
+        # Add features to detections
+        #-------------------------------------------------------------------
+        add_declare_config_trait("add_features_to_detections", 'True',
+                                 'Should we add internally computed features to detections?')
+        #-------------------------------------------------------------------
 
     # ----------------------------------------------
     def _configure(self):

--- a/arrows/pytorch/srnn_tracker.py
+++ b/arrows/pytorch/srnn_tracker.py
@@ -336,21 +336,21 @@ class SRNNTracker(KwiverProcess):
 
                 # get new track state from new frame and detections
                 for idx, item in enumerate(dos):
-                    if self._gtbbox_flag is True:
+                    if self._gtbbox_flag:
                         bbox = item
                         fid = self._step_id
                         ts = self._step_id
-                        d_obj = DetectedObject(bbox=item , confidence=1.0)
+                        d_obj = DetectedObject(bbox=item, confidence=1.0)
                     else:
                         bbox = item.bounding_box()
                         fid = timestamp.get_frame()
                         ts = timestamp.get_time_usec()
                         d_obj = item
 
-                    # store app feature to detected_object
-                    app_f = new_descriptor(g_config.A_F_num)
-                    app_f[:] = pt_app_features[idx].numpy()
                     if self._add_features_to_detections:
+                        # store app feature to detected_object
+                        app_f = new_descriptor(g_config.A_F_num)
+                        app_f[:] = pt_app_features[idx].numpy()
                         d_obj.set_descriptor(app_f)
                     det_obj_set.add(d_obj)
 

--- a/arrows/pytorch/track.py
+++ b/arrows/pytorch/track.py
@@ -29,7 +29,6 @@
 
 import numpy as np
 import torch
-import copy
 import collections
 
 class track_state(object):


### PR DESCRIPTION
This PR provides (some) clean-up for `dev/add-pytorch-arrow`. Types of changes include:
- Formatting (reduced excess whitespace, fewer line-continuation backslashes)
- More Pythonic iteration
- Factoring out of repetitive code
- Misc. (documentation, printing, an unneeded import...)

This is not comprehensive. I didn't go through everything, and there are some things I noticed that I didn't fix (e.g. indentation in multi-line expressions).