### PR TITLE
remove scheduler.wait call in embedded_pipeline stop()

### DIFF
--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -412,9 +412,6 @@ embedded_pipeline
   // Note: Can throws stop_before_start_exception Thrown when the
   // scheduler has not been started
   m_priv->m_scheduler->stop();
-
-  // Wait for scheduler to terminate.
-  m_priv->m_scheduler->wait();
 }
 
 


### PR DESCRIPTION
This PR contains a very small change to embedded_pipelines stop() fxn. Before this fix, the stop() function called stop() and wait() on the scheduler member variable, which threw an exception