### PR TITLE
Dev/remove sensor altitude

### DIFF
--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -150,7 +150,7 @@ TEST( load_save, geo_point_2d )
 }
 
 // ----------------------------------------------------------------------------
-TEST( load_save, geo_point_raw )
+TEST( load_save, geo_point_3d )
 {
   kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
   kwiver::vital::geo_point obj( geo, kwiver::vital::SRID::lat_lon_WGS84 );
@@ -460,11 +460,11 @@ TEST( load_save, track_set )
   {
     auto trk = kwiver::vital::track::create();
     trk->set_id( trk_id );
-   
+
     for ( int i=trk_id*10; i < ( trk_id+1 )*10; i++ )
     {
       auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( i );
-      bool insert_success = trk->insert( trk_state_sptr );  
+      bool insert_success = trk->insert( trk_state_sptr );
       if ( !insert_success )
       {
         std::cerr << "Failed to insert track state" << std::endl;
@@ -495,16 +495,16 @@ TEST( load_save, track_set )
   for ( kwiver::vital::track_id_t trk_id=1; trk_id<5; ++trk_id )
   {
     auto trk = trk_set_sptr->get_track( trk_id );
-    auto trk_dser = trk_set_sptr_dser->get_track( trk_id );  
+    auto trk_dser = trk_set_sptr_dser->get_track( trk_id );
     EXPECT_EQ( trk->id(), trk_dser->id() );
     for ( int i=trk_id*10; i < ( trk_id+1 )*10; i++ )
     {
       auto obj_trk_state_sptr = *trk->find( i );
       auto dser_trk_state_sptr = *trk_dser->find( i );
 
-      EXPECT_EQ( obj_trk_state_sptr->frame(), dser_trk_state_sptr->frame() );    
+      EXPECT_EQ( obj_trk_state_sptr->frame(), dser_trk_state_sptr->frame() );
     }
-  }  
+  }
 
 }
 
@@ -526,15 +526,15 @@ TEST( load_save, object_track_set )
       dot->set_score( "third", 101 );
       dot->set_score( "last", 121 );
 
-      auto dobj_sptr = std::make_shared< kwiver::vital::detected_object>( 
-                              kwiver::vital::bounding_box_d{ 1, 2, 3, 4 }, 
+      auto dobj_sptr = std::make_shared< kwiver::vital::detected_object>(
+                              kwiver::vital::bounding_box_d{ 1, 2, 3, 4 },
                                   3.14159265, dot );
       dobj_sptr->set_detector_name( "test_detector" );
       dobj_sptr->set_index( 1234 );
-      auto obj_trk_state_sptr = std::make_shared< kwiver::vital::object_track_state > 
+      auto obj_trk_state_sptr = std::make_shared< kwiver::vital::object_track_state >
                                   ( i, i, dobj_sptr );
 
-      bool insert_success = trk->insert( obj_trk_state_sptr );  
+      bool insert_success = trk->insert( obj_trk_state_sptr );
       if ( !insert_success )
       {
         std::cerr << "Failed to insert object track state" << std::endl;
@@ -561,19 +561,19 @@ TEST( load_save, object_track_set )
     cereal::JSONInputArchive ar( msg );
     cereal::load( ar, *obj_trk_set_sptr_dser );
   }
-  
+
   for ( kwiver::vital::track_id_t trk_id=1; trk_id<3; ++trk_id )
   {
     auto trk = obj_trk_set_sptr->get_track( trk_id );
-    auto trk_dser = obj_trk_set_sptr_dser->get_track( trk_id );  
+    auto trk_dser = obj_trk_set_sptr_dser->get_track( trk_id );
     EXPECT_EQ( trk->id(), trk_dser->id() );
     for ( int i=trk_id*2; i < ( trk_id+1 )*2; i++ )
     {
       auto trk_state_sptr = *trk->find( i );
       auto dser_trk_state_sptr = *trk_dser->find( i );
-      
+
       EXPECT_EQ( trk_state_sptr->frame(), dser_trk_state_sptr->frame() );
-      auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );   
+      auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
       auto dser_obj_trk_state_sptr = kwiver::vital::object_track_state::
                                                       downcast( dser_trk_state_sptr );
 
@@ -602,6 +602,6 @@ TEST( load_save, object_track_set )
           EXPECT_EQ( dser_it->second, dser_it->second );
         }
       }
-    }    
-  }  
+    }
+  }
 }

--- a/arrows/serialize/protobuf/tests/test_serialize_metadata.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize_metadata.cxx
@@ -90,8 +90,8 @@ TEST( serialize_metadata, metadata )
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_FRAME_CENTER );
 
-    kwiver::vital::geo_point::geo_2d_point_t geo_2d( 42.50, 73.54 );
-    kwiver::vital::geo_point pt (  geo_2d, kwiver::vital::SRID::lat_lon_WGS84 );
+    kwiver::vital::geo_point::geo_3d_point_t geo_3d( 42.50, 73.54, 100 );
+    kwiver::vital::geo_point pt (  geo_3d, kwiver::vital::SRID::lat_lon_WGS84 );
     auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
     meta_sptr->add( item );
   }

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -79,8 +79,8 @@ basename_from_metadata(metadata_sptr md,
   return basename;
 }
 
-
-/// Read in a POS file, producing a metadata object
+// ----------------------------------------------------------------------------
+// Read in a POS file, producing a metadata object
 metadata_sptr
 read_pos_file( path_t const& file_path )
 {
@@ -166,8 +166,8 @@ read_pos_file( path_t const& file_path )
   return md;
 }
 
-
-/// Output the given \c metadata object to the specified POS file path
+// ----------------------------------------------------------------------------
+// Output the given \c metadata object to the specified POS file path
 void
 write_pos_file( metadata const& md,
                 path_t const& file_path )
@@ -224,11 +224,6 @@ write_pos_file( metadata const& md,
     auto const& raw_loc = geo_pt.location( SRID::lat_lon_WGS84 );
     // altitude is in feet in a POS file and needs to be converted to feet
     constexpr double feet2meters = 0.3048;
-    double altitude = 0.0;
-    if (auto& mdi = md.find(VITAL_META_SENSOR_ALTITUDE))
-    {
-      altitude = mdi.as_double() / feet2meters;
-    }
     ofile << raw_loc[1] << ", "
           << raw_loc[0] << ", "
           << raw_loc[2] / feet2meters << ", ";

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -80,7 +80,7 @@ basename_from_metadata(metadata_sptr md,
 }
 
 // ----------------------------------------------------------------------------
-// Read in a POS file, producing a metadata object
+/// Read in a POS file, producing a metadata object
 metadata_sptr
 read_pos_file( path_t const& file_path )
 {

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -151,7 +151,7 @@ void convert_metadata
 ::convert_0104_metadata( klv_uds_vector_t const& uds, metadata& md )
 {
   //
-  // Data items that are used to collect multi-value metadataa items such as
+  // Data items that are used to collect multi-value metadata items such as
   // lat-lon points and image corner points. All geodetic points are assumed to
   // be WGS84 lat-lon.
   //

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -87,6 +87,16 @@ is_valid_lon_lat( vector_2d const& vec )
          ( lon >= -180.0 && lon <= 360.0 );
 }
 
+// ----------------------------------------------------------------------------
+bool
+is_valid_lon_lat( vector_3d const& vec )
+{
+  auto const lat = vec[1];
+  auto const lon = vec[0];
+  return ( lat >= -90.0 && lat <= 90.0 ) &&
+         ( lon >= -180.0 && lon <= 360.0 );
+}
+
 } // end namespace
 
 // ----------------------------------------------------------------------------
@@ -145,7 +155,7 @@ void convert_metadata
   // lat-lon points and image corner points. All geodetic points are assumed to
   // be WGS84 lat-lon.
   //
-  auto raw_sensor_location = empty_vector<2>();
+  auto raw_sensor_location = empty_vector<3>();
   auto raw_frame_center = empty_vector<2>();
   auto raw_corner_pt1 = empty_vector<2>(); // offsets relative to frame_center
   auto raw_corner_pt2 = empty_vector<2>();
@@ -210,7 +220,6 @@ case klv_0104::N:                                         \
       CASE( PLATFORM_DESIGNATION );
       CASE( IMAGE_SOURCE_SENSOR );
       CASE( IMAGE_COORDINATE_SYSTEM );
-      CASE( SENSOR_ALTITUDE );
       CASE( SENSOR_HORIZONTAL_FOV );
       CASE( SENSOR_VERTICAL_FOV );
       CASE( SENSOR_ROLL_ANGLE );
@@ -232,6 +241,10 @@ case klv_0104::N:                                         \
 
 #undef CASE
 #undef CASE2
+
+    case klv_0104::SENSOR_ALTITUDE:
+      raw_sensor_location[2] =  kwiver::vital::any_cast< double >(data) ;
+      break;
 
     case klv_0104::SENSOR_LATITUDE:
       raw_sensor_location[1] =  kwiver::vital::any_cast< double >(data) ;
@@ -299,12 +312,7 @@ case klv_0104::N:                                         \
     }
     else
     {
-      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], 0.0);
-      // add altitude, if available, to the sensor location
-      if (auto const& alt = md.find(VITAL_META_SENSOR_ALTITUDE))
-      {
-        sensor_loc[2] = alt.as_double();
-      }
+      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], raw_sensor_location[2]);
       auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
       md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
     }

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -91,10 +91,7 @@ is_valid_lon_lat( vector_2d const& vec )
 bool
 is_valid_lon_lat( vector_3d const& vec )
 {
-  auto const lat = vec[1];
-  auto const lon = vec[0];
-  return ( lat >= -90.0 && lat <= 90.0 ) &&
-         ( lon >= -180.0 && lon <= 360.0 );
+  return is_valid_lon_lat( static_cast< vector_2d >(vec.head(2)) );
 }
 
 } // end namespace

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -242,7 +242,6 @@ convert_metadata
       CASE( SENSOR_REL_ROLL_ANGLE );
       CASE( SLANT_RANGE );
       CASE( TARGET_WIDTH );
-      CASE( FRAME_CENTER_ELEV );
       CASE( ICING_DETECTED);
       CASE( WIND_DIRECTION );
       CASE( WIND_SPEED );
@@ -299,6 +298,10 @@ convert_metadata
 
     case KLV_0601_FRAME_CENTER_LONG:
       raw_frame_center[0] = klv_0601_value_double( KLV_0601_FRAME_CENTER_LONG, data );
+      break;
+
+    case KLV_0601_FRAME_CENTER_ELEV:
+      raw_frame_center[2] = klv_0601_value_double( KLV_0601_FRAME_CENTER_ELEV, data );
       break;
 
       // Sometimes these offsets are set to zero. Even if the image is

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -184,7 +184,7 @@ convert_metadata
   auto raw_corner_pt2 = empty_vector<2>();
   auto raw_corner_pt3 = empty_vector<2>();
   auto raw_corner_pt4 = empty_vector<2>();
-  auto raw_target_location = empty_vector<2>();
+  auto raw_target_location = empty_vector<3>();
 
   for ( auto itr = lds.begin(); itr != lds.end(); ++itr )
   {
@@ -249,7 +249,6 @@ convert_metadata
       CASE( STATIC_PRESSURE );
       CASE( DENSITY_ALTITUDE );
       CASE( OUTSIDE_AIR_TEMPERATURE );
-      CASE( TARGET_LOCATION_ELEV );
       CASE( TARGET_TRK_GATE_WIDTH );
       CASE( TARGET_TRK_GATE_HEIGHT );
       CASE_COPY( SECURITY_LOCAL_MD_SET );
@@ -388,16 +387,16 @@ convert_metadata
     }
       break;
 
+    case KLV_0601_TARGET_LOCATION_ELEV:
+      raw_target_location[2] = klv_0601_value_double( KLV_0601_TARGET_LOCATION_LAT, data );
+      break;
+
     case KLV_0601_TARGET_LOCATION_LAT:
-    {
       raw_target_location[1] = klv_0601_value_double( KLV_0601_TARGET_LOCATION_LAT, data );
-    }
       break;
 
     case KLV_0601_TARGET_LOCATION_LONG:
-    {
       raw_target_location[0] = klv_0601_value_double( KLV_0601_TARGET_LOCATION_LONG, data );
-    }
       break;
 
     default:

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -96,10 +96,7 @@ is_valid_lon_lat( vector_2d const& vec )
 bool
 is_valid_lon_lat( vector_3d const& vec )
 {
-  auto const lat = vec[1];
-  auto const lon = vec[0];
-  return ( lat >= -90.0 && lat <= 90.0 ) &&
-         ( lon >= -180.0 && lon <= 360.0 );
+  return is_valid_lon_lat( static_cast< vector_2d >(vec.head( 2 )) );
 }
 
 } // end namespace
@@ -179,7 +176,7 @@ convert_metadata
   // be WGS84 lat-lon.
   //
   auto raw_sensor_location = empty_vector<3>();
-  auto raw_frame_center = empty_vector<2>();
+  auto raw_frame_center = empty_vector<3>();
   auto raw_corner_pt1 = empty_vector<2>(); // offsets relative to frame_center
   auto raw_corner_pt2 = empty_vector<2>();
   auto raw_corner_pt3 = empty_vector<2>();

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -178,7 +178,7 @@ convert_metadata
   // lat-lon points and image corner points. All geodetic points are assumed to
   // be WGS84 lat-lon.
   //
-  auto raw_sensor_location = empty_vector<2>();
+  auto raw_sensor_location = empty_vector<3>();
   auto raw_frame_center = empty_vector<2>();
   auto raw_corner_pt1 = empty_vector<2>(); // offsets relative to frame_center
   auto raw_corner_pt2 = empty_vector<2>();
@@ -235,7 +235,6 @@ convert_metadata
       CASE( PLATFORM_DESIGNATION );
       CASE( IMAGE_SOURCE_SENSOR );
       CASE( IMAGE_COORDINATE_SYSTEM );
-      CASE2( SENSOR_TRUE_ALTITUDE, SENSOR_ALTITUDE );
       CASE( SENSOR_HORIZONTAL_FOV );
       CASE( SENSOR_VERTICAL_FOV );
       CASE( SENSOR_REL_AZ_ANGLE );
@@ -283,28 +282,24 @@ convert_metadata
 
       // option (2) Use klv 0601 native to double converter.
 
+    case KLV_0601_SENSOR_TRUE_ALTITUDE:
+      raw_sensor_location[2] = klv_0601_value_double( KLV_0601_SENSOR_TRUE_ALTITUDE, data );
+      break;
+
     case KLV_0601_SENSOR_LATITUDE:
-    {
       raw_sensor_location[1] = klv_0601_value_double( KLV_0601_SENSOR_LATITUDE, data );
-    }
       break;
 
     case KLV_0601_SENSOR_LONGITUDE:
-    {
       raw_sensor_location[0] = klv_0601_value_double( KLV_0601_SENSOR_LONGITUDE, data );
-    }
       break;
 
     case KLV_0601_FRAME_CENTER_LAT:
-    {
       raw_frame_center[1] = klv_0601_value_double( KLV_0601_FRAME_CENTER_LAT, data );
-    }
       break;
 
     case KLV_0601_FRAME_CENTER_LONG:
-    {
       raw_frame_center[0] = klv_0601_value_double( KLV_0601_FRAME_CENTER_LONG, data );
-    }
       break;
 
       // Sometimes these offsets are set to zero. Even if the image is
@@ -422,12 +417,7 @@ convert_metadata
     }
     else
     {
-      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], 0.0);
-      // add altitude, if available, to the sensor location
-      if (auto const& alt = md.find(VITAL_META_SENSOR_ALTITUDE))
-      {
-        sensor_loc[2] = alt.as_double();
-      }
+      vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], raw_sensor_location[2]);
       auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
       md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
     }

--- a/vital/klv/klv_0104.cxx
+++ b/vital/klv/klv_0104.cxx
@@ -174,7 +174,6 @@ klv_0104::klv_0104()
   m_key_to_tag[klv_uds_key( 0x060e2b3401010101UL, 0x0105050000000000UL )] = MISSION_NUMBER;
   m_key_to_tag[klv_uds_key( 0x060e2b3401010101UL, 0x0701100101000000UL )] = SENSOR_ROLL_ANGLE;
   m_key_to_tag[klv_uds_key( 0x060e2b3401010101UL, 0x0701100102000000UL )] = ANGLE_TO_NORTH;
-  m_key_to_tag[klv_uds_key( 0x060e2b3401010101UL, 0x0701100103000000UL )] = OBLIQUITY_ANGLE;
 
   //UNKNOWN is the last entry of the enum and thus the number of tags
   m_traitsvec.resize( UNKNOWN );
@@ -186,7 +185,7 @@ klv_0104::klv_0104()
   m_traitsvec[PLATFORM_DESIGNATION_ALT] =    NEW_TRAIT( std::string,  "Platform designation (alternate key)" );
   m_traitsvec[STREAM_ID] =                   NEW_TRAIT( std::string,  "Stream ID" );
   m_traitsvec[ITEM_DESIGNATOR_ID] =          NEW_TRAIT( std::string,  "Item Designator ID (16 bytes)" );
-  m_traitsvec[CLASSIFICATION] =              NEW_TRAIT( std_0102_lds,  "Classification" );
+  m_traitsvec[CLASSIFICATION] =              NEW_TRAIT( std_0102_lds, "Classification" );
   m_traitsvec[SECURITY_CLASSIFICATION] =     NEW_TRAIT( std::string,  "Security Classification" );
   m_traitsvec[IMAGE_SOURCE_SENSOR] =         NEW_TRAIT( std::string,  "Image Source sensor" );
   m_traitsvec[SENSOR_HORIZONTAL_FOV] =       NEW_TRAIT( double,       "Sensor horizontal field of view" );
@@ -229,8 +228,6 @@ klv_0104::klv_0104()
   m_traitsvec[MISSION_ID] =                  NEW_TRAIT( std::string,  "Mission ID" );
   m_traitsvec[PLATFORM_TAIL_NUMBER] =        NEW_TRAIT( std::string,  "Platform tail number" );
   m_traitsvec[MISSION_NUMBER] =              NEW_TRAIT( std::string,  "Episode Number" );
-  m_traitsvec[ANGLE_TO_NORTH] =              NEW_TRAIT( double,       "Angle to North" );
-  m_traitsvec[OBLIQUITY_ANGLE] =             NEW_TRAIT( double,       "Sensor Elevation Angle" );
   m_traitsvec[SENSOR_ROLL_ANGLE] =           NEW_TRAIT( double,       "Sensor Roll Angle" );
 
 #undef NEW_TRAIT

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -264,7 +264,7 @@ metadata
 
   switch (tag)
   {
-#define VITAL_META_TRAIT_CASE(TAG, NAME, T) case VITAL_META_ ## TAG: return typeid(T);
+#define VITAL_META_TRAIT_CASE(TAG, NAME, T, ...) case VITAL_META_ ## TAG: return typeid(T);
 
     KWIVER_VITAL_METADATA_TAGS( VITAL_META_TRAIT_CASE )
 

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -56,7 +56,6 @@ namespace vital {
       : metadata_item( "Requested metadata item is not in collection", 0, VITAL_META_UNKNOWN )
     { }
 
-    virtual ~unknown_metadata_item() {}
     virtual bool is_valid() const { return false; }
     virtual vital_metadata_tag tag() const { return static_cast< vital_metadata_tag >(0); }
     virtual std::type_info const& type() const { return typeid( void ); }
@@ -80,11 +79,6 @@ metadata_item
     : m_name( name )
     , m_data( data )
     , m_tag( tag )
-{ }
-
-
-metadata_item
-::~metadata_item()
 { }
 
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -71,7 +71,7 @@ namespace vital {
 class VITAL_EXPORT metadata_item
 {
 public:
-  virtual ~metadata_item();
+  virtual ~metadata_item() = default;
 
   /// Test if metadata item is valid.
   /**

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -48,94 +48,94 @@
 //      tag                          string name                        type
 //      ---                          -----------                        ----
 #define KWIVER_VITAL_METADATA_TAGS(CALL)                                \
-CALL( UNKNOWN,                     "Unknown / Undefined entry",       int) \
-CALL( METADATA_ORIGIN,             "Origin of metadata",              std::string ) \
-CALL( UNIX_TIMESTAMP,              "Unix Time Stamp",                 uint64_t) \
-CALL( MISSION_ID,                  "Mission ID",                      std::string) \
-CALL( MISSION_NUMBER,              "Episode Number",                  std::string) \
-CALL( PLATFORM_TAIL_NUMBER,        "Platform Tail Number",            std::string) \
-CALL( PLATFORM_HEADING_ANGLE,      "Platform Heading Angle",          double) \
-CALL( PLATFORM_PITCH_ANGLE,        "Platform Pitch Angle",            double) \
-CALL( PLATFORM_ROLL_ANGLE,         "Platform Roll Angle",             double) \
-CALL( PLATFORM_TRUE_AIRSPEED,      "Platform True Airspeed",          double) \
-CALL( PLATFORM_INDICATED_AIRSPEED, "Platform Indicated Airspeed",     double) \
-CALL( PLATFORM_DESIGNATION,        "Platform Designation",            std::string) \
-CALL( IMAGE_SOURCE_SENSOR,         "Image Source Sensor",             std::string) \
-CALL( IMAGE_COORDINATE_SYSTEM,     "Image Coordinate System",         std::string) \
-CALL( IMAGE_URI,                   "Image URI",                       std::string) \
-CALL( VIDEO_URI,                   "Video URI",                       std::string) \
-CALL( VIDEO_KEY_FRAME,             "Is frame a key frame",            bool) \
-CALL( SENSOR_LOCATION,             "Sensor Geodetic Location, L/L/A", geo_point) \
-CALL( SENSOR_HORIZONTAL_FOV,       "Sensor Horizontal Field of View", double) \
-CALL( SENSOR_VERTICAL_FOV,         "Sensor Vertical Field of View",   double) \
-CALL( SENSOR_REL_AZ_ANGLE,         "Sensor Relative Azimuth Angle",   double) \
-CALL( SENSOR_REL_EL_ANGLE,         "Sensor Relative Elevation Angle", double) \
-CALL( SENSOR_REL_ROLL_ANGLE,       "Sensor Relative Roll Angle",      double) \
-CALL( SENSOR_YAW_ANGLE,            "Sensor yaw angle",                double ) \
-CALL( SENSOR_PITCH_ANGLE,          "Sensor pitch angle",              double ) \
-CALL( SENSOR_ROLL_ANGLE,           "Sensor Roll Angle",               double) \
-CALL( SENSOR_TYPE,                 "Sensor Type",                     std::string) \
-CALL( SLANT_RANGE,                 "Slant Range",                     double) \
-CALL( TARGET_WIDTH,                "Target Width",                    double) \
-CALL( FRAME_CENTER,                "Geodetic Frame Center",           geo_point) \
-CALL( FRAME_CENTER_ELEV,           "Frame Center Elevation",          double) /* TODO: merge with previous? */ \
-CALL( CORNER_POINTS,               "Corner points",                   geo_polygon) \
-CALL( ICING_DETECTED,              "Icing Detected",                  uint64_t) \
-CALL( WIND_DIRECTION,              "Wind Direction",                  double) \
-CALL( WIND_SPEED,                  "Wind Speed",                      double) \
-CALL( STATIC_PRESSURE,             "Static Pressure",                 double) \
-CALL( DENSITY_ALTITUDE,            "Density Altitude",                double) \
-CALL( OUTSIDE_AIR_TEMPERATURE,     "Outside Air Temperature",         double) \
-CALL( TARGET_LOCATION,             "Target Geodetic Location",        geo_point) \
-CALL( TARGET_LOCATION_ELEV,        "Target Location Elevation",       double) /* TODO: merge with previous? */ \
-CALL( TARGET_TRK_GATE_WIDTH,       "Target Track Gate Width",         double) \
-CALL( TARGET_TRK_GATE_HEIGHT,      "Target Track Gate Height",        double) \
-CALL( TARGET_ERROR_EST_CE90,       "Target Error Estimate - CE90",    double) \
-CALL( TARGET_ERROR_EST_LE90,       "Target Error Estimate - LE90",    double) \
-CALL( DIFFERENTIAL_PRESSURE,       "Differential Pressure",           double) \
-CALL( PLATFORM_ANG_OF_ATTACK,      "Platform Angle of Attack",        double) \
-CALL( PLATFORM_VERTICAL_SPEED,     "Platform Vertical Speed",         double) \
-CALL( PLATFORM_SIDESLIP_ANGLE,     "Platform Sideslip Angle",         double) \
-CALL( AIRFIELD_BAROMET_PRESS,      "Airfield Barometric Pressure",    double) \
-CALL( AIRFIELD_ELEVATION,          "Airfield Elevation",              double) \
-CALL( RELATIVE_HUMIDITY,           "Relative Humidity",               double) \
-CALL( PLATFORM_GROUND_SPEED,       "Platform Ground Speed",           double) \
-CALL( GROUND_RANGE,                "Ground Range",                    double) \
-CALL( PLATFORM_FUEL_REMAINING,     "Platform Fuel Remaining",         double) \
-CALL( PLATFORM_CALL_SIGN,          "Platform Call Sign",              std::string) \
-CALL( LASER_PRF_CODE,              "Laser PRF Code",                  uint64_t) \
-CALL( SENSOR_FOV_NAME,             "Sensor Field of View Name",       uint64_t) \
-CALL( PLATFORM_MAGNET_HEADING,     "Platform Magnetic Heading",       double) \
-CALL( UAS_LDS_VERSION_NUMBER,      "UAS LDS Version Number",          uint64_t) \
-CALL( ANGLE_TO_NORTH,              "Angle to North",                  double) \
-CALL( OBLIQUITY_ANGLE,             "Sensor Elevation Angle",          double) \
-CALL( START_DATE_TIME_UTC,         "Start Date Time - UTC",           std::string ) \
-CALL( EVENT_START_DATE_TIME_UTC,   "Event Start Date Time - UTC",     std::string ) \
-CALL( MISSION_START_TIME_UTC,      "Mission Start Date Time - UTC",   std::string ) \
-CALL( SECURITY_CLASSIFICATION,     "Security Classification",         std::string ) \
-CALL( CLASSIFICATION,              "Classification (0102 lds)",       std::string ) \
-CALL( SECURITY_LOCAL_MD_SET,       "Security Local Metadata Set",     std::string ) /* really std_0102_lds */ \
-CALL( 0601_WEAPON_LOAD,            "Weapon Load",                     uint64_t) \
-CALL( 0601_WEAPON_FIRED,           "Weapon Fired",                    uint64_t) \
-CALL( AVERAGE_GSD,                 "Average GSD value",               double) \
-CALL( GPS_SEC,                     "GPS seconds",                     double ) \
-CALL( GPS_WEEK,                    "GPS week",                        int ) \
-CALL( NORTHING_VEL,                "Northing velocity",               double ) \
-CALL( EASTING_VEL,                 "Easting velocity",                double ) \
-CALL( UP_VEL,                      "UP velocity",                     double ) \
-CALL( IMU_STATUS,                  "IMU status",                      int ) \
-CALL( LOCAL_ADJ,                   "Local adj",                       int ) \
-CALL( DST_FLAGS,                   "Dst flags",                       int ) \
-CALL( RPC_HEIGHT_OFFSET,           "RPC height offset",               double ) \
-CALL( RPC_HEIGHT_SCALE,            "RPC height scale",                double ) \
-CALL( RPC_LONG_OFFSET,             "RPC longitude offset",            double ) \
-CALL( RPC_LONG_SCALE,              "RPC longitude scale",             double ) \
-CALL( RPC_LAT_OFFSET,              "RPC latitude offset",             double ) \
-CALL( RPC_LAT_SCALE,               "RPC latitude scale",              double ) \
-CALL( RPC_ROW_OFFSET,              "RPC row offset",                  double ) \
-CALL( RPC_ROW_SCALE,               "RPC row scale",                   double ) \
-CALL( RPC_COL_OFFSET,              "RPC column offset",               double ) \
-CALL( RPC_COL_SCALE ,              "RPC column scale",                double ) \
+CALL( UNKNOWN,                     "Unknown / Undefined entry",            int ) \
+CALL( METADATA_ORIGIN,             "Origin of metadata",                   std::string ) \
+CALL( UNIX_TIMESTAMP,              "Unix Time Stamp",                      uint64_t ) \
+CALL( MISSION_ID,                  "Mission ID",                           std::string ) \
+CALL( MISSION_NUMBER,              "Episode Number",                       std::string ) \
+CALL( PLATFORM_TAIL_NUMBER,        "Platform Tail Number",                 std::string ) \
+CALL( PLATFORM_HEADING_ANGLE,      "Platform Heading Angle",               double ) \
+CALL( PLATFORM_PITCH_ANGLE,        "Platform Pitch Angle",                 double ) \
+CALL( PLATFORM_ROLL_ANGLE,         "Platform Roll Angle",                  double ) \
+CALL( PLATFORM_TRUE_AIRSPEED,      "Platform True Airspeed",               double ) \
+CALL( PLATFORM_INDICATED_AIRSPEED, "Platform Indicated Airspeed",          double ) \
+CALL( PLATFORM_DESIGNATION,        "Platform Designation",                 std::string ) \
+CALL( IMAGE_SOURCE_SENSOR,         "Image Source Sensor",                  std::string ) \
+CALL( IMAGE_COORDINATE_SYSTEM,     "Image Coordinate System",              std::string ) \
+CALL( IMAGE_URI,                   "Image URI",                            std::string ) \
+CALL( VIDEO_URI,                   "Video URI",                            std::string ) \
+CALL( VIDEO_KEY_FRAME,             "Is frame a key frame",                 bool ) \
+CALL( SENSOR_LOCATION,             "Sensor Geodetic Location, Lat/Lon/Alt", geo_point ) \
+CALL( SENSOR_HORIZONTAL_FOV,       "Sensor Horizontal Field of View",      double ) \
+CALL( SENSOR_VERTICAL_FOV,         "Sensor Vertical Field of View",        double ) \
+CALL( SENSOR_REL_AZ_ANGLE,         "Sensor Relative Azimuth Angle",        double ) \
+CALL( SENSOR_REL_EL_ANGLE,         "Sensor Relative Elevation Angle",      double ) \
+CALL( SENSOR_REL_ROLL_ANGLE,       "Sensor Relative Roll Angle",           double ) \
+CALL( SENSOR_YAW_ANGLE,            "Sensor yaw angle",                     double ) \
+CALL( SENSOR_PITCH_ANGLE,          "Sensor pitch angle",                   double ) \
+CALL( SENSOR_ROLL_ANGLE,           "Sensor Roll Angle",                    double ) \
+CALL( SENSOR_TYPE,                 "Sensor Type",                          std::string ) \
+CALL( SLANT_RANGE,                 "Slant Range",                          double ) \
+CALL( TARGET_WIDTH,                "Target Width",                         double ) \
+CALL( FRAME_CENTER,                "Geodetic Frame Center",                geo_point ) \
+CALL( FRAME_CENTER_ELEV,           "Frame Center Elevation",               double ) /* TODO: merge with previous? */ \
+CALL( CORNER_POINTS,               "Corner points",                        geo_polygon ) \
+CALL( ICING_DETECTED,              "Icing Detected",                       uint64_t ) \
+CALL( WIND_DIRECTION,              "Wind Direction",                       double ) \
+CALL( WIND_SPEED,                  "Wind Speed",                           double ) \
+CALL( STATIC_PRESSURE,             "Static Pressure",                      double ) \
+CALL( DENSITY_ALTITUDE,            "Density Altitude",                     double ) \
+CALL( OUTSIDE_AIR_TEMPERATURE,     "Outside Air Temperature",              double ) \
+CALL( TARGET_LOCATION,             "Target Geodetic Location",             geo_point ) \
+CALL( TARGET_LOCATION_ELEV,        "Target Location Elevation",            double ) /* TODO: merge with previous? */ \
+CALL( TARGET_TRK_GATE_WIDTH,       "Target Track Gate Width",              double ) \
+CALL( TARGET_TRK_GATE_HEIGHT,      "Target Track Gate Height",             double ) \
+CALL( TARGET_ERROR_EST_CE90,       "Target Error Estimate - CE90",         double ) \
+CALL( TARGET_ERROR_EST_LE90,       "Target Error Estimate - LE90",         double ) \
+CALL( DIFFERENTIAL_PRESSURE,       "Differential Pressure",                double ) \
+CALL( PLATFORM_ANG_OF_ATTACK,      "Platform Angle of Attack",             double ) \
+CALL( PLATFORM_VERTICAL_SPEED,     "Platform Vertical Speed",              double ) \
+CALL( PLATFORM_SIDESLIP_ANGLE,     "Platform Sideslip Angle",              double ) \
+CALL( AIRFIELD_BAROMET_PRESS,      "Airfield Barometric Pressure",         double ) \
+CALL( AIRFIELD_ELEVATION,          "Airfield Elevation",                   double ) \
+CALL( RELATIVE_HUMIDITY,           "Relative Humidity",                    double ) \
+CALL( PLATFORM_GROUND_SPEED,       "Platform Ground Speed",                double ) \
+CALL( GROUND_RANGE,                "Ground Range",                         double ) \
+CALL( PLATFORM_FUEL_REMAINING,     "Platform Fuel Remaining",              double ) \
+CALL( PLATFORM_CALL_SIGN,          "Platform Call Sign",                   std::string ) \
+CALL( LASER_PRF_CODE,              "Laser PRF Code",                       uint64_t ) \
+CALL( SENSOR_FOV_NAME,             "Sensor Field of View Name",            uint64_t ) \
+CALL( PLATFORM_MAGNET_HEADING,     "Platform Magnetic Heading",            double ) \
+CALL( UAS_LDS_VERSION_NUMBER,      "UAS LDS Version Number",               uint64_t ) \
+CALL( ANGLE_TO_NORTH,              "Angle to North",                       double ) \
+CALL( OBLIQUITY_ANGLE,             "Sensor Elevation Angle",               double ) \
+CALL( START_DATE_TIME_UTC,         "Start Date Time - UTC",                std::string ) \
+CALL( EVENT_START_DATE_TIME_UTC,   "Event Start Date Time - UTC",          std::string ) \
+CALL( MISSION_START_TIME_UTC,      "Mission Start Date Time - UTC",        std::string ) \
+CALL( SECURITY_CLASSIFICATION,     "Security Classification",              std::string ) \
+CALL( CLASSIFICATION,              "Classification (0102 lds )",           std::string ) \
+CALL( SECURITY_LOCAL_MD_SET,       "Security Local Metadata Set",          std::string ) /* really std_0102_lds */ \
+CALL( 0601_WEAPON_LOAD,            "Weapon Load",                          uint64_t ) \
+CALL( 0601_WEAPON_FIRED,           "Weapon Fired",                         uint64_t ) \
+CALL( AVERAGE_GSD,                 "Average GSD value",                    double ) \
+CALL( GPS_SEC,                     "GPS seconds",                          double ) \
+CALL( GPS_WEEK,                    "GPS week",                             int ) \
+CALL( NORTHING_VEL,                "Northing velocity",                    double ) \
+CALL( EASTING_VEL,                 "Easting velocity",                     double ) \
+CALL( UP_VEL,                      "UP velocity",                          double ) \
+CALL( IMU_STATUS,                  "IMU status",                           int ) \
+CALL( LOCAL_ADJ,                   "Local adj",                            int ) \
+CALL( DST_FLAGS,                   "Dst flags",                            int ) \
+CALL( RPC_HEIGHT_OFFSET,           "RPC height offset",                    double ) \
+CALL( RPC_HEIGHT_SCALE,            "RPC height scale",                     double ) \
+CALL( RPC_LONG_OFFSET,             "RPC longitude offset",                 double ) \
+CALL( RPC_LONG_SCALE,              "RPC longitude scale",                  double ) \
+CALL( RPC_LAT_OFFSET,              "RPC latitude offset",                  double ) \
+CALL( RPC_LAT_SCALE,               "RPC latitude scale",                   double ) \
+CALL( RPC_ROW_OFFSET,              "RPC row offset",                       double ) \
+CALL( RPC_ROW_SCALE,               "RPC row scale",                        double ) \
+CALL( RPC_COL_OFFSET,              "RPC column offset",                    double ) \
+CALL( RPC_COL_SCALE ,              "RPC column scale",                     double ) \
 CALL( RPC_ROW_NUM_COEFF,           "RPC row numerator coefficients",       std::string ) \
 CALL( RPC_ROW_DEN_COEFF,           "RPC row denominator coefficients",     std::string ) \
 CALL( RPC_COL_NUM_COEFF,           "RPC column numerator coefficients",    std::string ) \
@@ -157,7 +157,7 @@ namespace vital {
 
 enum vital_metadata_tag {
 
-#define ENUM_ITEM( TAG, NAME, T) VITAL_META_ ## TAG,
+#define ENUM_ITEM(TAG, NAME, T) VITAL_META_ ## TAG,
 
   // Generate enum items
   KWIVER_VITAL_METADATA_TAGS( ENUM_ITEM )

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -44,107 +44,452 @@
 //
 // Add another line to the macro to add another tag.
 
-//
-//      tag                          string name                        type
-//      ---                          -----------                        ----
-#define KWIVER_VITAL_METADATA_TAGS(CALL)                                \
-CALL( UNKNOWN,                     "Unknown / Undefined entry",            int ) \
-CALL( METADATA_ORIGIN,             "Origin of metadata",                   std::string ) \
-CALL( UNIX_TIMESTAMP,              "Unix Time Stamp",                      uint64_t ) \
-CALL( MISSION_ID,                  "Mission ID",                           std::string ) \
-CALL( MISSION_NUMBER,              "Episode Number",                       std::string ) \
-CALL( PLATFORM_TAIL_NUMBER,        "Platform Tail Number",                 std::string ) \
-CALL( PLATFORM_HEADING_ANGLE,      "Platform Heading Angle",               double ) \
-CALL( PLATFORM_PITCH_ANGLE,        "Platform Pitch Angle",                 double ) \
-CALL( PLATFORM_ROLL_ANGLE,         "Platform Roll Angle",                  double ) \
-CALL( PLATFORM_TRUE_AIRSPEED,      "Platform True Airspeed",               double ) \
-CALL( PLATFORM_INDICATED_AIRSPEED, "Platform Indicated Airspeed",          double ) \
-CALL( PLATFORM_DESIGNATION,        "Platform Designation",                 std::string ) \
-CALL( IMAGE_SOURCE_SENSOR,         "Image Source Sensor",                  std::string ) \
-CALL( IMAGE_COORDINATE_SYSTEM,     "Image Coordinate System",              std::string ) \
-CALL( IMAGE_URI,                   "Image URI",                            std::string ) \
-CALL( VIDEO_URI,                   "Video URI",                            std::string ) \
-CALL( VIDEO_KEY_FRAME,             "Is frame a key frame",                 bool ) \
-CALL( SENSOR_LOCATION,             "Sensor Geodetic Location, Lat/Lon/Alt", geo_point ) \
-CALL( SENSOR_HORIZONTAL_FOV,       "Sensor Horizontal Field of View",      double ) \
-CALL( SENSOR_VERTICAL_FOV,         "Sensor Vertical Field of View",        double ) \
-CALL( SENSOR_REL_AZ_ANGLE,         "Sensor Relative Azimuth Angle",        double ) \
-CALL( SENSOR_REL_EL_ANGLE,         "Sensor Relative Elevation Angle",      double ) \
-CALL( SENSOR_REL_ROLL_ANGLE,       "Sensor Relative Roll Angle",           double ) \
-CALL( SENSOR_YAW_ANGLE,            "Sensor yaw angle",                     double ) \
-CALL( SENSOR_PITCH_ANGLE,          "Sensor pitch angle",                   double ) \
-CALL( SENSOR_ROLL_ANGLE,           "Sensor Roll Angle",                    double ) \
-CALL( SENSOR_TYPE,                 "Sensor Type",                          std::string ) \
-CALL( SLANT_RANGE,                 "Slant Range",                          double ) \
-CALL( TARGET_WIDTH,                "Target Width",                         double ) \
-CALL( FRAME_CENTER,                "Geodetic Frame Center, Lat/Lon",       geo_point ) \
-CALL( FRAME_CENTER_ELEV,           "Frame Center Elevation",               double ) /* TODO: merge with previous? */ \
-CALL( CORNER_POINTS,               "Corner points",                        geo_polygon ) \
-CALL( ICING_DETECTED,              "Icing Detected",                       uint64_t ) \
-CALL( WIND_DIRECTION,              "Wind Direction",                       double ) \
-CALL( WIND_SPEED,                  "Wind Speed",                           double ) \
-CALL( STATIC_PRESSURE,             "Static Pressure",                      double ) \
-CALL( DENSITY_ALTITUDE,            "Density Altitude",                     double ) \
-CALL( OUTSIDE_AIR_TEMPERATURE,     "Outside Air Temperature",              double ) \
-CALL( TARGET_LOCATION,             "Target Geodetic Location, Lat/Lon/Alt", geo_point ) \
-CALL( TARGET_TRK_GATE_WIDTH,       "Target Track Gate Width",              double ) \
-CALL( TARGET_TRK_GATE_HEIGHT,      "Target Track Gate Height",             double ) \
-CALL( TARGET_ERROR_EST_CE90,       "Target Error Estimate - CE90",         double ) \
-CALL( TARGET_ERROR_EST_LE90,       "Target Error Estimate - LE90",         double ) \
-CALL( DIFFERENTIAL_PRESSURE,       "Differential Pressure",                double ) \
-CALL( PLATFORM_ANG_OF_ATTACK,      "Platform Angle of Attack",             double ) \
-CALL( PLATFORM_VERTICAL_SPEED,     "Platform Vertical Speed",              double ) \
-CALL( PLATFORM_SIDESLIP_ANGLE,     "Platform Sideslip Angle",              double ) \
-CALL( AIRFIELD_BAROMET_PRESS,      "Airfield Barometric Pressure",         double ) \
-CALL( AIRFIELD_ELEVATION,          "Airfield Elevation",                   double ) \
-CALL( RELATIVE_HUMIDITY,           "Relative Humidity",                    double ) \
-CALL( PLATFORM_GROUND_SPEED,       "Platform Ground Speed",                double ) \
-CALL( GROUND_RANGE,                "Ground Range",                         double ) \
-CALL( PLATFORM_FUEL_REMAINING,     "Platform Fuel Remaining",              double ) \
-CALL( PLATFORM_CALL_SIGN,          "Platform Call Sign",                   std::string ) \
-CALL( LASER_PRF_CODE,              "Laser PRF Code",                       uint64_t ) \
-CALL( SENSOR_FOV_NAME,             "Sensor Field of View Name",            uint64_t ) \
-CALL( PLATFORM_MAGNET_HEADING,     "Platform Magnetic Heading",            double ) \
-CALL( UAS_LDS_VERSION_NUMBER,      "UAS LDS Version Number",               uint64_t ) \
-CALL( ANGLE_TO_NORTH,              "Angle to North",                       double ) \
-CALL( OBLIQUITY_ANGLE,             "Sensor Elevation Angle",               double ) \
-CALL( START_DATE_TIME_UTC,         "Start Date Time - UTC",                std::string ) \
-CALL( EVENT_START_DATE_TIME_UTC,   "Event Start Date Time - UTC",          std::string ) \
-CALL( MISSION_START_TIME_UTC,      "Mission Start Date Time - UTC",        std::string ) \
-CALL( SECURITY_CLASSIFICATION,     "Security Classification",              std::string ) \
-CALL( CLASSIFICATION,              "Classification (0102 lds )",           std::string ) \
-CALL( SECURITY_LOCAL_MD_SET,       "Security Local Metadata Set",          std::string ) /* really std_0102_lds */ \
-CALL( 0601_WEAPON_LOAD,            "Weapon Load",                          uint64_t ) \
-CALL( 0601_WEAPON_FIRED,           "Weapon Fired",                         uint64_t ) \
-CALL( AVERAGE_GSD,                 "Average GSD value",                    double ) \
-CALL( GPS_SEC,                     "GPS seconds",                          double ) \
-CALL( GPS_WEEK,                    "GPS week",                             int ) \
-CALL( NORTHING_VEL,                "Northing velocity",                    double ) \
-CALL( EASTING_VEL,                 "Easting velocity",                     double ) \
-CALL( UP_VEL,                      "UP velocity",                          double ) \
-CALL( IMU_STATUS,                  "IMU status",                           int ) \
-CALL( LOCAL_ADJ,                   "Local adj",                            int ) \
-CALL( DST_FLAGS,                   "Dst flags",                            int ) \
-CALL( RPC_HEIGHT_OFFSET,           "RPC height offset",                    double ) \
-CALL( RPC_HEIGHT_SCALE,            "RPC height scale",                     double ) \
-CALL( RPC_LONG_OFFSET,             "RPC longitude offset",                 double ) \
-CALL( RPC_LONG_SCALE,              "RPC longitude scale",                  double ) \
-CALL( RPC_LAT_OFFSET,              "RPC latitude offset",                  double ) \
-CALL( RPC_LAT_SCALE,               "RPC latitude scale",                   double ) \
-CALL( RPC_ROW_OFFSET,              "RPC row offset",                       double ) \
-CALL( RPC_ROW_SCALE,               "RPC row scale",                        double ) \
-CALL( RPC_COL_OFFSET,              "RPC column offset",                    double ) \
-CALL( RPC_COL_SCALE ,              "RPC column scale",                     double ) \
-CALL( RPC_ROW_NUM_COEFF,           "RPC row numerator coefficients",       std::string ) \
-CALL( RPC_ROW_DEN_COEFF,           "RPC row denominator coefficients",     std::string ) \
-CALL( RPC_COL_NUM_COEFF,           "RPC column numerator coefficients",    std::string ) \
-CALL( RPC_COL_DEN_COEFF,           "RPC column denominator coefficients",  std::string ) \
-CALL( NITF_IDATIM,                 "NITF IDATIM",                          std::string ) \
-CALL( NITF_BLOCKA_FRFC_LOC_01,     "First Row First Column Location",      std::string ) \
-CALL( NITF_BLOCKA_FRLC_LOC_01,     "First Row Last Column Location",       std::string ) \
-CALL( NITF_BLOCKA_LRLC_LOC_01,     "Last Row Last Column Location",        std::string ) \
-CALL( NITF_BLOCKA_LRFC_LOC_01,     "Last Row First Column Location",       std::string ) \
-CALL( NITF_IMAGE_COMMENTS,         "Image Comments for NITF File",         std::string )
+#define KWIVER_VITAL_METADATA_TAGS( CALL )                              \
+  CALL( UNKNOWN,                                                        \
+        "Unknown / Undefined entry",                                    \
+        int,                                                            \
+        "" )                                                            \
+  CALL( METADATA_ORIGIN,                                                \
+        "Origin of metadata",                                           \
+        std::string,                                                    \
+        "Name of the metadata standard which was the origin of these "  \
+        "metadata vaules if "                                           \
+        "they originated from a video stream. Can be omitted." )        \
+  CALL( UNIX_TIMESTAMP,                                                 \
+        "Unix Time Stamp",                                              \
+        uint64_t,                                                       \
+        "" )                                                            \
+  CALL( MISSION_ID,                                                     \
+        "Mission ID",                                                   \
+        std::string,                                                    \
+        "Descriptive Mission Identifier to distinguish event or sortie. "\
+        "Value field is Free Text." )                                   \
+  CALL( MISSION_NUMBER,                                                 \
+        "Episode Number",                                               \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( PLATFORM_TAIL_NUMBER,                                           \
+        "Platform Tail Number",                                         \
+        std::string,                                                    \
+        "Identifier of platform as posted." )                           \
+  CALL( PLATFORM_HEADING_ANGLE,                                         \
+        "Platform Heading Angle (deg)",                                 \
+        double,                                                         \
+        "Aircraft heading angle.  Relative between longitudinal axis "  \
+        "and True North measured in the horizontal plane." )            \
+  CALL( PLATFORM_PITCH_ANGLE,                                           \
+        "Platform Pitch Angle (deg)",                                   \
+        double,                                                         \
+        "Aircraft pitch angle. Angle between longitudinal axis and "    \
+        "horzontal plane.  Positive angles above horizontal plane." )   \
+  CALL( PLATFORM_ROLL_ANGLE,                                            \
+        "Platform Roll Angle (deg)",                                    \
+        double,                                                         \
+        "Platform roll angle. Angle between transverse axis and "       \
+        "horizontal plane. Positive angles for right wing lowered "     \
+        "below horizontal plane." )                                     \
+  CALL( PLATFORM_TRUE_AIRSPEED,                                         \
+        "Platform True Airspeed (meters/sec)",                          \
+        double,                                                         \
+        "True airspeed (TAS) of platform. Indicated Airspeed "          \
+        "adjusted for temperature and altitude." )                      \
+  CALL( PLATFORM_INDICATED_AIRSPEED,                                    \
+        "Platform Indicated Airspeed (meters/sec)",                     \
+        double,                                                         \
+        "Indicated airspeed (IAS) of platform. Derived from Pitot "     \
+        "tube and static pressure sensors." )                           \
+  CALL( PLATFORM_DESIGNATION,                                           \
+        "Platform Designation",                                         \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( IMAGE_SOURCE_SENSOR,                                            \
+        "Image Source Sensor",                                          \
+        std::string,                                                    \
+        "String of image source sensor.  E.g.: 'EO Nose', "             \
+        "'EO Zoom (DLTV)', 'EO Spotter', "                              \
+        "'IR Mitsubishi PtSi Model 500', 'IR InSb Amber Model TBT', "   \
+        "'LYNX SAR Imagery', 'TESAR Imagery', etc." )                   \
+  CALL( IMAGE_COORDINATE_SYSTEM,                                        \
+        "Image Coordinate System",                                      \
+        std::string,                                                    \
+        "Coordinate system used. E.g.: 'Geodetic WGS84', "              \
+        "'Geocentric WGS84', 'TUM', 'None', etc." )                     \
+  CALL( IMAGE_URI,                                                      \
+        "Image URI",                                                    \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( VIDEO_URI,                                                      \
+        "Video URI",                                                    \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( VIDEO_KEY_FRAME,                                                \
+        "Is frame a key frame",                                         \
+        bool,                                                           \
+        "" )                                                            \
+  CALL( SENSOR_LOCATION,                                                \
+        "Sensor Geodetic Location (lon/lat/meters)",                    \
+        geo_point,                                                      \
+        "Contains the 3D coordinate of the sensor. "                    \
+        "The location is ordered lon, lat. "                            \
+        "The altitude is optional and is in meters." )                  \
+  CALL( SENSOR_HORIZONTAL_FOV,                                          \
+        "Sensor Horizontal Field of View (deg)",                        \
+        double,                                                         \
+        "Horizontal field of view of selected imaging sensor." )        \
+  CALL( SENSOR_VERTICAL_FOV,                                            \
+        "Sensor Vertical Field of View (deg)",                          \
+        double,                                                         \
+        "Vertical field of view of selected imaging sensor." )          \
+  CALL( SENSOR_REL_AZ_ANGLE,                                            \
+        "Sensor Relative Azimuth Angle (deg)",                          \
+        double,                                                         \
+        "Relative rotation angle of sensor to platform longitudinal axis. " \
+        "Rotation angle between platform longitudinal axis and " \
+        "camera pointing direction as seen from above the platform." )  \
+  CALL( SENSOR_REL_EL_ANGLE,                                            \
+        "Sensor Relative Elevation Angle (deg)",                        \
+        double,                                                         \
+        "Relative Elevation Angle of sensor to platform "               \
+        "longitudinal-transverse plane. Negative angles down." )        \
+  CALL( SENSOR_REL_ROLL_ANGLE,                                          \
+        "Sensor Relative Roll Angle (deg)",                             \
+        double,                                                         \
+        "Relative roll angle of sensor to aircraft platform. "          \
+        "Twisting angle of camera about lens axis. "                    \
+        "Top of image is zero degrees.  "                               \
+        "Positive angles are clockwise when looking from behind camera." ) \
+  CALL( SENSOR_YAW_ANGLE,                                               \
+        "Sensor yaw angle (deg)",                                       \
+        double,                                                         \
+        "" )                                                            \
+  CALL( SENSOR_PITCH_ANGLE,                                             \
+        "Sensor pitch angle (deg)",                                     \
+        double,                                                         \
+        "" )                                                            \
+  CALL( SENSOR_ROLL_ANGLE,                                              \
+        "Sensor Roll Angle (deg)",                                      \
+        double,                                                         \
+        "" )                                                            \
+  CALL( SENSOR_TYPE,                                                    \
+        "Sensor Type",                                                  \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( SLANT_RANGE,                                                    \
+        "Slant Range (meters)",                                         \
+        double,                                                         \
+        "Distance to target." )                                         \
+  CALL( TARGET_WIDTH,                                                   \
+        "Target Width (meters)",                                        \
+        double,                                                         \
+        "Target Width within sensor field of view." )                   \
+  CALL( FRAME_CENTER,                                                   \
+        "Geodetic Frame Center, (lon/lat)",                             \
+        geo_point,                                                      \
+        "Contains the 2D coordinate of the frame center. "              \
+        "The location is ordered lon, lat." )                           \
+  CALL( FRAME_CENTER_ELEV,                                              \
+        "Frame Center Elevation (meters)",                              \
+        double,                                                         \
+        "" ) /* TODO: merge with previous? */                           \
+  CALL( CORNER_POINTS,                                                  \
+        "Corner points (lon/lat)",                                      \
+        geo_polygon,                                                    \
+        "A four sided polygon representing the image bounds, "          \
+        "The corners are ordered "                                      \
+        "upper left, upper right, lower right, lower left.")            \
+  CALL( ICING_DETECTED,                                                 \
+        "Icing Detected",                                               \
+        uint64_t,                                                       \
+        "Flag for icing detected at aircraft location." )               \
+  CALL( WIND_DIRECTION,                                                 \
+        "Wind Direction (deg)",                                         \
+        double,                                                         \
+        "Wind direction at aircraft location. This is the direction "   \
+        "the wind is coming from relative to true north." )             \
+  CALL( WIND_SPEED,                                                     \
+        "Wind Speed (meters/sec)",                                      \
+        double,                                                         \
+        "Wind speed at aircraft location." )                            \
+  CALL( STATIC_PRESSURE,                                                \
+        "Static Pressure (millibar)",                                   \
+        double,                                                         \
+        "Static pressure at aircraft location." )                       \
+  CALL( DENSITY_ALTITUDE,                                               \
+        "Density Altitude (meters)",                                    \
+        double,                                                         \
+        "Density altitude at aircraft location. Relative aircraft "     \
+        "performance metric based on outside air temperature, static "  \
+        "pressure, and humidity." )                                     \
+  CALL( OUTSIDE_AIR_TEMPERATURE,                                        \
+        "Outside Air Temperature (Celsius)",                            \
+        double,                                                         \
+        "Temperature outside aircraft." )                               \
+  CALL( TARGET_LOCATION,                                                \
+        "Target Geodetic Locationq (lon/lat/meters)",                   \
+        geo_point,                                                      \
+        "Contains the 3D coordinate of the target. "                    \
+        "The location is ordered lon, lat. "                            \
+        "The altitude is optional and is in meters." )                  \
+  CALL( TARGET_TRK_GATE_WIDTH,                                          \
+        "Target Track Gate Width (pixels)",                             \
+        double,                                                         \
+        "Tracking gate width (x value) of tracked target within field " \
+        "of view.  Closely tied to source video resolution in pixels." ) \
+  CALL( TARGET_TRK_GATE_HEIGHT,                                         \
+        "Target Track Gate Height (pixels)",                            \
+        double,                                                         \
+        "Tracking gate height (y value) of tracked target within field " \
+        "of view.  Closely tied to source video resolution in pixels." ) \
+  CALL( TARGET_ERROR_EST_CE90,                                          \
+        "Target Error Estimate - CE90 (meters)",                        \
+        double,                                                         \
+        "Circular Error 90 (CE90) is the estimated error distance "     \
+        "in the horizontal direction.  Specifies the radius of 90% "    \
+        "probability on a plane tangent to the earth’s surface." )      \
+  CALL( TARGET_ERROR_EST_LE90,                                          \
+        "Target Error Estimate - LE90 (meters)",                        \
+        double,                                                         \
+        "Lateral Error 90 (LE90) is the estimated error distance "      \
+        "in the vertical (or lateral) direction.  Specifies the "       \
+        "interval of 90% probability in the local vertical direction." ) \
+  CALL( DIFFERENTIAL_PRESSURE,                                          \
+        "Differential Pressure (millibar)",                             \
+        double,                                                         \
+        "Differential pressure at aircraft location. "                  \
+        "Measured as the Stagnation/impact/total pressure minus "       \
+        "static pressure." )                                            \
+  CALL( PLATFORM_ANG_OF_ATTACK,                                         \
+        "Platform Angle of Attack (deg)",                               \
+        double,                                                         \
+        "Platform Attack Angle. Angle between platform longitudinal "   \
+        "axis and relative wind. Positive angles for upward "           \
+        "relative wind." )                                              \
+  CALL( PLATFORM_VERTICAL_SPEED,                                        \
+        "Platform Vertical Speed (meters/sec)",                         \
+        double,                                                         \
+        "Vertical speed of the aircraft relative to zenith. "           \
+        "Positive ascending, negative descending." )                    \
+  CALL( PLATFORM_SIDESLIP_ANGLE,                                        \
+        "Platform Sideslip Angle (deg)",                                \
+        double,                                                         \
+        "The sideslip angle is the angle between the platform "         \
+        "longitudinal axis and relative wind. "                         \
+        "Positive angles to right wing, neg to left." )                 \
+  CALL( AIRFIELD_BAROMET_PRESS,                                         \
+        "Airfield Barometric Pressure (millibars)",                     \
+        double,                                                         \
+        "Local pressure at airfield of known height. "                  \
+        "Pilot's responsibility to update." )                           \
+  CALL( AIRFIELD_ELEVATION,                                             \
+        "Airfield Elevation (meters)",                                  \
+        double,                                                         \
+        "Elevation of Airfield corresponding to Airfield "              \
+        "Barometric Pressure." )                                        \
+  CALL( RELATIVE_HUMIDITY,                                              \
+        "Relative Humidity (percent)",                                  \
+        double,                                                         \
+        "Relative Humidty at aircraft location." )                      \
+  CALL( PLATFORM_GROUND_SPEED,                                          \
+        "Platform Ground Speed (meters/sec)",                           \
+        double,                                                         \
+        "Speed projected to the ground of an airborne platform "        \
+        " passing overhead." )                                          \
+  CALL( GROUND_RANGE,                                                   \
+        "Ground Range (meters)",                                        \
+        double,                                                         \
+        "Horizontal distance from ground position of aircraft "         \
+        "relative to nadir, and target of interest. "                   \
+        "Dependent upon Slant Range and `Depression Angle." )           \
+  CALL( PLATFORM_FUEL_REMAINING,                                        \
+        "Platform Fuel Remaining (Kilogram)",                           \
+        double,                                                         \
+        "Remainging fuel on airborne platform. "                        \
+        "Metered as fuel weight remaining." )                           \
+  CALL( PLATFORM_CALL_SIGN,                                             \
+        "Platform Call Sign",                                           \
+        std::string,                                                    \
+        "Call Sign of platform or operating unit." )                    \
+  CALL( LASER_PRF_CODE,                                                 \
+        "Laser PRF Code",                                               \
+        uint64_t,                                                       \
+        "A laser's Pulse Repetition Frequency (PRF) code used to "      \
+        "mark a target. The Laser PRF code is a three or four digit "   \
+        "number consisting of the values 1..8." )                       \
+  CALL( SENSOR_FOV_NAME,                                                \
+        "Sensor Field of View Name",                                    \
+        uint64_t,                                                       \
+        "Names sensor field of view quantized steps. "                  \
+        "00 = Ultranarrow; 01 = Narrow; 02 = Medium; 03 = Wide; "       \
+        "04 = Ultrawide; 05 = Narrow Medium; 06 = 2x Ultranarrow; "     \
+        "07 = 4x Ultranarrow" )                                         \
+  CALL( PLATFORM_MAGNET_HEADING,                                        \
+        "Platform Magnetic Heading (deg)",                              \
+        double,                                                         \
+        "Aircraft magnetic heading angle. Relative between "            \
+        "longitudinal axis and Magnetic North measured in the "         \
+        "horizontal plane." )                                           \
+  CALL( UAS_LDS_VERSION_NUMBER,                                         \
+        "UAS LDS Version Number",                                       \
+        uint64_t,                                                       \
+        "" )                                                            \
+  CALL( ANGLE_TO_NORTH,                                                 \
+        "Angle to North (deg)",                                         \
+        double,                                                         \
+        "" )                                                            \
+  CALL( OBLIQUITY_ANGLE,                                                \
+        "Sensor Elevation Angle (deg)",                                 \
+        double,                                                         \
+        "" )                                                            \
+  CALL( START_DATE_TIME_UTC,                                            \
+        "Start Date Time (UTC)",                                        \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( EVENT_START_DATE_TIME_UTC,                                      \
+        "Event Start Date Time (UTC)",                                  \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( MISSION_START_TIME_UTC,                                         \
+        "Mission Start Date Time (UTC)",                                \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( SECURITY_CLASSIFICATION,                                        \
+        "Security Classification",                                      \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( CLASSIFICATION,                                                 \
+        "Classification (0102 lds)",                                    \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( SECURITY_LOCAL_MD_SET,                                          \
+        "Security Local Metadata Set",                                  \
+        std::string,                                                    \
+        "Refer to std 0102 lds" )                                       \
+  CALL( 0601_WEAPON_LOAD,                                               \
+        "Weapon Load",                                                  \
+        uint64_t,                                                       \
+        "Current weapons stored on aircraft" )                          \
+  CALL( 0601_WEAPON_FIRED,                                              \
+        "Weapon Fired",                                                 \
+        uint64_t,                                                       \
+        "Indication when a particular weapon is released. "             \
+        "Correlate with Unix Time stamp. "                              \
+        "Identical format to Weapon Load." )                            \
+  CALL( AVERAGE_GSD,                                                    \
+        "Average GSD value (meters/pixel)",                             \
+        double,                                                         \
+        "" )                                                            \
+  CALL( GPS_SEC,                                                        \
+        "GPS seconds",                                                  \
+        double,                                                         \
+        "" )                                                            \
+  CALL( GPS_WEEK,                                                       \
+        "GPS week",                                                     \
+        int,                                                            \
+        "" )                                                            \
+  CALL( NORTHING_VEL,                                                   \
+        "Northing velocity (meters/sec)",                               \
+        double,                                                         \
+        "" )                                                            \
+  CALL( EASTING_VEL,                                                    \
+        "Easting velocity (meters/sec)",                                \
+        double,                                                         \
+        "" )                                                            \
+  CALL( UP_VEL,                                                         \
+        "UP velocity (meters/sec)",                                     \
+        double,                                                         \
+        "" )                                                            \
+  CALL( IMU_STATUS,                                                     \
+        "IMU status",                                                   \
+        int,                                                            \
+        "" )                                                            \
+  CALL( LOCAL_ADJ,                                                      \
+        "Local adj",                                                    \
+        int,                                                            \
+        "" )                                                            \
+  CALL( DST_FLAGS,                                                      \
+        "Dst flags",                                                    \
+        int,                                                            \
+        "" )                                                            \
+  CALL( RPC_HEIGHT_OFFSET,                                              \
+        "RPC height offset",                                            \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_HEIGHT_SCALE,                                               \
+        "RPC height scale",                                             \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_LONG_OFFSET,                                                \
+        "RPC longitude offset",                                         \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_LONG_SCALE,                                                 \
+        "RPC longitude scale",                                          \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_LAT_OFFSET,                                                 \
+        "RPC latitude offset",                                          \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_LAT_SCALE,                                                  \
+        "RPC latitude scale",                                           \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_ROW_OFFSET,                                                 \
+        "RPC row offset",                                               \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_ROW_SCALE,                                                  \
+        "RPC row scale",                                                \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_COL_OFFSET,                                                 \
+        "RPC column offset",                                            \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_COL_SCALE,                                                  \
+        "RPC column scale",                                             \
+        double,                                                         \
+        "" )                                                            \
+  CALL( RPC_ROW_NUM_COEFF,                                              \
+        "RPC row numerator coefficients",                               \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( RPC_ROW_DEN_COEFF,                                              \
+        "RPC row denominator coefficients",                             \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( RPC_COL_NUM_COEFF,                                              \
+        "RPC column numerator coefficients",                            \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( RPC_COL_DEN_COEFF,                                              \
+        "RPC column denominator coefficients",                          \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_IDATIM,                                                    \
+        "NITF IDATIM",                                                  \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_BLOCKA_FRFC_LOC_01,                                        \
+        "First Row First Column Location",                              \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_BLOCKA_FRLC_LOC_01,                                        \
+        "First Row Last Column Location",                               \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_BLOCKA_LRLC_LOC_01,                                        \
+        "Last Row Last Column Location",                                \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_BLOCKA_LRFC_LOC_01,                                        \
+        "Last Row First Column Location",                               \
+        std::string,                                                    \
+        "" )                                                            \
+  CALL( NITF_IMAGE_COMMENTS,                                            \
+        "Image Comments for NITF File",                                 \
+        std::string,                                                    \
+        "" )
 
 // ------------------------------------------------------------------
 //
@@ -156,7 +501,7 @@ namespace vital {
 
 enum vital_metadata_tag {
 
-#define ENUM_ITEM(TAG, NAME, T) VITAL_META_ ## TAG,
+#define ENUM_ITEM(TAG, NAME, T, ...) VITAL_META_ ## TAG,
 
   // Generate enum items
   KWIVER_VITAL_METADATA_TAGS( ENUM_ITEM )

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -48,7 +48,7 @@
   CALL( UNKNOWN,                                                        \
         "Unknown / Undefined entry",                                    \
         int,                                                            \
-        "" )                                                            \
+        "Undefined entry" )                                             \
   CALL( METADATA_ORIGIN,                                                \
         "Origin of metadata",                                           \
         std::string,                                                    \

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -77,7 +77,7 @@ CALL( SENSOR_ROLL_ANGLE,           "Sensor Roll Angle",                    doubl
 CALL( SENSOR_TYPE,                 "Sensor Type",                          std::string ) \
 CALL( SLANT_RANGE,                 "Slant Range",                          double ) \
 CALL( TARGET_WIDTH,                "Target Width",                         double ) \
-CALL( FRAME_CENTER,                "Geodetic Frame Center",                geo_point ) \
+CALL( FRAME_CENTER,                "Geodetic Frame Center, Lat/Lon",       geo_point ) \
 CALL( FRAME_CENTER_ELEV,           "Frame Center Elevation",               double ) /* TODO: merge with previous? */ \
 CALL( CORNER_POINTS,               "Corner points",                        geo_polygon ) \
 CALL( ICING_DETECTED,              "Icing Detected",                       uint64_t ) \
@@ -86,8 +86,7 @@ CALL( WIND_SPEED,                  "Wind Speed",                           doubl
 CALL( STATIC_PRESSURE,             "Static Pressure",                      double ) \
 CALL( DENSITY_ALTITUDE,            "Density Altitude",                     double ) \
 CALL( OUTSIDE_AIR_TEMPERATURE,     "Outside Air Temperature",              double ) \
-CALL( TARGET_LOCATION,             "Target Geodetic Location",             geo_point ) \
-CALL( TARGET_LOCATION_ELEV,        "Target Location Elevation",            double ) /* TODO: merge with previous? */ \
+CALL( TARGET_LOCATION,             "Target Geodetic Location, Lat/Lon/Alt", geo_point ) \
 CALL( TARGET_TRK_GATE_WIDTH,       "Target Track Gate Width",              double ) \
 CALL( TARGET_TRK_GATE_HEIGHT,      "Target Track Gate Height",             double ) \
 CALL( TARGET_ERROR_EST_CE90,       "Target Error Estimate - CE90",         double ) \

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -183,14 +183,11 @@
         double,                                                         \
         "Target Width within sensor field of view." )                   \
   CALL( FRAME_CENTER,                                                   \
-        "Geodetic Frame Center, (lon/lat)",                             \
+        "Geodetic Frame Center, (lon/lat/meters)",                      \
         geo_point,                                                      \
-        "Contains the 2D coordinate of the frame center. "              \
-        "The location is ordered lon, lat." )                           \
-  CALL( FRAME_CENTER_ELEV,                                              \
-        "Frame Center Elevation (meters)",                              \
-        double,                                                         \
-        "" ) /* TODO: merge with previous? */                           \
+        "Contains the 3D coordinate of the frame center. "              \
+        "The location is ordered lon, lat, and altitude in meters. "    \
+        "Altitude is not always set." )                                 \
   CALL( CORNER_POINTS,                                                  \
         "Corner points (lon/lat)",                                      \
         geo_polygon,                                                    \

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -65,8 +65,7 @@ CALL( IMAGE_COORDINATE_SYSTEM,     "Image Coordinate System",         std::strin
 CALL( IMAGE_URI,                   "Image URI",                       std::string) \
 CALL( VIDEO_URI,                   "Video URI",                       std::string) \
 CALL( VIDEO_KEY_FRAME,             "Is frame a key frame",            bool) \
-CALL( SENSOR_LOCATION,             "Sensor Geodetic Location",        geo_point) \
-CALL( SENSOR_ALTITUDE,             "Sensor Altitude",                 double) /* TODO: merge with previous? */ \
+CALL( SENSOR_LOCATION,             "Sensor Geodetic Location, L/L/A", geo_point) \
 CALL( SENSOR_HORIZONTAL_FOV,       "Sensor Horizontal Field of View", double) \
 CALL( SENSOR_VERTICAL_FOV,         "Sensor Vertical Field of View",   double) \
 CALL( SENSOR_REL_AZ_ANGLE,         "Sensor Relative Azimuth Angle",   double) \

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -42,9 +42,8 @@ template <vital_metadata_tag tag>
 struct vital_meta_trait_object
   : public vital_meta_trait_base
 {
-  virtual ~vital_meta_trait_object() {}
   virtual std::string name() const override { return vital_meta_trait<tag>::name(); }
-  virtual const std::string& description() const { return vital_meta_trait<tag>::description(); }
+  virtual std::string description() const { return vital_meta_trait<tag>::description(); }
   virtual std::type_info const& tag_type() const override { return vital_meta_trait<tag>::tag_type(); }
   virtual bool is_integral() const override { return vital_meta_trait<tag>::is_integral(); }
   virtual bool is_floating_point() const override { return vital_meta_trait<tag>::is_floating_point(); }
@@ -64,9 +63,8 @@ struct vital_meta_trait_object
   struct vital_meta_trait_object<VITAL_META_ ## TAG>                    \
     : public vital_meta_trait_base                                      \
   {                                                                     \
-    virtual ~vital_meta_trait_object() override {}                      \
-    virtual std::string name() const override { return NAME; }          \
-    virtual std::string const& description() const override { return TD; } \
+    virtual std::string name() const override { return std::string(NAME); } \
+    virtual std::string description() const override { return std::string(TD); } \
     virtual std::type_info const& tag_type() const override { return typeid(T); } \
     virtual bool is_integral() const override { return std::is_integral<T>::value; } \
     virtual bool is_floating_point() const override { return std::is_floating_point<T>::value; } \
@@ -162,7 +160,7 @@ metadata_traits
 
 
 // ------------------------------------------------------------------
-std::string const&
+std::string
 metadata_traits
 ::tag_to_description( vital_metadata_tag tag ) const
 {

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -44,6 +44,7 @@ struct vital_meta_trait_object
 {
   virtual ~vital_meta_trait_object() {}
   virtual std::string name() const override { return vital_meta_trait<tag>::name(); }
+  virtual const std::string& description() const { return vital_meta_trait<tag>::description(); }
   virtual std::type_info const& tag_type() const override { return vital_meta_trait<tag>::tag_type(); }
   virtual bool is_integral() const override { return vital_meta_trait<tag>::is_integral(); }
   virtual bool is_floating_point() const override { return vital_meta_trait<tag>::is_floating_point(); }
@@ -58,13 +59,14 @@ template <vital_metadata_tag tag>
 struct vital_meta_trait_object
   : public vital_meta_trait_base {};
 
-#define DEFINE_VITAL_META_TRAIT(TAG, NAME, T)                           \
+#define DEFINE_VITAL_META_TRAIT(TAG, NAME, T, TD)                       \
   template <>                                                           \
   struct vital_meta_trait_object<VITAL_META_ ## TAG>                    \
     : public vital_meta_trait_base                                      \
   {                                                                     \
     virtual ~vital_meta_trait_object() override {}                      \
     virtual std::string name() const override { return NAME; }          \
+    virtual std::string const& description() const override { return TD; } \
     virtual std::type_info const& tag_type() const override { return typeid(T); } \
     virtual bool is_integral() const override { return std::is_integral<T>::value; } \
     virtual bool is_floating_point() const override { return std::is_floating_point<T>::value; } \
@@ -83,7 +85,7 @@ metadata_traits
   : m_logger( kwiver::vital::get_logger( "vital.metadata_traits" ) )
 {
   // Create trait table
-#define TABLE_ENTRY(TAG, NAME, TYPE) \
+#define TABLE_ENTRY(TAG, NAME, TYPE, ...)        \
   m_trait_table[VITAL_META_ ## TAG] = trait_ptr( \
     static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
 
@@ -133,7 +135,7 @@ std::string
 metadata_traits
 ::tag_to_symbol( vital_metadata_tag tag ) const
 {
-#define TAG_CASE( TAG, NAME, TYPE ) case VITAL_META_##TAG: return "VITAL_META_" #TAG;
+#define TAG_CASE( TAG, NAME, TYPE, ... ) case VITAL_META_##TAG: return "VITAL_META_" #TAG;
 
   switch (tag)
   {
@@ -156,6 +158,16 @@ metadata_traits
 {
   vital_meta_trait_base const& trait = find( tag );
   return trait.name();
+}
+
+
+// ------------------------------------------------------------------
+std::string const&
+metadata_traits
+::tag_to_description( vital_metadata_tag tag ) const
+{
+  vital_meta_trait_base const& trait = find( tag );
+  return trait.description();
 }
 
 

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -40,7 +40,6 @@
 #include <vital/types/geo_point.h>
 #include <vital/types/geo_polygon.h>
 #include <vital/types/matrix.h>
-#include <vital/types/metadata_tags.h>
 #include <vital/types/metadata.h>
 
 #include <vital/logger/logger.h>
@@ -58,9 +57,9 @@ namespace vital {
  */
 struct vital_meta_trait_base
 {
-  virtual ~vital_meta_trait_base() {}
+  virtual ~vital_meta_trait_base() = default;
   virtual std::string name() const = 0;
-  virtual const std::string& description() const = 0;
+  virtual std::string description() const = 0;
   virtual std::type_info const& tag_type() const = 0;
   virtual bool is_integral() const = 0;
   virtual bool is_floating_point() const = 0;
@@ -82,8 +81,8 @@ template <vital_metadata_tag tag> struct vital_meta_trait;
   template <>                                                           \
   struct vital_meta_trait<TAG>                                          \
   {                                                                     \
-    static std::string name() { return NAME; }                          \
-    static std::string  description() { return LD; }                    \
+    static std::string name() { return std::string(NAME); }             \
+    static std::string  description() { return std::string(LD); }       \
     static std::type_info const& tag_type() { return typeid(T); }       \
     static bool is_integral() { return std::is_integral<T>::value; }    \
     static bool is_floating_point() { return std::is_floating_point<T>::value; } \
@@ -168,7 +167,7 @@ public:
    *
    * @return Long description for this tag.
    */
-  std::string const& tag_to_description( vital_metadata_tag tag ) const;
+  std::string tag_to_description( vital_metadata_tag tag ) const;
 
 
 private:

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -60,6 +60,7 @@ struct vital_meta_trait_base
 {
   virtual ~vital_meta_trait_base() {}
   virtual std::string name() const = 0;
+  virtual const std::string& description() const = 0;
   virtual std::type_info const& tag_type() const = 0;
   virtual bool is_integral() const = 0;
   virtual bool is_floating_point() const = 0;
@@ -77,11 +78,12 @@ template <vital_metadata_tag tag> struct vital_meta_trait;
 
 // Macro to define basic metadata trait
 // This macro is available for others to create separate sets of traits.
-#define DEFINE_VITAL_METADATA_TRAIT(TAG, NAME, T)                       \
+#define DEFINE_VITAL_METADATA_TRAIT(TAG, NAME, T, LD)                   \
   template <>                                                           \
   struct vital_meta_trait<TAG>                                          \
   {                                                                     \
     static std::string name() { return NAME; }                          \
+    static std::string  description() { return LD; }                    \
     static std::type_info const& tag_type() { return typeid(T); }       \
     static bool is_integral() { return std::is_integral<T>::value; }    \
     static bool is_floating_point() { return std::is_floating_point<T>::value; } \
@@ -90,7 +92,7 @@ template <vital_metadata_tag tag> struct vital_meta_trait;
   };
 
 // Macro to define build-in traits.
-#define DEFINE_VITAL_META_TRAIT(TAG, NAME, T)   DEFINE_VITAL_METADATA_TRAIT( VITAL_META_ ## TAG, NAME, T )
+#define DEFINE_VITAL_META_TRAIT(TAG, NAME, T, LD)   DEFINE_VITAL_METADATA_TRAIT( VITAL_META_ ## TAG, NAME, T, LD )
 
 //
 // Define all compile time metadata traits
@@ -156,6 +158,17 @@ public:
    */
   std::string tag_to_name( vital_metadata_tag tag ) const;
 
+
+  // Get metadata tag description
+  /**
+   * This method returns the long description string for the specified
+   * tag.
+   *
+   * @param tag Metadata tag value.
+   *
+   * @return Long description for this tag.
+   */
+  std::string const& tag_to_description( vital_metadata_tag tag ) const;
 
 
 private:


### PR DESCRIPTION
Rationalize sensor altitude in metadata.

Combined SENSOR_ALTITUDE into SENSOR_LOCATION by leveraging 3D geo point. Removed SENSOR_ALTITUDE metadata tag since it now redundant. This change removed warning about unreferenced altitude.

Also consolidated target location

Reformatted the metadata tags table in a separate commit so white-space changes do not overshadow the more substantial changes.

