### PR TITLE
Remove unneeded include.

### DIFF
--- a/vital/plugin_loader/plugin_manager.cxx
+++ b/vital/plugin_loader/plugin_manager.cxx
@@ -36,7 +36,6 @@
 #include "plugin_manager.h"
 
 #include <vital/algorithm_plugin_manager_paths.h> //+ maybe rename later
-#include <vital/applets/applet_registrar.h>
 #include <vital/logger/logger.h>
 #include <vital/plugin_loader/plugin_filter_category.h>
 #include <vital/plugin_loader/plugin_filter_default.h>


### PR DESCRIPTION
This include created an unnecessary coupling to the tools. This
would cause a build problem if the tools were not enabled.