### PR TITLE
Fixes / enhancements for reading .ply files

### DIFF
--- a/vital/io/mesh_io.cxx
+++ b/vital/io/mesh_io.cxx
@@ -213,6 +213,7 @@ mesh_sptr read_ply(std::istream& is)
   {
     vector_3d& vert = (*verts)[v];
     is >> vert[0] >> vert[1] >> vert[2];
+    is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   }
   for (unsigned int f=0; f<num_faces; ++f)
   {


### PR DESCRIPTION
Currently the `read_ply` function assumes exactly three values for vertices.  This quick fix ignores the rest of the vertex line in case there are other properties present (color data in my specific use case).

A more robust (and involved) fix would be to actually read the property values in the header and parse out the needed values rather than assume a certain ordering.

Also it seems to be assumed that the .ply files are in ascii (not binary) form.  Might be good to detect this as well and at least emit a warning / error if it's not ascii (or handle the binary form).

Thoughts?

(I'm even less familiar with the .ply2 format, but I'm assuming this fix should be applied to that reader as well?)