### PR TITLE
SiameseFeatureExtractor improvements

### DIFF
--- a/arrows/pytorch/siamese_feature_extractor.py
+++ b/arrows/pytorch/siamese_feature_extractor.py
@@ -96,7 +96,6 @@ class SiameseFeatureExtractor(object):
         ])
         self._img_size = img_size
         self._b_size = batch_size
-        self.frame = None
 
     def _strip_prefix(string, prefix):
         if not string.startswith(prefix):
@@ -104,14 +103,14 @@ class SiameseFeatureExtractor(object):
                     format(string, prefix))
         return string[len(prefix):]
     
-    def __call__(self, bbox_list, mot_flag):
-        return self._obtain_feature(bbox_list, mot_flag)
+    def __call__(self, frame, bbox_list, mot_flag):
+        return self._obtain_features(frame, bbox_list, mot_flag)
 
-    def _obtain_feature(self, bbox_list, mot_flag):
+    def _obtain_features(self, frame, bbox_list, mot_flag):
         kwargs = {'num_workers': 0, 'pin_memory': True}
-        if self.frame is not None:
+        if frame is not None:
             bbox_loader_class = SiameseDataLoader(bbox_list, self._transform, 
-                                    self.frame, self._img_size, mot_flag)
+                                    frame, self._img_size, mot_flag)
         else:
             raise ValueError("Trying to create SiameseDataLoader without providing frame")
 

--- a/arrows/pytorch/siamese_feature_extractor.py
+++ b/arrows/pytorch/siamese_feature_extractor.py
@@ -95,7 +95,6 @@ class SiameseFeatureExtractor(object):
             transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
         ])
         self._img_size = img_size
-        self._frame = pilImage.new('RGB', (img_size, img_size))
         self._b_size = batch_size
         self.frame = None
 
@@ -112,7 +111,7 @@ class SiameseFeatureExtractor(object):
         kwargs = {'num_workers': 0, 'pin_memory': True}
         if self.frame is not None:
             bbox_loader_class = SiameseDataLoader(bbox_list, self._transform, 
-                                    self._frame, self._img_size, mot_flag)
+                                    self.frame, self._img_size, mot_flag)
         else:
             raise ValueError("Trying to create SiameseDataLoader without providing frame")
 

--- a/arrows/pytorch/srnn_tracker.py
+++ b/arrows/pytorch/srnn_tracker.py
@@ -298,9 +298,8 @@ class SRNNTracker(KwiverProcess):
             dos_ptr = self.grab_input_using_trait('detected_object_set')
             print('timestamp = {!r}'.format(timestamp))
 
-            # Get current frame and give it to app feature extractor
+            # Get current frame
             im = get_pil_image(in_img_c.image()).convert('RGB')
-            self._app_feature_extractor.frame = im
 
             # Get detection bbox
             if self._gtbbox_flag:
@@ -323,7 +322,7 @@ class SRNNTracker(KwiverProcess):
 
                 # appearance features (format: pytorch tensor)
                 app_f_begin = timer()
-                pt_app_features = self._app_feature_extractor(dos, self._gtbbox_flag)
+                pt_app_features = self._app_feature_extractor(im, dos, self._gtbbox_flag)
                 app_f_end = timer()
                 print('%%%app feature elapsed time: {}'.format(app_f_end - app_f_begin))
 


### PR DESCRIPTION
This PR provides two improvements to `SiameseFeatureExtractor`:
- Fixing a bug that prevented the actual frame data from being used
- Passing the frame data by argument instead of by modifying an instance variable

Only `SRNNTracker` appears to use `SiameseFeatureExtractor` (in the `pytorch` folder, at least), so the API change should be complete.