### PR TITLE
Don't use AV_TIME_BASE_Q

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018-2019 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -286,7 +286,7 @@ public:
         return false;
     }
 
-    auto seek_timestamp = av_rescale_q( 0, AV_TIME_BASE_Q,
+    auto seek_timestamp = av_rescale_q( 0, av_get_time_base_q(),
                                         this->f_video_stream->time_base );
     // Now seek back to the start of the video
     auto seek_rslt = av_seek_frame( this->f_format_context,
@@ -455,7 +455,7 @@ public:
     bool advance_successful = false;
     do
     {
-      auto rescaled_frame_ts = av_rescale_q( frame_ts, AV_TIME_BASE_Q,
+      auto rescaled_frame_ts = av_rescale_q( frame_ts, av_get_time_base_q(),
                                           this->f_video_stream->time_base );
       auto seek_rslt = av_seek_frame( this->f_format_context,
                                       this->f_video_index, rescaled_frame_ts,


### PR DESCRIPTION
Replace use of `AV_TIME_BASE_Q`, which (for some versions of ffmpeg) expands to a C cast from an initializer list to a struct, which is invalid C++, with use of the equivalent `av_get_time_base_q()`.

See also https://stackoverflow.com/questions/23038893.

This should fix the Windows build failures which have started cropping up for reasons unknown. See for example [this build](https://open.cdash.org/viewBuildError.php?buildid=6312509).