### PR TITLE
adapter_data_set::add_value and ::add_datum now overwrite

### DIFF
--- a/sprokit/processes/adapters/adapter_data_set.cxx
+++ b/sprokit/processes/adapters/adapter_data_set.cxx
@@ -75,7 +75,7 @@ void
 adapter_data_set
 ::add_datum( sprokit::process::port_t const& port, sprokit::datum_t const& datum )
 {
-  m_port_datum_set.emplace( port, datum );
+  m_port_datum_set[port] = datum ;
 }
 
 

--- a/sprokit/processes/adapters/adapter_data_set.h
+++ b/sprokit/processes/adapters/adapter_data_set.h
@@ -146,7 +146,8 @@ public:
    * @brief Add typed value to data set.
    *
    * This method adds the specified value to the adapter data set. The
-   * value is copied into the data set.
+   * value is copied into the data set. This will overwrite the value
+   * at the port
    *
    * @param port Name of the port where data is sent.
    * @param val Value to be wrapped in datum for port.
@@ -154,7 +155,7 @@ public:
   template <typename T>
   void add_value( sprokit::process::port_t const& port, T const& val )
   {
-    m_port_datum_set.emplace( port, sprokit::datum::new_datum<T>( val ) );
+    m_port_datum_set[port] = sprokit::datum::new_datum<T>( val );
   }
 
   /**


### PR DESCRIPTION
The adapter_data_set::add_value and adapter_data_set::add_datum used emplace() to insert values at certain ports. The comments above add_datum() indicate that these methods should overwrite a pre-existing value, which emplace() does not do. These functions now use the indexing operator, which overwrites. 