### PR TITLE
Add transform_2d::inverse method

### DIFF
--- a/vital/exceptions/math.cxx
+++ b/vital/exceptions/math.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014 by Kitware, Inc.
+ * Copyright 2014, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,14 +51,14 @@ math_exception
 }
 
 
-non_invertible_matrix
-::non_invertible_matrix() noexcept
+non_invertible
+::non_invertible() noexcept
 {
-  m_what = "A matrix was found to be non-invertible";
+  m_what = "A transformation was found to be non-invertible";
 }
 
-non_invertible_matrix
-::~non_invertible_matrix() noexcept
+non_invertible
+::~non_invertible() noexcept
 {
 }
 

--- a/vital/exceptions/math.h
+++ b/vital/exceptions/math.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,15 +56,16 @@ public:
 };
 
 
-/// Exception for when a matrix is non-invertible
-class VITAL_EXCEPTIONS_EXPORT non_invertible_matrix
+/// Exception for when an instance of a conceptually invertible object is
+/// non-invertible
+class VITAL_EXCEPTIONS_EXPORT non_invertible
   : public math_exception
 {
 public:
   /// Constructor
-  non_invertible_matrix() noexcept;
+  non_invertible() noexcept;
   /// Destructor
-  virtual ~non_invertible_matrix() noexcept;
+  virtual ~non_invertible() noexcept;
 };
 
 

--- a/vital/types/homography.cxx
+++ b/vital/types/homography.cxx
@@ -56,7 +56,7 @@ h_map_point( Eigen::Matrix< T, 3, 3 > const& h, Eigen::Matrix< T, 2, 1 > const& 
 
   if ( fabs( out_pt[2] ) <= Eigen::NumTraits< T >::dummy_precision() )
   {
-    throw point_maps_to_infinity();
+    VITAL_THROW(point_maps_to_infinity);
   }
   return Eigen::Matrix< T, 2, 1 > ( out_pt[0] / out_pt[2], out_pt[1] / out_pt[2] );
 }
@@ -178,7 +178,7 @@ homography_< T >
   this->h_.computeInverseWithCheck( inv, isvalid );
   if ( ! isvalid )
   {
-    throw non_invertible();
+    VITAL_THROW(non_invertible);
   }
   return std::make_shared< homography_< T > >( inv );
 }

--- a/vital/types/homography.cxx
+++ b/vital/types/homography.cxx
@@ -162,7 +162,7 @@ homography_< T >
   {
     norm /= norm( 2, 2 );
   }
-  return homography_sptr( new homography_< T > ( norm ) );
+  return std::make_shared< homography_< T > >( norm );
 }
 
 
@@ -180,7 +180,7 @@ homography_< T >
   {
     throw non_invertible_matrix();
   }
-  return homography_sptr( new homography_< T > ( inv ) );
+  return std::make_shared< homography_< T > >( inv );
 }
 
 

--- a/vital/types/homography.cxx
+++ b/vital/types/homography.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015, 2019 by Kitware, Inc.
+ * Copyright 2015, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -178,7 +178,7 @@ homography_< T >
   this->h_.computeInverseWithCheck( inv, isvalid );
   if ( ! isvalid )
   {
-    throw non_invertible_matrix();
+    throw non_invertible();
   }
   return std::make_shared< homography_< T > >( inv );
 }

--- a/vital/types/homography.h
+++ b/vital/types/homography.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2015, 2019 by Kitware, Inc.
+ * Copyright 2014-2015, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -167,7 +167,8 @@ public:
 
   /// Get a new \p homography that has been inverted.
   /**
-   * \throws non_invertible_matrix When the homography matrix is non-invertible.
+   * \throws non_invertible
+   *   When the homography matrix is non-invertible.
    * \return New homography transformation instance.
    */
   homography_sptr inverse() const;

--- a/vital/types/homography.h
+++ b/vital/types/homography.h
@@ -87,7 +87,8 @@ public:
   /**
    * \return New homography transformation instance.
    */
-  virtual homography_sptr inverse() const = 0;
+  homography_sptr inverse() const
+  { return std::static_pointer_cast< homography >( this->inverse_() ); }
 };
 
 
@@ -138,20 +139,20 @@ public:
   // ---- Abstract method definitions ----
 
   /// Access the type info of the underlying data
-  virtual std::type_info const& data_type() const { return typeid( T ); }
+  std::type_info const& data_type() const override { return typeid( T ); }
 
   /// Create a clone of ourself as a shared pointer
   /**
    * \return A new clone of this homography transformation.
    */
-  virtual transform_2d_sptr clone() const;
+  transform_2d_sptr clone() const override;
 
   /// Get a double-typed copy of the underlying matrix transformation
   /**
    * \return A copy of the transformation matrix represented in the double
    *         type.
    */
-  virtual Eigen::Matrix< double, 3, 3 > matrix() const;
+  Eigen::Matrix< double, 3, 3 > matrix() const override;
 
   /// Get a new \p homography that has been normalized
   /**
@@ -162,21 +163,21 @@ public:
    *
    * \return New homography transformation instance.
    */
-  virtual homography_sptr normalize() const;
+  homography_sptr normalize() const override;
 
   /// Get a new \p homography that has been inverted.
   /**
    * \throws non_invertible_matrix When the homography matrix is non-invertible.
    * \return New homography transformation instance.
    */
-  virtual homography_sptr inverse() const;
+  homography_sptr inverse() const;
 
   /// Map a 2D double-type point using this homography
   /**
    * \param p Point to map against this homography
    * \return New point in the projected coordinate system.
    */
-  virtual vector_2d map( vector_2d const& p ) const;
+  vector_2d map( vector_2d const& p ) const override;
 
   // ---- Member Functions ----
 
@@ -206,8 +207,9 @@ public:
    */
   virtual homography_< T > operator*( homography_< T > const& rhs ) const;
 
-
 protected:
+  transform_2d_sptr inverse_() const { return this->inverse(); }
+
   /// homography transformation matrix
   matrix_t h_;
 };

--- a/vital/types/transform_2d.h
+++ b/vital/types/transform_2d.h
@@ -1,5 +1,5 @@
 /*ckwg +30
- * Copyright 2019 by Kitware, Inc.
+ * Copyright 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,8 +76,9 @@ public:
 
   /// Return an inverse of this transform object
   /**
-   * \return A new transform object that is the inverse of this transformation,
-   *         or a null pointer if the transformation is not invertible.
+   * \throws non_invertible
+   *   When the transformation is non-invertible.
+   * \return A new transform object that is the inverse of this transformation.
    */
   transform_2d_sptr inverse() const { return this->inverse_(); }
 

--- a/vital/types/transform_2d.h
+++ b/vital/types/transform_2d.h
@@ -73,6 +73,13 @@ public:
    * \return New point in the projected coordinate system.
    */
   virtual vector_2d map( vector_2d const& p ) const = 0;
+
+  /// Return an inverse of this transform object
+  /**
+   * \return A new transform object that is the inverse of this transformation,
+   *         or a null pointer if the transformation is not invertible.
+   */
+  virtual transform_2d_sptr inverse() const = 0;
 };
 
 } // namespace vital

--- a/vital/types/transform_2d.h
+++ b/vital/types/transform_2d.h
@@ -79,7 +79,10 @@ public:
    * \return A new transform object that is the inverse of this transformation,
    *         or a null pointer if the transformation is not invertible.
    */
-  virtual transform_2d_sptr inverse() const = 0;
+  transform_2d_sptr inverse() const { return this->inverse_(); }
+
+protected:
+  virtual transform_2d_sptr inverse_() const = 0;
 };
 
 } // namespace vital


### PR DESCRIPTION
Add a new method to `transform_2d` to get the inverse of a transformation. Rename `non_invertible_matrix` exception to `non_invertible_transform`. Change return type of `homography::inverse` so that it implements `transform_2d::inverse` rather than shadowing the same. Use `override` keyword. Fix some methods that were using naked `new` to use `std::make_shared` instead.
