### PR TITLE
Refactor detected_object_set-move operations out of class

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -45,6 +45,9 @@ Vital Types
  * Added iterator, const_iterator and iterable classes to support container-
    independent iteration.
 
+ * Refactored detected_object_set to convert some methods to external
+   functions since they were not properties of the class.
+
 Vital Bindings
 
  * Remove ctypes python bindings

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -91,29 +91,28 @@ set( vital_public_headers
   types/bounding_box.h
   types/camera.h
   types/camera_intrinsics.h
+  types/camera_map.h
   types/camera_perspective.h
   types/camera_perspective_map.h
   types/camera_rpc.h
-  types/camera_map.h
   types/category_hierarchy.h
   types/color.h
   types/covariance.h
   types/database_query.h
   types/descriptor.h
-  types/descriptor_set.h
   types/descriptor_request.h
+  types/descriptor_set.h
   types/detected_object.h
   types/detected_object_set.h
+  types/detected_object_set_util.h
   types/detected_object_type.h
   types/essential_matrix.h
-  types/detected_object.h
-  types/detected_object_set.h
   types/feature.h
   types/feature_set.h
   types/feature_track_set.h
   types/fundamental_matrix.h
-  types/geo_covariance.h
   types/geo_MGRS.h
+  types/geo_covariance.h
   types/geo_point.h
   types/geo_polygon.h
   types/geodesy.h
@@ -134,8 +133,8 @@ set( vital_public_headers
   types/mesh.h
   types/metadata.h
   types/metadata_map.h
-  types/metadata_traits.h
   types/metadata_tags.h
+  types/metadata_traits.h
   types/object_track_set.h
   types/point.h
   types/polygon.h
@@ -147,13 +146,13 @@ set( vital_public_headers
   types/timestamp.h
   types/timestamp_config.h
   types/track.h
-  types/track_interval.h
-  types/track_set.h
   types/track_descriptor.h
   types/track_descriptor_set.h
+  types/track_interval.h
+  types/track_set.h
   types/transform_2d.h
-  types/vector.h
   types/uid.h
+  types/vector.h
 )
 
 # ----------------------
@@ -179,13 +178,14 @@ set( vital_sources
   types/descriptor_request.cxx
   types/detected_object.cxx
   types/detected_object_set.cxx
+  types/detected_object_set_util.cxx
   types/detected_object_type.cxx
   types/essential_matrix.cxx
   types/feature.cxx
   types/feature_track_set.cxx
   types/fundamental_matrix.cxx
-  types/geo_covariance.cxx
   types/geo_MGRS.cxx
+  types/geo_covariance.cxx
   types/geo_point.cxx
   types/geo_polygon.cxx
   types/geodesy.cxx

--- a/vital/types/bounding_box.h
+++ b/vital/types/bounding_box.h
@@ -267,14 +267,13 @@ bounding_box<T> & translate( bounding_box<T>& bbox,
 /**
  * @brief Scale a box by some scale factor.
  *
- * This operator scales bounding_box by the specified
- * amount.
+ * This operator scales bounding_box by the specified factor. A new
+ * box is returned that has been scaled from the input box.
  *
- * @param[in,out] bbox Box to translate
- * @param[in] scale_factor Scale factor to use
+ * @param bbox Box to scale
+ * @param scale_factor Scale factor to use
  *
- * @return The specified parameter box, updated with the new
- * coordinates, is returned.
+ * @return A new bounding box that has been scaled.
  */
 template < typename T >
 bounding_box<T> scale( bounding_box<T> const& bbox,

--- a/vital/types/detected_object_set.h
+++ b/vital/types/detected_object_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017,2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,8 @@ namespace vital {
 class detected_object_set;
 
 // typedef for a detected_object shared pointer
-typedef std::shared_ptr< detected_object_set > detected_object_set_sptr;
+using detected_object_set_sptr = std::shared_ptr< detected_object_set >;
+using detected_object_set_scptr = std::shared_ptr< detected_object_set const >;
 
 // ----------------------------------------------------------------
 /**
@@ -70,8 +71,8 @@ class VITAL_EXPORT detected_object_set
   : private noncopyable
 {
 public:
-  typedef std::vector< detected_object_sptr >::iterator iterator;
-  typedef std::vector< detected_object_sptr >::const_iterator const_iterator;
+  using iterator = std::vector< detected_object_sptr >::iterator;
+  using  const_iterator = std::vector< detected_object_sptr >::const_iterator;
 
   /**
    * @brief Create an empty detection set.
@@ -228,7 +229,9 @@ public:
    *
    * @param scale Scale factor
    */
-  void scale( double scale_factor );
+  void
+  VITAL_DEPRECATED
+  scale( double scale_factor );
 
   /**
    * @brief Shift all detection locations by some translation offset.
@@ -244,7 +247,9 @@ public:
    * @param col_shift Column  (a.k.a. x, i, width) translation factor
    * @param row_shift Row (a.k.a. y, j, height) translation factor
    */
-  void shift( double col_shift, double row_shift );
+  void
+  VITAL_DEPRECATED
+  shift( double col_shift, double row_shift );
 
   /**
    * @brief Get attributes set.

--- a/vital/types/detected_object_set_util.cxx
+++ b/vital/types/detected_object_set_util.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,67 +28,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * \file
- * \brief Implementation of source_location class.
- */
-
-#include "source_location.h"
+#include "detected_object_set_util.h"
 
 namespace kwiver {
 namespace vital {
 
 // ------------------------------------------------------------------
-source_location::
-source_location()
-  : m_line_num(0)
-{ }
-
-
-// ------------------------------------------------------------------
-source_location::
-source_location( std::shared_ptr< std::string > f, int l)
-  : m_file_name(f)
-  , m_line_num(l)
-{ }
-
-
-// ------------------------------------------------------------------
-source_location::
-source_location( const source_location& other )
-  : m_file_name(other.m_file_name)
-  , m_line_num( other.m_line_num )
-{ }
-
-
-// ------------------------------------------------------------------
-source_location::
-~source_location()
-{ }
-
-
-// ------------------------------------------------------------------
-std::ostream &
-source_location::
-format (std::ostream & str) const
+void
+scale_detections( detected_object_set_sptr dos,
+       double scale_factor )
 {
-  if (m_line_num > 0)
+  if( scale_factor == 1.0 )
   {
-    str << *m_file_name << ":" << m_line_num;
+    return;
   }
 
-  return str;
+  for( auto detection : *dos )
+  {
+    auto bbox = detection->bounding_box();
+    bbox = kwiver::vital::scale( bbox, scale_factor );
+    detection->set_bounding_box( bbox );
+  }
 }
 
-
 // ------------------------------------------------------------------
-bool
-source_location::
-valid() const
+void
+shift_detections( detected_object_set_sptr dos,
+       double col_shift, double row_shift )
 {
-  return (  m_line_num > 0) &&
-    ( m_file_name ) &&
-    ( ! m_file_name->empty() );
+  if( col_shift == 0.0 && row_shift == 0.0 )
+  {
+    return;
+  }
+
+  for( auto detection : *dos )
+  {
+    auto bbox = detection->bounding_box();
+    bbox = kwiver::vital::translate( bbox,
+      bounding_box_d::vector_type( col_shift, row_shift ) );
+    detection->set_bounding_box( bbox );
+  }
 }
 
 } } // end namespace

--- a/vital/types/detected_object_set_util.h
+++ b/vital/types/detected_object_set_util.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,67 +28,45 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * \file
- * \brief Implementation of source_location class.
- */
+#ifndef VITAL_DETECTED_OBJECT_SET_UTIL_H
+#define VITAL_DETECTED_OBJECT_SET_UTIL_H
 
-#include "source_location.h"
+#include <vital/vital_export.h>
+#include "detected_object_set.h"
 
 namespace kwiver {
 namespace vital {
 
-// ------------------------------------------------------------------
-source_location::
-source_location()
-  : m_line_num(0)
-{ }
+/**
+ * @brief Scale all detection locations by some scale factor.
+ *
+ * This method changes the bounding boxes within all stored detections
+ * by scaling them by some scale factor.
+ *
+ * @param scale Scale factor
+ */
+void VITAL_EXPORT
+scale_detections( detected_object_set_sptr dos,
+                  double scale_factor );
 
-
-// ------------------------------------------------------------------
-source_location::
-source_location( std::shared_ptr< std::string > f, int l)
-  : m_file_name(f)
-  , m_line_num(l)
-{ }
-
-
-// ------------------------------------------------------------------
-source_location::
-source_location( const source_location& other )
-  : m_file_name(other.m_file_name)
-  , m_line_num( other.m_line_num )
-{ }
-
-
-// ------------------------------------------------------------------
-source_location::
-~source_location()
-{ }
-
-
-// ------------------------------------------------------------------
-std::ostream &
-source_location::
-format (std::ostream & str) const
-{
-  if (m_line_num > 0)
-  {
-    str << *m_file_name << ":" << m_line_num;
-  }
-
-  return str;
-}
-
-
-// ------------------------------------------------------------------
-bool
-source_location::
-valid() const
-{
-  return (  m_line_num > 0) &&
-    ( m_file_name ) &&
-    ( ! m_file_name->empty() );
-}
+/**
+ * @brief Shift all detection locations by some translation offset.
+ *
+ * This method shifts the bounding boxes within all stored detections
+ * by a supplied column and row shift.
+ *
+ * Note: Detections in this set can be shared by multiple sets, so
+ * shifting the detections in this set will also shift the detection
+ * in other sets that share this detection. If this is going to be a
+ * problem, clone() this set before shifting.
+ *
+ * @param col_shift Column  (a.k.a. x, i, width) translation factor
+ * @param row_shift Row (a.k.a. y, j, height) translation factor
+ */
+void VITAL_EXPORT
+shift_detections( detected_object_set_sptr dos,
+                  double col_shift, double row_shift );
 
 } } // end namespace
+
+#endif // VITAL_DETECTED_OBJECT_SET_UTIL_H

--- a/vital/types/detected_object_type.cxx
+++ b/vital/types/detected_object_type.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2018, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -271,9 +271,27 @@ detected_object_type
 // ------------------------------------------------------------------
 detected_object_type::class_const_iterator_t
 detected_object_type
+::cbegin() const
+{
+  return m_classes.cbegin();
+}
+
+
+// ------------------------------------------------------------------
+detected_object_type::class_const_iterator_t
+detected_object_type
 ::end() const
 {
   return m_classes.end();
+}
+
+
+// ------------------------------------------------------------------
+detected_object_type::class_const_iterator_t
+detected_object_type
+::cend() const
+{
+  return m_classes.cend();
 }
 
 

--- a/vital/types/detected_object_type.h
+++ b/vital/types/detected_object_type.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -227,6 +227,7 @@ public:
    */
   size_t size() const;
 
+  //@{
   /**
    * @brief Get start iterator to all class/score pairs.
    *
@@ -239,7 +240,10 @@ public:
    * @sa end
    */
   class_const_iterator_t begin() const;
+  class_const_iterator_t cbegin() const;
+  //@}
 
+  //@{
   /**
    * @brief Get end iterator to all class/score pairs.
    *
@@ -251,6 +255,8 @@ public:
    * @sa begin
    */
   class_const_iterator_t end() const;
+  class_const_iterator_t cend() const;
+  //@}
 
   /**
    * @brief Get list of all class_names in use.
@@ -290,7 +296,8 @@ private:
 };
 
 // typedef for a object_type shared pointer
-typedef std::shared_ptr< detected_object_type > detected_object_type_sptr;
+using detected_object_type_sptr = std::shared_ptr< detected_object_type >;
+using detected_object_type_scptr = std::shared_ptr< detected_object_type const >;
 
 } }
 

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -217,9 +217,25 @@ metadata
 
 metadata::const_iterator_t
 metadata
+::cbegin() const
+{
+  return m_metadata_map.cbegin();
+}
+
+
+metadata::const_iterator_t
+metadata
 ::end() const
 {
   return m_metadata_map.end();
+}
+
+
+metadata::const_iterator_t
+metadata
+::cend() const
+{
+  return m_metadata_map.cend();
 }
 
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -394,6 +394,7 @@ public:
   metadata_item const& find( vital_metadata_tag tag ) const;
 
 
+  //@{
   /// Get starting iterator for collection of metadata items.
   /**
    * This method returns the const iterator to the first element in
@@ -410,8 +411,10 @@ public:
    * @return Iterator pointing to the first element in the collection.
    */
   const_iterator_t begin() const;
+  const_iterator_t cbegin() const;
+  //@}
 
-
+  //@{
   /// Get ending iterator for collection of metadata.
   /**
    * This method returns the ending iterator for the collection of
@@ -428,7 +431,8 @@ public:
    * @return Ending iterator for collection
    */
   const_iterator_t end() const;
-
+  const_iterator_t cend() const;
+  //@}
 
   /// Get the number of metadata items in the collection.
   /**

--- a/vital/util/transform_image.h
+++ b/vital/util/transform_image.h
@@ -47,7 +47,7 @@ namespace vital {
 
 /// Transform a given image in place given a unary function
 /**
- * Apply a given unary function to all pixels in the image. This is guareteed
+ * Apply a given unary function to all pixels in the image. This is guarateed
  * to traverse the pixels in an optimal order, i.e. in-memory-order traversal.
  *
  * Example:
@@ -223,7 +223,7 @@ void cast_image( image const& img_in, image_of<T>& img_out )
 
 /// Call a unary function on every pixel in a const image
 /**
- * Apply a given unary function to all pixels in the image. This is guareteed
+ * Apply a given unary function to all pixels in the image. This is guarateed
  * to traverse the pixels in an optimal order, i.e. in-memory-order traversal.
  *
  * Example:
@@ -283,8 +283,6 @@ void foreach_pixel( image_of<T> const& img, OP op )
   }
 }
 
-
 } }   // end namespace vital
-
 
 #endif // VITAL_TRANSFORM_IMAGE_H_


### PR DESCRIPTION
The scale and translate methods are not inherently operate on the collection, but on each individual element and are not properties of the set. These methods were converted into unbound functions to reduce method proliferation in the detected_object_set class.

The existing methods are marked as DEPRECATED and will be removed at a later time.

- moved scale and translate from class to stand-alone operations
- Updated. improved and corrected documentation
- Added const iterators (cbegin, cend) to some collections
- Fixed pointer dereference bug