### PR TITLE
Dev/add null checks track descriptor

### DIFF
--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ kwiver_discover_gtests(vital rotation                       LIBRARIES ${test_lib
 kwiver_discover_gtests(vital similarity                     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital timestamp                      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital track                          LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital track_descriptor               LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital track_set                      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital vector                         LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital uid                            LIBRARIES ${test_libraries})

--- a/vital/tests/test_track_descriptor.cxx
+++ b/vital/tests/test_track_descriptor.cxx
@@ -1,0 +1,123 @@
+/*ckwg +29
+ * Copyright 2016-2017 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief core track_descriptor class tests
+ */
+
+#include <vital/types/track_descriptor.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// The following tests are meant only for debug mode
+// The functions being tested only throw exceptions in DEBUG
+#ifdef DEBUG
+// ----------------------------------------------------------------------------
+TEST(track_descriptor, size_with_exit)
+{
+  track_descriptor_sptr td = track_descriptor::create("foo_type");
+  ASSERT_THROW(td->descriptor_size(), std::logic_error);
+}
+
+// ----------------------------------------------------------------------------
+TEST(track_descriptor, at_with_exit)
+{
+  track_descriptor_sptr td = track_descriptor::create("foo_type");
+  ASSERT_THROW(td->at(0), std::logic_error);
+  ASSERT_THROW(td->at(0) = 5, std::logic_error);
+}
+#endif
+
+// ----------------------------------------------------------------------------
+TEST(track_descriptor, has_descriptor)
+{
+  track_descriptor_sptr td = track_descriptor::create("foo_type");
+
+  // Case where data_ is NULL
+  ASSERT_FALSE( td->has_descriptor() );
+
+  td->resize_descriptor( 0 );
+  ASSERT_FALSE( td->has_descriptor() );
+
+  td->resize_descriptor( 1 );
+  ASSERT_TRUE( td->has_descriptor() );
+
+  td->at(0) = 5;
+  ASSERT_TRUE( td->has_descriptor() );
+}
+
+// ----------------------------------------------------------------------------
+TEST(track_descriptor, size_no_exit)
+{
+  track_descriptor_sptr td = track_descriptor::create("foo_type");
+
+  td->resize_descriptor( 0 );
+  ASSERT_EQ( td->descriptor_size(), 0 );
+
+  td->resize_descriptor( 1 );
+  ASSERT_EQ( td->descriptor_size(), 1 );
+
+  td->at(0) = 5;
+  ASSERT_EQ( td->descriptor_size(), 1 );
+
+  td->resize_descriptor( 100 );
+  ASSERT_EQ( td->descriptor_size(), 100 );
+
+}
+
+// ----------------------------------------------------------------------------
+TEST(track_descriptor, at_no_exit)
+{
+  track_descriptor_sptr td = track_descriptor::create("foo_type");
+
+  td->resize_descriptor( 3 );
+  td->at(0) = 5;
+  td->at(1) = 10;
+  td->at(2) = 15;
+
+  EXPECT_EQ( td->at(0), 5 );
+  EXPECT_EQ( td->at(1), 10 );
+  EXPECT_EQ( td->at(2), 15 );
+
+  td->resize_descriptor( 1 );
+  td->at(0) = 20;
+
+  EXPECT_EQ( td->at(0), 20);
+}

--- a/vital/tests/test_track_descriptor.cxx
+++ b/vital/tests/test_track_descriptor.cxx
@@ -37,6 +37,11 @@
 
 #include <gtest/gtest.h>
 
+// Only run debug tests if in debug mode
+#ifndef NDEBUG
+#define RUN_DEBUG_TESTS
+#endif
+
 using namespace kwiver::vital;
 
 // ----------------------------------------------------------------------------
@@ -46,18 +51,18 @@ int main(int argc, char** argv)
   return RUN_ALL_TESTS();
 }
 
-// The following tests are meant only for debug mode
-// The functions being tested only throw exceptions in DEBUG
-#ifdef DEBUG
+// The following tests are meant only for a debug build,
+// as the functions only throw the tested exceptions in debug builds
+#ifdef RUN_DEBUG_TESTS
 // ----------------------------------------------------------------------------
-TEST(track_descriptor, size_with_exit)
+TEST(track_descriptor, size_with_throw)
 {
   track_descriptor_sptr td = track_descriptor::create("foo_type");
   ASSERT_THROW(td->descriptor_size(), std::logic_error);
 }
 
 // ----------------------------------------------------------------------------
-TEST(track_descriptor, at_with_exit)
+TEST(track_descriptor, at_with_throw)
 {
   track_descriptor_sptr td = track_descriptor::create("foo_type");
   ASSERT_THROW(td->at(0), std::logic_error);
@@ -84,7 +89,7 @@ TEST(track_descriptor, has_descriptor)
 }
 
 // ----------------------------------------------------------------------------
-TEST(track_descriptor, size_no_exit)
+TEST(track_descriptor, size_no_throw)
 {
   track_descriptor_sptr td = track_descriptor::create("foo_type");
 
@@ -103,7 +108,7 @@ TEST(track_descriptor, size_no_exit)
 }
 
 // ----------------------------------------------------------------------------
-TEST(track_descriptor, at_no_exit)
+TEST(track_descriptor, at_no_throw)
 {
   track_descriptor_sptr td = track_descriptor::create("foo_type");
 

--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -30,7 +30,6 @@
 
 #include "track_descriptor.h"
 
-#include <assert.h>
 #include <sstream>
 
 
@@ -154,7 +153,14 @@ double&
 track_descriptor
 ::at( const size_t idx )
 {
-  assert(this->data_); // Only runs in Debug
+  #ifdef DEBUG
+  if (!this->data_)
+  {
+    std::stringstream msg;
+    msg << "Attempted to access raw data of null descriptor ptr";
+    throw std::logic_error( msg.str() );
+  }
+  #endif
 
   // validate element index
   if ( idx >= this->data_->size() )
@@ -174,7 +180,14 @@ double const&
 track_descriptor
 ::at( const size_t idx ) const
 {
-  assert(this->data_);
+  #ifdef DEBUG
+  if (!this->data_)
+  {
+    std::stringstream msg;
+    msg << "Attempted to access raw data of null descriptor ptr";
+    throw std::logic_error( msg.str() );
+  }
+  #endif
 
   // validate element index
   if ( idx >= this->data_->size() )
@@ -194,7 +207,15 @@ size_t
 track_descriptor
 ::descriptor_size() const
 {
-  assert(this->data_);
+  #ifdef DEBUG
+  if (!this->data_)
+  {
+    std::stringstream msg;
+    msg << "Attempted to access size of null descriptor ptr";
+    throw std::logic_error( msg.str() );
+  }
+  #endif
+
   return this->data_->size();
 }
 

--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -224,8 +224,7 @@ bool
 track_descriptor
 ::has_descriptor() const
 {
-  assert(this->data_);
-  return this->data_->size() != 0;
+  return (this->data_ && this->data_->size());
 }
 
 

--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -160,9 +160,7 @@ track_descriptor
   #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
-    std::stringstream msg;
-    msg << "Attempted to access raw data of null descriptor ptr";
-    throw std::logic_error( msg.str() );
+    throw std::logic_error( "Attempted to access raw data of null descriptor ptr" );
   }
   #endif
 
@@ -187,9 +185,7 @@ track_descriptor
   #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
-    std::stringstream msg;
-    msg << "Attempted to access raw data of null descriptor ptr";
-    throw std::logic_error( msg.str() );
+    throw std::logic_error( "Attempted to access raw data of null descriptor ptr" );
   }
   #endif
 
@@ -214,9 +210,7 @@ track_descriptor
   #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
-    std::stringstream msg;
-    msg << "Attempted to access size of null descriptor ptr";
-    throw std::logic_error( msg.str() );
+    throw std::logic_error( "Attempted to access size of null descriptor ptr" );
   }
   #endif
 

--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -30,6 +30,7 @@
 
 #include "track_descriptor.h"
 
+#include <assert.h>
 #include <sstream>
 
 
@@ -153,6 +154,8 @@ double&
 track_descriptor
 ::at( const size_t idx )
 {
+  assert(this->data_); // Only runs in Debug
+
   // validate element index
   if ( idx >= this->data_->size() )
   {
@@ -171,6 +174,8 @@ double const&
 track_descriptor
 ::at( const size_t idx ) const
 {
+  assert(this->data_);
+
   // validate element index
   if ( idx >= this->data_->size() )
   {
@@ -189,6 +194,7 @@ size_t
 track_descriptor
 ::descriptor_size() const
 {
+  assert(this->data_);
   return this->data_->size();
 }
 
@@ -218,6 +224,7 @@ bool
 track_descriptor
 ::has_descriptor() const
 {
+  assert(this->data_);
   return this->data_->size() != 0;
 }
 

--- a/vital/types/track_descriptor.cxx
+++ b/vital/types/track_descriptor.cxx
@@ -32,6 +32,10 @@
 
 #include <sstream>
 
+#ifndef NDEBUG
+// Only check null data_ in debug mode
+#define DEBUG_CHECK_DATA_NULL
+#endif
 
 namespace kwiver {
 namespace vital {
@@ -153,7 +157,7 @@ double&
 track_descriptor
 ::at( const size_t idx )
 {
-  #ifdef DEBUG
+  #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
     std::stringstream msg;
@@ -180,7 +184,7 @@ double const&
 track_descriptor
 ::at( const size_t idx ) const
 {
-  #ifdef DEBUG
+  #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
     std::stringstream msg;
@@ -207,7 +211,7 @@ size_t
 track_descriptor
 ::descriptor_size() const
 {
-  #ifdef DEBUG
+  #ifdef DEBUG_CHECK_DATA_NULL
   if (!this->data_)
   {
     std::stringstream msg;


### PR DESCRIPTION
This PR adds logic for throwing an std::logic_error in track_descriptor::at and track_descriptor::descriptor_size. The exceptions guard against dereferencing the "data_" member variable if its still NULL, which causes a segfault. These changes are only compiled for debug builds.

track_descriptor::has_descriptor has also been modified to return false if the data_ member is still NULL