### PR TITLE
Callbacks in loggers

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -20,6 +20,9 @@ Vital
  * Added a variant of config_block::get_enum_value that accepts a default
    value to fall back on.
 
+ * Added support for registering callbacks to the KWIVER logger.  Callbacks
+   receive any message that is logged with the KWIVER logging framework.
+
 Vital Util
 
 Vital Tools

--- a/vital/logger/default_logger.cxx
+++ b/vital/logger/default_logger.cxx
@@ -214,6 +214,7 @@ private:
                             std::string const&  msg )
   {
     log_message_i( level, msg, "" );
+    do_callback(level, msg, location_info());
   }
 
 
@@ -270,6 +271,7 @@ private:
     loc << location.get_file_name() << "(" << location.get_line_number() << "): ";
 
     log_message_i( level, msg, loc.str() );
+    do_callback(level, msg, location);
   }
 
 

--- a/vital/logger/kwiver_logger.cxx
+++ b/vital/logger/kwiver_logger.cxx
@@ -39,7 +39,8 @@ class kwiver_logger::impl
 public:
   impl( logger_ns::kwiver_logger_factory* f, std::string const& node )
     : m_factory( f ),
-      m_loggingNode( node )
+      m_loggingNode( node ),
+      m_local_callback( nullptr )
   { }
 
 
@@ -48,7 +49,15 @@ public:
 
   /// Hierarchical logging node.
   std::string m_loggingNode;
+
+  /// Local callback called only for this instance
+  kwiver_logger::callback_t m_local_callback;
+
+  /// Global callback shared by all logger instances
+  static kwiver_logger::callback_t m_global_callback;
 };
+
+kwiver_logger::callback_t kwiver_logger::impl::m_global_callback = nullptr;
 
 
 // ------------------------------------------------------------------
@@ -86,7 +95,7 @@ char const* kwiver_logger
 
 // ------------------------------------------------------------------
 std::string kwiver_logger
-::get_name()
+::get_name() const
 {
   return m_impl->m_loggingNode;
 }
@@ -97,6 +106,35 @@ std::string const& kwiver_logger
 ::get_factory_name() const
 {
   return m_impl->m_factory->get_factory_name();
+}
+
+// ------------------------------------------------------------------
+void kwiver_logger
+::set_local_callback(callback_t cb)
+{
+  m_impl->m_local_callback = cb;
+}
+
+// ------------------------------------------------------------------
+void kwiver_logger
+::set_global_callback(callback_t cb)
+{
+  kwiver_logger::impl::m_global_callback = cb;
+}
+
+// ------------------------------------------------------------------
+void kwiver_logger
+::do_callback(log_level_t level, std::string const& msg,
+              logger_ns::location_info const & location) const
+{
+  if (m_impl->m_local_callback)
+  {
+    m_impl->m_local_callback(level, this->get_name(), msg, location);
+  }
+  if (m_impl->m_global_callback)
+  {
+    m_impl->m_global_callback(level, this->get_name(), msg, location);
+  }
 }
 
 } } // end namespace

--- a/vital/logger/kwiver_logger.cxx
+++ b/vital/logger/kwiver_logger.cxx
@@ -74,7 +74,7 @@ kwiver_logger
 
 // ----------------------------------------------------------------
 char const* kwiver_logger
-::get_level_string(kwiver_logger::log_level_t lev) const
+::get_level_string(kwiver_logger::log_level_t lev)
 {
   switch (lev)
   {

--- a/vital/logger/kwiver_logger.h
+++ b/vital/logger/kwiver_logger.h
@@ -36,6 +36,7 @@
 
 #include <sstream>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 
 #include <vital/noncopyable.h>
@@ -87,10 +88,22 @@ public:
   virtual void set_level( log_level_t lev) = 0;
   virtual log_level_t get_level() const = 0;
 
+  /// Type alias for the callback function signature
+  using callback_t =
+    std::function<void(log_level_t, std::string const& name,
+                       std::string const& msg,
+                       logger_ns::location_info const& loc)>;
+
+  /// Set a callback to be called on logging events for this logger instance
+  void set_local_callback(callback_t cb);
+
+  /// Set a callback to be called on logging events for all logger instances
+  static void set_global_callback(callback_t cb);
+
   /**
    * @brief Get logger name.
    */
-  std::string get_name();
+  std::string get_name() const;
 
   /**
    * @brief Log a message string with the FATAL level.
@@ -310,6 +323,12 @@ protected:
    * @param name Name of logger to create
    */
   kwiver_logger( logger_ns::kwiver_logger_factory* fact, std::string const& name );
+
+ /**
+  * @brief Call the registered callback functions, if any
+  */
+  void do_callback(log_level_t level, std::string const& msg,
+                   logger_ns::location_info const & location) const;
 
 private:
 

--- a/vital/logger/kwiver_logger.h
+++ b/vital/logger/kwiver_logger.h
@@ -300,7 +300,7 @@ public:
    *
    * @param lev level value to convert
   */
-  char const* get_level_string(kwiver_logger::log_level_t lev) const;
+  static char const* get_level_string(kwiver_logger::log_level_t lev);
 
   /**
    * @brief Get name of logger factory / back-end provider

--- a/vital/logger/log4cplus_factory.cxx
+++ b/vital/logger/log4cplus_factory.cxx
@@ -135,6 +135,7 @@ virtual void log_fatal (std::string const & msg)
     ::log4cplus::FATAL_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_FATAL, msg, location_info());
 }
 
 
@@ -147,6 +148,7 @@ virtual void log_fatal (std::string const & msg)
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_FATAL, msg, location);
 }
 
 
@@ -157,6 +159,7 @@ virtual void log_error (std::string const & msg)
     ::log4cplus::ERROR_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_ERROR, msg, location_info());
 }
 
 
@@ -169,6 +172,7 @@ virtual void log_error (std::string const & msg,
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_ERROR, msg, location);
 }
 
 
@@ -179,6 +183,7 @@ virtual void log_warn (std::string const & msg)
     ::log4cplus::WARN_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_WARN, msg, location_info());
 }
 
 
@@ -191,6 +196,7 @@ virtual void log_warn (std::string const & msg,
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_WARN, msg, location);
 }
 
 
@@ -201,6 +207,7 @@ virtual void log_info (std::string const & msg)
     ::log4cplus::INFO_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_INFO, msg, location_info());
 }
 
 
@@ -213,6 +220,7 @@ virtual void log_info (std::string const & msg,
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_INFO, msg, location);
 }
 
 
@@ -223,6 +231,7 @@ virtual void log_debug (std::string const & msg)
     ::log4cplus::DEBUG_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_DEBUG, msg, location_info());
 }
 
 
@@ -235,6 +244,7 @@ virtual void log_debug (std::string const & msg,
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_DEBUG, msg, location);
 }
 
 
@@ -245,6 +255,7 @@ virtual void log_trace (std::string const & msg)
     log4cplus::TRACE_LOG_LEVEL,
     msg,
     0, 0, 0);
+  do_callback(LEVEL_TRACE, msg, location_info());
 }
 
 
@@ -257,6 +268,7 @@ virtual void log_trace (std::string const & msg,
     msg,
     location.get_file_name_ptr(), location.get_line_number(),
     location.get_method_name_ptr());
+  do_callback(LEVEL_TRACE, msg, location);
 }
 
 

--- a/vital/logger/log4cxx_factory.cxx
+++ b/vital/logger/log4cxx_factory.cxx
@@ -129,6 +129,7 @@ public:
   virtual void log_fatal( std::string const& msg )
   {
     this->m_loggerImpl->fatal( msg );
+    do_callback(LEVEL_FATAL, msg, location_info());
   }
 
 
@@ -140,6 +141,7 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->fatal( msg, cxx_location );
+    do_callback(LEVEL_FATAL, msg, location));
   }
 
 
@@ -147,6 +149,7 @@ public:
   virtual void log_error( std::string const& msg )
   {
     this->m_loggerImpl->error( msg );
+    do_callback(LEVEL_ERROR, msg, location_info());
   }
 
 
@@ -158,6 +161,7 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->error( msg, cxx_location );
+    do_callback(LEVEL_ERROR, msg, location);
   }
 
 
@@ -165,6 +169,7 @@ public:
   virtual void log_warn( std::string const& msg )
   {
     this->m_loggerImpl->warn( msg );
+    do_callback(LEVEL_WARN, msg, location_info());
   }
 
   virtual void log_warn( std::string const&                       msg,
@@ -175,12 +180,14 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->warn( msg, cxx_location );
+    do_callback(LEVEL_WARN, msg, location);
   }
 
   // ------------------------------------------------------------------
   virtual void log_info( std::string const& msg )
   {
     this->m_loggerImpl->info( msg );
+    do_callback(LEVEL_INFO, msg, location_info());
   }
 
 
@@ -192,6 +199,7 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->info( msg, cxx_location );
+    do_callback(LEVEL_INFO, msg, location);
   }
 
 
@@ -199,6 +207,7 @@ public:
   virtual void log_debug( std::string const& msg )
   {
     this->m_loggerImpl->debug( msg );
+    do_callback(LEVEL_DEBUG, msg, location_info());
   }
 
 
@@ -210,6 +219,7 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->debug( msg, cxx_location );
+    do_callback(LEVEL_DEBUG, msg, location);
   }
 
 
@@ -217,6 +227,7 @@ public:
   virtual void log_trace( std::string const& msg )
   {
     this->m_loggerImpl->trace( msg );
+    do_callback(LEVEL_TRACE, msg, location_info());
   }
 
 
@@ -228,6 +239,7 @@ public:
                                              location.get_line_number() );
 
     this->m_loggerImpl->trace( msg, cxx_location );
+    do_callback(LEVEL_TRACE, msg, location);
   }
 
 


### PR DESCRIPTION
I'd like to get initial impression on this attempt to add callbacks to the logger framework.  So far this is only implemented for the default and log4cplus loggers.  Each logger instance can register a callback, but there is also a global callback that will apply to all loggers.  The global callback is the one I am most interested in.  My use case is capturing log messages to display in a GUI window.

There is currently a difference in approach between the default and log4cplus loggers treatment of global callbacks.  The default logger overrides the local callback for each logger when a global callback is set.  So there is always only one callback.  The log4cplus logger supports both local and global callbacks at the same time.  I'm not sure which approach is better.

log4cplus has it's own callback mechanism which could be used, but does not appear to be supported until a later version of log4cplus than we have in Fletch.