### PR TITLE
Change test for boolean options.

### DIFF
--- a/vital/applets/cxxopts.hpp
+++ b/vital/applets/cxxopts.hpp
@@ -690,16 +690,14 @@ namespace cxxopts
     parse_value(const std::string& text, bool& value)
     {
       REGEX_NS::smatch result;
-      REGEX_NS::regex_match(text, result, truthy_pattern);
 
-      if (!result.empty())
+      if (REGEX_NS::regex_match(text, result, truthy_pattern))
       {
         value = true;
         return;
       }
 
-      REGEX_NS::regex_match(text, result, falsy_pattern);
-      if (!result.empty())
+      if (REGEX_NS::regex_match(text, result, falsy_pattern))
       {
         value = false;
         return;


### PR DESCRIPTION
When BOOST regex is used on CentOS, the test for boolean options
were failing due to possible undefined behaviour.

For boost::regex_match() - If the function regex_match() returns false, then the effect on parameter match_results m is undefined.

For std::regex_match() - If the recex_match() returns false, then the effect on parameter match_results m is as follows:
m.ready() == true; m.empty() == true; m.size() == 0

