### PR TITLE
Improve vital::point construction (again)

### DIFF
--- a/vital/types/point.h
+++ b/vital/types/point.h
@@ -55,8 +55,21 @@ public:
   using vector_type = Eigen::Matrix< T, N, 1 >;
   using covariance_type = covariance_<N, float>;
 
-  point() { }
-  point(vector_type const& v) : m_value(v) { }
+  point() {}
+  explicit point( vector_type const& v, covariance_type const& c = {} )
+    : m_value{ v }, m_covariance{ c } {}
+
+  template < unsigned K = N,
+             typename std::enable_if< K == 2, bool >::type = true >
+  point( T x, T y ) : m_value{ x, y } {}
+
+  template < unsigned K = N,
+             typename std::enable_if< K == 3, bool >::type = true >
+  point( T x, T y, T z ) : m_value{ x, y, z } {}
+
+  template < unsigned K = N,
+             typename std::enable_if< K == 4, bool >::type = true >
+  point( T x, T y, T z, T w ) : m_value{ x, y, z, w } {}
 
   virtual ~point() = default;
 

--- a/vital/types/point.h
+++ b/vital/types/point.h
@@ -1,4 +1,4 @@
-/*ckwg +29
+/*ckwg +30
  * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
@@ -12,20 +12,21 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
  */
 
 /**
@@ -38,14 +39,16 @@
 #ifndef KWIVER_VITAL_POINT_H_
 #define KWIVER_VITAL_POINT_H_
 
-#include <vital/vital_config.h>
-#include <vital/vital_export.h>
 #include <vital/types/covariance.h>
 #include <vital/types/vector.h>
+
+#include <vital/vital_config.h>
+#include <vital/vital_export.h>
 
 #include <memory>
 
 namespace kwiver {
+
 namespace vital {
 
 template < unsigned N, typename T >
@@ -53,7 +56,7 @@ class VITAL_EXPORT point
 {
 public:
   using vector_type = Eigen::Matrix< T, N, 1 >;
-  using covariance_type = covariance_<N, float>;
+  using covariance_type = covariance_< N, float >;
 
   point() {}
   explicit point( vector_type const& v, covariance_type const& c = {} )
@@ -74,13 +77,10 @@ public:
   virtual ~point() = default;
 
   vector_type value() const { return m_value; }
-  void set_value(vector_type v) { m_value = v; }
+  void set_value( vector_type v ) { m_value = v; }
 
   covariance_type covariance() const { return m_covariance; }
-  void set_covariance(covariance_type v)
-  {
-    m_covariance = v;
-  }
+  void set_covariance( covariance_type const& v ) { m_covariance = v; }
 
 protected:
   vector_type m_value = vector_type::Zero();
@@ -96,14 +96,16 @@ using point_3f = point< 3, float >;
 using point_4d = point< 4, double >;
 using point_4f = point< 4, float >;
 
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_2i const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_2d const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_2f const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_3d const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_3f const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_4d const& obj );
-VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, point_4f const& obj );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_2i const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_2d const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_2f const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_3d const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_3f const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_4d const& );
+VITAL_EXPORT ::std::ostream& operator<<( ::std::ostream&, point_4f const& );
 
-} } // end namespace
+} // namespace vital
+
+} // namespace kwiver
 
 #endif


### PR DESCRIPTION
Since @mleotta [objected](https://github.com/Kitware/kwiver/pull/894#issuecomment-548803398) to inheriting from an Eigen type (and since doing so has [some issues](https://open.cdash.org/viewBuildError.php?buildid=6180125), due to Eigen's mechanism for handling what methods should or should not being available resulting in those types being non-instantiable), instead do this the hard way, by duplicating the set of constructors that we want to replicate. Unlike Eigen, however, properly use `enable_if` to ensure that only the appropriate overloads are available.

Also, fix the style in `point.h`.