### PR TITLE
Dev/fix applet parameter errors

### DIFF
--- a/sprokit/src/applets/pipe_to_dot.cxx
+++ b/sprokit/src/applets/pipe_to_dot.cxx
@@ -90,7 +90,7 @@ add_command_options()
     ( "T,cluster-type", "Cluster type to export", cxxopts::value<std::string>());
 
   m_cmd_options->add_options("output")
-    ( "n,name", "Name of the graph", cxxopts::value<std::string>())
+    ( "n,name", "Name of the graph", cxxopts::value<std::string>()->default_value( "unnamed" )  )
     ( "o,output", "Name of output file or '-' for stdout.",
       cxxopts::value<std::string>()->default_value("-"))
     ( "P,link-prefix", "Prefix for links when formatting for sphinx",
@@ -126,8 +126,8 @@ run()
   sprokit::process_cluster_t cluster;
   sprokit::pipeline_t pipe;
 
-  bool const have_cluster = cmd_args["cluster"].as<bool>();
-  bool const have_cluster_type = cmd_args["cluster-type"].as<bool>();
+  bool const have_cluster = ( cmd_args["cluster"].count() > 0 );
+  bool const have_cluster_type = ( cmd_args["cluster-type"].count() > 0 );
   bool const have_pipeline = ( cmd_args.count("pipe-file") > 0 );
   bool const have_setup = cmd_args["setup"].as<bool>();
   bool const have_link = ( cmd_args.count("link-prefix") > 0 );
@@ -150,7 +150,7 @@ run()
     return EXIT_FAILURE;
   }
 
-  std::string const graph_name = cmd_args["name"].as<std::string>();
+  const std::string graph_name = cmd_args["name"].as<std::string>();
 
   sprokit::pipeline_builder builder;
 

--- a/vital/applets/cxxopts.hpp
+++ b/vital/applets/cxxopts.hpp
@@ -552,9 +552,7 @@ namespace cxxopts
     integer_parser(const std::string& text, T& value)
     {
       REGEX_NS::smatch match;
-      REGEX_NS::regex_match(text, match, integer_pattern);
-
-      if (match.length() == 0)
+      if (!REGEX_NS::regex_match(text, match, integer_pattern))
       {
         throw argument_incorrect_type(text);
       }
@@ -1521,9 +1519,7 @@ OptionAdder::operator()
 )
 {
   REGEX_NS::match_results<const char*> result;
-  REGEX_NS::regex_match(opts.c_str(), result, option_specifier);
-
-  if (result.empty())
+  if (!REGEX_NS::regex_match(opts.c_str(), result, option_specifier))
   {
     throw invalid_option_format_error(opts);
   }
@@ -1728,9 +1724,7 @@ ParseResult::parse(int& argc, char**& argv)
     }
 
     REGEX_NS::match_results<const char*> result;
-    REGEX_NS::regex_match(argv[current], result, option_matcher);
-
-    if (result.empty())
+    if (!REGEX_NS::regex_match(argv[current], result, option_matcher))
     {
       //not a flag
 


### PR DESCRIPTION
Changed remaining instances of regex_match to use return code as indication of success,
Also fixed some command line parameter handling errors in applet.