### PR TITLE
Fix KW18 writer

### DIFF
--- a/arrows/core/write_object_track_set_kw18.cxx
+++ b/arrows/core/write_object_track_set_kw18.cxx
@@ -131,7 +131,7 @@ void write_object_track_set_kw18
                << "0 "                     // 15: world-loc x
                << "0 "                     // 16: world-loc y
                << "0 "                     // 17: world-loc z
-               << ts->frame() << " "       // 18: timestamp
+               << ts->time() << " "        // 18: timestamp
                << det->confidence()        // 19: confidence
                << std::endl;
     }


### PR DESCRIPTION
Fix a bug in the KW18 writer where, instead of the time, the frame number was being written out twice.

It would appear that this has never worked right...