### PR TITLE
Move plugin filter out of API

### DIFF
--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,8 +28,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "plugin_loader.h"
 #include "plugin_factory.h"
+#include "plugin_loader.h"
+#include "plugin_loader_filter.h"
 
 #include <vital/exceptions/plugin.h>
 #include <vital/logger/logger.h>

--- a/vital/plugin_loader/plugin_loader.h
+++ b/vital/plugin_loader/plugin_loader.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016, 2019 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,6 @@
 #define KWIVER_VITAL_PLUGIN_LOADER_H_
 
 #include <vital/plugin_loader/vital_vpm_export.h>
-#include <vital/plugin_loader/plugin_loader_filter.h>
 
 #include <vital/vital_types.h>
 #include <vital/logger/logger.h>
@@ -50,11 +49,13 @@ namespace vital {
 
 // base class of factory hierarchy
 class plugin_factory;
+class plugin_loader_filter;
 
 using plugin_factory_handle_t = std::shared_ptr< plugin_factory >;
 using plugin_factory_vector_t = std::vector< plugin_factory_handle_t >;
 using plugin_map_t            = std::map< std::string, plugin_factory_vector_t >;
-using plugin_module_map_t     =  std::map< std::string, path_t >;
+using plugin_module_map_t     = std::map< std::string, path_t >;
+using plugin_filter_handle_t  = std::shared_ptr< plugin_loader_filter >;
 
 class plugin_loader_impl;
 


### PR DESCRIPTION
The plugin filter include file was included in the main API, but that include file is not installed. The fix is to remove the include file from the external interface and use incomplete types.