### PR TITLE
Dev/update plugin registrar

### DIFF
--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -165,6 +165,17 @@ public:
   {
   }
 
+    // Use forced naming convention for modules
+  bool is_module_loaded() override
+  {
+    return plugin_loader().is_module_loaded( "epx." + module_name() );
+  }
+
+  void mark_module_as_loaded() override
+  {
+    plugin_loader().mark_module_as_loaded( "epx." + module_name() );
+  }
+
   // ----------------------------------------------------------------------------
   /// Register an Embedded Pipeline Extension plugin.
   /**

--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,9 +33,11 @@
 
 #include <sprokit/processes/adapters/kwiver_adapter_export.h>
 
+#include <sprokit/pipeline/pipeline.h>
 #include <vital/config/config_block.h>
 #include <vital/logger/logger.h>
-#include <sprokit/pipeline/pipeline.h>
+#include <vital/plugin_loader/plugin_info.h>
+#include <vital/plugin_loader/plugin_registrar.h>
 
 #include <memory>
 
@@ -143,6 +145,54 @@ protected:
 
 // define pointer type for this interface
 using embedded_pipeline_extension_sptr = std::shared_ptr< embedded_pipeline_extension >;
+
+
+// ============================================================================
+/// Derived class to register Embedded Pipeline Extensions
+/**
+ * Embedded Pipeline Extension Registrar
+ *
+ * This class assists in registering embedded pipeline extensions
+ *
+ */
+class embedded_pipeline_extension_registrar
+  : public plugin_registrar
+{
+public:
+  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl,
+                    const std::string& mod_name )
+    : plugin_registrar( vpl, mod_name )
+  {
+  }
+
+  // ----------------------------------------------------------------------------
+  /// Register an Embedded Pipeline Extension plugin.
+  /**
+   * A EPX of the specified type is registered with the plugin
+   * manager.
+   *
+   * @tparam epx_t Type of the EPX being registered.
+   *
+   * @return The plugin loader reference is returned.
+   */
+  template <typename epx_t>
+  kwiver::vital::plugin_factory_handle_t register_EPX()
+  {
+    using kvpf = kwiver::vital::plugin_factory;
+
+    kwiver::vital::plugin_factory* fact = new kwiver::vital::plugin_factory_0< epx_t >(
+      typeid( kwiver::embedded_pipeline_extension ).name() );
+
+    fact->add_attribute( kvpf::PLUGIN_NAME,      epx_t::_plugin_name )
+      .add_attribute( kvpf::PLUGIN_DESCRIPTION,  epx_t::_plugin_description )
+      .add_attribute( kvpf::PLUGIN_MODULE_NAME,  this->module_name() )
+      .add_attribute( kvpf::PLUGIN_ORGANIZATION, this->organization() )
+      .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, "embedded-pipeline-extension" )
+      ;
+
+    return plugin_loader().add_factory( fact );
+  }
+};
 
 } // end namespace
 

--- a/sprokit/processes/adapters/epx_test.cxx
+++ b/sprokit/processes/adapters/epx_test.cxx
@@ -103,24 +103,15 @@ void
 register_factories( kwiver::vital::plugin_loader& vpm )
 
 {
-  static auto const module_name = kwiver::vital::plugin_manager::module_t( "kwiver_epx_test" );
+  kwiver::embedded_pipeline_extension_registrar reg( vpm, "kwiver_epx_test" );
+  using namespace kwiver;
 
-  if ( vpm.is_module_loaded( module_name ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
 
-  // ----------------------------------------------------------------------------
-  // Add test embedded pipeline extension
-  auto fact = vpm.ADD_FACTORY( kwiver::embedded_pipeline_extension, kwiver::epx_test );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "test")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                       "Extension for testing.")
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_CATEGORY, "embedded-pipeline-extension" )
-    ;
-  // - - - - - - - - - - - - - - - - - - - - - - -
-  vpm.mark_module_as_loaded( module_name );
+  reg.register_EPX< epx_test >();
+
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/adapters/epx_test.h
+++ b/sprokit/processes/adapters/epx_test.h
@@ -46,6 +46,9 @@ class KWIVER_EPX_TEST_NO_EXPORT epx_test
   : public embedded_pipeline_extension
 {
 public:
+  PLUGIN_INFO( "test",
+               "Embedded Pipeline Extension used for testing" );
+
   // -- CONSTRUCTORS --
   epx_test();
   virtual ~epx_test() = default;

--- a/sprokit/processes/adapters/register_processes.cxx
+++ b/sprokit/processes/adapters/register_processes.cxx
@@ -51,7 +51,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_adapters" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -60,5 +60,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< kwiver::output_adapter_process >( process_registrar::no_test );
 
   // - - - - - - - - - - - - - - - - - - - - - - -
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/core/register_processes.cxx
+++ b/sprokit/processes/core/register_processes.cxx
@@ -92,7 +92,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_core" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -140,5 +140,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< detect_motion_process >();
   reg.register_process< shift_detected_object_set_frames_process >();
 
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 } // register_process

--- a/sprokit/processes/examples/process_template/algo_wrapper_process.h
+++ b/sprokit/processes/examples/process_template/algo_wrapper_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,9 @@ class KWIVER_PROCESSES_NO_EXPORT algo_wrapper_process
   : public sprokit::process
 {
 public:
+  PLUGIN_INFO( "algo_wrapper",
+               "Template process to wrap an algo" );
+
   algo_wrapper_process( kwiver::vital::config_block_sptr const& config );
   virtual ~algo_wrapper_process();
 

--- a/sprokit/processes/examples/process_template/register_processes.cxx
+++ b/sprokit/processes/examples/process_template/register_processes.cxx
@@ -44,29 +44,22 @@ TEMPLATE_PROCESSES_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  // The module name identifies this loadable collection or
-  // processes. The name must be unique across all loadable modules,
-  // since we check to see if it is already loaded.
-  static const auto module_name = kwiver::vital::plugin_manager::module_t( "template_processes" ); //++ <- replace with real name of module
+  // The process registrar does all the hard work of registering the
+  // process with the plugin loader.
+  sprokit::process_registrar reg( vpm, "template_process" );
 
   // Check to see if module is already loaded. If so, then don't do again.
-  if ( sprokit::is_process_module_loaded( vpm, module_name ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
 
   // ----------------------------------------------------------------
-
-  auto fact = vpm.ADD_PROCESS( group_ns::template_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "template" ) //+ use your process name
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
-                    "Description of process. Make as long as necessary to fully explain what the process does "
-                    "and how to use it. Explain specific algorithms used, etc." )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+  // The process registrar registers the specified process type.
+  reg.register_process< group_ns::template_process >();
 
   //++ Add more additional processes here.
 
 // - - - - - - - - - - - - - - - - - - - - - - -
-  sprokit::mark_process_module_as_loaded( vpm, module_name );
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/examples/process_template/template_process.h
+++ b/sprokit/processes/examples/process_template/template_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016. 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,6 +60,10 @@ class TEMPLATE_PROCESSES_NO_EXPORT template_process
   : public sprokit::process
 {
 public:
+  PLUGIN_INFO( "template",
+               "Description of process. Make as long as necessary to fully explain what the process does "
+               "and how to use it. Explain specific algorithms used, etc." );
+
   template_process( kwiver::vital::config_block_sptr const& config );
   virtual ~template_process();
 
@@ -68,15 +72,15 @@ protected:
   //++ configure() and step() are generally needed.  Not all of the
   //++ others are needed in every process, so they can be omitted if not
   //++ used.
-  virtual void _configure();
-  virtual void _step();
+  void _configure() override;
+  void _step() override;
 
   //++ These methods are not usually needed by a simple process.
   //++ They are only included for completeness. If not needed then delete them.
-  virtual void _init();
-  virtual void _reset();
-  virtual void _flush();
-  virtual void _reconfigure(kwiver::vital::config_block_sptr const& conf);
+  void _init() override;
+  void _reset() override;
+  void _flush() override;
+  void _reconfigure(kwiver::vital::config_block_sptr const& conf) override;
 
 private:
   //++ these methods group config creation operations and port

--- a/sprokit/processes/flow/registration.cxx
+++ b/sprokit/processes/flow/registration.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2018 by Kitware, Inc.
+ * Copyright 2011-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 {
   sprokit::process_registrar reg( vpm, "flow_processes" );
 
-  if (sprokit::is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -65,6 +65,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< sprokit::mux_process>();
 
   // - - - - - - - - - - - - - - - - - - - - - - -
-  sprokit::mark_process_module_as_loaded( vpm, reg.module_name() );
-
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/ocv/register_processes.cxx
+++ b/sprokit/processes/ocv/register_processes.cxx
@@ -48,7 +48,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_ocv" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -56,5 +56,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< kwiver::image_viewer_process >();
 
 // - - - - - - - - - - - - - - - - - - - - - - -
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/tests/register_processes.cxx
+++ b/sprokit/processes/tests/register_processes.cxx
@@ -48,7 +48,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_test" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -56,5 +56,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< kwiver::test_proc_seq >();
 
 // - - - - - - - - - - - - - - - - - - - - - - -
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/processes/transport/register_processes.cxx
+++ b/sprokit/processes/transport/register_processes.cxx
@@ -55,7 +55,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_transport_export" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -70,5 +70,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 #endif
 
  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 } // register_processes

--- a/sprokit/processes/vxl/register_processes.cxx
+++ b/sprokit/processes/vxl/register_processes.cxx
@@ -48,7 +48,7 @@ void register_factories( kwiver::vital::plugin_loader& vpm )
 
   process_registrar reg( vpm, "kwiver_processes_vxl" );
 
-  if ( is_process_module_loaded( vpm, reg.module_name() ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -56,6 +56,6 @@ void register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_process< kwiver::kw_archive_writer_process >();
 
   // - - - - - - - - - - - - - - - - - - - - - - -
-  mark_process_module_as_loaded( vpm, reg.module_name() );
+  reg.mark_module_as_loaded();
 
 }

--- a/sprokit/src/processes/clusters/registration.cxx
+++ b/sprokit/src/processes/clusters/registration.cxx
@@ -72,11 +72,12 @@ PROCESSES_CLUSTERS_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  static auto const module_name = module_t("cluster_processes");
+  process_registrar reg( vpm, "cluster_processes" );
+
   static kwiver::vital::logger_handle_t logger = kwiver::vital::get_logger( "sprokit.register_cluster" );
 
   // See if clusters have already been loaded
-  if (sprokit::is_process_module_loaded(vpm, module_name))
+  if ( reg.is_module_loaded() )
   {
     return;
   }
@@ -172,5 +173,5 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     }
   }
 
-  sprokit::mark_process_module_as_loaded( vpm, module_name );
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/src/processes/examples/any_source_process.h
+++ b/sprokit/src/processes/examples/any_source_process.h
@@ -63,27 +63,31 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT any_source_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    any_source_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~any_source_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "any_source",
+               "A process which creates arbitrary data" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  any_source_process(kwiver::vital::config_block_sptr const &config);
+  /**
+   * \brief Destructor.
+   */
+  ~any_source_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
-}
+} // namespace sprokit
 
 #endif // SPROKIT_PROCESSES_EXAMPLES_ANY_SOURCE_PROCESS_H

--- a/sprokit/src/processes/examples/const_number_process.h
+++ b/sprokit/src/processes/examples/const_number_process.h
@@ -67,32 +67,35 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT const_number_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    const_number_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~const_number_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "const_number",
+               "Outputs a constant number" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  const_number_process(kwiver::vital::config_block_sptr const &config);
+  /**
+   * \brief Destructor.
+   */
+  ~const_number_process();
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
-
 }
 
 #endif // SPROKIT_PROCESSES_EXAMPLES_CONST_NUMBER_PROCESS_H

--- a/sprokit/src/processes/examples/const_process.h
+++ b/sprokit/src/processes/examples/const_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,27 +61,31 @@ namespace sprokit {
  * \ingroup examples
  */
 class PROCESSES_EXAMPLES_NO_EXPORT const_process
-  : public process
+    : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    const_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~const_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "const",
+               "A process wth a const flag" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  const_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~const_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/data_dependent_process.h
+++ b/sprokit/src/processes/examples/data_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,44 +64,47 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT data_dependent_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    data_dependent_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~data_dependent_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-    /**
-     * \brief Reset the process.
-     */
-    void _reset();
-    /**
-     * \brief Set the type for an output port.
-     *
-     * \param port The name of the port.
-     * \param new_type The type of the connected port.
-     *
-     * \returns True if the type can work, false otherwise.
-     */
-    bool _set_output_port_type(port_t const& port, port_type_t const& new_type);
-  private:
-    void make_ports();
+public:
+  PLUGIN_INFO( "data_dependent",
+               "A process with a data dependent type" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  data_dependent_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~data_dependent_process();
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+  /**
+   * \brief Reset the process.
+   */
+  void _reset() override;
+  /**
+   * \brief Set the type for an output port.
+   *
+   * \param port The name of the port.
+   * \param new_type The type of the connected port.
+   *
+   * \returns True if the type can work, false otherwise.
+   */
+  bool _set_output_port_type(port_t const& port, port_type_t const& new_type) override;
 
-    class priv;
-    std::unique_ptr<priv> d;
+private:
+  void make_ports();
+
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/duplicate_process.h
+++ b/sprokit/src/processes/examples/duplicate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017, 2020 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,30 +68,35 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT duplicate_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    duplicate_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~duplicate_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "duplicate",
+               "A process which duplicates input" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  duplicate_process(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+  /**
+   * \brief Destructor.
+   */
+  ~duplicate_process();
+
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/expect_process.h
+++ b/sprokit/src/processes/examples/expect_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,24 +66,28 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT expect_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    expect_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~expect_process();
-  protected:
-    void _configure();
-    void _step();
-    void _reconfigure(kwiver::vital::config_block_sptr const& conf);
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "expect",
+               "A process which expects some conditions" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  expect_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~expect_process();
+
+protected:
+  void _configure() override;
+  void _step() override;
+  void _reconfigure(kwiver::vital::config_block_sptr const& conf) override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/feedback_process.h
+++ b/sprokit/src/processes/examples/feedback_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,31 +68,35 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT feedback_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    feedback_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~feedback_process();
-  protected:
-    /**
-     * \brief Flush the process.
-     */
-    void _flush();
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "feedback",
+               "A process which feeds data into itself" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  feedback_process(kwiver::vital::config_block_sptr const &config);
+  /**
+   * \brief Destructor.
+   */
+  ~feedback_process();
+
+protected:
+  /**
+   * \brief Flush the process.
+   */
+  void _flush() override;
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
-}
+} // namespace sprokit
 
 #endif // SPROKIT_PROCESSES_EXAMPLES_FEEDBACK_PROCESS_H

--- a/sprokit/src/processes/examples/flow_dependent_process.h
+++ b/sprokit/src/processes/examples/flow_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,54 +64,58 @@ namespace sprokit {
  *
  * \ingroup examples
  */
-class PROCESSES_EXAMPLES_NO_EXPORT flow_dependent_process
-  : public process
-{
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    flow_dependent_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~flow_dependent_process();
-  protected:
-    /**
-     * \brief Reset the process.
-     */
-    void _reset();
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-    /**
-     * \brief Set the type for an input port.
-     *
-     * \param port The name of the port.
-     * \param new_type The type of the connected port.
-     *
-     * \returns True if the type can work, false otherwise.
-     */
-    bool _set_input_port_type(port_t const& port, port_type_t const& new_type);
-    /**
-     * \brief Set the type for an output port.
-     *
-     * \param port The name of the port.
-     * \param new_type The type of the connected port.
-     *
-     * \returns True if the type can work, false otherwise.
-     */
-    bool _set_output_port_type(port_t const& port, port_type_t const& new_type);
-  private:
-    void make_ports();
+class PROCESSES_EXAMPLES_NO_EXPORT flow_dependent_process : public process {
+public:
+  PLUGIN_INFO( "flow_dependent",
+               "A process with a flow dependent type" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  flow_dependent_process(kwiver::vital::config_block_sptr const &config);
+  /**
+   * \brief Destructor.
+   */
+  ~flow_dependent_process();
 
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Reset the process.
+   */
+
+  void _reset() override;
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+  /**
+   * \brief Set the type for an input port.
+   *
+   * \param port The name of the port.
+   * \param new_type The type of the connected port.
+   *
+   * \returns True if the type can work, false otherwise.
+   */
+  bool _set_input_port_type(port_t const &port, port_type_t const &new_type) override;
+
+  /**
+   * \brief Set the type for an output port.
+   *
+   * \param port The name of the port.
+   * \param new_type The type of the connected port.
+   *
+   * \returns True if the type can work, false otherwise.
+   */
+  bool _set_output_port_type(port_t const &port, port_type_t const &new_type) override;
+
+private:
+  void make_ports();
+
+  class priv;
+  std::unique_ptr<priv> d;
 };
-
 }
 
 #endif // SPROKIT_PROCESSES_EXAMPLES_FLOW_DEPENDENT_PROCESS_H

--- a/sprokit/src/processes/examples/multiplication_process.h
+++ b/sprokit/src/processes/examples/multiplication_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,25 +68,30 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT multiplication_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    multiplication_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~multiplication_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "multiplication",
+               "Multiplies numbers" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+
+  multiplication_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~multiplication_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/multiplier_cluster.h
+++ b/sprokit/src/processes/examples/multiplier_cluster.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,22 +55,24 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT multiplier_cluster
   : public process_cluster
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    multiplier_cluster(kwiver::vital::config_block_sptr const& config);
+public:
+  PLUGIN_INFO( "multiplier_cluster",
+               "A constant factor multiplier cluster" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  multiplier_cluster(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Destructor.
-     */
-    virtual ~multiplier_cluster();
+  /**
+   * \brief Destructor.
+   */
+  virtual ~multiplier_cluster();
 
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/mutate_process.h
+++ b/sprokit/src/processes/examples/mutate_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,25 +63,30 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT mutate_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    mutate_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~mutate_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "mutate",
+               "A process with a mutable flag" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  mutate_process(kwiver::vital::config_block_sptr const& config);
+
+  /**
+   * \brief Destructor.
+   */
+  ~mutate_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/number_process.h
+++ b/sprokit/src/processes/examples/number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2012, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,32 +72,36 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT number_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    number_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~number_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "numbers",
+               "Outputs numbers within a range" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  number_process(kwiver::vital::config_block_sptr const &config);
+  /**
+   * \brief Destructor.
+   */
+  ~number_process();
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
-}
+} // namespace sprokit
 
 #endif // SPROKIT_PROCESSES_EXAMPLES_NUMBER_PROCESS_H

--- a/sprokit/src/processes/examples/orphan_cluster.h
+++ b/sprokit/src/processes/examples/orphan_cluster.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012 by Kitware, Inc.
+ * Copyright 2012, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,17 +56,20 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT orphan_cluster
   : public process_cluster
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    orphan_cluster(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~orphan_cluster();
+public:
+  PLUGIN_INFO( "orphan_cluster",
+               "A dummy cluster" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  orphan_cluster(kwiver::vital::config_block_sptr const& config);
+
+  /**
+   * \brief Destructor.
+   */
+  ~orphan_cluster();
 };
 
 }

--- a/sprokit/src/processes/examples/orphan_process.h
+++ b/sprokit/src/processes/examples/orphan_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2012, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,17 +56,20 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT orphan_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    orphan_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~orphan_process();
+public:
+  PLUGIN_INFO( "orphan",
+               "A dummy process" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+
+  orphan_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~orphan_process();
 };
 
 }

--- a/sprokit/src/processes/examples/print_number_process.h
+++ b/sprokit/src/processes/examples/print_number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,35 +67,40 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT print_number_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    print_number_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~print_number_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "print_number",
+               "Print numbers to a file" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  print_number_process(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Reset the process.
-     */
-    void _reset();
+  /**
+   * \brief Destructor.
+   */
+  ~print_number_process();
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Reset the process.
+   */
+  void _reset() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/registration.cxx
+++ b/sprokit/src/processes/examples/registration.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2016 by Kitware, Inc.
+ * Copyright 2011-2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,138 +63,37 @@ PROCESSES_EXAMPLES_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  static const auto module_name = kwiver::vital::plugin_manager::module_t( "example_processes" );
+  using namespace sprokit;
 
-  if ( sprokit::is_process_module_loaded( vpm, module_name ) )
+  process_registrar reg( vpm, "sprokit.example_processes" );
+
+  if ( reg.is_module_loaded() )
   {
     return;
   }
 
-  auto fact = vpm.ADD_PROCESS( sprokit::any_source_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "any_source" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process which creates arbitrary data" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+  reg.register_process< any_source_process >();
+  reg.register_process< const_number_process >();
+  reg.register_process< const_process >();
+  reg.register_process< data_dependent_process >();
+  reg.register_process< duplicate_process >();
+  reg.register_process< expect_process >();
+  reg.register_process< feedback_process >();
+  reg.register_process< flow_dependent_process >();
+  reg.register_process< multiplication_process >();
+  reg.register_process< multiplier_cluster >();
+  reg.register_process< mutate_process >();
+  reg.register_process< number_process >();
+  reg.register_process< orphan_cluster >();
+  reg.register_process< orphan_process >();
+  reg.register_process< print_number_process >();
+  reg.register_process< shared_process >();
+  reg.register_process< skip_process >();
+  reg.register_process< tagged_flow_dependent_process >();
+  reg.register_process< take_number_process >();
+  reg.register_process< take_string_process >();
+  reg.register_process< tunable_process >();
 
-  fact = vpm.ADD_PROCESS( sprokit::const_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "const" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process wth a const flag" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::const_number_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "const_number" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Outputs a constant number" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::data_dependent_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "data_dependent" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with a data dependent type" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::duplicate_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "duplicate" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process which duplicates input" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::expect_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "expect" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process which expects some conditions" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::feedback_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "feedback" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process which feeds data into itself" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::flow_dependent_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "flow_dependent" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with a flow dependent type" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::multiplication_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "multiplication" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Multiplies numbers" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::multiplier_cluster );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "multiplier_cluster" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A constant factor multiplier cluster" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::mutate_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "mutate" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with a mutable flag" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::number_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "numbers" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Outputs numbers within a range" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::orphan_cluster );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "orphan_cluster" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A dummy cluster" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::orphan_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "orphan" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A dummy process" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::print_number_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "print_number" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Print numbers to a file" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::shared_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "shared" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with the shared flag" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::skip_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "skip" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process which skips input data" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::tagged_flow_dependent_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "tagged_flow_dependent" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with a tagged flow dependent types" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::take_number_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "take_number" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Print numbers to a file" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::take_string_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "take_string" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Print strings to a file" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  fact = vpm.ADD_PROCESS( sprokit::tunable_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "tunable" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A process with a tunable parameter" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
-
-  sprokit::mark_process_module_as_loaded( vpm, module_name );
+// - - - - - - - - - - - - - - - - - - - - - - -
+  reg.mark_module_as_loaded();
 }

--- a/sprokit/src/processes/examples/shared_process.h
+++ b/sprokit/src/processes/examples/shared_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,25 +64,30 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT shared_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    shared_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~shared_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "shared",
+               "A process with the shared flag" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  shared_process(kwiver::vital::config_block_sptr const& config);
+
+  /**
+   * \brief Destructor.
+   */
+  ~shared_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/skip_process.h
+++ b/sprokit/src/processes/examples/skip_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2013-2017, 2020 by Kitware, Inc. All Rights Reserved. Please refer to
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,30 +73,35 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT skip_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    skip_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~skip_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "skip",
+               "A process which skips input data" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  skip_process(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+  /**
+   * \brief Destructor.
+   */
+  ~skip_process();
+
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/tagged_flow_dependent_process.h
+++ b/sprokit/src/processes/examples/tagged_flow_dependent_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,32 +66,37 @@ namespace sprokit
 class PROCESSES_EXAMPLES_NO_EXPORT tagged_flow_dependent_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    tagged_flow_dependent_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~tagged_flow_dependent_process();
-  protected:
-    /**
-     * \brief Reset the process.
-     */
-    void _reset();
+public:
+  PLUGIN_INFO( "tagged_flow_dependent",
+               "A process with a tagged flow dependent types" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  tagged_flow_dependent_process(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    void make_ports();
+  /**
+   * \brief Destructor.
+   */
+  ~tagged_flow_dependent_process();
 
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Reset the process.
+   */
+  void _reset() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  void make_ports();
+
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/take_number_process.h
+++ b/sprokit/src/processes/examples/take_number_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2012-2017 by Kitware, Inc.
+ * Copyright 2012-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,25 +63,29 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT take_number_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    take_number_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~take_number_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "take_number",
+               "Print numbers to a file" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  take_number_process(kwiver::vital::config_block_sptr const& config);
+  /**
+   * \brief Destructor.
+   */
+  ~take_number_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/take_string_process.h
+++ b/sprokit/src/processes/examples/take_string_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2017 by Kitware, Inc.
+ * Copyright 2011-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,25 +63,30 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT take_string_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    take_string_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~take_string_process();
-  protected:
-    /**
-     * \brief Step the process.
-     */
-    void _step();
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+public:
+  PLUGIN_INFO( "take_string",
+               "Print strings to a file" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  take_string_process(kwiver::vital::config_block_sptr const& config);
+
+  /**
+   * \brief Destructor.
+   */
+  ~take_string_process();
+
+protected:
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/processes/examples/tunable_process.h
+++ b/sprokit/src/processes/examples/tunable_process.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2017 by Kitware, Inc.
+ * Copyright 2013-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,35 +69,40 @@ namespace sprokit {
 class PROCESSES_EXAMPLES_NO_EXPORT tunable_process
   : public process
 {
-  public:
-    /**
-     * \brief Constructor.
-     *
-     * \param config The configuration for the process.
-     */
-    tunable_process(kwiver::vital::config_block_sptr const& config);
-    /**
-     * \brief Destructor.
-     */
-    ~tunable_process();
-  protected:
-    /**
-     * \brief Configure the process.
-     */
-    void _configure();
+public:
+  PLUGIN_INFO( "tunable",
+               "A process with a tunable parameter" );
+  /**
+   * \brief Constructor.
+   *
+   * \param config The configuration for the process.
+   */
+  tunable_process(kwiver::vital::config_block_sptr const& config);
 
-    /**
-     * \brief Step the process.
-     */
-    void _step();
+  /**
+   * \brief Destructor.
+   */
+  ~tunable_process();
 
-    /**
-     * \brief Step the process.
-     */
-    void _reconfigure(kwiver::vital::config_block_sptr const& conf);
-  private:
-    class priv;
-    std::unique_ptr<priv> d;
+protected:
+  /**
+   * \brief Configure the process.
+   */
+  void _configure() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _step() override;
+
+  /**
+   * \brief Step the process.
+   */
+  void _reconfigure(kwiver::vital::config_block_sptr const& conf) override;
+
+private:
+  class priv;
+  std::unique_ptr<priv> d;
 };
 
 }

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -215,6 +215,18 @@ public:
   {
   }
 
+  // Use forced naming convention for processes
+  bool is_module_loaded() override
+  {
+    return plugin_loader().is_module_loaded( "process." + module_name() );
+  }
+
+  void mark_module_as_loaded() override
+  {
+    plugin_loader().mark_module_as_loaded( "process." + module_name() );
+  }
+
+
   // ----------------------------------------------------------------------------
   /// Register a process plugin.
   /**

--- a/sprokit/tests/sprokit/pipeline/processes_test.cxx
+++ b/sprokit/tests/sprokit/pipeline/processes_test.cxx
@@ -39,6 +39,9 @@ class PROCESSES_TEST_NO_EXPORT test_process
   : public sprokit::process
 {
   public:
+  PLUGIN_INFO( "test",
+               "A test process" );
+
     test_process(kwiver::vital::config_block_sptr const& config);
     ~test_process();
 };
@@ -60,17 +63,14 @@ PROCESSES_TEST_EXPORT
 void
 register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  static auto const module_name = kwiver::vital::plugin_manager::module_t("test_processes");
+  process_registrar reg( vpm, "test_processes" );
 
-  if ( sprokit::is_process_module_loaded( vpm, module_name ) )
+  if ( reg.is_module_loaded() )
   {
     return;
   }
 
-  auto fact = vpm.ADD_PROCESS( test_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "test" )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )
-    .add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "A test process" );
+  reg.register_process< test_process >();
 
-  sprokit::mark_process_module_as_loaded( vpm, module_name );
+  reg.mark_module_as_loaded();
 }

--- a/vital/plugin_loader/plugin_registrar.h
+++ b/vital/plugin_loader/plugin_registrar.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,11 +66,13 @@ public:
   {
   }
 
+  virtual ~plugin_registrar() = default;
+
   /// Check if module is loaded.
-  bool is_module_loaded() { return m_plugin_loader.is_module_loaded( mod_name ); }
+  virtual bool is_module_loaded() { return m_plugin_loader.is_module_loaded( mod_name ); }
 
   /// Mark module as loaded.
-  void mark_module_as_loaded() { m_plugin_loader.mark_module_as_loaded( mod_name ); }
+  virtual void mark_module_as_loaded() { m_plugin_loader.mark_module_as_loaded( mod_name ); }
 
   /// Return module name.
   const std::string& module_name() const { return this->mod_name; }


### PR DESCRIPTION
- Added plugin registrar for embedded pipeline extension. Since this is a plugin class (albeit infrequently used), it should have a registrar.
- Make module loaded methods virtual. The base methods is_module_loaded() and mark_module_as_loaded() can be overridden in the derived class to disambiguate the module name. Module names are unconstrained so it is possible for two modules to have the same name. The derived class can add a prefix to make sure there are no collisions.
- All legacy sprokit example process have been upgraded to use the new PLUGIN_INFO() macro with the new process registrar.