### PR TITLE
database_query::set_temporal_bounds now throws logic_error appropriately

### DIFF
--- a/vital/tests/test_database_query.cxx
+++ b/vital/tests/test_database_query.cxx
@@ -63,3 +63,48 @@ TEST(database_query, ensure_values)
 
   EXPECT_EQ( query.type(), database_query::RETRIEVAL );
 }
+
+// ----------------------------------------------------------------------------
+TEST(database_query, check_temporal_bounds)
+{
+  database_query query;
+  timestamp ts_lower( 5000000, 123 );
+  timestamp ts_upper( 6000000, 124 );
+
+  // Set the bounds
+  query.set_temporal_bounds(ts_lower, ts_upper);
+  // Check that they were set
+  EXPECT_EQ( query.temporal_lower_bound(), ts_lower );
+  EXPECT_EQ( query.temporal_upper_bound(), ts_upper );
+}
+
+// ----------------------------------------------------------------------------
+TEST(database_query, check_temporal_bounds_logic_error)
+{
+  database_query query;
+  timestamp lower1( 3000000, 121 );
+  timestamp upper1( 4000000, 122 );
+  timestamp lower2( 5000000, 123 );
+  timestamp upper2( 6000000, 124 );
+
+  // Set it to some valid timestamps first
+  query.set_temporal_bounds(lower1, upper1);
+  EXPECT_EQ( query.temporal_lower_bound(), lower1 );
+  EXPECT_EQ( query.temporal_upper_bound(), upper1 );
+
+  // Now try adding improper bounds. where upper < lower
+  // Should throw an std::logic_error
+  ASSERT_THROW(query.set_temporal_bounds(upper2, lower2), std::logic_error);
+
+  // Check that the previous bounds are still set
+  EXPECT_EQ( query.temporal_lower_bound(), lower1 );
+  EXPECT_EQ( query.temporal_upper_bound(), upper1 );
+
+  // Check that one timestamp can be both bounds
+  timestamp lower_and_upper( 700000, 125 );
+  ASSERT_NO_THROW(query.set_temporal_bounds(lower_and_upper, lower_and_upper));
+
+  // Check that the bounds were set correctly
+  EXPECT_EQ( query.temporal_lower_bound(), lower_and_upper );
+  EXPECT_EQ( query.temporal_upper_bound(), lower_and_upper );
+}

--- a/vital/types/database_query.cxx
+++ b/vital/types/database_query.cxx
@@ -115,6 +115,10 @@ void
 database_query
 ::set_temporal_bounds( timestamp const& lower, timestamp const& upper )
 {
+  if (upper < lower)
+  {
+    throw std::logic_error("upper temporal bound less than lower temporal bound");
+  }
   m_temporal_lower = lower;
   m_temporal_upper = upper;
 }

--- a/vital/types/database_query.cxx
+++ b/vital/types/database_query.cxx
@@ -34,6 +34,7 @@
  */
 
 #include "database_query.h"
+#include <stdexcept>
 
 namespace kwiver {
 namespace vital {

--- a/vital/types/database_query.h
+++ b/vital/types/database_query.h
@@ -45,6 +45,7 @@
 #include <vital/vital_config.h>
 
 #include <memory>
+#include <stdexcept>
 
 namespace kwiver {
 namespace vital {

--- a/vital/types/database_query.h
+++ b/vital/types/database_query.h
@@ -45,7 +45,6 @@
 #include <vital/vital_config.h>
 
 #include <memory>
-#include <stdexcept>
 
 namespace kwiver {
 namespace vital {


### PR DESCRIPTION
This PR fixes database_query::set_temporal_bounds. The comments indicate that the function should throw an std::logic_error if the upper bound parameter is less than the lower bound parameter, but this was not implemented. This PR adds the exception, and tests to show that the function now works as expected.