### PR TITLE
Normalizing config for algorithms in processes.

### DIFF
--- a/arrows/burnout/burnout_pixel_classification.cxx
+++ b/arrows/burnout/burnout_pixel_classification.cxx
@@ -120,13 +120,13 @@ burnout_pixel_classification
   if( !d->m_process.set_params( vidtk_config ) )
   {
     std::string reason = "Failed to set pipeline parameters";
-    throw vital::algorithm_configuration_exception( type_name(), impl_name(), reason );
+    VITAL_THROW( vital::algorithm_configuration_exception, type_name(), impl_name(), reason );
   }
 
   if( !d->m_process.initialize() )
   {
     std::string reason = "Failed to initialize pipeline";
-    throw vital::algorithm_configuration_exception( type_name(), impl_name(), reason );
+    VITAL_THROW( vital::algorithm_configuration_exception, type_name(), impl_name(), reason );
   }
 }
 

--- a/arrows/core/applets/track_features.cxx
+++ b/arrows/core/applets/track_features.cxx
@@ -338,7 +338,7 @@ run()
       std::ifstream mask_ifs(mask_list_file.c_str());
       if( !mask_ifs )
       {
-        throw kwiver::vital::path_not_exists(mask_list_file);
+        VITAL_THROW( kwiver::vital::path_not_exists, mask_list_file );
       }
       // load filepaths from file
       for( std::string line; std::getline(mask_ifs, line); )
@@ -346,14 +346,15 @@ run()
         mask_files.push_back(line);
         if( ! ST::FileExists( mask_files[mask_files.size()-1], true ) )
         {
-          throw kwiver::vital::path_not_exists( mask_files[mask_files.size()-1] );
+          VITAL_THROW( kwiver::vital::path_not_exists, mask_files[mask_files.size()-1] );
         }
       }
       // Check that image/mask list sizes are the same
       if( timestamps.size() != mask_files.size() )
       {
-        throw kwiver::vital::invalid_value("video and mask file lists have "
-                                           "different frame counts");
+        VITAL_THROW( kwiver::vital::invalid_value,
+                     "video and mask file lists have "
+                     "different frame counts");
       }
       LOG_DEBUG( main_logger,
                  "Validated " << mask_files.size() << " mask image files." );

--- a/arrows/ocv/merge_images.cxx
+++ b/arrows/ocv/merge_images.cxx
@@ -52,16 +52,10 @@ merge_images
 {
 }
 
-/// Destructor
-merge_images
-::~merge_images()
-{
-}
-
 /// Merge images
 kwiver::vital::image_container_sptr
 merge_images::merge(kwiver::vital::image_container_sptr image1,
-        kwiver::vital::image_container_sptr image2) const
+                    kwiver::vital::image_container_sptr image2) const
 {
   cv::Mat cv_image1 = ocv::image_container::vital_to_ocv(image1->get_image(),
     ocv::image_container::RGB_COLOR);

--- a/arrows/ocv/merge_images.h
+++ b/arrows/ocv/merge_images.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,29 +43,33 @@ namespace kwiver {
 namespace arrows {
 namespace ocv {
 
-/// A class for writing out image chips around detections, useful as a debugging process
-/// for ensuring that the refine detections process is running on desired ROIs.
+// Implementation of merge image channels.
 class KWIVER_ALGO_OCV_EXPORT merge_images
   : public vital::algorithm_impl<merge_images, vital::algo::merge_images>
 {
 public:
   PLUGIN_INFO( "ocv",
-               "Merge two images into one using opencv functions" )
+               "Merge two images into one using opencv functions.\n\n"
+               "The channels from the first image are added to the "
+               "output image first, followed by the channels from the "
+               "second image. This implementation takes no configuration "
+               "parameters."
+    )
 
   /// Constructor
   merge_images();
 
   /// Destructor
-  virtual ~merge_images();
+  virtual ~merge_images() = default;
 
-  virtual void set_configuration( kwiver::vital::config_block_sptr ) { }
-  virtual bool check_configuration( kwiver::vital::config_block_sptr config )
-    const { return true; }
+  void set_configuration( kwiver::vital::config_block_sptr ) override { }
+  bool check_configuration( kwiver::vital::config_block_sptr config ) const override
+  { return true; }
 
   /// Merge images
-  virtual kwiver::vital::image_container_sptr
-  merge(kwiver::vital::image_container_sptr image1,
-        kwiver::vital::image_container_sptr image2) const;
+  kwiver::vital::image_container_sptr
+    merge(kwiver::vital::image_container_sptr image1,
+          kwiver::vital::image_container_sptr image2) const override;
 };
 
 } // end namespace ocv

--- a/sprokit/processes/core/associate_detections_to_tracks_process.cxx
+++ b/sprokit/processes/core/associate_detections_to_tracks_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,8 @@ namespace kwiver
 
 namespace algo = vital::algo;
 
+create_algorithm_name_config_trait( track_associator );
+
 create_port_trait( unused_detections,
   detected_object_set,
   "Set of detected objects not linked to any tracks." );
@@ -94,23 +96,27 @@ void associate_detections_to_tracks_process
 
   vital::config_block_sptr algo_config = get_config();
 
-  algo::associate_detections_to_tracks::set_nested_algo_configuration(
-    "track_associator", algo_config, d->m_track_associator );
+  algo::associate_detections_to_tracks::set_nested_algo_configuration_using_trait(
+    track_associator,
+    algo_config,
+    d->m_track_associator );
 
   if( !d->m_track_associator )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create associate_detections_to_tracks" );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Unable to create associate_detections_to_tracks" );
   }
 
-  algo::associate_detections_to_tracks::get_nested_algo_configuration(
-    "track_associator", algo_config, d->m_track_associator );
+  algo::associate_detections_to_tracks::get_nested_algo_configuration_using_trait(
+    track_associator,
+    algo_config,
+    d->m_track_associator );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::associate_detections_to_tracks::check_nested_algo_configuration(
-    "track_associator", algo_config ) )
+  if( !algo::associate_detections_to_tracks::check_nested_algo_configuration_using_trait(
+    track_associator, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception(
+    VITAL_THROW( sprokit::invalid_configuration_exception,
       name(), "Configuration check failed." );
   }
 }
@@ -189,7 +195,7 @@ void associate_detections_to_tracks_process
 void associate_detections_to_tracks_process
 ::make_config()
 {
-
+  declare_config_using_trait( track_associator);
 }
 
 

--- a/sprokit/processes/core/close_loops_process.cxx
+++ b/sprokit/processes/core/close_loops_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,11 +45,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
-create_config_trait( detect_loops, std::string, "",
-                     "Algorithm configuration subblock." );
+create_algorithm_name_config_trait( close_loops );
 
 create_port_trait( next_tracks, feature_track_set,
                    "feature track set for the next frame.  Features are not yet matched for "
@@ -151,10 +149,10 @@ void close_loops_process
   // Get our process config
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  const std::string algo_name = "close_loops";
-
   // Instantiate the configured algorithm
-  algo::close_loops::set_nested_algo_configuration(algo_name, algo_config,
+  algo::close_loops::set_nested_algo_configuration_using_trait(
+    close_loops,
+    algo_config,
     d->m_loop_closer );
 
   if ( ! d->m_loop_closer )
@@ -163,13 +161,15 @@ void close_loops_process
       "Unable to create close_loops" );
   }
 
-  algo::close_loops::get_nested_algo_configuration(algo_name, algo_config,
+  algo::close_loops::get_nested_algo_configuration_using_trait(
+    close_loops,
+    algo_config,
     d->m_loop_closer);
 
   //// Check config so it will give run-time diagnostic if any config problems
   // are found
-  if ( ! algo::close_loops::check_nested_algo_configuration(
-      algo_name, algo_config ) )
+  if ( ! algo::close_loops::check_nested_algo_configuration_using_trait(
+         close_loops, algo_config ) )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Configuration check failed." );
@@ -245,7 +245,7 @@ void close_loops_process
 void close_loops_process
 ::make_config()
 {
-  declare_config_using_trait( detect_loops );
+  declare_config_using_trait( close_loops );
 }
 
 

--- a/sprokit/processes/core/compute_association_matrix_process.cxx
+++ b/sprokit/processes/core/compute_association_matrix_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,8 +43,9 @@
 
 #include <sprokit/pipeline/process_exception.h>
 
-namespace kwiver
-{
+namespace kwiver {
+
+create_algorithm_name_config_trait( matrix_generator );
 
 namespace algo = vital::algo;
 
@@ -91,24 +92,28 @@ void compute_association_matrix_process
 
   vital::config_block_sptr algo_config = get_config();
 
-  algo::compute_association_matrix::set_nested_algo_configuration(
-    "matrix_generator", algo_config, d->m_matrix_generator );
+  algo::compute_association_matrix::set_nested_algo_configuration_using_trait(
+    matrix_generator,
+    algo_config,
+    d->m_matrix_generator );
 
   if( !d->m_matrix_generator )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create compute_association_matrix" );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Unable to create compute_association_matrix" );
   }
 
-  algo::compute_association_matrix::get_nested_algo_configuration(
-    "matrix_generator", algo_config, d->m_matrix_generator );
+  algo::compute_association_matrix::get_nested_algo_configuration_using_trait(
+    matrix_generator,
+    algo_config,
+    d->m_matrix_generator );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::compute_association_matrix::check_nested_algo_configuration(
-    "matrix_generator", algo_config ) )
+  if( !algo::compute_association_matrix::check_nested_algo_configuration_using_trait(
+    matrix_generator, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Configuration check failed." );
   }
 }
 
@@ -213,6 +218,7 @@ void compute_association_matrix_process
 void compute_association_matrix_process
 ::make_config()
 {
+  declare_config_using_trait( matrix_generator );
 }
 
 

--- a/sprokit/processes/core/compute_homography_process.cxx
+++ b/sprokit/processes/core/compute_homography_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,8 @@ namespace algo = kwiver::vital::algo;
 
 namespace kwiver
 {
-create_config_trait( homography_generator, std::string, "", "Name of algorithm config block." );
+
+create_algorithm_name_config_trait( homography_generator );
 
 // ----------------------------------------------------------------
 /**
@@ -121,19 +122,27 @@ void compute_homography_process
   kwiver::vital::config_block_sptr algo_config = get_config();
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! algo::compute_ref_homography::check_nested_algo_configuration("homography_generator", algo_config ) )
+  if ( ! algo::compute_ref_homography::check_nested_algo_configuration_using_trait(
+         homography_generator,
+         algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  algo::compute_ref_homography::set_nested_algo_configuration( "homography_generator", algo_config, d->m_compute_homog );
+  algo::compute_ref_homography::set_nested_algo_configuration_using_trait(
+    homography_generator,
+    algo_config,
+    d->m_compute_homog );
   if ( ! d->m_compute_homog )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create compute_ref_homography" );
   }
 
-  algo::compute_ref_homography::get_nested_algo_configuration( "homography_generator", algo_config, d->m_compute_homog );
+  algo::compute_ref_homography::get_nested_algo_configuration_using_trait(
+    homography_generator,
+    algo_config,
+    d->m_compute_homog );
 }
 
 
@@ -184,6 +193,7 @@ void compute_homography_process
 void compute_homography_process
 ::make_config()
 {
+  declare_config_using_trait( homography_generator );
 }
 
 

--- a/sprokit/processes/core/compute_stereo_depth_map_process.cxx
+++ b/sprokit/processes/core/compute_stereo_depth_map_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 
 namespace kwiver {
 
-create_config_trait( computer, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( computer );
 
 // ----------------------------------------------------------------
 /**
@@ -104,19 +104,26 @@ _configure()
 
   vital::config_block_sptr algo_config = get_config();
 
-  vital::algo::compute_stereo_depth_map::set_nested_algo_configuration( "computer", algo_config, d->m_computer );
+  vital::algo::compute_stereo_depth_map::set_nested_algo_configuration_using_trait(
+    computer,
+    algo_config,
+    d->m_computer );
 
   if ( ! d->m_computer )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create computer" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create computer" );
   }
 
-  vital::algo::compute_stereo_depth_map::get_nested_algo_configuration( "computer", algo_config, d->m_computer );
+  vital::algo::compute_stereo_depth_map::get_nested_algo_configuration_using_trait(
+    computer,
+    algo_config,
+    d->m_computer );
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::compute_stereo_depth_map::check_nested_algo_configuration( "computer", algo_config ) )
+  if ( ! vital::algo::compute_stereo_depth_map::check_nested_algo_configuration_using_trait(
+         computer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 

--- a/sprokit/processes/core/compute_track_descriptors_process.cxx
+++ b/sprokit/processes/core/compute_track_descriptors_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017, 2019 by Kitware, Inc.
+ * Copyright 2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,10 +44,11 @@
 
 #include <sprokit/pipeline/process_exception.h>
 
-namespace kwiver
-{
+namespace kwiver {
 
 namespace algo = vital::algo;
+
+create_algorithm_name_config_trait( computer );
 
 create_config_trait( inject_to_detections, bool, "false",
   "If the input are single frame detections (not tracks) then "
@@ -112,24 +113,28 @@ void compute_track_descriptors_process
 
   vital::config_block_sptr algo_config = get_config();
 
-  algo::compute_track_descriptors::set_nested_algo_configuration(
-    "computer", algo_config, d->m_computer );
+  algo::compute_track_descriptors::set_nested_algo_configuration_using_trait(
+    computer,
+    algo_config,
+    d->m_computer );
 
   if( !d->m_computer )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create compute_track_descriptors" );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Unable to create compute_track_descriptors" );
   }
 
-  algo::compute_track_descriptors::get_nested_algo_configuration(
-    "computer", algo_config, d->m_computer );
+  algo::compute_track_descriptors::get_nested_algo_configuration_using_trait(
+    computer,
+    algo_config,
+    d->m_computer );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::compute_track_descriptors::check_nested_algo_configuration(
-    "computer", algo_config ) )
+  if( !algo::compute_track_descriptors::check_nested_algo_configuration_using_trait(
+        computer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Configuration check failed." );
   }
 
   d->inject_to_detections = config_value_using_trait( inject_to_detections );
@@ -198,7 +203,7 @@ compute_track_descriptors_process
 
   if( detections && tracks )
   {
-    throw sprokit::invalid_configuration_exception(
+    VITAL_THROW( sprokit::invalid_configuration_exception,
       name(), "Cannot connect both detections and tracks to process" );
   }
 
@@ -307,6 +312,7 @@ void compute_track_descriptors_process
 void compute_track_descriptors_process
 ::make_config()
 {
+  declare_config_using_trait( computer );
   declare_config_using_trait( inject_to_detections );
   declare_config_using_trait( add_custom_uid );
   declare_config_using_trait( uid_basename );

--- a/sprokit/processes/core/detect_features_if_keyframe_process.cxx
+++ b/sprokit/processes/core/detect_features_if_keyframe_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,11 +44,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
-  create_config_trait(detect_features_if_keyframe_process, std::string, "",
-    "Algorithm configuration subblock." )
+create_algorithm_name_config_trait( augment_keyframes );
 
 /**
  * \class detect_features_if_keyframe_process
@@ -135,26 +133,28 @@ void detect_features_if_keyframe_process
   // Get our process config
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  const std::string track_features_name = "augment_keyframes";
-
   // Instantiate the configured algorithm
-  algo::track_features::set_nested_algo_configuration(
-    track_features_name, algo_config, d->m_tracker );
+  algo::track_features::set_nested_algo_configuration_using_trait(
+    augment_keyframes,
+    algo_config,
+    d->m_tracker );
   if ( ! d->m_tracker )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Unable to create detect_features_if_keyframe" );
   }
 
-  algo::track_features::get_nested_algo_configuration(
-    track_features_name, algo_config, d->m_tracker);
+  algo::track_features::get_nested_algo_configuration_using_trait(
+    augment_keyframes,
+    algo_config,
+    d->m_tracker);
 
   // Check config so it will give run-time diagnostic if any config problems
   // are found
-  if ( ! algo::track_features::check_nested_algo_configuration(
-        track_features_name, algo_config ) )
+  if ( ! algo::track_features::check_nested_algo_configuration_using_trait(
+        augment_keyframes, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Configuration check failed." );
   }
 }
@@ -241,7 +241,7 @@ void detect_features_if_keyframe_process
 void detect_features_if_keyframe_process
 ::make_config()
 {
-  declare_config_using_trait(detect_features_if_keyframe_process);
+  declare_config_using_trait( augment_keyframes );
 }
 
 

--- a/sprokit/processes/core/detect_features_process.cxx
+++ b/sprokit/processes/core/detect_features_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,10 +44,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
-  create_config_trait( feature_detector, std::string, "", "Algorithm configuration subblock." )
+create_algorithm_name_config_trait( feature_detector );
 
 /**
  * \class detect_features_process
@@ -120,16 +119,20 @@ void detect_features_process
   kwiver::vital::config_block_sptr algo_config = get_config();
 
   // Check config so it will give run-time diagnostic if any config problems are found
-  if ( ! algo::detect_features::check_nested_algo_configuration( "feature_detector", algo_config ) )
+  if ( ! algo::detect_features::check_nested_algo_configuration_using_trait(
+         feature_detector, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // Instantiate the configured algorithm
-  algo::detect_features::set_nested_algo_configuration( "feature_detector", algo_config, d->m_detector );
+  algo::detect_features::set_nested_algo_configuration_using_trait(
+    feature_detector,
+    algo_config,
+    d->m_detector );
   if ( ! d->m_detector )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create feature_detector" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create feature_detector" );
   }
 }
 

--- a/sprokit/processes/core/detect_motion_process.cxx
+++ b/sprokit/processes/core/detect_motion_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@
 
 namespace kwiver {
 
-create_config_trait( algo, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( algo );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -83,14 +83,15 @@ _configure()
   // Check config so it will give run-time diagnostic of config problems
   if ( ! vital::algo::detect_motion::check_nested_algo_configuration_using_trait( algo, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   vital::algo::detect_motion::set_nested_algo_configuration_using_trait( algo, algo_config, d->m_algo );
 
   if ( ! d->m_algo )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create motion detector algorithm" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create motion detector algorithm" );
   }
 }
 

--- a/sprokit/processes/core/detected_object_filter_process.cxx
+++ b/sprokit/processes/core/detected_object_filter_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@
 
 namespace kwiver {
 
-create_config_trait( filter, std::string, "", "Algorithm configuration subblock." )
+create_algorithm_name_config_trait( filter );
 
 // ----------------------------------------------------------------
 /**
@@ -114,15 +114,20 @@ detected_object_filter_process
   vital::config_block_sptr algo_config = get_config();
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::detected_object_filter::check_nested_algo_configuration( "filter", algo_config ) )
+  if ( ! vital::algo::detected_object_filter::check_nested_algo_configuration_using_trait(
+         filter, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  vital::algo::detected_object_filter::set_nested_algo_configuration( "filter", algo_config, d->m_filter );
+  vital::algo::detected_object_filter::set_nested_algo_configuration_using_trait(
+    filter,
+    algo_config,
+    d->m_filter );
+
   if ( ! d->m_filter )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create filter" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create filter" );
   }
 }
 

--- a/sprokit/processes/core/detected_object_input_process.cxx
+++ b/sprokit/processes/core/detected_object_input_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,8 @@ namespace kwiver {
 
 // (config-key, value-type, default-value, description )
 create_config_trait( file_name, std::string, "", "Name of the detection set file to read." );
-create_config_trait( reader, std::string , "", "Algorithm type to use as the reader." );
+
+create_algorithm_name_config_trait( reader )
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -94,21 +95,25 @@ void detected_object_input_process
   d->m_file_name = config_value_using_trait( file_name );
   if ( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-             "Required file name not specified." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Required file name not specified." );
   }
 
   // Get algo config entries
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if ( ! algo::detected_object_set_input::check_nested_algo_configuration( "reader", algo_config ) )
+  if ( ! algo::detected_object_set_input::check_nested_algo_configuration_using_trait(
+         reader, algo_config ) )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::detected_object_set_input::set_nested_algo_configuration( "reader", algo_config, d->m_reader);
+  algo::detected_object_set_input::set_nested_algo_configuration_using_trait(
+    reader,
+    algo_config,
+    d->m_reader);
   if ( ! d->m_reader )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(),

--- a/sprokit/processes/core/detected_object_output_process.cxx
+++ b/sprokit/processes/core/detected_object_output_process.cxx
@@ -49,8 +49,7 @@ namespace kwiver {
 
 // (config-key, value-type, default-value, description )
 create_config_trait( file_name, std::string, "", "Name of the detection set file to write." );
-create_config_trait( writer, std::string , "", "Block name for algorithm parameters. "
-                     "e.g. writer:type would be used to specify the algorithm type." );
+create_algorithm_name_config_trait( writer );
 
 /**
  * \class detected_object_output_process
@@ -120,7 +119,7 @@ void detected_object_output_process
   d->m_file_name = config_value_using_trait( file_name );
   if ( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Required file name not specified." );
   }
 
@@ -128,16 +127,21 @@ void detected_object_output_process
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if ( ! algo::detected_object_set_output::check_nested_algo_configuration( "writer", algo_config ) )
+  if ( ! algo::detected_object_set_output::check_nested_algo_configuration_using_trait(
+         writer,
+         algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::detected_object_set_output::set_nested_algo_configuration( "writer", algo_config, d->m_writer);
+  algo::detected_object_set_output::set_nested_algo_configuration_using_trait(
+    writer,
+    algo_config,
+    d->m_writer);
   if ( ! d->m_writer )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create writer." );
   }
 }

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -93,8 +93,6 @@ downsample_process
   : process( config ),
     d( new downsample_process::priv( this ) )
 {
-  attach_logger( vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }

--- a/sprokit/processes/core/draw_detected_object_set_process.cxx
+++ b/sprokit/processes/core/draw_detected_object_set_process.cxx
@@ -39,9 +39,7 @@
 namespace kwiver {
 
 // (config-key, value-type, default-value, description )
-  create_config_trait( draw_algo, std::string, "", "Name of drawing algorithm config block.\n\n"
-                       "Specify an implementation of the `draw_detected_object_set` algorithm "
-                       "as draw_algo:type = <type>");
+create_algorithm_name_config_trait( draw_algo );
 
 // ----------------------------------------------------------------
 /**
@@ -110,15 +108,19 @@ void draw_detected_object_set_process
   auto algo_config = get_config();
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::draw_detected_object_set::check_nested_algo_configuration( "draw_algo", algo_config ) )
+  if ( ! vital::algo::draw_detected_object_set::check_nested_algo_configuration_using_trait(
+         draw_algo, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  vital::algo::draw_detected_object_set::set_nested_algo_configuration( "draw_algo", algo_config, d->m_algo );
+  vital::algo::draw_detected_object_set::set_nested_algo_configuration_using_trait(
+    draw_algo,
+    algo_config,
+    d->m_algo );
   if ( ! d->m_algo )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create algorithm." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create algorithm." );
   }
 }
 
@@ -168,7 +170,6 @@ void draw_detected_object_set_process
 {
   declare_config_using_trait( draw_algo );
 }
-
 
 // ================================================================
 draw_detected_object_set_process::priv

--- a/sprokit/processes/core/draw_tracks_process.cxx
+++ b/sprokit/processes/core/draw_tracks_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ namespace kwiver
 create_port_trait( output_image, image, "Image with tracks" );
 
 // config items
-//          None for now
+create_algorithm_name_config_trait( draw_tracks );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -93,20 +93,28 @@ draw_tracks_process
 
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  algo::draw_tracks::set_nested_algo_configuration( "draw_tracks", algo_config, d->m_draw_tracks );
+  algo::draw_tracks::set_nested_algo_configuration_using_trait(
+    draw_tracks,
+    algo_config,
+    d->m_draw_tracks );
   if ( ! d->m_draw_tracks )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create draw_tracks" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create draw_tracks" );
   }
 
-  algo::draw_tracks::get_nested_algo_configuration( "draw_tracks", algo_config, d->m_draw_tracks );
+  algo::draw_tracks::get_nested_algo_configuration_using_trait(
+    draw_tracks,
+    algo_config,
+    d->m_draw_tracks );
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! algo::draw_tracks::check_nested_algo_configuration( "draw_tracks", algo_config ) )
+  if ( ! algo::draw_tracks::check_nested_algo_configuration_using_trait(
+         draw_tracks, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Configuration check failed." );
   }
-
 }
 
 
@@ -159,6 +167,7 @@ void
 draw_tracks_process
 ::make_config()
 {
+  declare_config_using_trait( draw_tracks );
 }
 
 

--- a/sprokit/processes/core/extract_descriptors_process.cxx
+++ b/sprokit/processes/core/extract_descriptors_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,8 +44,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
+
+create_algorithm_name_config_trait( descriptor_extractor );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -92,18 +93,26 @@ void extract_descriptors_process
   kwiver::vital::config_block_sptr algo_config = get_config();
 
   // Instantiate the configured algorithm
-  algo::extract_descriptors::set_nested_algo_configuration( "descriptor_extractor", algo_config, d->m_extractor );
+  algo::extract_descriptors::set_nested_algo_configuration_using_trait(
+    descriptor_extractor,
+    algo_config,
+    d->m_extractor );
   if ( ! d->m_extractor )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create descriptor_extractor" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create descriptor_extractor" );
   }
 
-  algo::extract_descriptors::get_nested_algo_configuration( "descriptor_extractor", algo_config, d->m_extractor );
+  algo::extract_descriptors::get_nested_algo_configuration_using_trait(
+    descriptor_extractor,
+    algo_config,
+    d->m_extractor );
 
   // Check config so it will give run-time diagnostic if any config problems are found
-  if ( ! algo::extract_descriptors::check_nested_algo_configuration( "descriptor_extractor", algo_config ) )
+  if ( ! algo::extract_descriptors::check_nested_algo_configuration_using_trait(
+         descriptor_extractor,
+         algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 
@@ -157,6 +166,7 @@ void extract_descriptors_process
 void extract_descriptors_process
 ::make_config()
 {
+  declare_config_using_trait( descriptor_extractor );
 }
 
 

--- a/sprokit/processes/core/frame_list_process.cxx
+++ b/sprokit/processes/core/frame_list_process.cxx
@@ -78,7 +78,7 @@ create_config_trait( frame_time, double, "0.03333333", "Inter frame time in seco
                      "timestamps for sequential frames. This can be used to simulate a frame rate in a "
                      "video stream application.");
 
-create_config_trait( image_reader, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( image_reader );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -139,19 +139,19 @@ void frame_list_process
 
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
-  algo::image_io::set_nested_algo_configuration( "image_reader", algo_config, d->m_image_reader);
+  algo::image_io::set_nested_algo_configuration_using_trait( image_reader, algo_config, d->m_image_reader);
   if ( ! d->m_image_reader )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create image_reader." );
   }
 
-  algo::image_io::get_nested_algo_configuration( "image_reader", algo_config, d->m_image_reader);
+  algo::image_io::get_nested_algo_configuration_using_trait( image_reader, algo_config, d->m_image_reader);
 
   // instantiate image reader and converter based on config type
-  if ( ! algo::image_io::check_nested_algo_configuration( "image_reader", algo_config ) )
+  if ( ! algo::image_io::check_nested_algo_configuration_using_trait( image_reader, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 
@@ -169,7 +169,7 @@ void frame_list_process
   {
     std::stringstream msg;
     msg <<  "Could not open image list \"" << d->m_config_image_list_filename << "\"";
-    throw sprokit::invalid_configuration_exception( this->name(), msg.str() );
+    VITAL_THROW( sprokit::invalid_configuration_exception, this->name(), msg.str() );
   }
 
   kwiver::vital::data_stream_reader stream_reader( ifs );
@@ -184,7 +184,7 @@ void frame_list_process
       resolved_file = kwiversys::SystemTools::FindFile( line, d->m_config_path, true );
       if ( resolved_file.empty() )
       {
-        throw kwiver::vital::file_not_found_exception( line, "could not locate file in path" );
+        VITAL_THROW( kwiver::vital::file_not_found_exception, line, "could not locate file in path" );
       }
     }
 

--- a/sprokit/processes/core/handle_descriptor_request_process.cxx
+++ b/sprokit/processes/core/handle_descriptor_request_process.cxx
@@ -45,15 +45,14 @@
 
 #include <boost/filesystem/path.hpp>
 
-namespace kwiver
-{
+namespace kwiver {
 
 namespace algo = vital::algo;
 
-create_port_trait( filename, file_name,
-  "KWA input filename" );
-create_port_trait( stream_id, string,
-  "Stream ID to place in file" );
+create_port_trait( filename, file_name, "KWA input filename" );
+create_port_trait( stream_id, string, "Stream ID to place in file" );
+
+create_algorithm_name_config_trait( handler );
 
 //------------------------------------------------------------------------------
 // Private implementation class
@@ -76,9 +75,6 @@ handle_descriptor_request_process
   : process( config ),
     d( new handle_descriptor_request_process::priv )
 {
-  // Attach our logger name to process logger
-  attach_logger( vital::get_logger( name() ) );
-
   make_ports();
   make_config();
 }
@@ -96,24 +92,28 @@ void handle_descriptor_request_process
 {
   vital::config_block_sptr algo_config = get_config();
 
-  algo::handle_descriptor_request::set_nested_algo_configuration(
-    "handler", algo_config, d->m_handler );
+  algo::handle_descriptor_request::set_nested_algo_configuration_using_trait(
+    handler,
+    algo_config,
+    d->m_handler );
 
   if( !d->m_handler )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create handle_descriptor_request" );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Unable to create handle_descriptor_request" );
   }
 
-  algo::handle_descriptor_request::get_nested_algo_configuration(
-    "handler", algo_config, d->m_handler );
+  algo::handle_descriptor_request::get_nested_algo_configuration_using_trait(
+    handler,
+    algo_config,
+    d->m_handler );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::handle_descriptor_request::check_nested_algo_configuration(
-    "handler", algo_config ) )
+  if( !algo::handle_descriptor_request::check_nested_algo_configuration_using_trait(
+    handler, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception,
+                 name(), "Configuration check failed." );
   }
 }
 
@@ -205,6 +205,7 @@ void handle_descriptor_request_process
 void handle_descriptor_request_process
 ::make_config()
 {
+  declare_config_using_trait( handler );
 }
 
 

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,8 +83,7 @@ create_config_trait( frame_time, double, "0.3333333", "Inter frame time in secon
                      "timestamps for sequential frames. This can be used to simulate a frame rate in a "
                      "video stream application.");
 
-create_config_trait( image_reader, std::string, "", "Algorithm configuration subblock." )
-
+create_algorithm_name_config_trait( image_reader );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -156,19 +155,27 @@ void image_file_reader_process
 
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
-  algo::image_io::set_nested_algo_configuration( "image_reader", algo_config, d->m_image_reader);
+  algo::image_io::set_nested_algo_configuration_using_trait(
+    image_reader,
+    algo_config,
+    d->m_image_reader);
   if ( ! d->m_image_reader )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-             "Unable to create image_reader." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create image_reader." );
   }
 
-  algo::image_io::get_nested_algo_configuration( "image_reader", algo_config, d->m_image_reader);
+  algo::image_io::get_nested_algo_configuration_using_trait(
+    image_reader,
+    algo_config,
+    d->m_image_reader);
 
   // instantiate image reader and converter based on config type
-  if ( ! algo::image_io::check_nested_algo_configuration( "image_reader", algo_config ) )
+  if ( ! algo::image_io::check_nested_algo_configuration_using_trait(
+         image_reader,
+         algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 
@@ -194,7 +201,7 @@ void image_file_reader_process
 
       case priv::ERROR_ABORT:
       default:
-        throw kwiver::vital::file_not_found_exception( file, "could not locate file in path" );
+        VITAL_THROW( kwiver::vital::file_not_found_exception, file, "could not locate file in path" );
       } // end switch
     }
   }

--- a/sprokit/processes/core/image_filter_process.cxx
+++ b/sprokit/processes/core/image_filter_process.cxx
@@ -37,7 +37,7 @@
 
 namespace kwiver {
 
-create_config_trait( filter, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( filter );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -78,19 +78,26 @@ _configure()
 
   vital::config_block_sptr algo_config = get_config();
 
-  vital::algo::image_filter::set_nested_algo_configuration( "filter", algo_config, d->m_filter );
+  vital::algo::image_filter::set_nested_algo_configuration_using_trait(
+    filter,
+    algo_config,
+    d->m_filter );
 
   if ( ! d->m_filter )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create filter" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create filter" );
   }
 
-  vital::algo::image_filter::get_nested_algo_configuration( "filter", algo_config, d->m_filter );
+  vital::algo::image_filter::get_nested_algo_configuration_using_trait(
+    filter,
+    algo_config,
+    d->m_filter );
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::image_filter::check_nested_algo_configuration( "filter", algo_config ) )
+  if ( ! vital::algo::image_filter::check_nested_algo_configuration_using_trait(
+         filter, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 

--- a/sprokit/processes/core/image_object_detector_process.cxx
+++ b/sprokit/processes/core/image_object_detector_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 
 namespace kwiver {
 
-create_config_trait( detector, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( detector );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -79,15 +79,15 @@ _configure()
   vital::config_block_sptr algo_config = get_config();
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::image_object_detector::check_nested_algo_configuration( "detector", algo_config ) )
+  if ( ! vital::algo::image_object_detector::check_nested_algo_configuration_using_trait( detector, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  vital::algo::image_object_detector::set_nested_algo_configuration( "detector", algo_config, d->m_detector );
+  vital::algo::image_object_detector::set_nested_algo_configuration_using_trait( detector, algo_config, d->m_detector );
   if ( ! d->m_detector )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create detector" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create detector" );
   }
 }
 

--- a/sprokit/processes/core/image_writer_process.cxx
+++ b/sprokit/processes/core/image_writer_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,10 +66,7 @@ create_config_trait( file_name_template, std::string, "image%04d.png",
                      "format specifier to convert an integer increasing image number. "
                      "The image file type is determined by the file extension and the concrete writer selected." );
 
-// This is more for documentation
-create_config_trait( image_writer, std::string , "", "Config block name to configure algorithm. "
-                       "The algorithm type is selected with \"image_writer:type\". Specific writer parameters "
-                       "depend on writer type selected.");
+create_algorithm_name_config_trait( image_writer );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -120,17 +117,23 @@ void image_writer_process
 
   // Get algo config entries
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
-  algo::image_io::set_nested_algo_configuration( "image_writer", algo_config, d->m_image_writer);
+
+  algo::image_io::set_nested_algo_configuration_using_trait(
+    image_writer,
+    algo_config,
+    d->m_image_writer);
   if ( ! d->m_image_writer )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create image_writer." );
   }
 
   // instantiate image reader and converter based on config type
-  if ( ! algo::image_io::check_nested_algo_configuration( "image_writer", algo_config ) )
+  if ( ! algo::image_io::check_nested_algo_configuration_using_trait(
+         image_writer,
+         algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 

--- a/sprokit/processes/core/initialize_object_tracks_process.cxx
+++ b/sprokit/processes/core/initialize_object_tracks_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,10 +42,11 @@
 
 #include <sprokit/pipeline/process_exception.h>
 
-namespace kwiver
-{
+namespace kwiver {
 
 namespace algo = vital::algo;
+
+create_algorithm_name_config_trait( track_initializer );
 
 //------------------------------------------------------------------------------
 // Private implementation class
@@ -85,24 +86,28 @@ void initialize_object_tracks_process
 
   vital::config_block_sptr algo_config = get_config();
 
-  algo::initialize_object_tracks::set_nested_algo_configuration(
-    "track_initializer", algo_config, d->m_track_initializer );
+  algo::initialize_object_tracks::set_nested_algo_configuration_using_trait(
+    track_initializer,
+    algo_config,
+    d->m_track_initializer );
 
   if( !d->m_track_initializer )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Unable to create initialize_object_tracks" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create initialize_object_tracks" );
   }
 
-  algo::initialize_object_tracks::get_nested_algo_configuration(
-    "track_initializer", algo_config, d->m_track_initializer );
+  algo::initialize_object_tracks::get_nested_algo_configuration_using_trait(
+    track_initializer,
+    algo_config,
+    d->m_track_initializer );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::initialize_object_tracks::check_nested_algo_configuration(
-    "track_initializer", algo_config ) )
+  if( !algo::initialize_object_tracks::check_nested_algo_configuration_using_trait(
+        track_initializer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception(
-      name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Configuration check failed." );
   }
 }
 
@@ -189,6 +194,7 @@ void initialize_object_tracks_process
 void initialize_object_tracks_process
 ::make_config()
 {
+  declare_config_using_trait( track_initializer );
 }
 
 

--- a/sprokit/processes/core/keyframe_selection_process.cxx
+++ b/sprokit/processes/core/keyframe_selection_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
+ * Copyright 2015-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,10 +46,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
-create_config_trait( keyframe_selection, std::string, "", "Algorithm configuration subblock." )
+create_algorithm_name_config_trait( keyframe_selection_1 );
 
 create_port_trait( next_tracks, feature_track_set,
                    "feature track set for the next frame.");
@@ -146,19 +145,24 @@ void keyframe_selection_process
   // Get our process config
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  const std::string algo_name = "keyframe_selection_1";
-
   // Instantiate the configured algorithm
-  algo::keyframe_selection::set_nested_algo_configuration(algo_name, algo_config, d->m_keyframe_selection );
+  algo::keyframe_selection::set_nested_algo_configuration_using_trait(
+    keyframe_selection_1,
+    algo_config,
+    d->m_keyframe_selection );
   if ( ! d->m_keyframe_selection )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create keyframe_selection" );
   }
 
-  algo::keyframe_selection::get_nested_algo_configuration(algo_name, algo_config, d->m_keyframe_selection);
+  algo::keyframe_selection::get_nested_algo_configuration_using_trait(
+    keyframe_selection_1,
+    algo_config,
+    d->m_keyframe_selection);
 
   //// Check config so it will give run-time diagnostic if any config problems are found
-  if ( ! algo::keyframe_selection::check_nested_algo_configuration(algo_name, algo_config ) )
+  if ( ! algo::keyframe_selection::check_nested_algo_configuration_using_trait(
+         keyframe_selection_1, algo_config ) )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
@@ -250,7 +254,7 @@ void keyframe_selection_process
 void keyframe_selection_process
 ::make_config()
 {
-  declare_config_using_trait( keyframe_selection );
+  declare_config_using_trait( keyframe_selection_1 );
 }
 
 

--- a/sprokit/processes/core/matcher_process.cxx
+++ b/sprokit/processes/core/matcher_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,8 +48,10 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
+
+create_algorithm_name_config_trait( feature_matcher );
+create_algorithm_name_config_trait( loop_closer );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -104,32 +106,46 @@ void matcher_process
   kwiver::vital::config_block_sptr algo_config = get_config();
 
   // Instantiate the configured algorithm
-  algo::match_features::set_nested_algo_configuration( "feature_matcher", algo_config, d->m_matcher );
+  algo::match_features::set_nested_algo_configuration_using_trait(
+    feature_matcher,
+    algo_config,
+    d->m_matcher );
   if ( ! d->m_matcher )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create feature_matcher" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create feature_matcher" );
   }
 
-  algo::match_features::get_nested_algo_configuration( "feature_matcher", algo_config, d->m_matcher );
+  algo::match_features::get_nested_algo_configuration_using_trait(
+    feature_matcher,
+    algo_config,
+    d->m_matcher );
 
   // Check config so it will give run-time diagnostic if any config problems are found
-  if ( ! algo::match_features::check_nested_algo_configuration( "feature_matcher", algo_config ) )
+  if ( ! algo::match_features::check_nested_algo_configuration_using_trait(
+         feature_matcher, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // - Loop closure algorithm
-  algo::close_loops::set_nested_algo_configuration( "loop_closer", algo_config, d->m_closer );
+  algo::close_loops::set_nested_algo_configuration_using_trait(
+    loop_closer,
+    algo_config,
+    d->m_closer );
   if ( ! d->m_closer )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create loop_closer" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create loop_closer" );
   }
 
-  algo::close_loops::get_nested_algo_configuration( "loop_closer", algo_config, d->m_closer );
+  algo::close_loops::get_nested_algo_configuration_using_trait(
+    loop_closer,
+    algo_config,
+    d->m_closer );
 
-  if ( ! algo::close_loops::check_nested_algo_configuration( "loop_closer", algo_config ) )
+  if ( ! algo::close_loops::check_nested_algo_configuration_using_trait(
+         loop_closer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 
@@ -250,6 +266,8 @@ void matcher_process
 void matcher_process
 ::make_config()
 {
+  declare_config_using_trait( feature_matcher );
+  declare_config_using_trait( loop_closer );
 }
 
 

--- a/sprokit/processes/core/merge_images_process.cxx
+++ b/sprokit/processes/core/merge_images_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,8 +41,7 @@ namespace algo = kwiver::vital::algo;
 
 namespace kwiver {
 
-  create_config_trait( merge_images, std::string, "",
-                       "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( merge_images );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -80,8 +79,10 @@ void merge_images_process
 {
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  algo::merge_images::set_nested_algo_configuration(
-    "merge_images", algo_config, d->m_images_merger );
+  algo::merge_images::set_nested_algo_configuration_using_trait(
+    merge_images,
+    algo_config,
+    d->m_images_merger );
 
   if( !d->m_images_merger )
   {
@@ -89,12 +90,14 @@ void merge_images_process
                  name(), "Unable to create \"merge_images\"" );
   }
 
-  algo::merge_images::get_nested_algo_configuration(
-      "merge_images", algo_config, d->m_images_merger );
+  algo::merge_images::get_nested_algo_configuration_using_trait(
+    merge_images,
+    algo_config,
+    d->m_images_merger );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::merge_images::check_nested_algo_configuration(
-        "merge_images", algo_config ) )
+  if( !algo::merge_images::check_nested_algo_configuration_using_trait(
+        merge_images, algo_config ) )
   {
     VITAL_THROW(  sprokit::invalid_configuration_exception,
                   name(), "Configuration check failed." );
@@ -189,7 +192,6 @@ merge_images_process
 
       d->p_port_list.insert( port_name );
     }
-
   }
 }
 

--- a/sprokit/processes/core/merge_images_process.h
+++ b/sprokit/processes/core/merge_images_process.h
@@ -58,7 +58,18 @@ class KWIVER_PROCESSES_NO_EXPORT merge_images_process
 {
 public:
   PLUGIN_INFO( "merge_image",
-               "Merge multiple images into one." )
+               "Merge multiple images into one.\n\n"
+               "This process merges all the channels in two input "
+               "images into a single output image based on the "
+               "implementation "
+               "of the 'merge_images' algorithm selected.\n"
+               "This process has two input ports accepting "
+               "the images. The first two connect commands will be "
+               "accepted as the input ports. The actual input port "
+               "names do not matter.\n"
+               "The channels from the image from the first port "
+               "connected will be added to the output image first."
+    )
 
   merge_images_process( kwiver::vital::config_block_sptr const& config );
   virtual ~merge_images_process();

--- a/sprokit/processes/core/perform_query_process.cxx
+++ b/sprokit/processes/core/perform_query_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,8 +41,7 @@
 
 #include <tuple>
 
-namespace kwiver
-{
+namespace kwiver {
 
 namespace algo = vital::algo;
 
@@ -58,6 +57,10 @@ create_port_trait( result_descriptor_uids, string_vector,
   "Descriptor set response from external query handler" );
 create_port_trait( result_descriptor_scores, double_vector,
   "Descriptor set scores from external query handler" );
+
+// -- config traits --
+create_algorithm_name_config_trait( descriptor_reader );
+create_algorithm_name_config_trait( track_reader );
 
 create_config_trait( external_handler, bool,
   "true", "Whether or not an external query handler is used" );
@@ -125,9 +128,6 @@ perform_query_process
   : process( config ),
     d( new perform_query_process::priv( this ) )
 {
-  // Attach our logger name to process logger
-  attach_logger( vital::get_logger( name() ) );
-
   // Required for external feedback loop
   set_data_checking_level( check_none );
 
@@ -157,42 +157,52 @@ void perform_query_process
 
   if( d->external_handler )
   {
-    algo::read_track_descriptor_set::set_nested_algo_configuration(
-      "descriptor_reader", algo_config, d->descriptor_reader );
+    algo::read_track_descriptor_set::set_nested_algo_configuration_using_trait(
+      descriptor_reader,
+      algo_config,
+      d->descriptor_reader );
 
     if( !d->descriptor_reader )
     {
-      throw sprokit::invalid_configuration_exception(
+      VITAL_THROW( sprokit::invalid_configuration_exception,
         name(), "Unable to create descriptor reader" );
     }
 
-    algo::read_track_descriptor_set::get_nested_algo_configuration(
-      "descriptor_reader", algo_config, d->descriptor_reader );
+    algo::read_track_descriptor_set::get_nested_algo_configuration_using_trait(
+      descriptor_reader,
+      algo_config,
+      d->descriptor_reader );
 
-    if( !algo::read_track_descriptor_set::check_nested_algo_configuration(
-      "descriptor_reader", algo_config ) )
+    if( !algo::read_track_descriptor_set::check_nested_algo_configuration_using_trait(
+          descriptor_reader,
+          algo_config ) )
     {
-      throw sprokit::invalid_configuration_exception(
-        name(), "Configuration check failed." );
+      VITAL_THROW( sprokit::invalid_configuration_exception,
+                   name(), "Configuration check failed." );
     }
 
-    algo::read_object_track_set::set_nested_algo_configuration(
-      "track_reader", algo_config, d->track_reader );
+  algo::read_object_track_set::set_nested_algo_configuration_using_trait(
+    track_reader,
+    algo_config,
+    d->track_reader );
 
     if( !d->track_reader )
     {
-      throw sprokit::invalid_configuration_exception(
-        name(), "Unable to create track reader" );
+      VITAL_THROW( sprokit::invalid_configuration_exception,
+                   name(), "Unable to create track reader" );
     }
 
-    algo::read_object_track_set::get_nested_algo_configuration(
-      "track_reader", algo_config, d->track_reader );
+    algo::read_object_track_set::get_nested_algo_configuration_using_trait(
+      track_reader,
+      algo_config,
+      d->track_reader );
 
-    if( !algo::read_object_track_set::check_nested_algo_configuration(
-      "track_reader", algo_config ) )
+    if( !algo::read_object_track_set::check_nested_algo_configuration_using_trait(
+          track_reader,
+          algo_config ) )
     {
-      throw sprokit::invalid_configuration_exception(
-        name(), "Configuration check failed." );
+      VITAL_THROW( sprokit::invalid_configuration_exception,
+                   name(), "Configuration check failed." );
     }
   }
 }
@@ -471,6 +481,8 @@ void perform_query_process
 void perform_query_process
 ::make_config()
 {
+  declare_config_using_trait( descriptor_reader );
+  declare_config_using_trait( track_reader );
   declare_config_using_trait( external_handler );
   declare_config_using_trait( database_folder );
   declare_config_using_trait( max_result_count );

--- a/sprokit/processes/core/read_object_track_process.cxx
+++ b/sprokit/processes/core/read_object_track_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,13 +45,11 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
+create_algorithm_name_config_trait( reader );
 create_config_trait( file_name, std::string, "",
   "Name of the track descriptor set file to read." );
-create_config_trait( reader, std::string , "",
-  "Algorithm type to use as the reader." );
 
 //--------------------------------------------------------------------------------
 // Private implementation class
@@ -95,7 +93,7 @@ void read_object_track_process
 
   if( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Required file name not specified." );
   }
 
@@ -103,24 +101,23 @@ void read_object_track_process
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if(  algo::read_object_track_set::check_nested_algo_configuration(
-         "reader",
-         algo_config ) )
+  if(  algo::read_object_track_set::check_nested_algo_configuration_using_trait(
+         reader, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::read_object_track_set::set_nested_algo_configuration(
-    "reader",
+  algo::read_object_track_set::set_nested_algo_configuration_using_trait(
+    reader,
     algo_config,
     d->m_reader );
 
   if( ! d->m_reader )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Unable to create reader." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create reader." );
   }
 }
 

--- a/sprokit/processes/core/read_track_descriptor_process.cxx
+++ b/sprokit/processes/core/read_track_descriptor_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,13 +45,12 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
 
 create_config_trait( file_name, std::string, "",
   "Name of the track descriptor set file to read." );
-create_config_trait( reader, std::string , "",
-  "Algorithm type to use as the reader." );
+
+create_algorithm_name_config_trait( reader );
 
 //--------------------------------------------------------------------------------
 // Private implementation class
@@ -97,32 +96,32 @@ void read_track_descriptor_process
 
   if( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Required file name not specified." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Required file name not specified." );
   }
 
   // Get algo config entries
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if(  algo::read_track_descriptor_set::check_nested_algo_configuration(
-         "reader",
+  if(  algo::read_track_descriptor_set::check_nested_algo_configuration_using_trait(
+         reader,
          algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::read_track_descriptor_set::set_nested_algo_configuration(
-    "reader",
+  algo::read_track_descriptor_set::set_nested_algo_configuration_using_trait(
+    reader,
     algo_config,
     d->m_reader );
 
   if( ! d->m_reader )
   {
-    throw sprokit::invalid_configuration_exception( name(),
-      "Unable to create reader." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                 "Unable to create reader." );
   }
 }
 

--- a/sprokit/processes/core/refine_detections_process.cxx
+++ b/sprokit/processes/core/refine_detections_process.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 
 namespace kwiver {
 
-create_config_trait( refiner, std::string, "", "Algorithm configuration subblock" );
+create_algorithm_name_config_trait( refiner );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -79,16 +79,20 @@ _configure()
   vital::config_block_sptr algo_config = get_config();
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! vital::algo::refine_detections::check_nested_algo_configuration( "refiner", algo_config ) )
+  if ( ! vital::algo::refine_detections::check_nested_algo_configuration_using_trait(
+         refiner, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  vital::algo::refine_detections::set_nested_algo_configuration( "refiner", algo_config, d->m_refiner );
+  vital::algo::refine_detections::set_nested_algo_configuration_using_trait(
+    refiner,
+    algo_config,
+    d->m_refiner );
 
   if ( ! d->m_refiner )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create refiner" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create refiner" );
   }
 }
 

--- a/sprokit/processes/core/split_image_process.cxx
+++ b/sprokit/processes/core/split_image_process.cxx
@@ -41,8 +41,9 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
+
+create_algorithm_name_config_trait( split_image );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -79,25 +80,24 @@ void split_image_process
 {
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  algo::split_image::set_nested_algo_configuration(
-    "split_image", algo_config, d->m_image_splitter );
+  algo::split_image::set_nested_algo_configuration_using_trait(
+    split_image, algo_config, d->m_image_splitter );
 
   if( !d->m_image_splitter )
   {
-    throw sprokit::invalid_configuration_exception(
+    VITAL_THROW( sprokit::invalid_configuration_exception,
       name(), "Unable to create \"split_image\"" );
   }
-  algo::split_image::get_nested_algo_configuration(
-    "split_image", algo_config, d->m_image_splitter );
+  algo::split_image::get_nested_algo_configuration_using_trait(
+    split_image, algo_config, d->m_image_splitter );
 
   // Check config so it will give run-time diagnostic of config problems
-  if( !algo::split_image::check_nested_algo_configuration(
-        "split_image", algo_config ) )
+  if( !algo::split_image::check_nested_algo_configuration_using_trait(
+        split_image, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Configuration check failed." );
   }
-
 }
 
 
@@ -147,7 +147,7 @@ void split_image_process
 void split_image_process
 ::make_config()
 {
-
+  declare_config_using_trait( split_image );
 }
 
 

--- a/sprokit/processes/core/stabilize_image_process.cxx
+++ b/sprokit/processes/core/stabilize_image_process.cxx
@@ -46,8 +46,10 @@
 
 namespace algo = kwiver::vital::algo;
 
-namespace kwiver
-{
+namespace kwiver {
+
+create_algorithm_name_config_trait( track_features );
+create_algorithm_name_config_trait( homography_generator );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -97,26 +99,30 @@ void stabilize_image_process
 
   kwiver::vital::config_block_sptr algo_config = get_config();
 
-  algo::track_features::set_nested_algo_configuration( "track_features", algo_config, d->m_feature_tracker );
+  algo::track_features::set_nested_algo_configuration_using_trait(
+    track_features, algo_config, d->m_feature_tracker );
   if ( ! d->m_feature_tracker )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create \"track_features\"" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create \"track_features\"" );
   }
-  algo::track_features::get_nested_algo_configuration( "track_features", algo_config, d->m_feature_tracker );
+  algo::track_features::get_nested_algo_configuration_using_trait(
+    track_features, algo_config, d->m_feature_tracker );
 
   // ----
-  algo::compute_ref_homography::set_nested_algo_configuration( "homography_generator", algo_config, d->m_compute_homog );
+  algo::compute_ref_homography::set_nested_algo_configuration_using_trait(
+    homography_generator, algo_config, d->m_compute_homog );
   if ( ! d->m_compute_homog )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create \"compute_ref_homography\"" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create \"compute_ref_homography\"" );
   }
-  algo::compute_ref_homography::get_nested_algo_configuration( "homography_generator", algo_config, d->m_compute_homog );
+  algo::compute_ref_homography::get_nested_algo_configuration_using_trait(
+    homography_generator, algo_config, d->m_compute_homog );
 
   // Check config so it will give run-time diagnostic of config problems
-  if ( ! algo::track_features::check_nested_algo_configuration( "track_features", algo_config ) ||
-       ! algo::compute_ref_homography::check_nested_algo_configuration("homography_generator", algo_config ) )
+  if ( ! algo::track_features::check_nested_algo_configuration_using_trait( track_features, algo_config ) ||
+       ! algo::compute_ref_homography::check_nested_algo_configuration_using_trait( homography_generator, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 }
 
@@ -175,7 +181,8 @@ void stabilize_image_process
 void stabilize_image_process
 ::make_config()
 {
-
+  declare_config_using_trait( track_features );
+  declare_config_using_trait( homography_generator );
 }
 
 

--- a/sprokit/processes/core/track_features_process.cxx
+++ b/sprokit/processes/core/track_features_process.cxx
@@ -48,8 +48,7 @@ namespace algo = kwiver::vital::algo;
 namespace kwiver
 {
 
-  create_config_trait( track_features, std::string, "",
-    "Algorithm configuration subblock." )
+create_algorithm_name_config_trait( track_features );
 
 /**
  * \class track_features_process
@@ -129,24 +128,28 @@ void track_features_process
   kwiver::vital::config_block_sptr algo_config = get_config();
 
   // Instantiate the configured algorithm
-  algo::track_features::set_nested_algo_configuration( "track_features",
-    algo_config, d->m_tracker );
+  algo::track_features::set_nested_algo_configuration_using_trait(
+    track_features,
+    algo_config,
+    d->m_tracker );
 
   if ( ! d->m_tracker )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Unable to create track_features" );
   }
 
-  algo::track_features::get_nested_algo_configuration("track_features",
-    algo_config, d->m_tracker);
+  algo::track_features::get_nested_algo_configuration_using_trait(
+    track_features,
+    algo_config,
+    d->m_tracker);
 
   //// Check config so it will give run-time diagnostic if any config problems
   // are found
-  if ( ! algo::track_features::check_nested_algo_configuration(
-          "track_features", algo_config ) )
+  if ( ! algo::track_features::check_nested_algo_configuration_using_trait(
+         track_features, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
       "Configuration check failed." );
   }
 

--- a/sprokit/processes/core/video_input_process.cxx
+++ b/sprokit/processes/core/video_input_process.cxx
@@ -55,8 +55,8 @@ namespace algo = kwiver::vital::algo;
 namespace kwiver {
 
 //                 (config-key, value-type, default-value, description )
-create_config_trait( video_reader, std::string, "", "Name of video input algorithm. "
-  " Name of the video reader algorithm plugin is specified as video_reader:type = <algo-name>" );
+create_algorithm_name_config_trait( video_reader );
+
 create_config_trait( video_filename, std::string, "", "Name of video file." );
 create_config_trait( frame_time, double, "0.03333333",
                      "Inter frame time in seconds. "
@@ -123,16 +123,18 @@ void video_input_process
     d->m_has_config_frame_time = true;
   }
 
-  if ( ! algo::video_input::check_nested_algo_configuration( "video_reader", algo_config ) )
+  if ( ! algo::video_input::check_nested_algo_configuration_using_trait(
+         video_reader, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // instantiate requested/configured algo type
-  algo::video_input::set_nested_algo_configuration( "video_reader", algo_config, d->m_video_reader );
+  algo::video_input::set_nested_algo_configuration_using_trait(
+    video_reader, algo_config, d->m_video_reader );
   if ( ! d->m_video_reader )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create video_reader." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create video_reader." );
   }
 }
 
@@ -182,8 +184,8 @@ void video_input_process
       // number or frame time or both.
       if ( ! d->m_video_traits.capability( kwiver::vital::algo::video_input::HAS_FRAME_DATA ) )
       {
-        throw sprokit::invalid_configuration_exception( name(),
-                                                        "Video reader selected does not supply image data." );
+        VITAL_THROW( sprokit::invalid_configuration_exception, name(),
+                     "Video reader selected does not supply image data." );
       }
 
 

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -50,9 +50,8 @@ namespace kwiver {
 // (config-key, value-type, default-value, description )
 create_config_trait( file_name, std::string, "",
   "Name of the track descriptor set file to write." );
-create_config_trait( writer, std::string , "",
-  "Block name for algorithm parameters. "
-  "e.g. writer:type would be used to specify the algorithm type." );
+
+create_algorithm_name_config_trait( writer );
 
 //--------------------------------------------------------------------------------
 // Private implementation class
@@ -98,7 +97,7 @@ void write_object_track_process
   d->m_file_name = config_value_using_trait( file_name );
   if ( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Required file name not specified." );
   }
 
@@ -106,17 +105,21 @@ void write_object_track_process
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if( ! algo::write_object_track_set::check_nested_algo_configuration( "writer", algo_config ) )
+  if( ! algo::write_object_track_set::check_nested_algo_configuration_using_trait(
+        writer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::write_object_track_set::set_nested_algo_configuration( "writer", algo_config, d->m_writer );
+  algo::write_object_track_set::set_nested_algo_configuration_using_trait(
+    writer,
+    algo_config,
+    d->m_writer );
 
   if( ! d->m_writer )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create writer." );
   }
 }

--- a/sprokit/processes/core/write_track_descriptor_process.cxx
+++ b/sprokit/processes/core/write_track_descriptor_process.cxx
@@ -50,9 +50,8 @@ namespace kwiver {
 // (config-key, value-type, default-value, description )
 create_config_trait( file_name, std::string, "",
   "Name of the track descriptor set file to write." );
-create_config_trait( writer, std::string , "",
-  "Block name for algorithm parameters. "
-  "e.g. writer:type would be used to specify the algorithm type." );
+
+create_algorithm_name_config_trait( writer );
 
 //--------------------------------------------------------------------------------
 // Private implementation class
@@ -97,7 +96,7 @@ void write_track_descriptor_process
   d->m_file_name = config_value_using_trait( file_name );
   if ( d->m_file_name.empty() )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Required file name not specified." );
   }
 
@@ -105,16 +104,20 @@ void write_track_descriptor_process
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if ( ! algo::write_track_descriptor_set::check_nested_algo_configuration( "writer", algo_config ) )
+  if ( ! algo::write_track_descriptor_set::check_nested_algo_configuration_using_trait(
+         writer, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   // instantiate image reader and converter based on config type
-  algo::write_track_descriptor_set::set_nested_algo_configuration( "writer", algo_config, d->m_writer);
+  algo::write_track_descriptor_set::set_nested_algo_configuration_using_trait(
+    writer,
+    algo_config,
+    d->m_writer);
   if ( ! d->m_writer )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
              "Unable to create writer." );
   }
 }

--- a/sprokit/processes/examples/process_template/algo_wrapper_process.cxx
+++ b/sprokit/processes/examples/process_template/algo_wrapper_process.cxx
@@ -46,7 +46,7 @@ namespace kwiver {
 //+ Define a config entry for the main algorithm configuration
 //+ subblock. A name other than "algorithm" can be used if it is more
 //+ descriptive. If so, change name throughout the rest of this file also.
-create_config_trait( algo, std::string, "", "Algorithm configuration subblock" );
+  create_algorithm_name_config_trait( algo );
 
 //----------------------------------------------------------------
 // Private implementation class
@@ -92,16 +92,18 @@ _configure()
   // Call check_nested_algo_configuration() first so that it will display a list of
   // concrete instances of the desired algorithms that are available if the config
   // does not select a valid one.
-  if ( ! vital::algo::refine_detections::check_nested_algo_configuration( "algo", algo_config ) )
+  if ( ! vital::algo::refine_detections::check_nested_algo_configuration_using_trait(
+         algo, algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
-  vital::algo::refine_detections::set_nested_algo_configuration( "algo", algo_config, d->m_algo );
+  vital::algo::refine_detections::set_nested_algo_configuration_using_trait(
+    algo, algo_config, d->m_algo );
 
   if ( ! d->m_algo )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create algorithm" );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create algorithm" );
   }
 
   stop_configure_processing();

--- a/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
+++ b/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
@@ -143,13 +143,13 @@ template_algo_wrapper
   //++ Note that these methods are static on the abstract base algorithm type.
   if ( ! kwiver::vital::algo::image_object_detector::check_nested_algo_configuration( "algo_name", algo_config ) )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Configuration check failed." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Configuration check failed." );
   }
 
   kwiver::vital::algo::image_object_detector::set_nested_algo_configuration( "algo_name", algo_config, d->m_algo );
   if ( ! d->m_algo )
   {
-    throw sprokit::invalid_configuration_exception( name(), "Unable to create algorithm." );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), "Unable to create algorithm." );
   }
 }
 

--- a/sprokit/processes/trait_utils.h
+++ b/sprokit/processes/trait_utils.h
@@ -116,6 +116,22 @@ kwiver::vital::config_block_description_t const  NAME ## _config_trait::descript
  */
 #define create_config_trait(KEY, TYPE, DEF, DESCR) create_named_config_trait( KEY, # KEY, TYPE, DEF, DESCR )
 
+/**
+ * \brief
+ *
+ * Specialized macro to create a uniform description of the config
+ * block that specifies an algorithm name. Being defined on one place
+ * all processes can have the documentation upgraded right here.
+ */
+#define create_algorithm_name_config_trait( NAME )                      \
+create_config_trait( NAME, std::string , "",                            \
+                     "Algorithm configuration subblock to select and configure desired implementation.\n\n" \
+                     "Configuration example:\n"                         \
+                     "block " #NAME "\n"                                \
+                     "    type = impl # desired implementation\n"       \
+                     "    impl:param = value # implementation specific config item\n" \
+                     "    # etc\n"                                      \
+                     "endblock" );
 
 #define declare_config_using_trait(KEY)                         \
 declare_configuration_key( KEY ## _config_trait::key,           \
@@ -134,8 +150,11 @@ declare_configuration_key( KEY ## _config_trait::key,                   \
 /// Get value from a specific config block using trait
 #define reconfig_value_using_trait(CONF,KEY) CONF->get_value< KEY ## _config_trait::type >( KEY ## _config_trait::key )
 
+/// Config block using traits
+#define set_value_using_trait( KEY, VAL ) set_value( KEY, VAL, KEY ## _config_trait::description )
+#define get_value_using_trait( KEY, ... ) get_value<KEY ## _config_trait::type>( KEY, __VA_ARG__ )
 
-// Algorithm interface using traits
+/// Algorithm interface using traits
 #define check_nested_algo_configuration_using_trait(KEY, ALGO) \
   check_nested_algo_configuration( KEY ## _config_trait::key, ALGO )
 

--- a/sprokit/processes/transport/file_transport_send_process.cxx
+++ b/sprokit/processes/transport/file_transport_send_process.cxx
@@ -89,7 +89,7 @@ void file_transport_send_process
   d->m_output_file.open( d->m_file_name );
   if ( ! d->m_output_file )
   {
-    throw sprokit::invalid_configuration_exception( name(),
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(),
                      "Unable to open output file." );
   }
 }

--- a/sprokit/processes/vxl/kw_archive_writer_process.cxx
+++ b/sprokit/processes/vxl/kw_archive_writer_process.cxx
@@ -210,7 +210,7 @@ kw_archive_writer_process
   if( ! *d->m_index_stream )
   {
     std::string const reason = "Failed to open " + index_filename + " for writing";
-    throw sprokit::invalid_configuration_exception( name(), reason );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), reason );
   }
 
   if( d->m_separate_meta )
@@ -222,7 +222,7 @@ kw_archive_writer_process
     if( ! *d->m_meta_stream )
     {
       std::string const reason = "Failed to open " + meta_filename + " for writing";
-      throw sprokit::invalid_configuration_exception( name(), reason );
+      VITAL_THROW( sprokit::invalid_configuration_exception, name(), reason );
     }
 
     d->m_meta_bstream.reset( new vsl_b_ostream( d->m_meta_stream.get() ) );
@@ -236,7 +236,7 @@ kw_archive_writer_process
   if( ! *d->m_data_stream )
   {
     std::string const reason = "Failed to open " + data_filename + " for writing";
-    throw sprokit::invalid_configuration_exception( name(), reason );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), reason );
   }
 
   // Write file headers
@@ -278,7 +278,7 @@ kw_archive_writer_process
       ( d->m_separate_meta && ! *d->m_meta_stream ) )
   {
     static std::string const reason = "Failed while writing file headers";
-    throw sprokit::invalid_configuration_exception( name(), reason );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), reason );
   }
 } // kw_archive_writer_process::_init
 
@@ -359,7 +359,7 @@ kw_archive_writer_process
   if( d->m_base_filename.empty() )
   {
     static std::string const reason = "No output filename specified";
-    throw sprokit::invalid_configuration_exception( name(), reason );
+    VITAL_THROW( sprokit::invalid_configuration_exception, name(), reason );
   }
 
   {

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
@@ -63,7 +63,7 @@ protected:
     std::stringstream str;
     str <<  "Entry for provider \"" << provider << "\" does not have an element \""
         << entry << "\"";
-    throw provider_error_exception( str.str() );
+    VITAL_THROW( provider_error_exception, str.str() );
 
     // Could do a log message instead
     return true;
@@ -74,7 +74,7 @@ protected:
   {
     std::stringstream str;
     str << "Provider \"" << provider << "\" is not available";
-    throw provider_error_exception( str.str() );
+    VITAL_THROW( provider_error_exception, str.str() );
 
     // Could do a log message instead
     return true;
@@ -210,7 +210,7 @@ bakery_base
       }
       else
       {
-        throw unrecognized_config_flag_exception( full_key, flag);
+        VITAL_THROW( unrecognized_config_flag_exception, full_key, flag);
       }
     } // end foreach over flags
   }
@@ -226,7 +226,7 @@ bakery_base
     catch ( const provider_error_exception &e )
     {
       // Rethrow exception after adding location
-      throw provider_error_exception( e.what(), value.loc );
+      VITAL_THROW( provider_error_exception, e.what(), value.loc );
     }
   }
 
@@ -316,9 +316,9 @@ extract_configuration_from_decls( bakery_base::config_decls_t& configs )
       }
       else
       {
-        throw relativepath_exception(
-               "Can not resolve relative path because original source file is not known.",
-               info.defined_loc );
+        VITAL_THROW( relativepath_exception,
+                     "Can not resolve relative path because original source file is not known.",
+                     info.defined_loc );
       }
     }
 

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
@@ -101,7 +101,7 @@ pipeline_builder
   std::ifstream input( def_file );
   if ( ! input )
   {
-    throw sprokit::file_no_exist_exception( def_file );
+    VITAL_THROW( sprokit::file_no_exist_exception, def_file );
   }
 
   // process the input stream
@@ -132,7 +132,7 @@ pipeline_builder
   std::ifstream input( def_file );
   if ( ! input )
   {
-    throw sprokit::file_no_exist_exception( def_file );
+    VITAL_THROW( sprokit::file_no_exist_exception, def_file );
   }
 
   // process the input stream
@@ -151,7 +151,7 @@ pipeline_builder
   std::ifstream input( path );
   if ( ! input )
   {
-    throw sprokit::file_no_exist_exception( path );
+    VITAL_THROW( sprokit::file_no_exist_exception, path );
   }
 
   // process the input stream

--- a/vital/algo/convert_image.h
+++ b/vital/algo/convert_image.h
@@ -43,7 +43,17 @@ namespace kwiver {
 namespace vital {
 namespace algo {
 
-/// An abstract base class for converting base image type
+/// An abstract base class for converting base image type.
+/**
+ * Arrows that implement this interface convert the input image type
+ * (e.g. BGR 16) to a different type (e.g. RGB 8). Concrete
+ * implementations usually work with a single image representation,
+ * such as VXL or OCV.
+ *
+ * If you are lookling for an interface for an image transform that
+ * will change the value of a pixel, then use the image_filter
+ * interface.
+ */
 class VITAL_ALGO_EXPORT convert_image
   : public kwiver::vital::algorithm_def<convert_image>
 {

--- a/vital/algo/image_filter.h
+++ b/vital/algo/image_filter.h
@@ -44,7 +44,12 @@ namespace kwiver {
 namespace vital {
 namespace algo {
 
-/// \brief Abstract base class for feature set filter algorithms.
+/// \brief Abstract base class for image set filter algorithms.
+/**
+ * This interface supports arrows/algorithms that do a pixel by pixel
+ * image modification, such as image enhancement. The resultant image
+ * must be the same size as the input image.
+ */
 class VITAL_ALGO_EXPORT image_filter
   : public kwiver::vital::algorithm_def<image_filter>
 {
@@ -55,10 +60,11 @@ public:
 
   /// Filter a  input image and return resulting image
   /**
-   * This method implements the filtering operation. The resulting
-   * image should be the same size as the input image.
+   * This method implements the filtering operation. The method does
+   * not modify the image in place. The resulting image must be a
+   * newly allocated image which is the same size as the input image.
    *
-   * \param[in] image_data Image to filter.
+   * \param image_data Image to filter.
    * \returns a filtered version of the input image
    */
   virtual kwiver::vital::image_container_sptr filter( kwiver::vital::image_container_sptr image_data ) = 0;

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -57,7 +57,7 @@ tags_to_vector( metadata_sptr const& md, std::vector<vital_metadata_tag> tags )
     }
     else
     {
-      throw metadata_exception("Missing RPC metadata: " +
+      VITAL_THROW( metadata_exception,"Missing RPC metadata: " +
                                md_traits.tag_to_name(tags[i]));
     }
   }
@@ -72,7 +72,7 @@ tags_to_matrix( metadata_sptr const& md, std::vector<vital_metadata_tag> tags )
   metadata_traits md_traits;
   if (tags.size() != 4)
   {
-    throw metadata_exception("Should have 4 metadata tags for RPC coefficients");
+    VITAL_THROW( metadata_exception,"Should have 4 metadata tags for RPC coefficients");
   }
 
   rpc_matrix rslt;
@@ -85,7 +85,7 @@ tags_to_matrix( metadata_sptr const& md, std::vector<vital_metadata_tag> tags )
     }
     else
     {
-      throw metadata_exception("Missing RPC metadata: " +
+      VITAL_THROW( metadata_exception,"Missing RPC metadata: " +
                                md_traits.tag_to_name(tags[i]));
     }
   }

--- a/vital/io/eigen_io.h
+++ b/vital/io/eigen_io.h
@@ -67,7 +67,7 @@ operator>>( std::istream& s, Matrix< T, M, N >& m )
     {
       if ( ! ( s >> std::skipws >> m( i, j ) ) )
       {
-        throw kwiver::vital::invalid_data( "Encountered a non-numeric value while "
+        VITAL_THROW( kwiver::vital::invalid_data, "Encountered a non-numeric value while "
                                     "parsing an Eigen::Matrix" );
       }
     }

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -123,7 +123,7 @@ read_pos_file( path_t const& file_path )
         << file_path
         << "  (discovered " << tokens.size() << " field(s), expected "
         << "14 or 15).";
-    throw vital::invalid_data( ss.str() );
+    VITAL_THROW( vital::invalid_data, ss.str() );
   }
 
   // make a new metadata container.

--- a/vital/klv/klv_0104.cxx
+++ b/vital/klv/klv_0104.cxx
@@ -349,7 +349,7 @@ traits< double >::convert( uint8_t const* data, std::size_t length )
   }
   else
   {
-    throw kwiver::vital::metadata_exception( "Length does not correspond to double or float." );
+    VITAL_THROW( kwiver::vital::metadata_exception, "Length does not correspond to double or float." );
   }
 
   return val;
@@ -410,7 +410,7 @@ klv_0104::get_value( tag tg, kwiver::vital::any const& data ) const
   traits< T >* t = dynamic_cast< traits< T >* > ( m_traitsvec[tg] );
   if ( ! t )
   {
-    throw kwiver::vital::metadata_exception( t->m_name + "' type mismatch" );
+    VITAL_THROW( kwiver::vital::metadata_exception, t->m_name + "' type mismatch" );
   }
 
   return kwiver::vital::any_cast< T > ( data );

--- a/vital/plugin_loader/plugin_factory.h
+++ b/vital/plugin_loader/plugin_factory.h
@@ -130,7 +130,7 @@ public:
       std::stringstream str;
       str << "Can not create object of requested type: " <<  typeid( T ).name()
           <<"  Factory created objects of type: " << m_interface_type;
-      throw kwiver::vital::plugin_factory_type_creation_error( str.str() );
+      VITAL_THROW( kwiver::vital::plugin_factory_type_creation_error, str.str() );
     }
 
     // Call derived class to create concrete type object
@@ -141,7 +141,7 @@ public:
 
       str << "plugin_factory:: Unable to create object of type "
           << typeid( T ).name();
-      throw kwiver::vital::plugin_factory_type_creation_error( str.str() );
+      VITAL_THROW( kwiver::vital::plugin_factory_type_creation_error, str.str() );
     }
 
     return new_object;

--- a/vital/plugin_loader/plugin_manager.h
+++ b/vital/plugin_loader/plugin_manager.h
@@ -368,7 +368,7 @@ public:
         << "\" for interface type \"" << demangle( typeid(I).name() )
         << "\"";
 
-    throw kwiver::vital::plugin_factory_not_found( str.str() );
+    VITAL_THROW( kwiver::vital::plugin_factory_not_found, str.str() );
   }
 
   /**

--- a/vital/types/descriptor.cxx
+++ b/vital/types/descriptor.cxx
@@ -45,13 +45,13 @@ int kwiver::vital::hamming_distance(vital::descriptor_sptr d1, vital::descriptor
 
   if (d1_bytes % 4)
   {
-    throw vital::invalid_value("Descriptor must be a multiple of four bytes long.");
+    VITAL_THROW( vital::invalid_value,"Descriptor must be a multiple of four bytes long.");
   }
 
   const int d2_bytes = d2->num_bytes();
   if (d1_bytes != d2_bytes)
   {
-    throw vital::invalid_value("Descriptors must be the same number of bytes long");
+    VITAL_THROW( vital::invalid_value,"Descriptors must be the same number of bytes long");
   }
 
   const int num_ints_long(d1_bytes / 4);

--- a/vital/types/detected_object_set.cxx
+++ b/vital/types/detected_object_set.cxx
@@ -314,7 +314,7 @@ detected_object_set
   return [=] () mutable ->iterator::reference {
     if( it == m_detected_objects.end() )
     {
-      throw stop_iteration_exception( "detected_object_set" );
+      VITAL_THROW( stop_iteration_exception, "detected_object_set" );
     }
     return *(it++);
   };
@@ -330,7 +330,7 @@ detected_object_set
   return [=] () mutable ->const_iterator::reference {
     if( cit == m_detected_objects.end() )
     {
-      throw stop_iteration_exception( "detected_object_set" );
+      VITAL_THROW( stop_iteration_exception, "detected_object_set" );
     }
     return *(cit++);
   };


### PR DESCRIPTION
Standardize config entry for specifying algorithm type. Rolled documentation into this entry so all processes that instantiate an algorithm get the same extended documentation. The goal is to make it easy to standardize the documentation and config handling.

- Convert throw to VITAL_THROW where applicable

- Clean up some inconsistencies how algo's are specified.

- Remove outdated attach_logger() call from processes.