### PR TITLE
Normalize virtual and override

### DIFF
--- a/arrows/core/applets/dump_klv.h
+++ b/arrows/core/applets/dump_klv.h
@@ -51,8 +51,8 @@ public:
               "This program displays the KLV metadata packets that are embedded in "
               "a video stream.");
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
 }; // end of class
 

--- a/arrows/core/applets/render_mesh.h
+++ b/arrows/core/applets/render_mesh.h
@@ -55,8 +55,8 @@ public:
                "various images such as depth map or height map.");
 
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
 protected:
 

--- a/arrows/ocv/descriptor_set.h
+++ b/arrows/ocv/descriptor_set.h
@@ -70,8 +70,8 @@ public:
   /// Return the native OpenCV descriptors as a matrix
   const cv::Mat& ocv_desc_matrix() const { return data_; }
 
-  virtual vital::descriptor_sptr at( size_t index ) override;
-  virtual vital::descriptor_sptr const at( size_t index ) const override;
+  vital::descriptor_sptr at( size_t index ) override;
+  vital::descriptor_sptr const at( size_t index ) const override;
 
 protected:
   iterator::next_value_func_t get_iter_next_func() override;

--- a/arrows/proj/geo_conv.h
+++ b/arrows/proj/geo_conv.h
@@ -56,9 +56,9 @@ public:
   geo_conversion() {}
   virtual ~geo_conversion();
 
-  virtual char const* id() const override;
+  char const* id() const override;
 
-  virtual vital::geo_crs_description_t describe( int crs ) override;
+  vital::geo_crs_description_t describe( int crs ) override;
 
   /// Conversion operator
   virtual vital::vector_2d operator()( vital::vector_2d const& point,

--- a/arrows/qt/EmbeddedPipelineWorker.cxx
+++ b/arrows/qt/EmbeddedPipelineWorker.cxx
@@ -67,8 +67,8 @@ public:
   bool hasOutput() const { return this->outputConnected_; }
 
 protected:
-  virtual bool connect_input_adapter() override;
-  virtual bool connect_output_adapter() override;
+  bool connect_input_adapter() override;
+  bool connect_output_adapter() override;
 
   RequiredEndcaps const endcaps_;
   bool inputConnected_ = false;
@@ -111,7 +111,7 @@ public:
 protected:
   KQ_DECLARE_PUBLIC_PTR( EmbeddedPipelineWorkerPrivate )
 
-  virtual void run() override;
+  void run() override;
 
 private:
   KQ_DECLARE_PUBLIC( EmbeddedPipelineWorkerPrivate )
@@ -135,7 +135,7 @@ public:
 protected:
   KQ_DECLARE_PUBLIC_PTR( EmbeddedPipelineWorker )
 
-  virtual void run() override;
+  void run() override;
 
 private:
   KQ_DECLARE_PUBLIC( EmbeddedPipelineWorker )

--- a/arrows/qt/applets/pipeline_viewer/pipeline_viewer.h
+++ b/arrows/qt/applets/pipeline_viewer/pipeline_viewer.h
@@ -48,7 +48,7 @@ public:
                "This program provides a simple Qt-based front-end "
                "for executing pipelines and viewing images produced by the same." );
 
-  virtual int run() override;
+  int run() override;
 };
 
 } // namespace tools

--- a/arrows/qt/image_container.h
+++ b/arrows/qt/image_container.h
@@ -76,22 +76,22 @@ public:
   bool operator!() const { return data_.isNull(); }
 
   /// \copydoc vital::image_container::size
-  virtual size_t size() const override
+  size_t size() const override
   { return static_cast< size_t >( data_.sizeInBytes() ); }
 
   /// \copydoc vital::image_container::width
-  virtual size_t width() const override
+  size_t width() const override
   { return static_cast< size_t >( data_.width() ); }
 
   /// \copydoc vital::image_container::height
-  virtual size_t height() const override
+  size_t height() const override
   { return static_cast< size_t >( data_.height() ); }
 
   /// \copydoc vital::image_container::depth
-  virtual size_t depth() const override;
+  size_t depth() const override;
 
   /// \copydoc vital::image_container::get_image
-  virtual vital::image get_image() const override
+  vital::image get_image() const override
   { return qt_to_vital( data_ ); }
   using vital::image_container::get_image;
 

--- a/doc/code-style.rst
+++ b/doc/code-style.rst
@@ -514,6 +514,8 @@ Miscellaneous: :a:`[misc]`
 
   - :a:`[misc.modern.override]`
     Always decorate virtual method overrides with :cpp:`override`.
+    Use of the :cpp:`virtual` keyword is discouraged in declarations
+    with :cpp:`override`.
 
   - :a:`[misc.modern.member_init]`
     Prefer inline member initialization when possible.

--- a/extras/process_instrumentation/process_instrumentation_plugin.cxx
+++ b/extras/process_instrumentation/process_instrumentation_plugin.cxx
@@ -59,8 +59,8 @@ public:
   process_instrumentation_explorer();
   virtual ~process_instrumentation_explorer();
 
-  virtual bool initialize( explorer_context* context ) override;
-  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
+  bool initialize( explorer_context* context ) override;
+  void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
 
   std::ostream& out_stream() { return m_context->output_stream(); }
 

--- a/sprokit/processes/adapters/epx_test.h
+++ b/sprokit/processes/adapters/epx_test.h
@@ -50,10 +50,10 @@ public:
   epx_test();
   virtual ~epx_test() = default;
 
-  virtual void pre_setup( context& ctxt ) override;
-  virtual void end_of_output( context& ctxt ) override;
-  virtual void configure( kwiver::vital::config_block_sptr const conf ) override;
-  virtual kwiver::vital::config_block_sptr get_configuration() const override;
+  void pre_setup( context& ctxt ) override;
+  void end_of_output( context& ctxt ) override;
+  void configure( kwiver::vital::config_block_sptr const conf ) override;
+  kwiver::vital::config_block_sptr get_configuration() const override;
 
 }; // end class epx_test
 

--- a/sprokit/processes/adapters/output_adapter_process.h
+++ b/sprokit/processes/adapters/output_adapter_process.h
@@ -77,7 +77,7 @@ private:
   void _configure();
 
   // This is used to intercept connections and make ports JIT
-  virtual void input_port_undefined(port_t const& port) override;
+  void input_port_undefined(port_t const& port) override;
 
   class priv;
   const std::unique_ptr<priv> d;

--- a/sprokit/processes/core/deserializer_process.h
+++ b/sprokit/processes/core/deserializer_process.h
@@ -61,8 +61,8 @@ protected:
   virtual void _init();
   virtual void _step();
 
-  virtual void input_port_undefined( port_t const& port ) override;
-  virtual void output_port_undefined( port_t const& port ) override;
+  void input_port_undefined( port_t const& port ) override;
+  void output_port_undefined( port_t const& port ) override;
 
   virtual bool _set_output_port_type(port_t const& port_name,
                                      port_type_t const& port_type);

--- a/sprokit/processes/core/merge_detection_sets_process.h
+++ b/sprokit/processes/core/merge_detection_sets_process.h
@@ -60,7 +60,7 @@ protected:
   virtual void _step();
   virtual void _init();
 
-  virtual void input_port_undefined( port_t const& port ) override;
+  void input_port_undefined( port_t const& port ) override;
 
 
 private:

--- a/sprokit/processes/core/merge_images_process.h
+++ b/sprokit/processes/core/merge_images_process.h
@@ -64,9 +64,9 @@ public:
   virtual ~merge_images_process();
 
 protected:
-  virtual void _configure() override;
-  virtual void _step() override;
-  virtual void input_port_undefined(port_t const& port) override;
+  void _configure() override;
+  void _step() override;
+  void input_port_undefined(port_t const& port) override;
 
 private:
   void make_ports();

--- a/sprokit/processes/core/print_config_process.h
+++ b/sprokit/processes/core/print_config_process.h
@@ -65,7 +65,7 @@ protected:
   virtual void _step();
 
   // This is used to intercept connections and make ports JIT
-  virtual void input_port_undefined(port_t const& port) override;
+  void input_port_undefined(port_t const& port) override;
 
 private:
   class priv;

--- a/sprokit/processes/core/serializer_process.h
+++ b/sprokit/processes/core/serializer_process.h
@@ -62,8 +62,8 @@ protected:
   virtual void _init();
   virtual void _step();
 
-  virtual void input_port_undefined( port_t const& port ) override;
-  virtual void output_port_undefined( port_t const& port )override;
+  void input_port_undefined( port_t const& port ) override;
+  void output_port_undefined( port_t const& port ) override;
 
   virtual bool _set_input_port_type( port_t const&      port_name,
                                      port_type_t const& port_type ) override;

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -313,8 +313,8 @@ public:
   process_explorer_rst();
   virtual ~process_explorer_rst();
 
-  virtual bool initialize( explorer_context* context ) override;
-  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
+  bool initialize( explorer_context* context ) override;
+  void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
 
   std::ostream& out_stream();
   std::string wrap_rst_text( const std::string& txt );
@@ -674,8 +674,8 @@ public:
   process_explorer_pipe();
   virtual ~process_explorer_pipe();
 
-  virtual bool initialize( explorer_context* context ) override;
-  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
+  bool initialize( explorer_context* context ) override;
+  void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
 
   std::ostream& out_stream() { return m_context->output_stream(); }
 

--- a/sprokit/src/applets/pipe_config.h
+++ b/sprokit/src/applets/pipe_config.h
@@ -45,8 +45,8 @@ class pipe_config
 public:
   pipe_config();
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
   PLUGIN_INFO( "pipe-config",
     "Configures a pipeline\n\n"

--- a/sprokit/src/applets/pipe_to_dot.h
+++ b/sprokit/src/applets/pipe_to_dot.h
@@ -45,8 +45,8 @@ class pipe_to_dot
 public:
   pipe_to_dot();
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
   PLUGIN_INFO( "pipe-to-dot",
                "Create DOT output of pipe topology")

--- a/sprokit/src/applets/pipeline_runner.h
+++ b/sprokit/src/applets/pipeline_runner.h
@@ -48,8 +48,8 @@ public:
   PLUGIN_INFO( "runner",
                "Runs a pipeline");
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
 }; // end of class
 

--- a/vital/algo/algo_explorer_plugin.cxx
+++ b/vital/algo/algo_explorer_plugin.cxx
@@ -175,8 +175,8 @@ public:
   algo_explorer_pipe();
   virtual ~algo_explorer_pipe();
 
-  virtual bool initialize( explorer_context* context ) override;
-  virtual void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
+  bool initialize( explorer_context* context ) override;
+  void explore( const kwiver::vital::plugin_factory_handle_t fact ) override;
 
 
   // instance data

--- a/vital/applets/config_explorer.h
+++ b/vital/applets/config_explorer.h
@@ -50,8 +50,8 @@ public:
                "This program assists in debugging config loading problems. It loads a "
                "configuration and displays the contents or displays the search path.");
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
 }; // end of class
 

--- a/vital/config/format_config_block_plugin.cxx
+++ b/vital/config/format_config_block_plugin.cxx
@@ -52,7 +52,7 @@ public:
   format_config_block_markdown();
   virtual ~format_config_block_markdown() = default;
 
-  virtual void print( std::ostream& str ) override;
+  void print( std::ostream& str ) override;
 
 }; // end class format_config_block_markdown
 
@@ -114,7 +114,7 @@ public:
   format_config_block_tree();
   virtual ~format_config_block_tree() = default;
 
-  virtual void print( std::ostream& str ) override;
+  void print( std::ostream& str ) override;
 
 protected:
   void format_block( std::ostream& str,

--- a/vital/types/descriptor_set.h
+++ b/vital/types/descriptor_set.h
@@ -98,14 +98,14 @@ public:
    *
    * @returns Number of elements in this set.
    */
-  virtual size_t size() const override;
+  size_t size() const override;
 
   /**
    * Whether or not this set is empty.
    *
    * @return True if this set is empty or false otherwise.
    */
-  virtual bool empty() const override;
+  bool empty() const override;
 
   //@{
   /**
@@ -115,8 +115,8 @@ public:
    * @throws std::out_of_range If position is now within the range of objects
    *                           in container.
    */
-  virtual descriptor_sptr at( size_t index ) override;
-  virtual descriptor_sptr const at( size_t index ) const override;
+  descriptor_sptr at( size_t index ) override;
+  descriptor_sptr const at( size_t index ) const override;
   //@}
 
   /// Return a vector of descriptor shared pointers

--- a/vital/types/detected_object_set.h
+++ b/vital/types/detected_object_set.h
@@ -127,7 +127,7 @@ public:
    *
    * @return Number of detections.
    */
-  virtual size_t size() const override;
+  size_t size() const override;
 
   /**
    * @brief Returns whether or not this set is empty.
@@ -136,7 +136,7 @@ public:
    *
    * @return Whether or not the set is empty.
    */
-  virtual bool empty() const override;
+  bool empty() const override;
 
   //@{
   /**
@@ -155,8 +155,8 @@ public:
    * @throws std::range if position is now within the range of objects
    * in container.
    */
-  virtual detected_object_sptr at( size_t pos ) override;
-  virtual const detected_object_sptr at( size_t pos ) const override;
+  detected_object_sptr at( size_t pos ) override;
+  const detected_object_sptr at( size_t pos ) const override;
   //@}
 
   /**

--- a/vital/types/image_container_set_simple.h
+++ b/vital/types/image_container_set_simple.h
@@ -55,10 +55,10 @@ public:
   explicit simple_image_container_set( std::vector< image_container_sptr > const& images );
 
   /// Return the number of items
-  virtual size_t size() const override;
-  virtual bool empty() const override;
-  virtual image_container_sptr at( size_t index ) override;
-  virtual image_container_sptr const at( size_t index ) const override;
+  size_t size() const override;
+  bool empty() const override;
+  image_container_sptr at( size_t index ) override;
+  image_container_sptr const at( size_t index ) const override;
 
 protected:
   using vec_t = std::vector< image_container_sptr >;


### PR DESCRIPTION
No need to label method as virtual if it is an override.
Removed virtual from method declaration which contained override.
Updated style guide