### PR TITLE
Add shared flag to output port declarations.

### DIFF
--- a/sprokit/processes/core/draw_detected_object_set_process.cxx
+++ b/sprokit/processes/core/draw_detected_object_set_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -147,7 +147,9 @@ void draw_detected_object_set_process
 ::make_ports()
 {
   // Set up for required ports
-  sprokit::process::port_flags_t optional;
+  sprokit::process::port_flags_t output;
+  output.insert( flag_output_shared );
+
   sprokit::process::port_flags_t required;
   required.insert( flag_required );
 
@@ -156,7 +158,7 @@ void draw_detected_object_set_process
   declare_input_port_using_trait( detected_object_set, required );
 
   // -- output --
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, output );
 }
 
 

--- a/sprokit/processes/core/frame_list_process.cxx
+++ b/sprokit/processes/core/frame_list_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -258,9 +258,11 @@ void frame_list_process
 {
   // Set up for required ports
   sprokit::process::port_flags_t optional;
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
 
   declare_output_port_using_trait( timestamp, optional );
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, shared );
   declare_output_port_using_trait( image_file_name, optional );
 }
 

--- a/sprokit/processes/core/handle_descriptor_request_process.cxx
+++ b/sprokit/processes/core/handle_descriptor_request_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -181,9 +181,12 @@ void handle_descriptor_request_process
 {
   // Set up for required ports
   sprokit::process::port_flags_t optional;
-  sprokit::process::port_flags_t required;
 
+  sprokit::process::port_flags_t required;
   required.insert( flag_required );
+
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
 
   // -- input --
   declare_input_port_using_trait( descriptor_request, required );
@@ -191,7 +194,7 @@ void handle_descriptor_request_process
   // -- output --
   declare_output_port_using_trait( track_descriptor_set, optional );
 
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, shared );
   declare_output_port_using_trait( timestamp, optional );
   declare_output_port_using_trait( filename, optional );
   declare_output_port_using_trait( stream_id, optional );

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -242,6 +242,9 @@ void image_file_reader_process
 {
   // Set up for required ports
   sprokit::process::port_flags_t optional;
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
+
   sprokit::process::port_flags_t required;
   required.insert( flag_required );
 
@@ -252,7 +255,7 @@ void image_file_reader_process
 
   // -- outputs --
   declare_output_port_using_trait( timestamp, optional );
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, shared );
   declare_output_port_using_trait( image_file_name, optional );
 
 }

--- a/sprokit/processes/core/image_filter_process.cxx
+++ b/sprokit/processes/core/image_filter_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,15 +122,18 @@ make_ports()
 {
   // Set up for required ports
   sprokit::process::port_flags_t required;
-  sprokit::process::port_flags_t optional;
-
   required.insert( flag_required );
+
+  // We are outputting a shared ref to the output image, therefore we
+  // should mark it as shared.
+  sprokit::process::port_flags_t output;
+  output.insert( flag_output_shared );
 
   // -- input --
   declare_input_port_using_trait( image, required );
 
   // -- output --
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, output );
 }
 
 

--- a/sprokit/processes/core/merge_images_process.cxx
+++ b/sprokit/processes/core/merge_images_process.cxx
@@ -30,23 +30,20 @@
 
 #include "merge_images_process.h"
 
-#include <vital/vital_types.h>
+#include <kwiver_type_traits.h>
+#include <sprokit/pipeline/process_exception.h>
+#include <vital/algo/merge_images.h>
 #include <vital/types/image_container.h>
 #include <vital/util/string.h>
-
-#include <vital/algo/merge_images.h>
-
-#include <kwiver_type_traits.h>
-
-#include <sprokit/pipeline/process_exception.h>
+#include <vital/vital_types.h>
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
-create_port_trait( image1, image, "Single frame first image." );
-create_port_trait( image2, image, "Single frame second image." );
+  create_config_trait( merge_images, std::string, "",
+                       "Algorithm configuration subblock" );
+
 //----------------------------------------------------------------
 // Private implementation class
 class merge_images_process::priv
@@ -55,7 +52,7 @@ public:
   priv();
   ~priv();
 
-  algo::merge_images_sptr         m_images_merger;
+  algo::merge_images_sptr m_images_merger;
   std::set< std::string > p_port_list;
 };
 
@@ -88,9 +85,10 @@ void merge_images_process
 
   if( !d->m_images_merger )
   {
-    throw sprokit::invalid_configuration_exception(
-        name(), "Unable to create \"merge_images\"" );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Unable to create \"merge_images\"" );
   }
+
   algo::merge_images::get_nested_algo_configuration(
       "merge_images", algo_config, d->m_images_merger );
 
@@ -98,10 +96,9 @@ void merge_images_process
   if( !algo::merge_images::check_nested_algo_configuration(
         "merge_images", algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Configuration check failed." );
+    VITAL_THROW(  sprokit::invalid_configuration_exception,
+                  name(), "Configuration check failed." );
   }
-
 }
 
 
@@ -112,7 +109,8 @@ merge_images_process
 {
   std::vector<kwiver::vital::image_container_sptr> image_list;
 
-  for ( const auto port_name : d->p_port_list ) {
+  for ( const auto port_name : d->p_port_list )
+  {
     kwiver::vital::image_container_sptr image_sptr =
         grab_from_port_as<kwiver::vital::image_container_sptr>( port_name );
     image_list.push_back(image_sptr);
@@ -133,14 +131,14 @@ void merge_images_process
 ::make_ports()
 {
   // Set up for required ports
-  sprokit::process::port_flags_t optional;
   sprokit::process::port_flags_t required;
   required.insert( flag_required );
+  required.insert( flag_output_shared );
 
   // -- input --
-//  declare_input_port_using_trait( image1, required );
-//  declare_input_port_using_trait( image2, required );
+  // input ports are defined based on connections
 
+  // -- output --
   declare_output_port_using_trait( image, required );
 }
 
@@ -149,22 +147,17 @@ void merge_images_process
 void merge_images_process
 ::make_config()
 {
-
+  declare_config_using_trait( merge_images );
 }
 
-
-// ================================================================
-merge_images_process::priv
-::priv()
-{
-}
-
-
-merge_images_process::priv
-::~priv()
-{
-}
-
+// ----------------------------------------------------------------------------
+/*
+ * This method accepts port names when connections are made and
+ * dynamically created the required ports.
+ *
+ * Note that only two connections are accepted and the ports are
+ * typed for images.
+ */
 void
 merge_images_process
 ::input_port_undefined(port_t const& port_name)
@@ -174,6 +167,13 @@ merge_images_process
   // Just create an input port to read detections from
   if (! kwiver::vital::starts_with( port_name, "_" ) )
   {
+    if ( d->p_port_list.size() >= 2)
+    {
+      LOG_ERROR( logger(), "Attempt to connect more than 2 input ports. "
+                 "Connection aborted.");
+      return;
+    }
+
     // Check for unique port name
     if ( d->p_port_list.count( port_name ) == 0 )
     {
@@ -189,7 +189,21 @@ merge_images_process
 
       d->p_port_list.insert( port_name );
     }
+
   }
 }
+
+// ================================================================
+merge_images_process::priv
+::priv()
+{
+}
+
+
+merge_images_process::priv
+::~priv()
+{
+}
+
 
 } // end namespace

--- a/sprokit/processes/core/serializer_process.cxx
+++ b/sprokit/processes/core/serializer_process.cxx
@@ -285,6 +285,7 @@ output_port_undefined(port_t const& port_name)
     {
       port_flags_t required;
       required.insert( flag_required );
+      required.insert( flag_output_shared );
 
       LOG_TRACE( logger(), "Creating output port: \"" << port_name << "\"" );
 

--- a/sprokit/processes/core/video_input_process.cxx
+++ b/sprokit/processes/core/video_input_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -265,9 +265,14 @@ void video_input_process
   // Set up for required ports
   sprokit::process::port_flags_t optional;
 
+  // We are outputting a shared ref to the output image, therefore we
+  // should mark it as shared.
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
+
   declare_output_port_using_trait( timestamp, optional );
-  declare_output_port_using_trait( image, optional );
-  declare_output_port_using_trait( metadata, optional );
+  declare_output_port_using_trait( image, shared );
+  declare_output_port_using_trait( metadata, shared );
   declare_output_port_using_trait( frame_rate, optional );
 }
 

--- a/sprokit/processes/examples/process_template/template_process.cxx
+++ b/sprokit/processes/examples/process_template/template_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -252,15 +252,22 @@ template_process
 {
   // Set up for required ports
   sprokit::process::port_flags_t required;
+
   sprokit::process::port_flags_t optional;
   required.insert( flag_required );
+
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
+
 
   // -- input --
   declare_input_port_using_trait( timestamp, optional );
   declare_input_port_using_trait( image, required );
 
   // -- output --
-  declare_output_port_using_trait( image, optional );
+  // since images are passed by shared ptr, they must be
+  // marked as shared.
+  declare_output_port_using_trait( image, shared );
 }
 
 

--- a/sprokit/processes/matlab/matlab_process.cxx
+++ b/sprokit/processes/matlab/matlab_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -221,15 +221,19 @@ matlab_process
 {
   // Set up for required ports
   sprokit::process::port_flags_t required;
+
   sprokit::process::port_flags_t optional;
   required.insert( flag_required );
+
+  sprokit::process::port_flags_t shared;
+  shared.insert( flag_output_shared );
 
   // -- input --
   declare_input_port_using_trait( timestamp, optional );
   declare_input_port_using_trait( image, required );
 
   // -- output --
-  declare_output_port_using_trait( image, optional );
+  declare_output_port_using_trait( image, shared );
 }
 
 


### PR DESCRIPTION
These processes push an image container smart pointer to an
output port. This means that all processes that have connected
to this output port are sharing the same image. Sprokit provides
a way to declare this and check to make sure none of the
processes that are using this port will change the shared data.
This type of port usage compatibility is checked when the pipeline
is built.