### PR TITLE
Add time and frame name to track writer

### DIFF
--- a/arrows/core/write_object_track_set_kw18.cxx
+++ b/arrows/core/write_object_track_set_kw18.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017, 2019 by Kitware, Inc.
+ * Copyright 2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -154,7 +154,10 @@ write_object_track_set_kw18
 // -------------------------------------------------------------------------------
 void
 write_object_track_set_kw18
-::write_set( const kwiver::vital::object_track_set_sptr set )
+::write_set(
+  kwiver::vital::object_track_set_sptr const& set,
+  kwiver::vital::timestamp const& /*ts*/,
+  std::string const& /*frame_identifier*/ )
 {
   if( d->m_first )
   {

--- a/arrows/core/write_object_track_set_kw18.cxx
+++ b/arrows/core/write_object_track_set_kw18.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017, 2019-2020 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,6 +89,12 @@ write_object_track_set_kw18
 write_object_track_set_kw18
 ::~write_object_track_set_kw18()
 {
+}
+
+
+void write_object_track_set_kw18
+::close()
+{
   for( auto trk_pair : d->m_tracks )
   {
     auto trk_ptr = trk_pair.second;
@@ -130,6 +136,8 @@ write_object_track_set_kw18
                << std::endl;
     }
   }
+
+  write_object_track_set::close();
 }
 
 

--- a/arrows/core/write_object_track_set_kw18.h
+++ b/arrows/core/write_object_track_set_kw18.h
@@ -66,6 +66,8 @@ public:
     kwiver::vital::timestamp const& ts = {},
     std::string const& frame_identifier = {} ) override;
 
+  void close() override;
+
 private:
   class priv;
   std::unique_ptr< priv > d;

--- a/arrows/core/write_object_track_set_kw18.h
+++ b/arrows/core/write_object_track_set_kw18.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2019 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,12 +56,15 @@ public:
                "Object track set kw18 writer." )
 
   write_object_track_set_kw18();
-  virtual ~write_object_track_set_kw18();
+  ~write_object_track_set_kw18();
 
-  virtual void set_configuration( vital::config_block_sptr config );
-  virtual bool check_configuration( vital::config_block_sptr config ) const;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
 
-  virtual void write_set( const kwiver::vital::object_track_set_sptr set );
+  void write_set(
+    kwiver::vital::object_track_set_sptr const& set,
+    kwiver::vital::timestamp const& ts = {},
+    std::string const& frame_identifier = {} ) override;
 
 private:
   class priv;

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -144,14 +144,8 @@ void write_object_track_process
   }
 
   auto const& input = grab_from_port_using_trait( object_track_set );
-  auto const& ts = grab_from_port_using_trait( timestamp );
-
-  // Image name is optional
-  auto file_name = std::string{};
-  if ( has_input_port_edge_using_trait( image_file_name ) )
-  {
-    file_name = grab_from_port_using_trait( image_file_name );
-  }
+  auto const& ts = try_grab_from_port_using_trait( timestamp );
+  auto const& file_name = try_grab_from_port_using_trait( image_file_name );
 
   {
     scoped_step_instrumentation();
@@ -172,7 +166,7 @@ void write_object_track_process
 
   declare_input_port_using_trait( image_file_name, optional );
   declare_input_port_using_trait( object_track_set, required );
-  declare_input_port_using_trait( timestamp, required );
+  declare_input_port_using_trait( timestamp, optional );
 }
 
 

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,21 +133,21 @@ void write_object_track_process
 void write_object_track_process
 ::_step()
 {
-  std::string file_name;
 
-  // image name is optional
+  auto const& input = grab_from_port_using_trait( object_track_set );
+  auto const& ts = grab_from_port_using_trait( timestamp );
+
+  // Image name is optional
+  auto file_name = std::string{};
   if ( has_input_port_edge_using_trait( image_file_name ) )
   {
     file_name = grab_from_port_using_trait( image_file_name );
   }
 
-  kwiver::vital::object_track_set_sptr input
-    = grab_from_port_using_trait( object_track_set );
-
   {
     scoped_step_instrumentation();
 
-    d->m_writer->write_set( input );
+    d->m_writer->write_set( input, ts, file_name );
   }
 }
 
@@ -163,6 +163,7 @@ void write_object_track_process
 
   declare_input_port_using_trait( image_file_name, optional );
   declare_input_port_using_trait( object_track_set, required );
+  declare_input_port_using_trait( timestamp, required );
 }
 
 

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017, 2020 by Kitware, Inc.
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,6 +78,7 @@ write_object_track_process
 {
   make_ports();
   make_config();
+  set_data_checking_level( check_sync );
 }
 
 
@@ -133,6 +134,14 @@ void write_object_track_process
 void write_object_track_process
 ::_step()
 {
+  auto const& port_info = peek_at_port_using_trait( object_track_set );
+  if( port_info.datum->type() == sprokit::datum::complete )
+  {
+    grab_edge_datum_using_trait( object_track_set );
+    d->m_writer->close();
+    mark_process_as_complete();
+    return;
+  }
 
   auto const& input = grab_from_port_using_trait( object_track_set );
   auto const& ts = grab_from_port_using_trait( timestamp );

--- a/sprokit/processes/trait_utils.h
+++ b/sprokit/processes/trait_utils.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015 by Kitware, Inc.
+ * Copyright 2015, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -423,15 +423,7 @@ grab_input_as< PN ## _port_trait::type > ( PN ## _port_trait::port_name )
  kwiver::vital::timestamp frame_time = grab_from_port_using_trait( timestamp );
  \endcode
  *
- * Optional ports can be handled as follows:
- *
-\code
-  // See if optional input port has been connected.
-  if ( has_input_port_edge_using_trait( timestamp ) )
-  {
-    frame_time = grab_input_using_trait( timestamp );
-  }
-\endcode
+ * Optional ports can be handled using #try_grab_from_port_using_trait.
  *
  * \sa sprokit::process::grab_from_port_as()
  *
@@ -442,6 +434,24 @@ grab_input_as< PN ## _port_trait::type > ( PN ## _port_trait::port_name )
 #define grab_from_port_using_trait(PN)                                  \
 grab_from_port_as< PN ## _port_trait::type > ( PN ## _port_trait::port_name )
 
+
+/**
+ * \brief Get input from port using port trait name.
+ *
+ * This method grabs an input value directly from the port specified by the
+ * port trait with \b no handling for static ports, iff that port is connected.
+ * This call will block until a datum is available.
+ *
+ * \sa grab_from_port_using_trait, sprokit::process::grab_from_port_as()
+ *
+ * \param PN Port trait name.
+ *
+ * \return Data value from port, or a default-constructed value of the port's
+ *         type if the port is not connected.
+ */
+#define try_grab_from_port_using_trait(PN) \
+  try_grab_from_port_as< PN ## _port_trait::type >( \
+    PN ## _port_trait::port_name )
 
 
 /**

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1199,6 +1199,25 @@ class SPROKIT_PIPELINE_EXPORT process
     T grab_from_port_as(port_t const& port) const;
 
     /**
+     * \brief Grab a datum from a port as a certain type.
+     *
+     * This method grabs an input value directly from the port with no handling
+     * for static ports, iff the port is connected. This call will block until
+     * a datum is available.
+     *
+     * \sa process::has_input_port_edge
+     *
+     * \param port The port to get data from.
+     *
+     * \throws no_such_port_exception if the named port does not exist.
+     *
+     * \returns The datum from the port, or a default-constructed value if the
+     *          port is not connected.
+     */
+    template <typename T>
+    T try_grab_from_port_as(port_t const& port) const;
+
+    /**
      * \brief Grab an input as a specific type.
      *
      * This method returns a data value form a port or the configured
@@ -1455,6 +1474,16 @@ process
   return grab_datum_from_port(port)->get_datum<T>();
 }
 
+// ----------------------------------------------------------------------------
+template <typename T>
+T
+process
+::try_grab_from_port_as(port_t const& port) const
+{
+  return (has_input_port_edge(port)
+          ? grab_datum_from_port(port)->get_datum<T>()
+          : T{} );
+}
 
 // ----------------------------------------------------------------------------
 template <typename T>

--- a/vital/algo/write_object_track_set.h
+++ b/vital/algo/write_object_track_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -103,9 +103,13 @@ public:
    * name to the currently open file.
    *
    * \param set Track object set
+   * \param ts Timestamp for the current frame
+   * \param frame_identifier Identifier for the current frame (e.g. file name)
    */
-  virtual void write_set( const kwiver::vital::object_track_set_sptr set ) = 0;
-
+  virtual void write_set(
+    kwiver::vital::object_track_set_sptr const& set,
+    kwiver::vital::timestamp const& ts = {},
+    std::string const& frame_identifier = {} ) = 0;
 
 protected:
   write_object_track_set();

--- a/vital/algo/write_object_track_set.h
+++ b/vital/algo/write_object_track_set.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017, 2020 by Kitware, Inc.
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,24 +78,23 @@ public:
    * \throws kwiver::vital::path_not_a_file Thrown when the given path does
    *    not point to a file (i.e. it points to a directory).
    */
-  void open( std::string const& filename );
+  virtual void open( std::string const& filename );
 
   /// Write object tracks to an existing stream
   /**
-   * This method specifies the output stream to use for reading
-   * object tracks. Using a stream is handy when the object tracks are
-   * available in a stream format.
+   * This method specifies the output stream to use for writing
+   * object tracks.
    *
    * @param strm output stream to use
    */
-  void use_stream( std::ostream* strm );
+  virtual void use_stream( std::ostream* strm );
 
   /// Close object track set file.
   /**
    * The currently open object track set file is closed. If there is no
    * currently open file, then this method does nothing.
    */
-  void close();
+  virtual void close();
 
   /// Write object track set.
   /**


### PR DESCRIPTION
Improve `write_object_track_set` algorithm to allow implementations to override more methods, and to include the time stamp and frame identifier (as needed for some formats) when writing a frame. Modify `write_object_track_process` and algorithm implementations accordingly. Don't pass track set pointer by value.

These changes are needed by [VIAME](/kitware/viame).