### PR TITLE
Update KPF reader to provide empty detected object sets from frame 1

### DIFF
--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -120,7 +120,7 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     d->m_first = false;
 
     // set up iterators for returning sets.
-    d->m_current_idx = d->m_detected_sets.begin()->first;
+    d->m_current_idx = 1;
     d->m_last_idx = d->m_detected_sets.rbegin()->first;
   } // end first
 
@@ -139,9 +139,15 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     set = d->m_detected_sets[d->m_current_idx];
   }
 
-  ++d->m_current_idx;
-
-  return true;
+  if ( d->m_current_idx > d->m_last_idx )
+  {
+    return false;
+  }
+  else
+  {
+    ++d->m_current_idx;
+    return true;
+  }
 }
 
 

--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -139,15 +139,8 @@ read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name
     set = d->m_detected_sets[d->m_current_idx];
   }
 
-  if ( d->m_current_idx > d->m_last_idx )
-  {
-    return false;
-  }
-  else
-  {
-    ++d->m_current_idx;
-    return true;
-  }
+  ++d->m_current_idx;
+  return true;
 }
 
 


### PR DESCRIPTION
Assume the first frame of the source of possible KPF detections is 1,
rather than whenever the first detection is reported.

When syncing the KPF detections with video for example, we want to know what (if any) were the detections starting from frame 1.  Currently, if the first detection in the KPF input file occurs on frame 10, it will be associated with the first frame of the video.

It's very possible that I've missed an option somewhere or another processes that's intended to correct for this.