### PR TITLE
Fix vital::point build errors on MSVC

### DIFF
--- a/vital/types/point.cxx
+++ b/vital/types/point.cxx
@@ -36,14 +36,6 @@
 namespace kwiver {
 namespace vital {
 
-template class point< 2, int >;
-template class point< 2, double >;
-template class point< 2, float >;
-template class point< 3, double >;
-template class point< 3, float >;
-template class point< 4, double >;
-template class point< 4, float >;
-
 // ----------------------------------------------------------------------------
 template < unsigned N, typename T >
 std::ostream&

--- a/vital/types/point.h
+++ b/vital/types/point.h
@@ -49,7 +49,7 @@ namespace kwiver {
 namespace vital {
 
 template < unsigned N, typename T >
-class VITAL_EXPORT point : protected Eigen::Matrix< T, N, 1 >
+class point : protected Eigen::Matrix< T, N, 1 >
 {
 public:
   using vector_type = Eigen::Matrix< T, N, 1 >;


### PR DESCRIPTION
Remove export decoration from `vital::point`; for some reason, this causes MSVC to try to over-instantiate the base `Eigen` type, which [ends badly](https://open.cdash.org/viewBuildError.php?buildid=6180125). (Why exporting causes this, when explicit instantiations don't, is not currently clear.) Because we never declare external instantiations, exporting isn't actually useful anyway, and other templated types (e.g. `vital::bounding_box`) also aren't exported.

~~Also, remove the virtual destructor from `vital::point`. It's not obvious why we would want this class to be polymorphic, and making it so adds overhead. (@aaron-bray, can you comment?)~~

See also https://stackoverflow.com/questions/58630573.