### PR TITLE
Improve file management in various I/O algos

### DIFF
--- a/vital/algo/detected_object_set_input.cxx
+++ b/vital/algo/detected_object_set_input.cxx
@@ -93,7 +93,7 @@ detected_object_set_input
   std::unique_ptr< std::istream > file( new std::ifstream( filename ) );
   if ( ! *file )
   {
-    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
   m_stream = file.release();

--- a/vital/algo/detected_object_set_input.cxx
+++ b/vital/algo/detected_object_set_input.cxx
@@ -35,6 +35,8 @@
 
 #include "detected_object_set_input.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -88,13 +90,13 @@ detected_object_set_input
   }
 
   // try to open the file
-  std::istream* file( new std::ifstream( filename ) );
+  std::unique_ptr< std::istream > file( new std::ifstream( filename ) );
   if ( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
 
   new_stream();

--- a/vital/algo/detected_object_set_input.cxx
+++ b/vital/algo/detected_object_set_input.cxx
@@ -89,7 +89,7 @@ detected_object_set_input
 
   // try to open the file
   std::istream* file( new std::ifstream( filename ) );
-  if ( ! file )
+  if ( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }

--- a/vital/algo/detected_object_set_output.cxx
+++ b/vital/algo/detected_object_set_output.cxx
@@ -72,7 +72,7 @@ detected_object_set_output
 {
   // try to open the file
   std::ostream* file( new std::ofstream( filename ) );
-  if ( ! file )
+  if ( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }

--- a/vital/algo/detected_object_set_output.cxx
+++ b/vital/algo/detected_object_set_output.cxx
@@ -76,7 +76,7 @@ detected_object_set_output
   std::unique_ptr< std::ostream > file( new std::ofstream( filename ) );
   if ( ! *file )
   {
-    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
   m_stream = file.release();

--- a/vital/algo/detected_object_set_output.cxx
+++ b/vital/algo/detected_object_set_output.cxx
@@ -35,6 +35,8 @@
 
 #include "detected_object_set_output.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -71,13 +73,13 @@ detected_object_set_output
 ::open( std::string const& filename )
 {
   // try to open the file
-  std::ostream* file( new std::ofstream( filename ) );
+  std::unique_ptr< std::ostream > file( new std::ofstream( filename ) );
   if ( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
   m_filename = filename;
 }

--- a/vital/algo/read_object_track_set.cxx
+++ b/vital/algo/read_object_track_set.cxx
@@ -101,7 +101,7 @@ read_object_track_set
 
   if( ! *file )
   {
-    kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
   m_stream = file.release();

--- a/vital/algo/read_object_track_set.cxx
+++ b/vital/algo/read_object_track_set.cxx
@@ -88,12 +88,12 @@ read_object_track_set
   // Make sure that the given file path exists and is a file.
   if( ! kwiversys::SystemTools::FileExists( filename ) )
   {
-    throw path_not_exists( filename );
+    VITAL_THROW( path_not_exists, filename );
   }
 
   if( kwiversys::SystemTools::FileIsDirectory( filename ) )
   {
-    throw path_not_a_file( filename );
+    VITAL_THROW( path_not_a_file, filename );
   }
 
   // try to open the file
@@ -101,7 +101,7 @@ read_object_track_set
 
   if( ! *file )
   {
-    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
   m_stream = file.release();

--- a/vital/algo/read_object_track_set.cxx
+++ b/vital/algo/read_object_track_set.cxx
@@ -97,7 +97,7 @@ read_object_track_set
   // try to open the file
   std::istream* file( new std::ifstream( filename ) );
 
-  if( ! file )
+  if( ! *file )
   {
     kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }

--- a/vital/algo/read_object_track_set.cxx
+++ b/vital/algo/read_object_track_set.cxx
@@ -35,6 +35,8 @@
 
 #include "read_object_track_set.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -95,14 +97,14 @@ read_object_track_set
   }
 
   // try to open the file
-  std::istream* file( new std::ifstream( filename ) );
+  std::unique_ptr< std::istream > file( new std::ifstream( filename ) );
 
   if( ! *file )
   {
     kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
 
   new_stream();

--- a/vital/algo/read_track_descriptor_set.cxx
+++ b/vital/algo/read_track_descriptor_set.cxx
@@ -35,6 +35,8 @@
 
 #include "read_track_descriptor_set.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -95,13 +97,13 @@ read_track_descriptor_set
   }
 
   // try to open the file
-  std::istream* file( new std::ifstream( filename ) );
+  std::unique_ptr< std::istream > file( new std::ifstream( filename ) );
   if( ! *file )
   {
     VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
 
   new_stream();

--- a/vital/algo/read_track_descriptor_set.cxx
+++ b/vital/algo/read_track_descriptor_set.cxx
@@ -96,7 +96,7 @@ read_track_descriptor_set
 
   // try to open the file
   std::istream* file( new std::ifstream( filename ) );
-  if( ! file )
+  if( ! *file )
   {
     VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }

--- a/vital/algo/write_object_track_set.cxx
+++ b/vital/algo/write_object_track_set.cxx
@@ -77,7 +77,7 @@ write_object_track_set
 
   if( ! *file )
   {
-    kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
   m_stream = file.release();

--- a/vital/algo/write_object_track_set.cxx
+++ b/vital/algo/write_object_track_set.cxx
@@ -77,7 +77,7 @@ write_object_track_set
 
   if( ! *file )
   {
-    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
   m_stream = file.release();

--- a/vital/algo/write_object_track_set.cxx
+++ b/vital/algo/write_object_track_set.cxx
@@ -73,7 +73,7 @@ write_object_track_set
   // try to open the file
   std::ostream* file( new std::ofstream( filename ) );
 
-  if( ! file )
+  if( ! *file )
   {
     kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }

--- a/vital/algo/write_object_track_set.cxx
+++ b/vital/algo/write_object_track_set.cxx
@@ -35,6 +35,8 @@
 
 #include "write_object_track_set.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -71,14 +73,14 @@ write_object_track_set
 ::open( std::string const& filename )
 {
   // try to open the file
-  std::ostream* file( new std::ofstream( filename ) );
+  std::unique_ptr< std::ostream > file( new std::ofstream( filename ) );
 
   if( ! *file )
   {
     kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
   m_filename = filename;
 }

--- a/vital/algo/write_track_descriptor_set.cxx
+++ b/vital/algo/write_track_descriptor_set.cxx
@@ -35,6 +35,8 @@
 
 #include "write_track_descriptor_set.h"
 
+#include <memory>
+
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
 #include <vital/vital_types.h>
@@ -71,14 +73,14 @@ write_track_descriptor_set
 ::open( std::string const& filename )
 {
   // try to open the file
-  std::ostream* file( new std::ofstream( filename ) );
+  std::unique_ptr< std::ostream > file( new std::ofstream( filename ) );
 
   if( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }
 
-  m_stream = file;
+  m_stream = file.release();
   m_stream_owned = true;
   m_filename = filename;
 }

--- a/vital/algo/write_track_descriptor_set.cxx
+++ b/vital/algo/write_track_descriptor_set.cxx
@@ -73,7 +73,7 @@ write_track_descriptor_set
   // try to open the file
   std::ostream* file( new std::ofstream( filename ) );
 
-  if( ! file )
+  if( ! *file )
   {
     throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
   }

--- a/vital/algo/write_track_descriptor_set.cxx
+++ b/vital/algo/write_track_descriptor_set.cxx
@@ -77,7 +77,7 @@ write_track_descriptor_set
 
   if( ! *file )
   {
-    throw kwiver::vital::file_not_found_exception( filename, "open failed"  );
+    VITAL_THROW( file_not_found_exception, filename, "open failed" );
   }
 
   m_stream = file.release();


### PR DESCRIPTION
These changes improve the file management in several readers and writers in `vital/algo` so that:
- An exception is thrown when the file fails to properly open
- Memory is not leaked when that exception is thrown
- *(Edit 2020-01-28):* All exceptions are thrown using `VITAL_THROW`

#547 was likely caused by the algos' previous state, so this PR should fix it.

Besides the changes made, I'll note that all the code in the `open` and `close` methods here is redundant between the various algos, so it would be good to factor it out, in particular to create a class to manage the ownership and get it right once using RAII, since errors remain in the ownership code. (`close` should be called in destructors but isn't consistently, and calling `open` twice without calling `close` in the middle results in a leaked stream in some of these classes. `close` should be the destructor of a maybe-owned smart pointer.) I don't know where such code would best be placed, though.