### PR TITLE
Enhance and add Python bindings for detected_object_set_output

### DIFF
--- a/sprokit/processes/core/detected_object_output_process.cxx
+++ b/sprokit/processes/core/detected_object_output_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -172,6 +172,14 @@ void detected_object_output_process
 
     d->m_writer->write_set( input, file_name );
   }
+}
+
+
+// ----------------------------------------------------------------
+void detected_object_output_process
+::_finalize()
+{
+  d->m_writer->complete();
 }
 
 

--- a/sprokit/processes/core/detected_object_output_process.h
+++ b/sprokit/processes/core/detected_object_output_process.h
@@ -59,6 +59,7 @@ protected:
   virtual void _configure();
   virtual void _init();
   virtual void _step();
+  virtual void _finalize();
 
 private:
   void make_ports();

--- a/sprokit/processes/core/detected_object_output_process.h
+++ b/sprokit/processes/core/detected_object_output_process.h
@@ -56,10 +56,10 @@ public:
   virtual ~detected_object_output_process();
 
 protected:
-  virtual void _configure();
-  virtual void _init();
-  virtual void _step();
-  virtual void _finalize();
+  void _configure() override;
+  void _init() override;
+  void _step() override;
+  void _finalize() override;
 
 private:
   void make_ports();

--- a/vital/algo/detected_object_set_output.cxx
+++ b/vital/algo/detected_object_set_output.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,6 +64,7 @@ detected_object_set_output
 detected_object_set_output
 ::~detected_object_set_output()
 {
+  close();
 }
 
 

--- a/vital/algo/detected_object_set_output.h
+++ b/vital/algo/detected_object_set_output.h
@@ -80,7 +80,7 @@ public:
    * \throws kwiver::vital::path_not_a_file Thrown when the given path does
    *    not point to a file (i.e. it points to a directory).
    */
-  void open( std::string const& filename );
+  virtual void open( std::string const& filename );
 
   /// Write detections to an existing stream
   /**
@@ -97,7 +97,7 @@ public:
    * The currently open detection set file is closed. If there is no
    * currently open file, then this method does nothing.
    */
-  void close();
+  virtual void close();
 
   /// Write detected object set.
   /**

--- a/vital/algo/detected_object_set_output.h
+++ b/vital/algo/detected_object_set_output.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -109,6 +109,12 @@ public:
    */
   virtual void write_set( const kwiver::vital::detected_object_set_sptr set,
                           std::string const& image_path ) = 0;
+
+  /// Perform end-of-stream actions.
+  /**
+   * This method writes any necessary final data to the currently open file.
+   */
+  virtual void complete() {}
 
 
 protected:

--- a/vital/bindings/python/vital/algo/CMakeLists.txt
+++ b/vital/bindings/python/vital/algo/CMakeLists.txt
@@ -5,11 +5,14 @@ include_directories(${pybind11_INCLUDE_DIR})
 kwiver_add_python_library(algorithm
   vital/algo
   algorithm.h
+  detected_object_set_output.h
   image_object_detector.h
   algorithm.cxx
+  detected_object_set_output.cxx
   image_object_detector.cxx
   algorithm_module.cxx
   trampoline/algorithm_trampoline.txx
+  trampoline/detected_object_set_output_trampoline.txx
   trampoline/image_object_detector_trampoline.txx
 )
 

--- a/vital/bindings/python/vital/algo/detected_object_set_output.cxx
+++ b/vital/bindings/python/vital/algo/detected_object_set_output.cxx
@@ -27,35 +27,20 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-/**
- * \file algorithm_implementation.cxx
- *
- * \brief python bindings for algorithm
- */
-
-
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-#include <vital/algo/algorithm.h>
-#include <vital/algo/image_object_detector.h>
 #include <vital/bindings/python/vital/algo/trampoline/detected_object_set_output_trampoline.txx>
-#include <vital/bindings/python/vital/algo/trampoline/image_object_detector_trampoline.txx>
-#include <vital/bindings/python/vital/algo/algorithm.h>
 #include <vital/bindings/python/vital/algo/detected_object_set_output.h>
-#include <vital/bindings/python/vital/algo/image_object_detector.h>
-#include <sstream>
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(algorithm, m)
+void detected_object_set_output(py::module &m)
 {
-  algorithm(m);
-  register_algorithm<kwiver::vital::algo::detected_object_set_output,
-	    algorithm_def_doso_trampoline<>>(m, "detected_object_set_output");
-  detected_object_set_output(m);
-  register_algorithm<kwiver::vital::algo::image_object_detector,
-            algorithm_def_iod_trampoline<>>(m, "image_object_detector");
-  image_object_detector(m);
+  py::class_< kwiver::vital::algo::detected_object_set_output,
+              std::shared_ptr<kwiver::vital::algo::detected_object_set_output>,
+              kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_output>,
+              detected_object_set_output_trampoline<> >(m, "DetectedObjectSetOutput")
+    .def(py::init())
+    .def_static("static_type_name", &kwiver::vital::algo::detected_object_set_output::static_type_name)
+    .def("write_set", &kwiver::vital::algo::detected_object_set_output::write_set)
+    .def("complete", &kwiver::vital::algo::detected_object_set_output::complete);
 }

--- a/vital/bindings/python/vital/algo/detected_object_set_output.cxx
+++ b/vital/bindings/python/vital/algo/detected_object_set_output.cxx
@@ -45,5 +45,7 @@ void detected_object_set_output(py::module &m)
     .def_static("static_type_name", &doso::static_type_name)
     .def("write_set", &doso::write_set)
     .def("complete", &doso::complete)
+    .def("open", &doso::open)
+    .def("close", &doso::close)
     ;
 }

--- a/vital/bindings/python/vital/algo/detected_object_set_output.cxx
+++ b/vital/bindings/python/vital/algo/detected_object_set_output.cxx
@@ -33,14 +33,17 @@
 
 namespace py = pybind11;
 
+using doso = kwiver::vital::algo::detected_object_set_output;
+
 void detected_object_set_output(py::module &m)
 {
-  py::class_< kwiver::vital::algo::detected_object_set_output,
-              std::shared_ptr<kwiver::vital::algo::detected_object_set_output>,
-              kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_output>,
+  py::class_< doso,
+              std::shared_ptr<doso>,
+              kwiver::vital::algorithm_def<doso>,
               detected_object_set_output_trampoline<> >(m, "DetectedObjectSetOutput")
     .def(py::init())
-    .def_static("static_type_name", &kwiver::vital::algo::detected_object_set_output::static_type_name)
-    .def("write_set", &kwiver::vital::algo::detected_object_set_output::write_set)
-    .def("complete", &kwiver::vital::algo::detected_object_set_output::complete);
+    .def_static("static_type_name", &doso::static_type_name)
+    .def("write_set", &doso::write_set)
+    .def("complete", &doso::complete)
+    ;
 }

--- a/vital/bindings/python/vital/algo/detected_object_set_output.h
+++ b/vital/bindings/python/vital/algo/detected_object_set_output.h
@@ -1,0 +1,7 @@
+#ifndef KWIVER_VITAL_PYTHON_DETECTED_OBJECT_SET_OUTPUT_H_
+#define KWIVER_VITAL_PYTHON_DETECTED_OBJECT_SET_OUTPUT_H_
+
+#include <pybind11/pybind11.h>
+
+void detected_object_set_output(pybind11::module &m);
+#endif

--- a/vital/bindings/python/vital/algo/trampoline/detected_object_set_output_trampoline.txx
+++ b/vital/bindings/python/vital/algo/trampoline/detected_object_set_output_trampoline.txx
@@ -1,0 +1,96 @@
+/*ckwg +29
+ * Copyright 2019-2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file detected_object_set_output_trampoline.txx
+ *
+ * \brief trampoline for overriding virtual functions of algorithm_def<detected_object_set_output> and detected_object_set_output
+ */
+
+#ifndef DETECTED_OBJECT_SET_OUTPUT_TRAMPOLINE_TXX
+#define DETECTED_OBJECT_SET_OUTPUT_TRAMPOLINE_TXX
+
+
+#include <vital/bindings/python/vital/util/pybind11.h>
+#include <vital/algo/detected_object_set_output.h>
+#include <vital/types/detected_object_set.h>
+#include <vital/types/image_container.h>
+#include <vital/bindings/python/vital/algo/trampoline/algorithm_trampoline.txx>
+
+
+
+template <class algorithm_def_doso_base=kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_output>>
+class algorithm_def_doso_trampoline :
+      public algorithm_trampoline<algorithm_def_doso_base>
+{
+  public:
+    using algorithm_trampoline<algorithm_def_doso_base>::algorithm_trampoline;
+
+    std::string type_name() const override
+    {
+      VITAL_PYBIND11_OVERLOAD(
+        std::string,
+        kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_output>,
+        type_name,
+      );
+    }
+};
+
+
+template <class detected_object_set_output_base=kwiver::vital::algo::detected_object_set_output>
+class detected_object_set_output_trampoline :
+      public algorithm_def_doso_trampoline<detected_object_set_output_base>
+{
+  public:
+    using algorithm_def_doso_trampoline<detected_object_set_output_base>::
+              algorithm_def_doso_trampoline;
+
+    void write_set(kwiver::vital::detected_object_set_sptr set, std::string const& image_path) override
+    {
+      VITAL_PYBIND11_OVERLOAD_PURE(
+        void,
+        kwiver::vital::algo::detected_object_set_output,
+        write_set,
+        set,
+	image_path
+      );
+    }
+
+    void complete() override
+    {
+      VITAL_PYBIND11_OVERLOAD(
+        void,
+	kwiver::vital::algo::detected_object_set_output,
+	complete,
+      );
+    }
+};
+
+#endif

--- a/vital/bindings/python/vital/algo/trampoline/detected_object_set_output_trampoline.txx
+++ b/vital/bindings/python/vital/algo/trampoline/detected_object_set_output_trampoline.txx
@@ -83,6 +83,25 @@ class detected_object_set_output_trampoline :
       );
     }
 
+    void open(std::string const& filename) override
+    {
+      VITAL_PYBIND11_OVERLOAD(
+        void,
+        kwiver::vital::algo::detected_object_set_output,
+        open,
+	filename
+      );
+    }
+
+    void close() override
+    {
+      VITAL_PYBIND11_OVERLOAD(
+        void,
+        kwiver::vital::algo::detected_object_set_output,
+        close,
+      );
+    }
+
     void complete() override
     {
       VITAL_PYBIND11_OVERLOAD(


### PR DESCRIPTION
This PR does two main things:
- Add a "`complete`" method to `detected_object_set_output` and have `detected_object_output_process` call it at the end of the input stream
- Add Python bindings to allow subclassing `detected_object_set_output`

It also fixes an issue with `detected_object_set_ouput`'s destructor.

The motivation for these changes is to allow writing an arrow for JSON (specifically, MS-COCO) output. I have a working prototype written using these changes.

As it stands on its own, I have the following questions/concerns about the changes:
- ~Is this the right way to detect the end of the input stream? (I essentially copied the changes from `compute_track_descriptors_process`.)~
  - *(Edit 2020-02-14):* Changed to use `_finalize`
- ~The wrapping is not complete; rather I only wrapped what I needed and `static_type_name`.~
  - *(Edit 2020-02-14):* `open` and `close` were added on Jan. 28
- `stream`, which is how one writes output, was awkward to wrap because it returns an `ostream`. I went for returning a file-like object. Perhaps `detected_object_set_output` could have a more wrappable interface?
  - *(Edit 2020-02-14):* `stream` is no longer wrapped (overriding `open` and `close` is preferred), though the question remains

~Also, it looks like @as6520 has made overlapping changes in [`dev/add-activity-detector`](https://github.com/Kitware/kwiver/compare/master...dev/add-activity-detector), namely b51fe5c4a and 30b0ec88c. Regarding the relation between these changes and those:~
- ~The other changes wrapped `open` and `close`, while I did not.~
  - ~These didn't seem useful to wrap, at least from the perspective of subclassing `detected_object_set_output`, since subclassing code isn't expected to call them.~
- ~The other changes made `open` and `close` virtual.~

*(Edit 2020-02-14):* Per above, things have largely been reconciled, though #925 still has overlapping changes.

I think it would be good to settle on a selection of features we want to add to `detected_object_set_output` and have in its bindings and then get that merged in. This is a smaller set of changes than `dev/add-activity-detector`, so perhaps that could be done using this PR. @as6520, how does that work for you? (Similarly, I plan to look at creating a MS-COCO reader as well, which I expect to involve a similar discussion.)