### PR TITLE
make travis call setup_kwiver.sh before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,5 @@ script:
           ../
   - make -j2
   - make install
+  - . ./setup_KWIVER.sh
   - ctest


### PR DESCRIPTION
This branch allows TravisCI on the new python branches to succeed.