### PR TITLE
Fix compile error with Boost dependencies for Sprokit

### DIFF
--- a/sprokit/src/tools/CMakeLists.txt
+++ b/sprokit/src/tools/CMakeLists.txt
@@ -34,6 +34,7 @@ add_tool(pipe_config
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY})
 
 add_tool(pipe_to_dot
@@ -42,7 +43,9 @@ add_tool(pipe_to_dot
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_THREAD_LIBRARY}
+  )
 
 add_tool(pipeline_runner
   sprokit_tools
@@ -50,4 +53,5 @@ add_tool(pipeline_runner
   vital_config vital_vpm
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY})


### PR DESCRIPTION
This change fixes the following compile issue on Linux with CMake v3.15.4 and GCC v9.2.0

```shell_session
[525/620] Linking CXX executable bin/pipeline_runner
FAILED: bin/pipeline_runner
: && /usr/bin/c++  -std=c++11 -pthread -fvisibility=hidden -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=narrowing -Werror=init-self -Werror=reorder -Werror=overloaded-virtual -Werror=cast-qual -Werror=vla -Wno-unknown-pragmas -Wl,--no-undefined -Wl,--copy-dt-needed-entries -g  -rdynamic sprokit/src/tools/CMakeFiles/pipeline_runner.dir/pipeline_runner.cxx.o  -o bin/pipeline_runner -L/Projects/fletch/install/lib  -L/Projects/fletch/bld/install/lib  -L/Projects/kwiver/bld/lib -Wl,-rpath,"\$ORIGIN/../lib:\$ORIGIN/" lib/libsprokit_tools.so.1.4.0 /Projects/fletch/install/lib/libboost_filesystem.so /Projects/fletch/install/lib/libboost_program_options.so /Projects/fletch/install/lib/libboost_system.so lib/libsprokit_pipeline_util.so.1.4.0 lib/libsprokit_pipeline.so.1.4.0 /Projects/fletch/install/lib/libboost_chrono.so lib/libvital_config.so.1.4.0 lib/libvital_vpm.so.1.4.0 lib/libvital_logger.so.1.4.0 /Projects/fletch/install/lib/libboost_filesystem.so /Projects/fletch/install/lib/libboost_system.so lib/libvital_exceptions.so.1.4.0 lib/libkwiversys.so.1.4.0 -ldl lib/libvital_util.so.1.4.0 && :
/usr/bin/ld: warning: libboost_thread.so.1.65.1, needed by lib/libsprokit_pipeline_util.so.1.4.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::interruption_point()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::~disable_interruption()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::detail::get_current_thread_data()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::disable_interruption()'
collect2: error: ld returned 1 exit status
[526/620] Linking CXX executable bin/pipe_config
FAILED: bin/pipe_config
: && /usr/bin/c++  -std=c++11 -pthread -fvisibility=hidden -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=narrowing -Werror=init-self -Werror=reorder -Werror=overloaded-virtual -Werror=cast-qual -Werror=vla -Wno-unknown-pragmas -Wl,--no-undefined -Wl,--copy-dt-needed-entries -g  -rdynamic sprokit/src/tools/CMakeFiles/pipe_config.dir/pipe_config.cxx.o  -o bin/pipe_config -L/Projects/fletch/install/lib  -L/Projects/fletch/bld/install/lib  -L/Projects/kwiver/bld/lib -Wl,-rpath,"\$ORIGIN/../lib:\$ORIGIN/" lib/libsprokit_tools.so.1.4.0 lib/libsprokit_pipeline_util.so.1.4.0 /Projects/fletch/install/lib/libboost_filesystem.so /Projects/fletch/install/lib/libboost_program_options.so /Projects/fletch/install/lib/libboost_system.so lib/libsprokit_pipeline.so.1.4.0 /Projects/fletch/install/lib/libboost_chrono.so /Projects/fletch/install/lib/libboost_system.so lib/libvital_config.so.1.4.0 lib/libvital_vpm.so.1.4.0 lib/libvital_logger.so.1.4.0 lib/libvital_exceptions.so.1.4.0 lib/libkwiversys.so.1.4.0 -ldl lib/libvital_util.so.1.4.0 && :
/usr/bin/ld: warning: libboost_thread.so.1.65.1, needed by lib/libsprokit_pipeline_util.so.1.4.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::interruption_point()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::~disable_interruption()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::detail::get_current_thread_data()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::disable_interruption()'
collect2: error: ld returned 1 exit status
[527/620] Linking CXX executable bin/pipe_to_dot
FAILED: bin/pipe_to_dot
: && /usr/bin/c++  -std=c++11 -pthread -fvisibility=hidden -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=narrowing -Werror=init-self -Werror=reorder -Werror=overloaded-virtual -Werror=cast-qual -Werror=vla -Wno-unknown-pragmas -Wl,--no-undefined -Wl,--copy-dt-needed-entries -g  -rdynamic sprokit/src/tools/CMakeFiles/pipe_to_dot.dir/pipe_to_dot.cxx.o  -o bin/pipe_to_dot -L/Projects/fletch/install/lib  -L/Projects/fletch/bld/install/lib  -L/Projects/kwiver/bld/lib -Wl,-rpath,"\$ORIGIN/../lib:\$ORIGIN/" lib/libsprokit_tools.so.1.4.0 /Projects/fletch/install/lib/libboost_filesystem.so /Projects/fletch/install/lib/libboost_program_options.so /Projects/fletch/install/lib/libboost_system.so lib/libsprokit_pipeline_util.so.1.4.0 lib/libsprokit_pipeline.so.1.4.0 /Projects/fletch/install/lib/libboost_chrono.so lib/libvital_config.so.1.4.0 lib/libvital_vpm.so.1.4.0 lib/libvital_logger.so.1.4.0 /Projects/fletch/install/lib/libboost_filesystem.so /Projects/fletch/install/lib/libboost_system.so lib/libvital_exceptions.so.1.4.0 lib/libkwiversys.so.1.4.0 -ldl lib/libvital_util.so.1.4.0 && :
/usr/bin/ld: warning: libboost_thread.so.1.65.1, needed by lib/libsprokit_pipeline_util.so.1.4.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::interruption_point()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::~disable_interruption()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::detail::get_current_thread_data()'
/usr/bin/ld: lib/libsprokit_pipeline.so.1.4.0: undefined reference to `boost::this_thread::disable_interruption::disable_interruption()'
collect2: error: ld returned 1 exit status
```