### PR TITLE
Aggressively prevent reparenting track states

### DIFF
--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -131,7 +131,7 @@ track
 /// Append a track state.
 bool
 track
-::append( track_state_sptr state )
+::append( track_state_sptr&& state )
 {
   if ( state && ! state->track_.expired() )
   {
@@ -144,8 +144,8 @@ track
   {
     return false;
   }
-  this->history_.push_back( state );
   state->track_ = this->shared_from_this();
+  this->history_.emplace_back( std::move( state ) );
   return true;
 }
 
@@ -176,7 +176,7 @@ track
 /// Insert a track state.
 bool
 track
-::insert( track_state_sptr state )
+::insert( track_state_sptr&& state )
 {
   if ( ! state )
   {
@@ -195,16 +195,21 @@ track
     return false;
   }
 
-  this->history_.insert(pos, state);
   state->track_ = this->shared_from_this();
+  this->history_.emplace( pos, std::move( state ) );
   return true;
 }
 
 /// Remove a track state
 bool
 track
-::remove(track_state_sptr state)
+::remove( track_state_sptr const& state )
 {
+  if ( !state )
+  {
+    return false;
+  }
+
   auto pos = std::lower_bound(this->history_.begin(), this->history_.end(),
     state->frame(), compare_state_frame());
 

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014, 2019 by Kitware, Inc.
+ * Copyright 2014, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,8 +133,12 @@ bool
 track
 ::append( track_state_sptr state )
 {
+  if ( state && ! state->track_.expired() )
+  {
+    throw std::logic_error( "track states may not be reparented" );
+  }
+
   if ( ! state ||
-       ! state->track_.expired() ||
        ( ! this->history_.empty() &&
        ( this->last_frame() >= state->frame() ) ) )
   {
@@ -174,16 +178,23 @@ bool
 track
 ::insert( track_state_sptr state )
 {
-  if ( ! state || ! state->track_.expired() )
+  if ( ! state )
   {
     return false;
   }
+
+  if ( ! state->track_.expired() )
+  {
+    throw std::logic_error( "track states may not be reparented" );
+  }
+
   auto pos = std::lower_bound( this->history_.begin(), this->history_.end(),
                                state->frame(), compare_state_frame() );
   if( pos != this->history_.end() && (*pos)->frame() == state->frame() )
   {
     return false;
   }
+
   this->history_.insert(pos, state);
   state->track_ = this->shared_from_this();
   return true;

--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017, 2019 by Kitware, Inc.
+ * Copyright 2013-2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -217,7 +217,10 @@ public:
    * \returns true if successful, false not correctly ordered
    * \param state track state to add to this track.
    */
-  bool append( track_state_sptr state );
+  bool append( track_state_sptr&& state );
+
+  bool append( track_state_sptr const& state )
+  { auto copy = state; return this->append( std::move( copy ) ); }
 
   /// Append the history contents of another track.
   /**
@@ -239,14 +242,17 @@ public:
    * \returns true if successful, false if already a state on this frame
    * \param state track state to add to this track.
    */
-  bool insert( track_state_sptr state );
+  bool insert( track_state_sptr&& state );
+
+  bool insert( track_state_sptr const& state )
+  { auto copy = state; return this->insert( std::move( copy ) ); }
 
   /// Remove track state
   /**
    * Removes the track state
    * Returns true if the state was found and removed
   */
-  bool remove(track_state_sptr state);
+  bool remove( track_state_sptr const& state );
 
   /// Access a const iterator to the start of the history
   history_const_itr begin() const { return history_.begin(); }


### PR DESCRIPTION
Track states differ from most objects in that they back-reference their owning track. Accordingly, we prevent them from being added to a track if they already have an owning track. However, users may not be aware of this caveat (and indeed, multiple instances of this form of misuse have been recently uncovered), and may not be checking for failures to add track states to a track, since the "obvious" failure cases can often be statically known to not occur.

In order to help address these issues, modify the code which adds track states to make it a logic error (i.e. literally throw `std::logic_error`) when attempting to add an already-owned track state to a track, as this almost always indicates that the code attempting to perform the operation does, in fact, contain a logic error. This should make it much easier to identify such code, rather than having to chase down more subtle bugs due to track states unexpectedly "going missing".