### PR TITLE
Dev/json process explorer output

### DIFF
--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -542,8 +542,6 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
   sprokit::process::properties_t const properties = proc->properties();
   if ( properties.size() > 0 )
   {
-    std::string const properties_str = join( properties, ", " );
-
     json_dict_key property_key_element( out_stream(), plugin_dict.indent(), "properties", false );
     json_array property_array_element ( out_stream(), property_key_element.indent() );
     json_array_items<sprokit::process::properties_t> properties_items( out_stream(), property_array_element.indent(), properties );
@@ -607,6 +605,7 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
       json_dict iport_dict( out_stream(), iport_array_element.indent(), first_element );
       json_dict_item iport_name_item( out_stream(), iport_dict.indent(), "name", port );
       json_dict_item iport_type_item( out_stream(), iport_dict.indent(), "type", type, false );
+      json_dict_item iport_desc_item( out_stream(), iport_dict.indent(), "description", escape_json(port_desc), false);
       json_dict_key iport_flags_key( out_stream(), iport_dict.indent(), "flags", false );
       json_array iport_flags_array( out_stream(), iport_flags_key.indent() );
       json_array_items<sprokit::process::port_flags_t> iport_flags_array_items( out_stream(), iport_flags_array.indent(), flags );
@@ -639,13 +638,14 @@ explore( const kwiver::vital::plugin_factory_handle_t fact )
       json_dict oport_dict( out_stream(), oport_array_element.indent(), first_element );
       json_dict_item oport_name_item( out_stream(), oport_dict.indent(), "name", port );
       json_dict_item oport_type_item( out_stream(), oport_dict.indent(), "type", type, false );
+      json_dict_item oport_desc_item( out_stream(), oport_dict.indent(), "description", escape_json(port_desc), false);
       json_dict_key oport_flags_key( out_stream(), oport_dict.indent(), "flags", false );
       json_array oport_flags_array( out_stream(), oport_flags_key.indent() );
       json_array_items<sprokit::process::port_flags_t> oport_flags_array_items( out_stream(), oport_flags_array.indent(), flags );
       first_element = false;
     }   // end foreach
   }
-} // process_explorer_rst::explore
+} // process_explorer_json::explore
 
 
 // ==================================================================

--- a/sprokit/processes/process_explorer_plugin.cxx
+++ b/sprokit/processes/process_explorer_plugin.cxx
@@ -504,8 +504,6 @@ process_explorer_json::
 initialize( explorer_context* context )
 {
   m_context = context;
-  m_root_array = std::make_shared< json_array >( out_stream(), 0 );
-
   return true;
 }
 
@@ -515,6 +513,11 @@ void
 process_explorer_json::
 explore( const kwiver::vital::plugin_factory_handle_t fact )
 {
+  if (m_first_process)
+  {
+    //Opens the first square bracket.
+    m_root_array = std::make_shared< json_array >( out_stream(), 0 );
+  }
   json_dict plugin_dict( out_stream(), m_root_array->indent(), m_first_process );
   m_first_process = false;
   std::string proc_type = "-- Not Set --";

--- a/sprokit/processes/python/ApplyDescriptor.py
+++ b/sprokit/processes/python/ApplyDescriptor.py
@@ -31,7 +31,6 @@ from sprokit.pipeline import process
 from kwiver.kwiver_process import KwiverProcess
 from vital.util.VitalPIL import from_pil, get_pil_image
 from sprokit import sprokit_logging
-
 logger = sprokit_logging.getLogger(__name__)
 
 apply_descriptor_test_mode = False

--- a/vital/tools/explorer_plugin.h
+++ b/vital/tools/explorer_plugin.h
@@ -38,9 +38,13 @@
 #include <vital/plugin_loader/plugin_factory.h>
 
 #include <kwiversys/CommandLineArguments.hxx>
+#include <memory>
 
 namespace kwiver {
 namespace vital {
+
+class category_explorer;
+typedef std::shared_ptr<category_explorer> category_explorer_sptr;
 
 // ----------------------------------------------------------------
 /**

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -306,8 +306,6 @@ void display_by_category( const kwiver::vital::plugin_map_t& plugin_map,
       continue;
     }
 
-    pe_out() << "\nPlugins that implement type \"" << ds << "\"" << std::endl;
-
     // Get vector of factories
     for( kwiver::vital::plugin_factory_handle_t const fact : facts )
     {

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -76,7 +76,7 @@ typedef kwiversys::SystemTools ST;
 // -- forward definitions --
 static void display_attributes( kwiver::vital::plugin_factory_handle_t const fact );
 static void display_by_category( const kwiver::vital::plugin_map_t& plugin_map, const std::string& category );
-static kwiver::vital::category_explorer* get_category_handler( const std::string& cat );
+static kwiver::vital::category_explorer_sptr get_category_handler( const std::string& cat );
 
 
 //==================================================================
@@ -103,7 +103,7 @@ static std::string version_string( PLUGIN_EXPLORER_VERSION );
 enum { prog_default, prog_processopedia, prog_alog_explorer };
 static int program_personality( prog_default );
 
-static std::map< const std::string, kwiver::vital::category_explorer *> category_map;
+static std::map< const std::string, kwiver::vital::category_explorer_sptr> category_map;
 
 // ==================================================================
 
@@ -278,7 +278,7 @@ display_factory( kwiver::vital::plugin_factory_handle_t const fact )
 void display_by_category( const kwiver::vital::plugin_map_t& plugin_map,
                           const std::string& category )
 {
-  kwiver::vital::category_explorer* cat_handler = get_category_handler( category );
+  kwiver::vital::category_explorer_sptr cat_handler = get_category_handler( category );
 
   for( auto it : plugin_map )
   {
@@ -337,7 +337,8 @@ void display_by_category( const kwiver::vital::plugin_map_t& plugin_map,
 
 
 // ------------------------------------------------------------------
-kwiver::vital::category_explorer* get_category_handler( const std::string& cat )
+kwiver::vital::category_explorer_sptr
+get_category_handler( const std::string& cat )
 {
   std::string handler_name = cat;
 
@@ -424,7 +425,7 @@ void load_explorer_plugins()
     std::string name;
     if ( fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, name ) )
     {
-      auto cat_ex = fact->create_object<kwiver::vital::category_explorer>();
+      auto cat_ex = kwiver::vital::category_explorer_sptr(fact->create_object<kwiver::vital::category_explorer>());
       if ( cat_ex )
       {
         if ( cat_ex->initialize( G_explorer_context ) )


### PR DESCRIPTION
Add support for the json format option in plugin_explorer for processes. Run "plugin_explorer --proc [PROCESS_NAME] --fmt json" to output information for a process in JSON.

Included are 8 files of expected output for specific plugin_explorer queries. To run the queries, run the above command with the process name specified in the filename after "expected_output". For example, run "plugin_explorer --proc tunable --fmt json", and compare to the "expected_output_tunable.txt" file.

Additionally, a simple Python script (check_valid_json.txt) is included to verify that the output is valid JSON. Run the script with the name of a file to check as a command line argument. For example, with "expected_output_tunable.txt" in the same directory as the script, running "python check_valid_json.txt expected_output_tunable.txt" should print "valid JSON".


[check_valid_json.txt](https://github.com/Kitware/kwiver/files/4277693/check_valid_json.txt)
[expected_output_const_number.txt](https://github.com/Kitware/kwiver/files/4277660/expected_output_const_number.txt)
[expected_output_distribute.txt](https://github.com/Kitware/kwiver/files/4277661/expected_output_distribute.txt)
[expected_output_file_transport_send.txt](https://github.com/Kitware/kwiver/files/4277662/expected_output_file_transport_send.txt)
[expected_output_handle_descriptor_request.txt](https://github.com/Kitware/kwiver/files/4277663/expected_output_handle_descriptor_request.txt)
[expected_output_multiplexer.txt](https://github.com/Kitware/kwiver/files/4277664/expected_output_multiplexer.txt)
[expected_output_orphan.txt](https://github.com/Kitware/kwiver/files/4277665/expected_output_orphan.txt)
[expected_output_track_descriptor.txt](https://github.com/Kitware/kwiver/files/4277666/expected_output_track_descriptor.txt)
[expected_output_tunable.txt](https://github.com/Kitware/kwiver/files/4277667/expected_output_tunable.txt)


