### PR TITLE
Fix missing header issue with vital/set.h

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -64,14 +64,16 @@ set( CMAKE_CXX_FLAGS ${save_flags} )
 #
 set( vital_public_headers
   vital_types.h
-  noncopyable.h
-  any.h
+
   algorithm_capabilities.h
+  any.h
   attribute_set.h
   exceptions.h
   iterator.h
   math_constants.h
+  noncopyable.h
   optional.h
+  set.h
 
   io/camera_from_metadata.h
   io/camera_io.h


### PR DESCRIPTION
This change fixes an issue when consuming the kwiver install tree in an
external project. The header "set.h" was missing from the install tree.