### PR TITLE
Wrap detected_object_set_input for Python

### DIFF
--- a/python/kwiver/vital/algo/detected_object_set_input.cxx
+++ b/python/kwiver/vital/algo/detected_object_set_input.cxx
@@ -30,13 +30,15 @@
 #include <utility>
 
 #include <pybind11/pybind11.h>
-#include <vital/bindings/python/vital/algo/trampoline/detected_object_set_input_trampoline.txx>
-#include <vital/bindings/python/vital/algo/detected_object_set_input.h>
+#include <python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx>
+#include <python/kwiver/vital/algo/detected_object_set_input.h>
 
 namespace py = pybind11;
 
 using dosi = kwiver::vital::algo::detected_object_set_input;
-
+namespace kwiver {
+namespace vital {
+namespace python {
 void detected_object_set_input(py::module &m)
 {
   py::class_< dosi,
@@ -56,4 +58,7 @@ file name, or None if the input is exhausted)")
     .def("open", &dosi::open)
     .def("close", &dosi::close)
     ;
+}
+}
+}
 }

--- a/python/kwiver/vital/algo/detected_object_set_input.cxx
+++ b/python/kwiver/vital/algo/detected_object_set_input.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2020 by Kitware, Inc.
+ * Copyright 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,31 +27,33 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <utility>
 
 #include <pybind11/pybind11.h>
-#include <python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx>
-#include <python/kwiver/vital/algo/detected_object_set_input.h>
+#include <vital/bindings/python/vital/algo/trampoline/detected_object_set_input_trampoline.txx>
+#include <vital/bindings/python/vital/algo/detected_object_set_input.h>
 
 namespace py = pybind11;
-namespace kwiver {
-namespace vital  {
-namespace python {
+
+using dosi = kwiver::vital::algo::detected_object_set_input;
+
 void detected_object_set_input(py::module &m)
 {
-  py::class_< kwiver::vital::algo::detected_object_set_input,
-              std::shared_ptr<kwiver::vital::algo::detected_object_set_input>,
-              kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_input>,
-              detected_object_set_input_trampoline<> >( m, "DetectedObjectSetInput" )
+  py::class_< dosi,
+              std::shared_ptr<dosi>,
+              kwiver::vital::algorithm_def<dosi>,
+              detected_object_set_input_trampoline<> >(m, "DetectedObjectSetInput")
     .def(py::init())
-    .def_static("static_type_name",
-                &kwiver::vital::algo::detected_object_set_input::static_type_name)
-    .def("open",
-         &kwiver::vital::algo::detected_object_set_input::open)
-    .def("close",
-         &kwiver::vital::algo::detected_object_set_input::close)
+    .def_static("static_type_name", &dosi::static_type_name)
     .def("read_set",
-         &kwiver::vital::algo::detected_object_set_input::read_set);
-}
-}
-}
+	 [](dosi& self) {
+	   std::pair<kwiver::vital::detected_object_set_sptr, std::string> result;
+	   bool has_result = self.read_set(result.first, result.second);
+	   return has_result ? py::cast(result) : py::cast(nullptr);
+	 },
+	 R"(Return a pair of the next DetectedObjectSet and the corresponding
+file name, or None if the input is exhausted)")
+    .def("open", &dosi::open)
+    .def("close", &dosi::close)
+    ;
 }

--- a/python/kwiver/vital/algo/detected_object_set_input.h
+++ b/python/kwiver/vital/algo/detected_object_set_input.h
@@ -3,5 +3,11 @@
 
 #include <pybind11/pybind11.h>
 
+namespace kwiver {
+namespace vital {
+namespace python {
 void detected_object_set_input(pybind11::module &m);
+}
+}
+}
 #endif

--- a/python/kwiver/vital/algo/detected_object_set_input.h
+++ b/python/kwiver/vital/algo/detected_object_set_input.h
@@ -1,44 +1,7 @@
-/*ckwg +29
- * Copyright 2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 #ifndef KWIVER_VITAL_PYTHON_DETECTED_OBJECT_SET_INPUT_H_
 #define KWIVER_VITAL_PYTHON_DETECTED_OBJECT_SET_INPUT_H_
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-namespace kwiver {
-namespace vital  {
-namespace python {
-void detected_object_set_input(py::module &m);
-}
-}
-}
+void detected_object_set_input(pybind11::module &m);
 #endif

--- a/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
+++ b/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
@@ -99,6 +99,15 @@ class detected_object_set_input_trampoline :
 	filename
       );
     }
+
+    void close() override
+    {
+      VITAL_PYBIND11_OVERLOAD(
+        void,
+        dosi,
+        close,
+      );
+    }
 };
 
 #endif

--- a/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
+++ b/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
@@ -39,13 +39,17 @@
 
 #include <tuple>
 
-#include <vital/bindings/python/vital/util/pybind11.h>
+#include <python/kwiver/vital/util/pybind11.h>
 #include <vital/algo/detected_object_set_input.h>
 #include <vital/types/detected_object_set.h>
 #include <vital/types/image_container.h>
-#include <vital/bindings/python/vital/algo/trampoline/algorithm_trampoline.txx>
+#include <python/kwiver/vital/algo/trampoline/algorithm_trampoline.txx>
 
 using dosi = kwiver::vital::algo::detected_object_set_input;
+
+namespace kwiver {
+namespace vital {
+namespace python {
 
 template <class algorithm_def_dosi_base=kwiver::vital::algorithm_def<dosi>>
 class algorithm_def_dosi_trampoline :
@@ -110,4 +114,7 @@ class detected_object_set_input_trampoline :
     }
 };
 
+}
+}
+}
 #endif

--- a/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
+++ b/python/kwiver/vital/algo/trampoline/detected_object_set_input_trampoline.txx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2020 by Kitware, Inc.
+ * Copyright 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,82 +31,74 @@
 /**
  * \file detected_object_set_input_trampoline.txx
  *
- * \brief trampoline for overriding virtual functions for
- *        \link kwiver::vital::algo::detected_object_set_input \endlink
+ * \brief trampoline for overriding virtual functions of algorithm_def<detected_object_set_input> and detected_object_set_input
  */
 
 #ifndef DETECTED_OBJECT_SET_INPUT_TRAMPOLINE_TXX
 #define DETECTED_OBJECT_SET_INPUT_TRAMPOLINE_TXX
 
-#include <python/kwiver/vital/util/pybind11.h>
-#include <python/kwiver/vital/algo/trampoline/algorithm_trampoline.txx>
-#include <vital/algo/detected_object_set_input.h>
+#include <tuple>
 
-namespace kwiver {
-namespace vital  {
-namespace python {
-template< class algorithm_def_dosi_base=
-           kwiver::vital::algorithm_def< kwiver::vital::algo::detected_object_set_input > >
+#include <vital/bindings/python/vital/util/pybind11.h>
+#include <vital/algo/detected_object_set_input.h>
+#include <vital/types/detected_object_set.h>
+#include <vital/types/image_container.h>
+#include <vital/bindings/python/vital/algo/trampoline/algorithm_trampoline.txx>
+
+using dosi = kwiver::vital::algo::detected_object_set_input;
+
+template <class algorithm_def_dosi_base=kwiver::vital::algorithm_def<dosi>>
 class algorithm_def_dosi_trampoline :
-      public algorithm_trampoline< algorithm_def_dosi_base>
+      public algorithm_trampoline<algorithm_def_dosi_base>
 {
   public:
-    using algorithm_trampoline< algorithm_def_dosi_base >::algorithm_trampoline;
+    using algorithm_trampoline<algorithm_def_dosi_base>::algorithm_trampoline;
 
     std::string type_name() const override
     {
       VITAL_PYBIND11_OVERLOAD(
         std::string,
-        kwiver::vital::algorithm_def<kwiver::vital::algo::detected_object_set_input>,
+        kwiver::vital::algorithm_def<dosi>,
         type_name,
       );
     }
 };
 
 
-template< class detected_object_set_input_base=kwiver::vital::algo::detected_object_set_input >
+template <class detected_object_set_input_base=dosi>
 class detected_object_set_input_trampoline :
-      public algorithm_def_dosi_trampoline< detected_object_set_input_base >
+      public algorithm_def_dosi_trampoline<detected_object_set_input_base>
 {
+  using super = algorithm_def_dosi_trampoline<detected_object_set_input_base>;
+
   public:
-    using algorithm_def_dosi_trampoline< detected_object_set_input_base >::
-              algorithm_def_dosi_trampoline;
+    using super::super;
 
-    void
-    open( std::string const& filename ) override
+    bool read_set(kwiver::vital::detected_object_set_sptr& set, std::string& image_path) override
     {
-      VITAL_PYBIND11_OVERLOAD_PURE(
+      kwiver::vital::python::gil_scoped_acquire gil;
+      pybind11::function overload = pybind11::get_overload(static_cast<dosi const*>(this), "read_set");
+      if (overload) {
+	auto o = overload();
+	if (pybind11::isinstance<pybind11::none>(o)) {
+	  return false;
+	}
+	std::tie(set, image_path) = o.cast<std::tuple<kwiver::vital::detected_object_set_sptr, std::string>>();
+	return true;
+      } else {
+	pybind11::pybind11_fail("Tried to call pure virtual function \"dosi::read_set\"");
+      }
+    }
+
+    void open(std::string const& filename) override
+    {
+      VITAL_PYBIND11_OVERLOAD(
         void,
-        kwiver::vital::algo::detected_object_set_input,
+        dosi,
         open,
-        filename
-      );
-    }
-
-    void
-    close() override
-    {
-      VITAL_PYBIND11_OVERLOAD_PURE(
-        void,
-        kwiver::vital::algo::detected_object_set_input,
-        close,
-      );
-    }
-
-    bool
-    read_set( kwiver::vital::detected_object_set_sptr& set,
-            std::string& image_name ) override
-    {
-      VITAL_PYBIND11_OVERLOAD_PURE(
-        bool,
-        kwiver::vital::algo::detected_object_set_input,
-        read_set,
-        set,
-        image_name
+	filename
       );
     }
 };
-}
-}
-}
+
 #endif

--- a/python/kwiver/vital/tests/CMakeLists.txt
+++ b/python/kwiver/vital/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ if(KWIVER_ENABLE_SPROKIT AND KWIVER_ENABLE_ARROWS)
   # ImageObjectDetector test requires config bindings in sprokit
   list(APPEND
       __testable_modnames
+      test_detected_object_set_input
       test_image_object_detector
     )
 endif()

--- a/python/kwiver/vital/tests/test_detected_object_set_input.py
+++ b/python/kwiver/vital/tests/test_detected_object_set_input.py
@@ -1,0 +1,85 @@
+"""
+ckwg +29
+Copyright 2019-2020 by Kitware, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither name of Kitware, Inc. nor the names of any contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Tests for the DetectedObjectSetInput wrapping class
+"""
+import unittest
+
+from vital.algo import DetectedObjectSetInput
+from vital.config import config
+from vital.modules.modules import load_known_modules
+from vital.types import DetectedObjectSet
+
+SIMULATOR_CONFIG = dict(
+    center_x=3,
+    center_y=5,
+    dx=0.3,
+    dy=0.2,
+    height=10,
+    width=15,
+    max_sets=10,
+    set_size=4,
+    image_name='foo.png',
+)
+
+def _create_simulator_config():
+    cfg = config.empty_config()
+    for k, v in SIMULATOR_CONFIG.items():
+        cfg[k] = v
+    return cfg
+
+class TestVitalDetectedObjectSetInput(unittest.TestCase):
+    def test_registered_names(self):
+        """Print all the registered detected object set input arrows"""
+        load_known_modules()
+        print("All registered detected object set input arrows:")
+        for arrow in DetectedObjectSetInput.registered_names():
+            print('  ' + arrow)
+
+    def test_open(self):
+        """Create a DetectedObjectSetInput and call .open on it"""
+        load_known_modules()
+        dosi = DetectedObjectSetInput.create('simulator')
+        # The simulator doesn't actually try to open its file
+        dosi.open('/example/file/path')
+
+    def test_read_set(self):
+        """Create and configure a DetectedObjectSetInput and call .read_set"""
+        load_known_modules()
+        dosi = DetectedObjectSetInput.create('simulator')
+        dosi.set_configuration(_create_simulator_config())
+        sets = list(iter(dosi.read_set, None))
+        self.assertEqual(len(sets), SIMULATOR_CONFIG['max_sets'])
+        for s in sets:
+            self.assertEqual(len(s), 2)
+            dos, image_name = s
+            self.assertIsInstance(dos, DetectedObjectSet)
+            self.assertEqual(len(dos), SIMULATOR_CONFIG['set_size'])
+            self.assertEqual(image_name, SIMULATOR_CONFIG['image_name'])

--- a/python/kwiver/vital/tests/test_detected_object_set_input.py
+++ b/python/kwiver/vital/tests/test_detected_object_set_input.py
@@ -32,10 +32,10 @@ Tests for the DetectedObjectSetInput wrapping class
 """
 import unittest
 
-from vital.algo import DetectedObjectSetInput
-from vital.config import config
-from vital.modules.modules import load_known_modules
-from vital.types import DetectedObjectSet
+from kwiver.vital.algo import DetectedObjectSetInput
+from kwiver.vital.config import config
+from kwiver.vital.modules.modules import load_known_modules
+from kwiver.vital.types import DetectedObjectSet
 
 SIMULATOR_CONFIG = dict(
     center_x=3,


### PR DESCRIPTION
This PR adds wrapping for the `detected_object_set_input` algo. In line with the choices made in #919, its `close` method is made virtual and `stream` is not wrapped. Of note is that `read_set`, which in C++ has a boolean return value and two by-reference output parameters, is wrapped to return a pair or `None`.

@mattdawkins, as I recall `viame/master` changes `read_set` to make `image_path` an in-out parameter (or more precisely, sometimes an input and sometimes an output parameter). That doesn't change the signature in C++, but it corresponds to a different Python signature (`path -> (set, path)` for in-out and `path -> set` for just output). For compatibility with that, I think a separate, for-VIAME patch that adds a Python method `read_set_by_path` that acts as the path-as-input "overload" for `read_set` would be the cleanest approach. This would leave the meaning and use of `read_set` in Python as it is in this PR. (This is relevant to VIAME/VIAME#101.)