### PR TITLE
Dev/plugin filter

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -23,6 +23,12 @@ Vital
  * Added support for registering callbacks to the KWIVER logger.  Callbacks
    receive any message that is logged with the KWIVER logging framework.
 
+Vital Plugin-loader
+
+ * Added support for filtering plugins when they are loaded. Filter
+   objects can be added to the plugin loader at run time to select or
+   exclude specific plugins.
+
 Vital Util
 
 Vital Tools

--- a/sprokit/processes/adapters/input_adapter_process.h
+++ b/sprokit/processes/adapters/input_adapter_process.h
@@ -51,7 +51,7 @@ class KWIVER_ADAPTER_EXPORT input_adapter_process
 {
 public:
   PLUGIN_INFO( "input_adapter",
-               "Source process for pipeline.\n\n"
+               "Source process for embedded pipeline.\n\n"
                "Pushes data items into pipeline ports. "
                "Ports are dynamically created as needed based on connections specified in the pipeline file." )
 

--- a/sprokit/processes/adapters/output_adapter_process.h
+++ b/sprokit/processes/adapters/output_adapter_process.h
@@ -51,7 +51,7 @@ class KWIVER_ADAPTER_EXPORT output_adapter_process
 {
 public:
   PLUGIN_INFO( "output_adapter",
-               "Sink process for pipeline.\n\n"
+               "Sink process for embedded pipeline.\n\n"
                "Accepts data items from pipeline ports. "
                "Ports are dynamically created as needed based on "
                "connections specified in the pipeline file." )

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -1351,7 +1351,7 @@ pipeline::priv
   {
     process::port_addr_t const& up_addr = connection.first;
 
-    const shared_port_map_t::const_iterator i = connected_shared_ports.find(up_addr);
+    shared_port_map_t::const_iterator const i = connected_shared_ports.find(up_addr);
 
     if (i == connected_shared_ports.end())
     {

--- a/sprokit/src/sprokit/pipeline/pipeline.cxx
+++ b/sprokit/src/sprokit/pipeline/pipeline.cxx
@@ -1325,16 +1325,23 @@ pipeline::priv
 
 
 // ------------------------------------------------------------------
+/// Check connection flags to see if they are consistent.
+/**
+ * This method checks the flags for a proposed connection to see if
+ * they are consistent and the connection should be allowed.
+ */
 bool
 pipeline::priv
 ::check_connection_flags(process::connection_t const& connection,
                          process::port_flags_t const& up_flags,
                          process::port_flags_t const& down_flags)
 {
+  // Test the port flags to see what has been specified at port creation time.
   bool const is_const = (0 != up_flags.count(process::flag_output_const));
   bool const is_shared = (0 != up_flags.count(process::flag_output_shared));
   bool const is_mutable = (0 != down_flags.count(process::flag_input_mutable));
 
+  // If "up" is const and "down" is mutable, then connection is not allowed
   if (is_const && is_mutable)
   {
     return false;
@@ -1344,16 +1351,17 @@ pipeline::priv
   {
     process::port_addr_t const& up_addr = connection.first;
 
-    shared_port_map_t::const_iterator const i = connected_shared_ports.find(up_addr);
+    const shared_port_map_t::const_iterator i = connected_shared_ports.find(up_addr);
 
     if (i == connected_shared_ports.end())
     {
       // Nothing is connected yet.
+      // Since the port is shared, then mark as mutable.
       connected_shared_ports[up_addr] = is_mutable;
     }
     else
     {
-      bool const& has_mutable = i->second;
+      const bool has_mutable = i->second;
 
       // Only one input can listen to a shared port if any are mutable.
       if (is_mutable || has_mutable)
@@ -1363,6 +1371,7 @@ pipeline::priv
     }
   }
 
+  // All other combinations are allowable
   return true;
 }
 

--- a/sprokit/src/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/sprokit/pipeline/process_factory.cxx
@@ -46,7 +46,7 @@ process_factory( const std::string& type,
 {
   this->add_attribute( CONCRETE_TYPE, type)
     .add_attribute( PLUGIN_FACTORY_TYPE, typeid(* this ).name() )
-    .add_attribute( PLUGIN_CATEGORY, "process" );
+    .add_attribute( PLUGIN_CATEGORY, PROCESS_CATEGORY );
 }
 
 
@@ -80,7 +80,7 @@ cpp_process_factory( const std::string& type,
 {
   this->add_attribute( CONCRETE_TYPE, type)
     .add_attribute( PLUGIN_FACTORY_TYPE, typeid(* this ).name() )
-    .add_attribute( PLUGIN_CATEGORY, "process" );
+    .add_attribute( PLUGIN_CATEGORY, PROCESS_CATEGORY );
 }
 
 

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -231,10 +231,10 @@ public:
   {
     using kvpf = kwiver::vital::plugin_factory;
 
-    auto fact = plugin_loader()
-      .add_factory( new sprokit::cpp_process_factory( typeid( process_t ).name(),
-                                                      typeid( sprokit::process ).name(),
-                                                      sprokit::create_new_process< process_t > ) );
+    kwiver::vital::plugin_factory* fact =  new sprokit::cpp_process_factory(
+      typeid( process_t ).name(),
+      typeid( sprokit::process ).name(),
+      sprokit::create_new_process< process_t > );
 
     fact->add_attribute( kvpf::PLUGIN_NAME,      process_t::_plugin_name )
       .add_attribute( kvpf::PLUGIN_DESCRIPTION,  process_t::_plugin_description )
@@ -247,7 +247,7 @@ public:
       fact->add_attribute( "no-test", "introspect" ); // do not include in introspection test
     }
 
-    return fact;
+    return plugin_loader().add_factory( fact );
   }
 };
 

--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -32,9 +32,12 @@
 #include <vital/applets/kwiver_applet.h>
 #include <vital/applets/applet_context.h>
 
-#include <vital/plugin_loader/plugin_manager.h>
-#include <vital/plugin_loader/plugin_factory.h>
+#include <vital/applets/applet_registrar.h>
 #include <vital/exceptions/base.h>
+#include <vital/plugin_loader/plugin_factory.h>
+#include <vital/plugin_loader/plugin_filter_category.h>
+#include <vital/plugin_loader/plugin_filter_default.h>
+#include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/get_paths.h>
 
 #include <cstdlib>
@@ -181,6 +184,8 @@ int main(int argc, char *argv[])
   // Global shared context
   // Allocated on the stack so it will automatically clean up
   //
+  using kvpf = kwiver::vital::plugin_factory;
+
   applet_context_t tool_context = std::make_shared< kwiver::tools::applet_context >();
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
@@ -188,6 +193,14 @@ int main(int argc, char *argv[])
   vpm.add_search_path(exec_path + "/../lib/kwiver/modules");
   vpm.add_search_path(exec_path + "/../lib/kwiver/modules/applets");
   vpm.add_search_path(exec_path + "/../lib/kwiver/processes");
+
+  // remove all default plugin filters
+  vpm.get_loader()->clear_filters();
+
+  // Add filter to select all plugins
+  kwiver::vital::plugin_filter_handle_t filt = std::make_shared<kwiver::vital::plugin_filter_default>();
+  vpm.get_loader()->add_filter( filt );
+
   vpm.load_all_plugins();
 
   // initialize the global context

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -66,7 +66,7 @@ public:
     : plugin_factory( algo ) // interface type
   {
     this->add_attribute( PLUGIN_NAME, impl )
-      .add_attribute( PLUGIN_CATEGORY, "algorithm" );
+      .add_attribute( PLUGIN_CATEGORY, ALGORITHM_CATEGORY );
   }
 
   virtual ~algorithm_factory() = default;
@@ -179,17 +179,16 @@ public:
   {
     using kvpf = kwiver::vital::plugin_factory;
 
-    auto fact = plugin_loader().
-      add_factory( new kwiver::vital::algorithm_factory_0<algorithm_t>(
-                     algorithm_t::static_type_name(),
-                     algorithm_t::_plugin_name ));
+    kwiver::vital::plugin_factory* fact = new kwiver::vital::algorithm_factory_0<algorithm_t>(
+      algorithm_t::static_type_name(),
+      algorithm_t::_plugin_name );
 
     fact->add_attribute( kvpf::PLUGIN_DESCRIPTION,  algorithm_t::_plugin_description)
       .add_attribute( kvpf::PLUGIN_MODULE_NAME,  this->module_name() )
       .add_attribute( kvpf::PLUGIN_ORGANIZATION, this->organization() )
       ;
 
-    return fact;
+    return plugin_loader().add_factory( fact );
   }
 };
 

--- a/vital/applets/applet_registrar.h
+++ b/vital/applets/applet_registrar.h
@@ -70,18 +70,17 @@ public:
   {
     using kvpf = kwiver::vital::plugin_factory;
 
-    auto fact = plugin_loader().
-      add_factory( new kwiver::vital::plugin_factory_0< tool_t >(
-                     typeid( kwiver::tools::kwiver_applet ).name() ) );
+    kwiver::vital::plugin_factory* fact = new kwiver::vital::plugin_factory_0< tool_t >(
+      typeid( kwiver::tools::kwiver_applet ).name() );
 
     fact->add_attribute( kvpf::PLUGIN_NAME,      tool_t::_plugin_name )
       .add_attribute( kvpf::PLUGIN_DESCRIPTION,  tool_t::_plugin_description )
       .add_attribute( kvpf::PLUGIN_MODULE_NAME,  this->module_name() )
       .add_attribute( kvpf::PLUGIN_ORGANIZATION, this->organization() )
-      .add_attribute( kvpf::PLUGIN_CATEGORY,     "kwiver-applet" )
+      .add_attribute( kvpf::PLUGIN_CATEGORY,     kvpf::APPLET_CATEGORY )
       ;
 
-    return fact;
+    return plugin_loader().add_factory( fact );
   }
 };
 

--- a/vital/bindings/python/vital/algo/algorithm_factory.cxx
+++ b/vital/bindings/python/vital/algo/algorithm_factory.cxx
@@ -45,7 +45,7 @@
 
 namespace py = pybind11;
 
-static void add_algorithm( const std::string& impl_name, std::string const& description, 
+static void add_algorithm( const std::string& impl_name, std::string const& description,
                             py::object conc_t );
 
 void mark_algorithm_as_loaded( const std::string& module_name );
@@ -111,6 +111,8 @@ kwiver::vital::algorithm_sptr python_algorithm_factory::create_object_a()
 static void add_algorithm( std::string const& impl_name, std::string const& description,
                             py::object conc_f)
 {
+  using kvpf = kwiver::vital::plugin_factory;
+
   kwiver::vital::python::gil_scoped_acquire acquire;
   (void)acquire;
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
@@ -120,7 +122,9 @@ static void add_algorithm( std::string const& impl_name, std::string const& desc
                                                               conc_f ));
 
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, impl_name)
-      .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, description );
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, description )
+    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, kvpf::ALGORITHM_CATEGORY )
+    ;
 }
 
 void mark_algorithm_as_loaded( const std::string& name )
@@ -154,4 +158,3 @@ static std::vector< std::string > implementation_names(const std::string& algori
 
   return all_implementations;
 }
-

--- a/vital/plugin_loader/CMakeLists.txt
+++ b/vital/plugin_loader/CMakeLists.txt
@@ -9,9 +9,6 @@ set(vital_vpm_headers
   plugin_manager.h
   plugin_info.h
   plugin_registrar.h
-  plugin_loader_filter.h
-  plugin_filter_default.h
-  plugin_filter_category.h
   )
 
 set(vital_vpm_sources
@@ -23,6 +20,9 @@ set(vital_vpm_sources
   )
 
 set(vital_vpm_headers_private
+  plugin_loader_filter.h
+  plugin_filter_default.h
+  plugin_filter_category.h
   ${CMAKE_CURRENT_BINARY_DIR}/vital_vpm_export.h
   )
 
@@ -48,6 +48,7 @@ target_link_libraries(vital_vpm
                       kwiversys
   PRIVATE             vital_logger
                       vital_exceptions
+                      ${VITAL_BOOST_REGEX}
   )
 
 ###

--- a/vital/plugin_loader/CMakeLists.txt
+++ b/vital/plugin_loader/CMakeLists.txt
@@ -9,12 +9,17 @@ set(vital_vpm_headers
   plugin_manager.h
   plugin_info.h
   plugin_registrar.h
+  plugin_loader_filter.h
+  plugin_filter_default.h
+  plugin_filter_category.h
   )
 
 set(vital_vpm_sources
   plugin_loader.cxx
   plugin_factory.cxx
   plugin_manager.cxx
+  plugin_filter_default.cxx
+  plugin_filter_category.cxx
   )
 
 set(vital_vpm_headers_private

--- a/vital/plugin_loader/plugin_factory.cxx
+++ b/vital/plugin_loader/plugin_factory.cxx
@@ -47,6 +47,10 @@ const std::string plugin_factory::PLUGIN_LICENSE( "plugin-license" );
 const std::string plugin_factory::PLUGIN_CATEGORY( "plugin-category" );
 const std::string plugin_factory::PLUGIN_PROCESS_PROPERTIES( "plugin-process-properties" );
 
+const std::string plugin_factory::APPLET_CATEGORY( "kwiver-applet" );
+const std::string plugin_factory::PROCESS_CATEGORY( "process" );
+const std::string plugin_factory::ALGORITHM_CATEGORY( "algorithm" );
+
 
 // ------------------------------------------------------------------
 plugin_factory::

--- a/vital/plugin_loader/plugin_factory.h
+++ b/vital/plugin_loader/plugin_factory.h
@@ -86,6 +86,10 @@ public:
   static const std::string PLUGIN_ORGANIZATION;
   static const std::string PLUGIN_LICENSE;
 
+  // plugin categories
+  static const std::string APPLET_CATEGORY;
+  static const std::string PROCESS_CATEGORY;
+  static const std::string ALGORITHM_CATEGORY;
 
   /**
    * @brief Get attribute from factory

--- a/vital/plugin_loader/plugin_filter_category.cxx
+++ b/vital/plugin_loader/plugin_filter_category.cxx
@@ -1,0 +1,85 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "plugin_filter_category.h"
+#include "plugin_factory.h"
+#include "plugin_loader.h"
+
+#include <iostream>
+
+namespace kwiver {
+namespace vital {
+
+// ----------------------------------------------------------------------------
+plugin_filter_category
+::plugin_filter_category( plugin_filter_category::condition cond,
+                          const std::string& cat)
+  : m_condition( cond ),
+    m_category( cat )
+{ }
+
+
+// ------------------------------------------------------------------
+/**
+ * @brief Filter select or reject plugins by category.
+ *
+ * This method compares the factory against the supplied category and,
+ * depending on whether the category is included or excluded, returns
+ * that indication.
+ *
+ * @param fact Factory object handle
+ *
+ * @return \b true if factory is to be added; \b false if factory
+ * should not be added.
+ *
+ */
+bool
+plugin_filter_category
+::add_factory( plugin_factory_handle_t fact ) const
+{
+  std::string cat;
+  if ( fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, cat ) )
+  {
+    if ( m_condition == condition::EQUAL )
+    {
+      return (cat == m_category );
+    }
+    else
+    {
+      return (cat != m_category );
+    }
+  }
+
+  // Select if category not available
+  return true;
+
+}
+
+} } // end namespace

--- a/vital/plugin_loader/plugin_filter_category.h
+++ b/vital/plugin_loader/plugin_filter_category.h
@@ -1,0 +1,73 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_FITAL_PLUGIN_FILTER_CATEGORY_H
+#define KWIVER_FITAL_PLUGIN_FILTER_CATEGORY_H
+
+#include <vital/plugin_loader/vital_vpm_export.h>
+
+#include <vital/plugin_loader/plugin_loader_filter.h>
+
+namespace kwiver {
+namespace vital {
+
+// -----------------------------------------------------------------
+/** Select plugin based on category name.
+ *
+ * This filter class selects a plugin based on the specified category
+ * name and condition. Plugins of a specific category can be included
+ * or excluded from loading.
+ *
+ * EQUAL selects or includes plugins of specified category.
+ * NOT_EQUAL excludes plugins of specified category.
+ */
+class VITAL_VPM_EXPORT plugin_filter_category
+  : public plugin_loader_filter
+{
+public:
+  enum class condition { EQUAL, // select plugins of specified category
+                         NOT_EQUAL }; // excludeplugins of specified category
+
+  // -- CONSTRUCTORS --
+  plugin_filter_category( plugin_filter_category::condition cond,
+                          const std::string& cat);
+  virtual ~plugin_filter_category() = default;
+
+  virtual bool add_factory( plugin_factory_handle_t fact ) const;
+
+private:
+  plugin_filter_category::condition m_condition;
+  std::string m_category;
+
+}; // end class plugin_filter_category
+
+} } // end namespace
+
+#endif // KWIVER_FITAL_PLUGIN_FILTER_CATEGORY_H

--- a/vital/plugin_loader/plugin_filter_default.cxx
+++ b/vital/plugin_loader/plugin_filter_default.cxx
@@ -1,0 +1,117 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "plugin_filter_default.h"
+#include "plugin_factory.h"
+#include "plugin_loader.h"
+
+#include <vital/exceptions/plugin.h>
+#include <vital/util/demangle.h>
+
+namespace kwiver {
+namespace vital {
+
+// ------------------------------------------------------------------
+/**
+ * @brief Detault add_factory filter
+ *
+ * This is the default implementation for the add_factory hook. This
+ * checks to see if the plugin is already registered. If it is, then
+ * an exception is thrown.
+ *
+ * The signature of a plugin consists of interface-type,
+ * concrete-type, and plugin-name.
+ *
+ * Note that derived classes can override this hook to give different
+ * behaviour.
+ *
+ * @param fact Factory object handle
+ *
+ * @return \b true if factory is to be added; \b false if factory
+ * should not be added.
+ *
+ * @throws plugin_already_exists if plugin is already registered
+ */
+bool
+plugin_filter_default
+::add_factory( plugin_factory_handle_t fact ) const
+{
+  std::string file_name;
+  fact->get_attribute( plugin_factory::PLUGIN_FILE_NAME, file_name );
+
+  std::string interface_type;
+  fact->get_attribute( plugin_factory::INTERFACE_TYPE, interface_type );
+
+  std::string concrete_type;
+  fact->get_attribute( plugin_factory::CONCRETE_TYPE, concrete_type );
+
+  std::string new_name;
+  fact->get_attribute( plugin_factory::PLUGIN_NAME, new_name );
+
+  auto plugin_map = m_loader->get_plugin_map();
+  auto fact_list = plugin_map[interface_type];
+
+  // Make sure factory is not already in the list.
+  // Check the two types and name as a signature.
+  if ( fact_list.size() > 0)
+  {
+    for( auto const afact : fact_list )
+    {
+      std::string interf;
+      afact->get_attribute( plugin_factory::INTERFACE_TYPE, interf );
+
+      std::string inst;
+      afact->get_attribute( plugin_factory::CONCRETE_TYPE, inst );
+
+      std::string name;
+      afact->get_attribute( plugin_factory::PLUGIN_NAME, name );
+
+      if ( (interface_type == interf) &&
+           (concrete_type == inst) &&
+           (new_name == name) )
+      {
+        std::string old_file;
+        afact->get_attribute( plugin_factory::PLUGIN_FILE_NAME, old_file );
+
+        std::stringstream str;
+        str << "Factory for \"" << demangle( interface_type ) << "\" : \""
+            << demangle( concrete_type ) << "\" already has been registered by "
+            << old_file << ".  This factory from "
+            << file_name << " will not be registered.";
+
+        VITAL_THROW( plugin_already_exists, str.str() );
+      }
+    } // end foreach
+  }
+
+  return true;
+}
+
+} } // end namespace

--- a/vital/plugin_loader/plugin_filter_default.h
+++ b/vital/plugin_loader/plugin_filter_default.h
@@ -42,7 +42,7 @@ namespace vital {
 /** Default plugin loader filter.
  *
  * This filter excludes duplicate plugins. An exception is thrown if a
- * suplicate is found.
+ * duplicate is found.
  */
 class VITAL_VPM_EXPORT plugin_filter_default
   : public plugin_loader_filter

--- a/vital/plugin_loader/plugin_filter_default.h
+++ b/vital/plugin_loader/plugin_filter_default.h
@@ -1,0 +1,61 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_FITAL_PLUGIN_FILTER_DEFAULT_H
+#define KWIVER_FITAL_PLUGIN_FILTER_DEFAULT_H
+
+#include <vital/plugin_loader/vital_vpm_export.h>
+
+#include <vital/plugin_loader/plugin_loader_filter.h>
+
+namespace kwiver {
+namespace vital {
+
+// -----------------------------------------------------------------
+/** Default plugin loader filter.
+ *
+ * This filter excludes duplicate plugins. An exception is thrown if a
+ * suplicate is found.
+ */
+class VITAL_VPM_EXPORT plugin_filter_default
+  : public plugin_loader_filter
+{
+public:
+  // -- CONSTRUCTORS --
+  plugin_filter_default() = default;
+  virtual ~plugin_filter_default() = default;
+
+  virtual bool add_factory( plugin_factory_handle_t fact ) const;
+
+}; // end class plugin_filter_default
+
+} } // end namespace
+
+#endif // KWIVER_FITAL_PLUGIN_FILTER_DEFAULT_H

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -48,7 +48,7 @@ namespace {
 
 using ST =  kwiversys::SystemTools;
 using DL =  kwiversys::DynamicLoader;
-  using library_t =  DL::LibraryHandle;
+using library_t =  DL::LibraryHandle;
 using function_t = DL::SymbolPointer;
 
 } // end anon namespace

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -46,10 +46,10 @@ namespace vital {
 
 namespace {
 
-typedef kwiversys::SystemTools     ST;
-typedef kwiversys::DynamicLoader   DL;
-typedef DL::LibraryHandle          library_t;
-typedef DL::SymbolPointer          function_t;
+using ST =  kwiversys::SystemTools;
+using DL =  kwiversys::DynamicLoader;
+  using library_t =  DL::LibraryHandle;
+using function_t = DL::SymbolPointer;
 
 } // end anon namespace
 
@@ -104,6 +104,9 @@ public:
 
   // Name of current module file we are processing
   std::string m_current_filename;
+
+  std::vector< plugin_filter_handle_t > m_filters;
+
 }; // end class plugin_loader_impl
 
 
@@ -113,7 +116,6 @@ plugin_loader
                  std::string const& shared_lib_suffix )
   : m_logger( kwiver::vital::get_logger( "vital.plugin_loader" ) )
   , m_impl( new plugin_loader_impl( this, init_function, shared_lib_suffix ) )
-
 { }
 
 
@@ -156,14 +158,17 @@ plugin_loader
   fact->get_attribute( plugin_factory::CONCRETE_TYPE, concrete_type );
 
   // If the hook has declined to register the factory, just return.
-  if ( ! this->add_factory_hook( fact_handle ) )
+  for ( auto filt : m_impl->m_filters )
   {
-    LOG_TRACE( m_logger, "add_factory_hook() declined to have this factory registered"
-               << " from file \"" << m_impl->m_current_filename << "\""
-               << " for interface: \"" << demangle( interface_type )
-               << "\" for derived type: \"" << demangle( concrete_type ) << "\""
-      );
-    return fact_handle;
+    if ( ! filt->add_factory( fact_handle ) )
+    {
+      LOG_TRACE( m_logger, "Factory filter() declined to have this factory registered"
+                 << " from file \"" << m_impl->m_current_filename << "\""
+                 << "\"" << demangle( interface_type )
+                 << "\" for derived type: \"" << demangle( concrete_type ) << "\""
+        );
+      return fact_handle;
+    }
   }
 
   // Add factory to rest of its family
@@ -400,10 +405,13 @@ plugin_loader_impl
 
   // Check with the load hook to see if there are any last minute
   // objections to loading this plugin.
-  if ( ! m_parent->load_plugin_hook( path, lib_handle ) )
+  for ( auto filter : m_filters )
   {
-    DL::CloseLibrary( lib_handle );
-    return;
+    if ( ! filter->load_plugin( path, lib_handle ) )
+    {
+      DL::CloseLibrary( lib_handle );
+      return;
+    }
   }
 
   // Save currently opened library in map
@@ -416,87 +424,20 @@ plugin_loader_impl
   ( *reg_fp )( m_parent ); // register plugins
 }
 
-
-// ------------------------------------------------------------------
-bool
-plugin_loader
-::load_plugin_hook( path_t const& path, DL::LibraryHandle lib_handle ) const
+// ----------------------------------------------------------------------------
+void plugin_loader
+::clear_filters()
 {
-  return true; // default is to always load
+  m_impl->m_filters.clear();
 }
 
-
-// ------------------------------------------------------------------
-/**
- * @brief Detault add_factory hook
- *
- * This is the default implementation for the add_factory hook. This
- * checks to see if the plugin is already registered. If it is, then
- * an exception is thrown.
- *
- * The signature of a plugin consists of interface-type,
- * concrete-type, and plugin-name.
- *
- * Note that derived classes can override this hook to give different
- * behaviour.
- *
- * @param fact Factory object handle
- *
- * @return \b true if factory is to be added; \b false if factory
- * should not be added.
- *
- * @throws plugin_already_exists if plugin is already registered
- */
-bool
-plugin_loader
-::add_factory_hook( plugin_factory_handle_t fact ) const
+// ----------------------------------------------------------------------------
+void plugin_loader
+::add_filter( plugin_filter_handle_t f )
 {
-  // Add the current file name as an attribute.
-  fact->add_attribute( plugin_factory::PLUGIN_FILE_NAME, m_impl->m_current_filename );
-
-  std::string interface_type;
-  fact->get_attribute( plugin_factory::INTERFACE_TYPE, interface_type );
-
-  std::string concrete_type;
-  fact->get_attribute( plugin_factory::CONCRETE_TYPE, concrete_type );
-
-  std::string new_name;
-  fact->get_attribute( plugin_factory::PLUGIN_NAME, new_name );
-
-  // Make sure factory is not already in the list.
-  // Check the two types and name as a signature.
-  if ( m_impl->m_plugin_map.count( interface_type ) != 0)
-  {
-    for( auto const fact : m_impl->m_plugin_map[interface_type] )
-    {
-      std::string interf;
-      fact->get_attribute( plugin_factory::INTERFACE_TYPE, interf );
-
-      std::string inst;
-      fact->get_attribute( plugin_factory::CONCRETE_TYPE, inst );
-
-      std::string name;
-      fact->get_attribute( plugin_factory::PLUGIN_NAME, name );
-
-      if ( (interface_type == interf) &&
-           (concrete_type == inst) &&
-           (new_name == name) )
-      {
-        std::string old_file;
-        fact->get_attribute( plugin_factory::PLUGIN_FILE_NAME, old_file );
-
-        std::stringstream str;
-        str << "Factory for \"" << demangle( interface_type ) << "\" : \""
-            << demangle( concrete_type ) << "\" already has been registered by "
-            << old_file << ".  This factory from "
-            << m_impl->m_current_filename << " will not be registered.";
-
-        VITAL_THROW( plugin_already_exists, str.str() );
-      }
-    } // end foreach
-  }
-
-  return true;
+  f->m_loader = this;
+  m_impl->m_filters.push_back( f );
 }
+
 
 } } // end namespace

--- a/vital/plugin_loader/plugin_loader.h
+++ b/vital/plugin_loader/plugin_loader.h
@@ -32,6 +32,7 @@
 #define KWIVER_VITAL_PLUGIN_LOADER_H_
 
 #include <vital/plugin_loader/vital_vpm_export.h>
+#include <vital/plugin_loader/plugin_loader_filter.h>
 
 #include <vital/vital_types.h>
 #include <vital/logger/logger.h>
@@ -50,10 +51,10 @@ namespace vital {
 // base class of factory hierarchy
 class plugin_factory;
 
-typedef std::shared_ptr< plugin_factory >         plugin_factory_handle_t;
-typedef std::vector< plugin_factory_handle_t >    plugin_factory_vector_t;
-typedef std::map< std::string, plugin_factory_vector_t > plugin_map_t;
-typedef std::map< std::string, path_t >           plugin_module_map_t;
+using plugin_factory_handle_t = std::shared_ptr< plugin_factory >;
+using plugin_factory_vector_t = std::vector< plugin_factory_handle_t >;
+using plugin_map_t            = std::map< std::string, plugin_factory_vector_t >;
+using plugin_module_map_t     =  std::map< std::string, path_t >;
 
 class plugin_loader_impl;
 
@@ -237,57 +238,12 @@ public:
    */
   plugin_module_map_t const& get_module_map() const;
 
+  void clear_filters();
+  void add_filter( plugin_filter_handle_t f );
 
 protected:
   friend class plugin_loader_impl;
 
-  /**
-   * @brief Test if plugin should be loaded.
-   *
-   * This method is a hook that can be implemented by a derived class
-   * to verify that the specified plugin should be loaded. This
-   * provides an application level approach to filter specific plugins
-   * from a directory. The default implementation is to load all
-   * discovered plugins.
-   *
-   * This method is called after the plugin is opened and the
-   * designated initialization method has been located but not yet
-   * called. Returning \b false from this method will result in the
-   * library being closed without further processing.
-   *
-   * The library handle can be used to inspect the contents of the
-   * plugin as needed.
-   *
-   * @param path File path to the plugin being loaded.
-   * @param lib_handle Handle to library.
-   *
-   * @return \b true if the plugin should be loaded, \b false if plugin should not be loaded
-   */
-  virtual bool load_plugin_hook( path_t const& path,
-                                 DL::LibraryHandle lib_handle ) const;
-
-  /**
-   * @brief Test if factory should be registered.
-   *
-   * This method is a hook that can be implemented by a derived class
-   * to verify that the specified factory should be registered. This
-   * provides an application level approach to filtering specific
-   * class factories from a plugin.
-   *
-   * This method is called as the plugin is registering class
-   * factories and can inspect attributes to determine if this factory
-   * should be registered. Returning \b false will prevent this
-   * factory from being registered with the plugin manager.
-   *
-   * A slight misapplication of this hook method could be to add
-   * specific attributes to a set of factories before they are
-   * registered.
-   *
-   * @param fact Pointer to the factory object.
-   *
-   * @return \b true if the plugin should be registered, \b false otherwise.
-   */
-  virtual bool add_factory_hook( plugin_factory_handle_t fact ) const;
 
   kwiver::vital::logger_handle_t m_logger;
 

--- a/vital/plugin_loader/plugin_loader_filter.h
+++ b/vital/plugin_loader/plugin_loader_filter.h
@@ -1,0 +1,123 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_VITAL_PLUGIN_LOADER_FILTER_H
+#define KWIVER_VITAL_PLUGIN_LOADER_FILTER_H
+
+#include <kwiversys/DynamicLoader.hxx>
+
+#include <vital/vital_types.h>
+
+#include <memory>
+
+namespace kwiver {
+namespace vital {
+
+// base class of factory hierarchy
+class plugin_factory;
+class plugin_loader;
+
+using plugin_factory_handle_t = std::shared_ptr< plugin_factory >;
+
+// -----------------------------------------------------------------
+/** Interface to plugin loader filters.
+ *
+ *
+ */
+class plugin_loader_filter
+{
+public:
+  using DL = kwiversys::DynamicLoader;
+
+  // -- CONSTRUCTORS --
+  plugin_loader_filter() = default;
+  virtual ~plugin_loader_filter() = default;
+
+  /**
+   * @brief Test if plugin should be loaded.
+   *
+   * This method is a hook that can be implemented by a derived class
+   * to verify that the specified plugin should be loaded. This
+   * provides an application level approach to filter specific plugins
+   * from a directory. The default implementation is to load all
+   * discovered plugins.
+   *
+   * This method is called after the plugin is opened and the
+   * designated initialization method has been located but not yet
+   * called. Returning \b false from this method will result in the
+   * library being closed without further processing.
+   *
+   * The library handle can be used to inspect the contents of the
+   * plugin as needed.
+   *
+   * @param path File path to the plugin being loaded.
+   * @param lib_handle Handle to library.
+   *
+   * @return \b true if the plugin should be loaded, \b false if plugin should not be loaded
+   */
+  virtual bool load_plugin( path_t const& path,
+                            DL::LibraryHandle lib_handle ) const
+    { return true; }
+
+  /**
+   * @brief Test if factory should be registered.
+   *
+   * This method is a hook that can be implemented by a derived class
+   * to verify that the specified factory should be registered. This
+   * provides an application level approach to filtering specific
+   * class factories from a plugin.
+   *
+   * This method is called as the plugin is registering class
+   * factories and can inspect attributes to determine if this factory
+   * should be registered. Returning \b false will prevent this
+   * factory from being registered with the plugin manager.
+   *
+   * A slight misapplication of this hook method could be to add
+   * specific attributes to a set of factories before they are
+   * registered.
+   *
+   * @param fact Pointer to the factory object.
+   *
+   * @return \b true if the plugin should be registered, \b false otherwise.
+   */
+  virtual bool add_factory( plugin_factory_handle_t fact ) const
+    { return true; }
+
+
+  // reference to the owning loader.
+  plugin_loader* m_loader;
+
+}; // end class plugin_loader_filter
+
+using plugin_filter_handle_t = std::shared_ptr< plugin_loader_filter >;
+
+} } // end namespace
+
+#endif //KWIVER_VITAL_PLUGIN_LOADER_FILTER_H

--- a/vital/plugin_loader/plugin_manager.cxx
+++ b/vital/plugin_loader/plugin_manager.cxx
@@ -36,8 +36,10 @@
 #include "plugin_manager.h"
 
 #include <vital/algorithm_plugin_manager_paths.h> //+ maybe rename later
-
+#include <vital/applets/applet_registrar.h>
 #include <vital/logger/logger.h>
+#include <vital/plugin_loader/plugin_filter_category.h>
+#include <vital/plugin_loader/plugin_filter_default.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -72,7 +74,18 @@ public:
     : m_all_loaded( false )
     , m_loader( new plugin_loader( register_function_name, shared_library_suffix ) )
     , m_logger( kwiver::vital::get_logger( "vital.plugin_manager" ) )
-  { }
+  {
+    using kvpf = kwiver::vital::plugin_factory;
+
+    // Add the default filter which checks for duplicate plugins
+    plugin_filter_handle_t filt = std::make_shared<kwiver::vital::plugin_filter_default>();
+    m_loader->add_filter( filt );
+
+    // Add filter that excludes applets
+    filt = std::make_shared<kwiver::vital::plugin_filter_category>(
+      plugin_filter_category::condition::NOT_EQUAL, kvpf::APPLET_CATEGORY );
+    m_loader->add_filter( filt );
+  }
 
 
   bool m_all_loaded;            ///< set if modules are loaded

--- a/vital/plugin_loader/plugin_manager.h
+++ b/vital/plugin_loader/plugin_manager.h
@@ -284,8 +284,9 @@ public:
    */
   kwiver::vital::logger_handle_t logger();
 
-protected:
   kwiver::vital::plugin_loader* get_loader();
+
+protected:
 
   plugin_manager();
   ~plugin_manager();

--- a/vital/plugin_loader/plugin_registrar.h
+++ b/vital/plugin_loader/plugin_registrar.h
@@ -32,6 +32,7 @@
 #define PLUGIN_LOADER_PLUGIN_REGISTRAR_H
 
 #include <vital/plugin_loader/plugin_factory.h>
+#include <vital/plugin_loader/plugin_loader.h>
 
 #if ! defined( KWIVER_DEFAULT_PLUGIN_ORGANIZATION )
 #define KWIVER_DEFAULT_PLUGIN_ORGANIZATION "undefined"


### PR DESCRIPTION
A plugin filter implementation has been added to provide
the capability for selecting/excluding sets of plugins.
Currently there is support for selecting/excluding by
plugin category. Others can be added as needed.

- Added generic plugin filter
- Added API to plugin loader to manage filters
- Removed internal filtering and use filtering delegate
- Moved default filtering to external filter
- Added filter to select/exclude by plugin category
- Used category filter to select/exclude applets
- Cleaned up category name handling