### PR TITLE
Add API to optionally load modules

### DIFF
--- a/CMake/setup_KWIVER.bat.in
+++ b/CMake/setup_KWIVER.bat.in
@@ -8,9 +8,9 @@ if [%1] == [] (
   set config=%1
 )
 
-set PATH=%~dp0/bin/%config%;%~dp0/lib/%config%/@kwiver_plugin_module_subdir@;%~dp0/lib/%config%/@kwiver_plugin_process_subdir@;@EXTRA_WIN32_PATH@;%PATH%
+set PATH=%~dp0/bin/%config%;%~dp0/lib/%config%/@kwiver_plugin_module_subdir@;%~dp0/lib/%config%/@kwiver_plugin_process_subdir@;%~dp0/lib/%config%/@kwiver_plugin_algorithms_subdir@;@EXTRA_WIN32_PATH@;%PATH%
 
-set KWIVER_PLUGIN_PATH=%~dp0/lib/%config%/@kwiver_plugin_module_subdir@;%~dp0/lib/%config%/@kwiver_plugin_process_subdir@
+set KWIVER_PLUGIN_PATH=%~dp0/lib/%config%/@kwiver_plugin_subdir@
 
 set KWIVER_CONFIG_PATH=%~dp0/share/kwiver/@KWIVER_VERSION@/config
 

--- a/CMake/setup_KWIVER.sh.in
+++ b/CMake/setup_KWIVER.sh.in
@@ -11,7 +11,6 @@ export @LIBRARY_PATH_VAR@="$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@:$@LIBRARY_PATH
 export KWIVER_PLUGIN_PATH=$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@/@kwiver_plugin_module_subdir@:$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@/@kwiver_plugin_process_subdir@:$KWIVER_PLUGIN_PATH
 export KWIVER_CONFIG_PATH=$this_dir/share/kwiver/@KWIVER_VERSION@/config
 
-# Set default log reporting level for default logger.
 # export KWIVER_DEFAULT_LOG_LEVEL=info
 
 # Additional pipeline include directories can be specified in the following env var.

--- a/CMake/setup_KWIVER.sh.in
+++ b/CMake/setup_KWIVER.sh.in
@@ -8,7 +8,7 @@ export VG_PLUGIN_PATH=$this_dir
 export PATH=$this_dir/bin:$PATH
 # shellcheck disable=SC2145
 export @LIBRARY_PATH_VAR@="$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@:$@LIBRARY_PATH_VAR@"
-export KWIVER_PLUGIN_PATH=$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@/@kwiver_plugin_module_subdir@:$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@/@kwiver_plugin_process_subdir@:$KWIVER_PLUGIN_PATH
+export KWIVER_PLUGIN_PATH=$this_dir/@KWIVER_DEFAULT_LIBRARY_DIR@/@kwiver_plugin_subdir@:$KWIVER_PLUGIN_PATH
 export KWIVER_CONFIG_PATH=$this_dir/share/kwiver/@KWIVER_VERSION@/config
 
 # export KWIVER_DEFAULT_LOG_LEVEL=info

--- a/CMake/utils/algorithm-utils-targets.cmake
+++ b/CMake/utils/algorithm-utils-targets.cmake
@@ -67,7 +67,7 @@ function(algorithms_create_plugin    base_lib)
   set( plugin_name   "${base_lib}_plugin" )
 
   # create module library given generated source, linked to given library
-  set(library_subdir /${kwiver_plugin_module_subdir})
+  set(library_subdir /${kwiver_plugin_algorithm_subdir})
   set(no_version ON)
 
   kwiver_add_plugin( ${plugin_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,14 +152,15 @@ set(BUILD_SHARED_LIBS ${KWIVER_BUILD_SHARED})
 
 # Set directories where loadable modules are stored.
 # These subdirs are under .../lib/
-set( kwiver_plugin_subdir                         kwiver )
+set( kwiver_plugin_subdir                         kwiver/plugins )
 set( kwiver_plugin_process_subdir                 ${kwiver_plugin_subdir}/processes )
-set( kwiver_plugin_process_instrumentation_subdir ${kwiver_plugin_subdir}/modules )
+set( kwiver_plugin_algorithm_subdir               ${kwiver_plugin_subdir}/algorithms )
+set( kwiver_plugin_process_instrumentation_subdir ${kwiver_plugin_subdir}/proc_instr )
 set( kwiver_plugin_scheduler_subdir               ${kwiver_plugin_subdir}/processes )
 set( kwiver_plugin_module_subdir                  ${kwiver_plugin_subdir}/modules )
-set( kwiver_plugin_plugin_explorer_subdir         ${kwiver_plugin_subdir}/modules/plugin_explorer )
-set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/modules )
-set( kwiver_plugin_applets                        ${kwiver_plugin_subdir}/modules/applets )
+set( kwiver_plugin_plugin_explorer_subdir         ${kwiver_plugin_subdir}/plugin_explorer )
+set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/modules/logger )
+set( kwiver_plugin_applets_subdir                 ${kwiver_plugin_subdir}/applets )
 
 ##
 # System specific compiler flags
@@ -369,28 +370,12 @@ foreach( p IN LISTS KWIVER_DEFAULT_MODULE_PATHS )
   kwiver_add_module_path( ${p} )
 endforeach(p)
 
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_process_subdir} )
+kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_subdir} )
 kwiver_add_module_path(  "${kwiver_module_path_result}" )
 
 if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_process_subdir} )
+  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_subdir} )
   kwiver_add_module_path(  "${kwiver_module_path_result}" )
-endif()
-
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_module_subdir} )
-kwiver_add_module_path(  "${kwiver_module_path_result}" )
-
-if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_module_subdir} )
-  kwiver_add_module_path(  "${kwiver_module_path_result}" )
-endif()
-
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_applets} )
-kwiver_add_module_path( "${kwiver_module_path_result}" )
-
-if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_applets} )
-  kwiver_add_module_path( "${kwiver_module_path_result}" )
 endif()
 
 # need to retrieve the GLOBAL PROPERTY kwiver_plugin_path and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,11 +155,11 @@ set(BUILD_SHARED_LIBS ${KWIVER_BUILD_SHARED})
 set( kwiver_plugin_subdir                         kwiver/plugins )
 set( kwiver_plugin_process_subdir                 ${kwiver_plugin_subdir}/processes )
 set( kwiver_plugin_algorithm_subdir               ${kwiver_plugin_subdir}/algorithms )
-set( kwiver_plugin_process_instrumentation_subdir ${kwiver_plugin_subdir}/proc_instr )
+set( kwiver_plugin_process_instrumentation_subdir ${kwiver_plugin_subdir}/processes )
 set( kwiver_plugin_scheduler_subdir               ${kwiver_plugin_subdir}/processes )
 set( kwiver_plugin_module_subdir                  ${kwiver_plugin_subdir}/modules )
 set( kwiver_plugin_plugin_explorer_subdir         ${kwiver_plugin_subdir}/plugin_explorer )
-set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/modules/logger )
+set( kwiver_plugin_logger_subdir                  ${kwiver_plugin_subdir}/logger )
 set( kwiver_plugin_applets_subdir                 ${kwiver_plugin_subdir}/applets )
 
 ##

--- a/arrows/core/applets/CMakeLists.txt
+++ b/arrows/core/applets/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 ###
 # Add applet plugin
 kwiver_add_plugin( kwiver_algo_core_applets
-  SUBDIR       ${kwiver_plugin_applets}
+  SUBDIR       ${kwiver_plugin_applets_subdir}
   SOURCES      ${sources} ${headers}
   PRIVATE      kwiver_algo_core
                kwiver_tools_applet

--- a/arrows/qt/applets/pipeline_viewer/CMakeLists.txt
+++ b/arrows/qt/applets/pipeline_viewer/CMakeLists.txt
@@ -20,7 +20,7 @@ set( headers
   )
 
 kwiver_add_plugin( kwiver_pipeline_viewer
-  SUBDIR       ${kwiver_plugin_applets}
+  SUBDIR       ${kwiver_plugin_applets_subdir}
   SOURCES      ${sources} ${headers}
   PRIVATE      kwiver_tools_applet
                kwiver_algo_qt

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -15,6 +15,14 @@ Vital Types
 
 Vital Plugin-loader
 
+ * Added support for filtering plugins when they are loaded. Filter
+   objects can be added to the plugin loader at run time to select or
+   exclude specific plugins.
+
+ * Added optional bit mask to load_all_plugins() which allows selected
+   groups of plugins to be loaded. In addition the build/install
+   directory structure for the plugins was reorganized.
+
 Vital Util
 
 Vital Logger
@@ -67,4 +75,3 @@ Arrows: Core
 Arrows: Ceres
 
 Arrows: Super3D
-

--- a/sprokit/src/applets/CMakeLists.txt
+++ b/sprokit/src/applets/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 ###
 # Add applet for tools plugin
 kwiver_add_plugin( sprokit_applets
-  SUBDIR       ${kwiver_plugin_applets}
+  SUBDIR       ${kwiver_plugin_applets_subdir}
   SOURCES      ${sources} ${headers}
   PRIVATE      vital
                vital_vpm

--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -37,7 +37,7 @@
 #include <vital/plugin_loader/plugin_factory.h>
 #include <vital/plugin_loader/plugin_filter_category.h>
 #include <vital/plugin_loader/plugin_filter_default.h>
-#include <vital/plugin_loader/plugin_manager.h>
+#include <vital/plugin_loader/plugin_manager_internal.h>
 #include <vital/util/get_paths.h>
 
 #include <cstdlib>
@@ -186,7 +186,8 @@ int main(int argc, char *argv[])
   //
   applet_context_t tool_context = std::make_shared< kwiver::tools::applet_context >();
 
-  kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
+  kwiver::vital::plugin_manager_internal& vpm = kwiver::vital::plugin_manager_internal::instance();
+
   const std::string exec_path = kwiver::vital::get_executable_path();
   vpm.add_search_path(exec_path + "/../lib/kwiver/plugins");
 

--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -191,13 +191,6 @@ int main(int argc, char *argv[])
   const std::string exec_path = kwiver::vital::get_executable_path();
   vpm.add_search_path(exec_path + "/../lib/kwiver/plugins");
 
-  // remove all default plugin filters
-  vpm.get_loader()->clear_filters();
-
-  // Add filter to select all plugins
-  kwiver::vital::plugin_filter_handle_t filt = std::make_shared<kwiver::vital::plugin_filter_default>();
-  vpm.get_loader()->add_filter( filt );
-
   vpm.load_all_plugins();
 
   // initialize the global context

--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -188,9 +188,7 @@ int main(int argc, char *argv[])
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   const std::string exec_path = kwiver::vital::get_executable_path();
-  vpm.add_search_path(exec_path + "/../lib/kwiver/modules");
-  vpm.add_search_path(exec_path + "/../lib/kwiver/modules/applets");
-  vpm.add_search_path(exec_path + "/../lib/kwiver/processes");
+  vpm.add_search_path(exec_path + "/../lib/kwiver/plugins");
 
   // remove all default plugin filters
   vpm.get_loader()->clear_filters();

--- a/vital/applets/CMakeLists.txt
+++ b/vital/applets/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries( kwiver_tools_applet
 ###
 # Add applet for tools plugin
 kwiver_add_plugin( vital_applets
-  SUBDIR       ${kwiver_plugin_applets}
+  SUBDIR       ${kwiver_plugin_applets_subdir}
   SOURCES      ${sources} ${headers}
   PRIVATE      vital
                vital_vpm

--- a/vital/bindings/python/vital/modules/CMakeLists.txt
+++ b/vital/bindings/python/vital/modules/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 if (KWIVER_ENABLE_TOOLS)
 kwiver_add_plugin( modules_python
-  SUBDIR          ${kwiver_plugin_module_subdir}
+  SUBDIR          ${kwiver_plugin_process_subdir}
   SOURCES         ${modules_python_srcs}
   PRIVATE         vital_python_util
                   kwiversys

--- a/vital/plugin_loader/CMakeLists.txt
+++ b/vital/plugin_loader/CMakeLists.txt
@@ -23,6 +23,7 @@ set(vital_vpm_headers_private
   plugin_loader_filter.h
   plugin_filter_default.h
   plugin_filter_category.h
+  plugin_manager_internal.h
   ${CMAKE_CURRENT_BINARY_DIR}/vital_vpm_export.h
   )
 

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -159,7 +159,7 @@ plugin_loader
   fact->get_attribute( plugin_factory::CONCRETE_TYPE, concrete_type );
 
   // If the hook has declined to register the factory, just return.
-  for ( auto filt : m_impl->m_filters )
+  for ( auto & filt : m_impl->m_filters )
   {
     if ( ! filt->add_factory( fact_handle ) )
     {

--- a/vital/plugin_loader/plugin_manager.cxx
+++ b/vital/plugin_loader/plugin_manager.cxx
@@ -74,15 +74,8 @@ public:
     , m_loader( new plugin_loader( register_function_name, shared_library_suffix ) )
     , m_logger( kwiver::vital::get_logger( "vital.plugin_manager" ) )
   {
-    using kvpf = kwiver::vital::plugin_factory;
-
     // Add the default filter which checks for duplicate plugins
     plugin_filter_handle_t filt = std::make_shared<kwiver::vital::plugin_filter_default>();
-    m_loader->add_filter( filt );
-
-    // Add filter that excludes applets
-    filt = std::make_shared<kwiver::vital::plugin_filter_category>(
-      plugin_filter_category::condition::NOT_EQUAL, kvpf::APPLET_CATEGORY );
     m_loader->add_filter( filt );
   }
 

--- a/vital/plugin_loader/plugin_manager.cxx
+++ b/vital/plugin_loader/plugin_manager.cxx
@@ -188,14 +188,6 @@ plugin_manager
         dirpath.push_back( dir_name );
       }
 
-      if ( SELECT( PROCESS_INSTRUMENTATION ) )
-      {
-        // load process instrumentation providers (or should this be
-        // grouped with processes?)
-        std::string dir_name = p + "/proc_instr";
-        dirpath.push_back( dir_name );
-      }
-
       if ( SELECT( OTHERS ) )
       {
         // load everything else

--- a/vital/plugin_loader/plugin_manager.h
+++ b/vital/plugin_loader/plugin_manager.h
@@ -67,14 +67,14 @@ public:
 
   enum class plugin_type
   {
-    PROCESSES               = 0x0001,
-    ALGORITHMS              = 0x0002,
-    APPLETS                 = 0x0004,
-    EXPLORER                = 0x0008,
-    PROCESS_INSTRUMENTATION = 0x0010,
-    OTHERS                  = 0x0020,
-    LEGACY                  = 0x0040,
-    ALL                     = 0xffff
+    PROCESSES  = 0x0001,
+    ALGORITHMS = 0x0002,
+    APPLETS    = 0x0004,
+    EXPLORER   = 0x0008,
+    OTHERS     = 0x0020,
+    LEGACY     = 0x0040,
+    DEFAULT    = 0x00f7,
+    ALL        = 0xffff
   };
 
 
@@ -96,7 +96,7 @@ public:
    *
    * @throws plugin_already_exists - if a duplicate plugin is detected
    */
-  void load_all_plugins( plugin_type type = plugin_type::ALL );
+  void load_all_plugins( plugin_type type = plugin_type::DEFAULT );
 
   /**
    * @brief Load plugins from list of directories.

--- a/vital/plugin_loader/plugin_manager_internal.h
+++ b/vital/plugin_loader/plugin_manager_internal.h
@@ -1,0 +1,64 @@
+/*ckwg +29
+ * Copyright 2019 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef VITAL_PLUGIN_MANAGER_INTERNAL_H
+#define VITAL_PLUGIN_MANAGER_INTERNAL_H
+
+#include <vital/plugin_loader/plugin_manager.h>
+namespace kwiver {
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/*
+ * This class just exposes the protected members of the base class.
+ * ---- For internal use only ----
+ */
+class plugin_manager_internal
+  : public plugin_manager
+{
+public:
+  static plugin_manager_internal& instance()
+  {
+    plugin_manager_internal* pm =
+      reinterpret_cast< plugin_manager_internal* >(&plugin_manager::instance() );
+    return *pm;
+  }
+
+  plugin_map_t const& plugin_map() { return plugin_manager::plugin_map(); }
+  std::map< std::string, std::string > const& module_map() const { return plugin_manager::module_map(); }
+  path_list_t const& search_path() const { return plugin_manager::search_path(); }
+  plugin_loader* get_loader() { return plugin_manager::get_loader(); }
+  std::vector< std::string > file_list() { return plugin_manager::file_list(); }
+
+};
+
+} } // end namespace
+
+#endif // VITAL_PLUGIN_MANAGER_INTERNAL_H

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -677,7 +677,7 @@ main( int argc, char* argv[] )
       vpm.add_search_path( path );
     }
 
-    vpm.load_all_plugins();
+    vpm.load_all_plugins( ::kwiver::vital::plugin_manager::plugin_type::ALL );
   }
 
   if ( G_context.opt_path_list )

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -663,8 +663,7 @@ main( int argc, char* argv[] )
   if (!G_context.opt_skip_relative)
   {
     // It is somewhat problematic to keep these in sync with the CMake values
-    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/modules");
-    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/sprokit");
+    vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/plugins");
   }
 
   // Look for plugin file name from command line

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -374,10 +374,13 @@ void load_explorer_plugins()
     p.append( "/plugin_explorer" );
   }
 
+  // Load explorer plugins
   pl.load_plugins( pathl );
 
   auto fact_list = pl.get_factories( typeid( kwiver::vital::category_explorer ).name() );
 
+  // Scan all implementations loaded and build map from plugin
+  // category to formatting plugin
   for( auto fact : fact_list )
   {
     std::string name;
@@ -653,16 +656,9 @@ main( int argc, char* argv[] )
   // ========
   kwiver::vital::plugin_manager_internal& vpm = kwiver::vital::plugin_manager_internal::instance();
 
-  // remove all default plugin filters
-  vpm.get_loader()->clear_filters();
-
-  // Add the default filter which checks for duplicate plugins
-  kwiver::vital::plugin_filter_handle_t filt = std::make_shared<kwiver::vital::plugin_filter_default>();
-  vpm.get_loader()->add_filter( filt );
-
   if (!G_context.opt_skip_relative)
   {
-    // It is somewhat problematic to keep these in sync with the CMake values
+    // Add path relative to the current executable/binary directory
     vpm.add_search_path(kwiver::vital::get_executable_path() + "/../lib/kwiver/plugins");
   }
 

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -40,7 +40,7 @@
 #include <vital/plugin_loader/plugin_factory.h>
 #include <vital/plugin_loader/plugin_filter_category.h>
 #include <vital/plugin_loader/plugin_filter_default.h>
-#include <vital/plugin_loader/plugin_manager.h>
+#include <vital/plugin_loader/plugin_manager_internal.h>
 #include <vital/util/demangle.h>
 #include <vital/util/get_paths.h>
 #include <vital/util/wrap_text_block.h>
@@ -651,7 +651,7 @@ main( int argc, char* argv[] )
   }
 
   // ========
-  kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
+  kwiver::vital::plugin_manager_internal& vpm = kwiver::vital::plugin_manager_internal::instance();
 
   // remove all default plugin filters
   vpm.get_loader()->clear_filters();


### PR DESCRIPTION
Add parameter to load_all_modules() to select subsets of modules to be loaded.
    
Plugins are distributed in sub-directories off a root directory. The plugin_manager is supplied with the rood directory and adds sub-directories to the search path depending on which plugin types are selected. This shortens the default plugin paths quite a bit.
    
To make this approach work, the build/install paths were changed to group like plugins into separate directories

Plugins are now stored in the following directories:
- processes: <root>/lib/kwiver/plugins/processes
- algorithms: <root>/lib/kwiver/plugins/algorithms
- schedulers: <root>/lib/kwiver/plugins/processes
- applets: <root>/lib/kwiver/plugins/applets
- process-instrumentation: <root>/lib/kwiver/plugins/proc_instr
- plugin explorer extensions: <root>/lib/kwiver/plugins/plugin_explorer
- logger plugins: <root>/lib/kwiver/plugins/logger
- config printer extensions: <root>/lib/kwiver/plugins/modules

Some of the lesser known plugins could be all put into the 'modules' subdirectory, such as process_instrumentation, plugin_explorer, and config extensions, but then you have to decide to give them a meaningful group name or just load them by default.