### PR TITLE
Add support for finalize stage of process life cycle.

### DIFF
--- a/doc/manuals/sprokit/process_patterns.rst
+++ b/doc/manuals/sprokit/process_patterns.rst
@@ -18,6 +18,8 @@ parameters, this code can be used to spot misspellings. Note that
 processes that wrap algorithms (arrows) can not usually do this since
 the configuration of the arrow is not known to the process.::
 
+    #include <vital/config/config_difference.h>
+
     void
     your_process
     ::_configure()
@@ -28,3 +30,45 @@ the configuration of the arrow is not known to the process.::
 
       // regular config processing
     }
+
+
+Using enums in config entries
+-----------------------------
+
+Quite often a configuration parameter can only take a fixed number of
+values such as when the user is trying to configure an enum. The enum
+support in vital directly supports converting strings to enum values
+with the use of the ``enum_converter`` and enum support in the config
+block. The enum converter will verify that the supplied string
+represents an enum value, and throw an error if it does not. The list
+of valid enum strings is provided to assist in documenting config
+entries.
+
+The following code snippet shows how to use the enum support to create
+a new config entry and convert config entry to an enum value.::
+
+   #include <vital/util/enum_converter.h>
+
+   using kvll = kwiver::vital::kwiver_logger::log_level_t;
+
+   // Declare the enum converter
+   //              converter-name   enum-type
+   ENUM_CONVERTER( level_converter, kvll,
+      { "trace", kvll::LEVEL_TRACE },
+      { "debug", kvll::LEVEL_DEBUG },
+      { "info",  kvll::LEVEL_INFO },
+      { "warn",  kvll::LEVEL_WARN },
+      { "error", kvll::LEVEL_ERROR }
+    );
+
+
+    // Create config entry from enum. level_converter supplies the list of
+    // valid enum strings.
+   conf->set_value( "level", level_converter().to_string( m_log_level ),
+                   "Logger level to use when generating log messages. "
+                   "Allowable values are: " + level_converter().element_name_string()
+    );
+
+
+   // Convert config entry to an enum value.
+   kvll log_level = conf->get_enum_value<level_converter>( "level" );

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -116,6 +116,11 @@ Sprokit: Processes
    the config supplied by the pipeline. Any differences can be written
    to the log. This is useful for identifying misspelled config items.
 
+ * Add finalize method to process base class which allows derived
+   processes to be optionally called when the all upstream processes
+   have terminated and a complete datum is present on all required
+   input ports.
+
 Tools
 
  * Converting stand-alone tools to reside under the main "kwiver" top

--- a/extras/RightTrack/rt_process_instrumentation.cxx
+++ b/extras/RightTrack/rt_process_instrumentation.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,12 +48,6 @@ rt_process_instrumentation::
 rt_process_instrumentation()
 {
 }
-
-
-// ------------------------------------------------------------------
-rt_process_instrumentation::
-~rt_process_instrumentation()
-{ }
 
 
 // ------------------------------------------------------------------
@@ -132,6 +126,24 @@ rt_process_instrumentation::
 stop_init_processing()
 {
   m_init_event->End();
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+start_finalize_processing( std::string const& data )
+{
+  m_finalize_event->Start( /* data */ );
+}
+
+
+// ------------------------------------------------------------------
+void
+rt_process_instrumentation::
+stop_finalize_processing()
+{
+  m_finalize!_event->End();
 }
 
 

--- a/extras/RightTrack/rt_process_instrumentation.h
+++ b/extras/RightTrack/rt_process_instrumentation.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,31 +52,35 @@ class RIGHTTRACK_PLUGIN_NO_EXPORT rt_process_instrumentation
 public:
   // -- CONSTRUCTORS --
   rt_process_instrumentation();
-  virtual ~rt_process_instrumentation();
+  virtual ~rt_process_instrumentation() = default;
 
-  virtual void configure( kwiver::vital::config_block_sptr const config );
-  virtual kwiver::vital::config_block_sptr get_configuration() const;
+  void configure( kwiver::vital::config_block_sptr const config ) override;
+  kwiver::vital::config_block_sptr get_configuration() const override;
 
-  virtual void start_init_processing( std::string const& data );
-  virtual void stop_init_processing();
+  void start_init_processing( std::string const& data ) override;
+  void stop_init_processing() override;
 
-  virtual void start_reset_processing( std::string const& data );
-  virtual void stop_reset_processing();
+  void start_finalize_processing( std::string const& data ) override;
+  void stop_finalize_processing() override;
 
-  virtual void start_flush_processing( std::string const& data );
-  virtual void stop_flush_processing();
+  void start_reset_processing( std::string const& data ) override;
+  void stop_reset_processing() override;
 
-  virtual void start_step_processing( std::string const& data );
-  virtual void stop_step_processing();
+  void start_flush_processing( std::string const& data ) override;
+  void stop_flush_processing() override;
 
-  virtual void start_configure_processing( std::string const& data );
-  virtual void stop_configure_processing();
+  void start_step_processing( std::string const& data ) override;
+  void stop_step_processing() override;
 
-  virtual void start_reconfigure_processing( std::string const& data );
-  virtual void stop_reconfigure_processing();
+  void start_configure_processing( std::string const& data ) override;
+  void stop_configure_processing() override;
+
+  void start_reconfigure_processing( std::string const& data ) override;
+  void stop_reconfigure_processing() override;
 
 private:
   std::unique_ptr< RightTrack::BoundedEvent > m_init_event;
+  std::unique_ptr< RightTrack::BoundedEvent > m_finalize_event;
   std::unique_ptr< RightTrack::BoundedEvent > m_reset_event;
   std::unique_ptr< RightTrack::BoundedEvent > m_flush_event;
   std::unique_ptr< RightTrack::BoundedEvent > m_step_event;

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -31,13 +31,27 @@
 #include "logger_process_instrumentation.h"
 
 #include <sprokit/pipeline/process.h>
+#include <vital/config/config_difference.h>
+#include <vital/util/enum_converter.h>
+#include <vital/util/string.h>
 
 namespace sprokit {
+
+using kvll = kwiver::vital::kwiver_logger::log_level_t;
+
+  ENUM_CONVERTER( level_converter, kvll,
+    { "trace", kvll::LEVEL_TRACE },
+    { "debug", kvll::LEVEL_DEBUG },
+    { "info",  kvll::LEVEL_INFO },
+    { "warn",  kvll::LEVEL_WARN },
+    { "error", kvll::LEVEL_ERROR }
+  );
 
 // ------------------------------------------------------------------
 logger_process_instrumentation::
 logger_process_instrumentation()
   : m_logger( kwiver::vital::get_logger( "sprokit.process_instrumentation" ) )
+  , m_log_level( kvll::LEVEL_INFO )
 { }
 
 
@@ -46,7 +60,7 @@ void
 logger_process_instrumentation::
   start_init_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_init_processing" );
+  log_message( process()->name() + ": start_init_processing" );
 }
 
 
@@ -55,7 +69,7 @@ void
 logger_process_instrumentation::
 stop_init_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_init_processing" );
+  log_message( process()->name() + ": stop_init_processing" );
 }
 
 
@@ -64,7 +78,7 @@ void
 logger_process_instrumentation::
   start_finalize_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_finalize_processing" );
+  log_message( process()->name() + ": start_finalize_processing" );
 }
 
 
@@ -73,7 +87,7 @@ void
 logger_process_instrumentation::
 stop_finalize_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_finalize_processing" );
+  log_message( process()->name() + ": stop_finalize_processing" );
 }
 
 
@@ -82,7 +96,7 @@ void
 logger_process_instrumentation::
 start_reset_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_init_processing" );
+  log_message( process()->name() + ": stop_init_processing" );
 }
 
 
@@ -91,7 +105,7 @@ void
 logger_process_instrumentation::
 stop_reset_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_reset_processing" );
+  log_message( process()->name() + ": stop_reset_processing" );
 }
 
 
@@ -100,7 +114,7 @@ void
 logger_process_instrumentation::
 start_flush_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_reset_processing" );
+  log_message( process()->name() + ": start_reset_processing" );
 }
 
 
@@ -109,7 +123,7 @@ void
 logger_process_instrumentation::
 stop_flush_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_flush_processing" );
+  log_message( process()->name() + ": stop_flush_processing" );
 }
 
 
@@ -118,7 +132,7 @@ void
 logger_process_instrumentation::
 start_step_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_step_processing" );
+  log_message( process()->name() + ": start_step_processing" );
 }
 
 
@@ -127,7 +141,7 @@ void
 logger_process_instrumentation::
 stop_step_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_step_processing" );
+  log_message( process()->name() + ": stop_step_processing" );
 }
 
 
@@ -136,7 +150,7 @@ void
 logger_process_instrumentation::
 start_configure_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_configure_processing" );
+  log_message( process()->name() + ": start_configure_processing" );
 }
 
 
@@ -145,7 +159,7 @@ void
 logger_process_instrumentation::
 stop_configure_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_configure_processing" );
+  log_message( process()->name() + ": stop_configure_processing" );
 }
 
 
@@ -154,7 +168,7 @@ void
 logger_process_instrumentation::
 start_reconfigure_processing( std::string const& data )
 {
-  LOG_INFO( m_logger, process()->name() << ": start_reconfigure_processing" );
+  log_message( process()->name() + ": start_reconfigure_processing" );
 }
 
 
@@ -163,8 +177,71 @@ void
 logger_process_instrumentation::
 stop_reconfigure_processing()
 {
-  LOG_INFO( m_logger, process()->name() << ": stop_reconfigure_processing" );
+  log_message( process()->name() + ": stop_reconfigure_processing" );
 }
 
+// ----------------------------------------------------------------------------
+void
+logger_process_instrumentation::
+configure( kwiver::vital::config_block_sptr const conf )
+{
+  kwiver::vital::config_difference cd( this->get_configuration(), conf );
+  const auto key_list = cd.extra_keys();
+  if ( ! key_list.empty() )
+  {
+    LOG_WARN( m_logger, "Additional parameters found in config block that are not required or desired: "
+              << kwiver::vital::join( key_list, ", " ) );
+  }
+
+  m_log_level = conf->get_enum_value<level_converter>( "level" );
+}
+
+
+// ----------------------------------------------------------------------------
+kwiver::vital::config_block_sptr
+logger_process_instrumentation::
+get_configuration() const
+{
+  auto conf = kwiver::vital::config_block::empty_config();
+
+  conf->set_value( "level", level_converter().to_string( m_log_level ),
+                   "Logger level top use when generating log messages. "
+                   "Allowable values are: " + level_converter().element_name_string()
+    );
+
+
+  return conf;
+}
+
+
+// ----------------------------------------------------------------------------
+void logger_process_instrumentation
+::log_message( const std::string& data )
+{
+  switch (m_log_level)
+  {
+  case kvll::LEVEL_TRACE:
+    LOG_TRACE( m_logger, data );
+    break;
+
+  case kvll::LEVEL_DEBUG:
+    LOG_DEBUG( m_logger, data );
+    break;
+
+  default:
+  case kvll::LEVEL_INFO:
+    LOG_INFO( m_logger, data );
+    break;
+
+  case kvll::LEVEL_WARN:
+    LOG_WARN( m_logger, data );
+    break;
+
+  case kvll::LEVEL_ERROR:
+    LOG_ERROR( m_logger, data );
+    break;
+
+  } // end switch
+}
 
 } // end namespace

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -205,7 +205,7 @@ get_configuration() const
   auto conf = kwiver::vital::config_block::empty_config();
 
   conf->set_value( "level", level_converter().to_string( m_log_level ),
-                   "Logger level top use when generating log messages. "
+                   "Logger level to use when generating log messages. "
                    "Allowable values are: " + level_converter().element_name_string()
     );
 

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,11 +41,6 @@ logger_process_instrumentation()
 { }
 
 
-logger_process_instrumentation::
-~logger_process_instrumentation()
-{ }
-
-
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
@@ -61,6 +56,24 @@ logger_process_instrumentation::
 stop_init_processing()
 {
   LOG_INFO( m_logger, process()->name() << ": stop_init_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+  start_finalize_processing( std::string const& data )
+{
+  LOG_INFO( m_logger, process()->name() << ": start_finalize_processing" );
+}
+
+
+// ------------------------------------------------------------------
+void
+logger_process_instrumentation::
+stop_finalize_processing()
+{
+  LOG_INFO( m_logger, process()->name() << ": stop_finalize_processing" );
 }
 
 

--- a/extras/process_instrumentation/logger_process_instrumentation.h
+++ b/extras/process_instrumentation/logger_process_instrumentation.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,25 +54,28 @@ class INSTRUMENTATION_PLUGIN_NO_EXPORT logger_process_instrumentation
 {
 public:
   logger_process_instrumentation();
-  virtual ~logger_process_instrumentation();
+  virtual ~logger_process_instrumentation() = default;
 
-  virtual void start_init_processing( std::string const& data );
-  virtual void stop_init_processing();
+  void start_init_processing( std::string const& data ) override;
+  void stop_init_processing() override;
 
-  virtual void start_reset_processing( std::string const& data );
-  virtual void stop_reset_processing();
+  void start_finalize_processing( std::string const& data ) override;
+  void stop_finalize_processing() override;
 
-  virtual void start_flush_processing( std::string const& data );
-  virtual void stop_flush_processing();
+  void start_reset_processing( std::string const& data ) override;
+  void stop_reset_processing() override;
 
-  virtual void start_step_processing( std::string const& data );
-  virtual void stop_step_processing();
+  void start_flush_processing( std::string const& data ) override;
+  void stop_flush_processing() override;
 
-  virtual void start_configure_processing( std::string const& data );
-  virtual void stop_configure_processing();
+  void start_step_processing( std::string const& data ) override;
+  void stop_step_processing() override;
 
-  virtual void start_reconfigure_processing( std::string const& data );
-  virtual void stop_reconfigure_processing();
+  void start_configure_processing( std::string const& data ) override;
+  void stop_configure_processing() override;
+
+  void start_reconfigure_processing( std::string const& data ) override;
+  void stop_reconfigure_processing() override;
 
 private:
   kwiver::vital::logger_handle_t m_logger;

--- a/extras/process_instrumentation/logger_process_instrumentation.h
+++ b/extras/process_instrumentation/logger_process_instrumentation.h
@@ -77,8 +77,14 @@ public:
   void start_reconfigure_processing( std::string const& data ) override;
   void stop_reconfigure_processing() override;
 
+  void configure( kwiver::vital::config_block_sptr const conf ) override;
+  kwiver::vital::config_block_sptr get_configuration() const override;
+
 private:
+  void log_message( const std::string& data );
+
   kwiver::vital::logger_handle_t m_logger;
+  kwiver::vital::kwiver_logger::log_level_t m_log_level;
 
 }; // end class logger_process_instrumentation
 

--- a/extras/process_instrumentation/timing_process_instrumentation.cxx
+++ b/extras/process_instrumentation/timing_process_instrumentation.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2019 by Kitware, Inc.
+ * Copyright 2017-2019, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -79,7 +79,7 @@ timing_process_instrumentation::
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-  start_init_processing( std::string const& data )
+start_init_processing( std::string const& data )
 {
   m_timer->start();
 }
@@ -95,6 +95,28 @@ stop_init_processing()
 
   // write elapsed time
   write_interval( "init", m_timer->elapsed() );
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+start_finalize_processing( std::string const& data )
+{
+  m_timer->start();
+}
+
+
+// ------------------------------------------------------------------
+void
+timing_process_instrumentation::
+stop_finalize_processing()
+{
+  // stop timer
+  m_timer->stop();
+
+  // write elapsed time
+  write_interval( "finalize", m_timer->elapsed() );
 }
 
 

--- a/extras/process_instrumentation/timing_process_instrumentation.h
+++ b/extras/process_instrumentation/timing_process_instrumentation.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,26 +75,29 @@ public:
   timing_process_instrumentation();
   virtual ~timing_process_instrumentation();
 
-  virtual void start_init_processing( std::string const& data );
-  virtual void stop_init_processing();
+  void start_init_processing( std::string const& data ) override;
+  void stop_init_processing() override;
 
-  virtual void start_reset_processing( std::string const& data );
-  virtual void stop_reset_processing();
+  void start_finalize_processing( std::string const& data ) override;
+  void stop_finalize_processing() override;
 
-  virtual void start_flush_processing( std::string const& data );
-  virtual void stop_flush_processing();
+  void start_reset_processing( std::string const& data ) override;
+  void stop_reset_processing() override;
 
-  virtual void start_step_processing( std::string const& data );
-  virtual void stop_step_processing();
+  void start_flush_processing( std::string const& data ) override;
+  void stop_flush_processing() override;
 
-  virtual void start_configure_processing( std::string const& data );
-  virtual void stop_configure_processing();
+  void start_step_processing( std::string const& data ) override;
+  void stop_step_processing() override;
 
-  virtual void start_reconfigure_processing( std::string const& data );
-  virtual void stop_reconfigure_processing();
+  void start_configure_processing( std::string const& data ) override;
+  void stop_configure_processing() override;
 
-  virtual void configure( kwiver::vital::config_block_sptr const conf );
-  virtual kwiver::vital::config_block_sptr get_configuration() const;
+  void start_reconfigure_processing( std::string const& data ) override;
+  void stop_reconfigure_processing() override;
+
+  void configure( kwiver::vital::config_block_sptr const conf ) override;
+  kwiver::vital::config_block_sptr get_configuration() const override;
 
 private:
   void write_interval( const std::string& tag, double interval );

--- a/sprokit/processes/CMakeLists.txt
+++ b/sprokit/processes/CMakeLists.txt
@@ -66,3 +66,7 @@ kwiver_add_plugin( process_explorer_plugin
            sprokit_pipeline
            explorer_plugin )
 endif()
+
+if (KWIVER_ENABLE_TESTS)
+  add_subdirectory( tests )
+endif()

--- a/sprokit/processes/adapters/tests/CMakeLists.txt
+++ b/sprokit/processes/adapters/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(arrows_adapters_tests)
+project(sprokit_adapters_tests)
 
 include(kwiver-test-setup)
 

--- a/sprokit/processes/tests/CMakeLists.txt
+++ b/sprokit/processes/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+project(sprokit_test_processes)
+
+include(kwiver-test-setup)
+
+set( test_libraries       vital sprokit_pipeline sprokit_pipeline_util kwiver_adapter )
+
+#############################
+# adapter process tests
+#############################
+
+#kwiver_discover_tests(adapter_basic     LIBRARIES ${test_libraries} )
+#kwiver_discover_tests(non_blocking      LIBRARIES ${test_libraries} )
+
+set( private_headers
+  test_proc_seq.h
+  )
+
+set( sources
+  register_processes.cxx
+
+  test_proc_seq.cxx
+  )
+
+include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
+
+kwiver_add_plugin( kwiver_processes_test
+  SUBDIR           ${kwiver_plugin_process_subdir}
+  SOURCES          ${sources}
+                   ${private_headers}
+  PRIVATE          sprokit_pipeline
+                   vital vital_vpm vital_logger vital_config
+                   kwiversys
+ )

--- a/sprokit/processes/tests/register_processes.cxx
+++ b/sprokit/processes/tests/register_processes.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
  *    to endorse or promote products derived from this software without specific
  *    prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
@@ -28,73 +28,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "take_number_process.h"
+#include <sprokit/processes/tests/kwiver_processes_test_export.h>
+#include <sprokit/pipeline/process_factory.h>
+#include <vital/plugin_loader/plugin_loader.h>
 
-#include <vital/config/config_block.h>
-#include <sprokit/pipeline/process_exception.h>
+// -- list processes to register --
+#include "test_proc_seq.h"
 
-#include <string>
-
-/**
- * \file take_number_process.cxx
+// ----------------------------------------------------------------
+/*! \brief Regsiter processes
  *
- * \brief Implementation of the number taking process.
  */
-
-namespace sprokit
-{
-
-class take_number_process::priv
-{
-  public:
-    typedef int32_t number_t;
-
-    priv();
-    ~priv();
-
-    static port_t const port_input;
-};
-
-process::port_t const take_number_process::priv::port_input = port_t("number");
-
-take_number_process
-::take_number_process(kwiver::vital::config_block_sptr const& config)
-  : process(config)
-  , d()
-{
-  port_flags_t required;
-
-  required.insert(flag_required);
-
-  declare_input_port(
-    priv::port_input,
-    "integer",
-    required,
-    port_description_t("Where numbers are read from."));
-}
-
-take_number_process
-::~take_number_process()
-{
-}
-
+extern "C"
+KWIVER_PROCESSES_TEST_EXPORT
 void
-take_number_process
-::_step()
+register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  (void)grab_from_port_as<priv::number_t>(priv::port_input);
+  using namespace sprokit;
 
-  process::_step();
-}
+  process_registrar reg( vpm, "kwiver_processes_test" );
 
-take_number_process::priv
-::priv()
-{
-}
+  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  {
+    return;
+  }
 
-take_number_process::priv
-::~priv()
-{
-}
+  reg.register_process< kwiver::test_proc_seq >();
 
+// - - - - - - - - - - - - - - - - - - - - - - -
+  mark_process_module_as_loaded( vpm, reg.module_name() );
 }

--- a/sprokit/processes/tests/test_proc_seq.cxx
+++ b/sprokit/processes/tests/test_proc_seq.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
  *    to endorse or promote products derived from this software without specific
  *    prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
@@ -28,73 +28,58 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "take_number_process.h"
+#include "test_proc_seq.h"
+#include <sprokit/processes/kwiver_type_traits.h>
 
-#include <vital/config/config_block.h>
-#include <sprokit/pipeline/process_exception.h>
+create_type_trait( number, "integer", int32_t );
 
-#include <string>
+create_port_trait( number, number, "number uint 32" );
 
-/**
- * \file take_number_process.cxx
- *
- * \brief Implementation of the number taking process.
- */
 
-namespace sprokit
+namespace kwiver {
+
+test_proc_seq
+::test_proc_seq( kwiver::vital::config_block_sptr const& config )
+  : process (config )
 {
+  sprokit::process::port_flags_t required;
+  required.insert( flag_required );
 
-class take_number_process::priv
-{
-  public:
-    typedef int32_t number_t;
-
-    priv();
-    ~priv();
-
-    static port_t const port_input;
-};
-
-process::port_t const take_number_process::priv::port_input = port_t("number");
-
-take_number_process
-::take_number_process(kwiver::vital::config_block_sptr const& config)
-  : process(config)
-  , d()
-{
-  port_flags_t required;
-
-  required.insert(flag_required);
-
-  declare_input_port(
-    priv::port_input,
-    "integer",
-    required,
-    port_description_t("Where numbers are read from."));
+  declare_input_port_using_trait( number, required );
 }
 
-take_number_process
-::~take_number_process()
+
+void test_proc_seq
+::_configure()
 {
+  scoped_configure_instrumentation();
+
 }
 
-void
-take_number_process
+void test_proc_seq
+::_init()
+{
+  scoped_init_instrumentation();
+
+}
+
+
+void test_proc_seq
 ::_step()
 {
-  (void)grab_from_port_as<priv::number_t>(priv::port_input);
+  scoped_step_instrumentation();
 
-  process::_step();
+  auto input = grab_from_port_using_trait( number );
+  LOG_INFO( logger(),  "Number: " << input );
 }
 
-take_number_process::priv
-::priv()
+
+void test_proc_seq
+::_finalize()
 {
-}
-
-take_number_process::priv
-::~priv()
-{
-}
+  scoped_finalize_instrumentation();
 
 }
+
+
+} // end namespace

--- a/sprokit/processes/tests/test_proc_seq.h
+++ b/sprokit/processes/tests/test_proc_seq.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
  *    to endorse or promote products derived from this software without specific
  *    prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
@@ -28,73 +28,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "take_number_process.h"
+#ifndef SPROKIT_PROCESSES_TEST_PROC_SEQ_H
+#define SPROKIT_PROCESSES_TEST_PROC_SEQ_H
 
-#include <vital/config/config_block.h>
-#include <sprokit/pipeline/process_exception.h>
+#include <sprokit/pipeline/process.h>
+#include "kwiver_processes_test_export.h"
 
-#include <string>
+namespace kwiver {
 
-/**
- * \file take_number_process.cxx
- *
- * \brief Implementation of the number taking process.
- */
-
-namespace sprokit
+class KWIVER_PROCESSES_TEST_NO_EXPORT test_proc_seq
+  : public sprokit::process
 {
+public:
+  PLUGIN_INFO( "test_proc_seq",
+               "Test method sequence in processes" )
 
-class take_number_process::priv
-{
-  public:
-    typedef int32_t number_t;
+  test_proc_seq( kwiver::vital::config_block_sptr const& config );
 
-    priv();
-    ~priv();
+  /**
+   * \brief Destructor.
+   */
+  virtual ~test_proc_seq() = default;
 
-    static port_t const port_input;
+protected:
+  void _configure() override;
+  void _init() override;
+  void _step() override;
+  void _finalize() override;
 };
 
-process::port_t const take_number_process::priv::port_input = port_t("number");
-
-take_number_process
-::take_number_process(kwiver::vital::config_block_sptr const& config)
-  : process(config)
-  , d()
-{
-  port_flags_t required;
-
-  required.insert(flag_required);
-
-  declare_input_port(
-    priv::port_input,
-    "integer",
-    required,
-    port_description_t("Where numbers are read from."));
 }
 
-take_number_process
-::~take_number_process()
-{
-}
-
-void
-take_number_process
-::_step()
-{
-  (void)grab_from_port_as<priv::number_t>(priv::port_input);
-
-  process::_step();
-}
-
-take_number_process::priv
-::priv()
-{
-}
-
-take_number_process::priv
-::~priv()
-{
-}
-
-}
+#endif // SPROKIT_PROCESSES_TEST_PROC_SEQ_H

--- a/sprokit/processes/tests/test_seq.pipe
+++ b/sprokit/processes/tests/test_seq.pipe
@@ -1,0 +1,21 @@
+#
+# Pipeline to test process lifecycle sequence
+#
+
+process num :: numbers
+  end = 10
+
+process seq :: test_proc_seq
+  block _instrumentation
+    type = logger
+
+    block logger
+       level = error
+    endblock
+  endblock
+connect from num.number to seq.number
+
+process print :: print_number
+  output = numbers.txt
+
+connect from num.number to print.number

--- a/sprokit/src/processes/examples/CMakeLists.txt
+++ b/sprokit/src/processes/examples/CMakeLists.txt
@@ -40,6 +40,7 @@ set(examples_private_headers
   orphan_cluster.h
   orphan_process.h
   print_number_process.h
+  process_traits.h
   shared_process.h
   skip_process.h
   tagged_flow_dependent_process.h

--- a/sprokit/src/processes/examples/process_traits.h
+++ b/sprokit/src/processes/examples/process_traits.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2019 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
  *    to endorse or promote products derived from this software without specific
  *    prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
@@ -28,73 +28,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "take_number_process.h"
+#ifndef SPROKIT_EXAMPLE_PROCESS_TRAITS_H
+#define SPROKIT_EXAMPLE_PROCESS_TRAITS_H
 
-#include <vital/config/config_block.h>
-#include <sprokit/pipeline/process_exception.h>
+#include <vital/vital_types.h>
 
-#include <string>
+create_type_trait( integer, "kwiver:test:integer", int32_t );
 
-/**
- * \file take_number_process.cxx
- *
- * \brief Implementation of the number taking process.
- */
+create_port_trait( integer, integer, "number uint 32" );
 
-namespace sprokit
-{
 
-class take_number_process::priv
-{
-  public:
-    typedef int32_t number_t;
-
-    priv();
-    ~priv();
-
-    static port_t const port_input;
-};
-
-process::port_t const take_number_process::priv::port_input = port_t("number");
-
-take_number_process
-::take_number_process(kwiver::vital::config_block_sptr const& config)
-  : process(config)
-  , d()
-{
-  port_flags_t required;
-
-  required.insert(flag_required);
-
-  declare_input_port(
-    priv::port_input,
-    "integer",
-    required,
-    port_description_t("Where numbers are read from."));
-}
-
-take_number_process
-::~take_number_process()
-{
-}
-
-void
-take_number_process
-::_step()
-{
-  (void)grab_from_port_as<priv::number_t>(priv::port_input);
-
-  process::_step();
-}
-
-take_number_process::priv
-::priv()
-{
-}
-
-take_number_process::priv
-::~priv()
-{
-}
-
-}
+#endif // SPROKIT_EXAMPLE_PROCESS_TRAITS_H

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -398,6 +398,8 @@ process
   /// \todo Should this really be done here?
   if (complete || d->required_outputs_done())
   {
+    _finalize();
+
     mark_process_as_complete();
   }
 }
@@ -749,6 +751,14 @@ process
 void
 process
 ::_step()
+{
+}
+
+
+// ------------------------------------------------------------------
+void
+process
+::_finalize()
 {
 }
 
@@ -1925,6 +1935,7 @@ void process::stop_ ## N ## _processing()                               \
 }
 
 INSTR( init )
+INSTR( finalize )
 INSTR( reset )
 INSTR( flush )
 INSTR( step )
@@ -2275,6 +2286,11 @@ process::priv
 
 
 // ------------------------------------------------------------------
+/*
+ * This method checks to make sure that all required output ports mave
+ * been marked as complete. They are marked complete by the receiving
+ * process (i.e. downstream process)
+ */
 bool
 process::priv
 ::required_outputs_done() const
@@ -2292,6 +2308,7 @@ process::priv
   {
     output_edge_map_t::const_iterator const i = output_edges.find(port);
 
+    // Output port not found.
     if (i == output_edges.end())
     {
       continue;
@@ -2306,6 +2323,7 @@ process::priv
     output_port_info_t const& info = *i->second;
     edges_t const& edges = info.edges;
 
+    // check all connections to this output port.
     for (edge_t const& edge : edges)
     {
       // If any required edge is not complete, then return false.
@@ -2313,8 +2331,8 @@ process::priv
       {
         return false;
       }
-    }
-  }
+    } // end for
+  } // end for
 
   return true;
 }

--- a/sprokit/src/sprokit/pipeline/process.h
+++ b/sprokit/src/sprokit/pipeline/process.h
@@ -727,8 +727,8 @@ class SPROKIT_PIPELINE_EXPORT process
      * \brief Post-connection initialization for subclasses.
      *
      * Initialization is the final step before a process is
-     * stepped. This is where processes should have a chance to get a
-     * first look at the edges that are connected to a port and change
+     * stepped. This is where processes have a chance to get a first
+     * look at the edges that are connected to a port and change
      * behavior based on them. After this is called, the process will
      * be stepped until it is either complete or the scheduler is
      * stopped.
@@ -760,9 +760,21 @@ class SPROKIT_PIPELINE_EXPORT process
      * \li Obtaining data from the input edges.
      * \li Running the algorithm.
      * \li Pushing data out via the output edges.
-     *
      */
     virtual void _step();
+
+    /**
+     * \brief Termination processing for subclasses.
+     *
+     * This method is called when the all upstream processes have
+     * terminated and a \c complete datum is present on all \b
+     * required input ports. The _step() method will never be called
+     * after this method is called.
+     *
+     * If a process self terminates by calling
+     * mark_process_as_complete(), this method will not be called.
+     */
+    virtual void _finalize();
 
     /**
      * \brief Runtime configuration for subclasses.
@@ -1348,6 +1360,10 @@ class SPROKIT_PIPELINE_EXPORT process
     void start_init_processing();
     void stop_init_processing();
 
+    void start_finalize_processing( std::string const& data );
+    void start_finalize_processing();
+    void stop_finalize_processing();
+
     void start_reset_processing( std::string const& data );
     void start_reset_processing();
     void stop_reset_processing( );
@@ -1392,6 +1408,7 @@ private:                                                                \
 }
 
 SCOPED_INSTRUMENTATION(init);
+SCOPED_INSTRUMENTATION(finalize);
 SCOPED_INSTRUMENTATION(reset);
 SCOPED_INSTRUMENTATION(flush);
 SCOPED_INSTRUMENTATION(step);
@@ -1408,6 +1425,7 @@ SCOPED_INSTRUMENTATION(reconfigure);
  * when the scope is exited.
  */
 #define scoped_init_instrumentation()        scoped_init_instrumentation_( this )
+#define scoped_finalize_instrumentation()    scoped_finalize_instrumentation_( this )
 #define scoped_reset_instrumentation()       scoped_reset_instrumentation_( this )
 #define scoped_flush_instrumentation()       scoped_flush_instrumentation_( this )
 #define scoped_step_instrumentation()        scoped_step_instrumentation_( this )

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.h
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.h
@@ -66,6 +66,9 @@ public:
   virtual void start_init_processing( std::string const& data ) = 0;
   virtual void stop_init_processing() = 0;
 
+  virtual void start_finalize_processing( std::string const& data ) = 0;
+  virtual void stop_finalize_processing() = 0;
+
   virtual void start_reset_processing( std::string const& data ) = 0;
   virtual void stop_reset_processing() = 0;
 


### PR DESCRIPTION
The finalize method is called when the process has determined that
there are no more inputs and it should terminate. This event is useful
so a process can gracefully terminate while the pipeline is still active
without having to wait for the DTOR (which may be too late).