### PR TITLE
Dev/fix geo precision

### DIFF
--- a/vital/tests/test_geo_point.cxx
+++ b/vital/tests/test_geo_point.cxx
@@ -40,16 +40,22 @@
 #include <vital/types/geodesy.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
-static auto const loc1 = kwiver::vital::vector_2d{ -73.759291, 42.849631 };
-static auto const loc2 = kwiver::vital::vector_2d{ -73.757161, 42.849764 };
-static auto const loc3 = kwiver::vital::vector_2d{ 601375.01, 4744863.31 };
+using namespace kwiver::vital;
 
-static auto const loc1a = kwiver::vital::vector_3d{ -73.759291, 42.849631, 50 };
-static auto const loc2a = kwiver::vital::vector_3d{ -73.757161, 42.849764, 50 };
-static auto const loc3a = kwiver::vital::vector_3d{ 601375.01, 4744863.31, 50 };
+namespace {
 
-static auto constexpr crs_ll = kwiver::vital::SRID::lat_lon_WGS84;
-static auto constexpr crs_utm_18n = kwiver::vital::SRID::UTM_WGS84_north + 18;
+auto const loc1 = vector_2d{ -73.759291, 42.849631 };
+auto const loc2 = vector_2d{ -73.757161, 42.849764 };
+auto const loc3 = vector_2d{ 601375.01, 4744863.31 };
+
+auto const loc1a = vector_3d{ -73.759291, 42.849631, 50 };
+auto const loc2a = vector_3d{ -73.757161, 42.849764, 50 };
+auto const loc3a = vector_3d{ 601375.01, 4744863.31, 50 };
+
+auto constexpr crs_ll = SRID::lat_lon_WGS84;
+auto constexpr crs_utm_18n = SRID::UTM_WGS84_north + 18;
+
+}
 
 // ----------------------------------------------------------------------------
 int
@@ -62,23 +68,23 @@ main(int argc, char* argv[])
 // ----------------------------------------------------------------------------
 TEST(geo_point, default_constructor)
 {
-  kwiver::vital::geo_point p;
+  geo_point p;
   EXPECT_TRUE( p.is_empty() );
 }
 
 // ----------------------------------------------------------------------------
 TEST(geo_point, constructor_point)
 {
-  kwiver::vital::geo_point p{ loc1, crs_ll };
+  geo_point p{ loc1, crs_ll };
   EXPECT_FALSE( p.is_empty() );
 }
 
 // ----------------------------------------------------------------------------
 TEST(geo_point, assignment)
 {
-  kwiver::vital::geo_point p;
-  kwiver::vital::geo_point const p1{ loc1, crs_ll };
-  kwiver::vital::geo_point const p2;
+  geo_point p;
+  geo_point const p1{ loc1, crs_ll };
+  geo_point const p2;
 
   // Paranoia-check initial state
   EXPECT_TRUE( p.is_empty() );
@@ -99,8 +105,8 @@ TEST(geo_point, assignment)
 // ----------------------------------------------------------------------------
 TEST(geo_point, api)
 {
-  kwiver::vital::geo_point p{ loc1, crs_ll };
-  kwiver::vital::vector_3d _loc1{ loc1[0], loc1[1], 0 };
+  geo_point p{ loc1, crs_ll };
+  vector_3d _loc1{ loc1[0], loc1[1], 0 };
 
   // Test values of the point as originally constructed
   EXPECT_EQ( crs_ll, p.crs() );
@@ -109,7 +115,7 @@ TEST(geo_point, api)
 
   // Modify the location and test the new values
   p.set_location( loc3, crs_utm_18n );
-  kwiver::vital::vector_3d _loc3{ loc3[0], loc3[1], 0 };
+  vector_3d _loc3{ loc3[0], loc3[1], 0 };
 
   EXPECT_EQ( crs_utm_18n, p.crs() );
   EXPECT_EQ( _loc3, p.location() );
@@ -117,7 +123,7 @@ TEST(geo_point, api)
 
   // Modify the location again and test the new values
   p.set_location( loc2, crs_ll );
-  kwiver::vital::vector_3d _loc2{ loc2[0], loc2[1], 0 };
+  vector_3d _loc2{ loc2[0], loc2[1], 0 };
 
   EXPECT_EQ( crs_ll, p.crs() );
   EXPECT_EQ( _loc2, p.location() );
@@ -141,18 +147,18 @@ TEST(geo_point, api)
 // ----------------------------------------------------------------------------
 TEST(geo_point, conversion)
 {
-  kwiver::vital::plugin_manager::instance().load_all_plugins();
+  plugin_manager::instance().load_all_plugins();
 
-  kwiver::vital::geo_point p_ll{ loc1, crs_ll };
-  kwiver::vital::geo_point p_utm{ loc3, crs_utm_18n };
+  geo_point p_ll{ loc1, crs_ll };
+  geo_point p_utm{ loc3, crs_utm_18n };
 
   auto const conv_loc_utm = p_ll.location( p_utm.crs() );
   auto const conv_loc_ll = p_utm.location( p_ll.crs() );
 
-  kwiver::vital::vector_3d _loc3{ loc3[0], loc3[1], 0 };
+  vector_3d _loc3{ loc3[0], loc3[1], 0 };
   auto const epsilon_ll_to_utm = ( _loc3 - conv_loc_utm ).norm();
 
-  kwiver::vital::vector_3d _loc1{ loc1[0], loc1[1], 0 };
+  vector_3d _loc1{ loc1[0], loc1[1], 0 };
   auto const epsilon_utm_to_ll = ( _loc1 - conv_loc_ll ).norm();
 
   EXPECT_MATRIX_NEAR( p_ll.location(), conv_loc_ll, 1e-7 );
@@ -164,8 +170,8 @@ TEST(geo_point, conversion)
   std::cout << "UTM->LL epsilon: " << epsilon_utm_to_ll << std::endl;
 
   // Test with altitude
-  kwiver::vital::geo_point p_lla{ loc1a, crs_ll };
-  kwiver::vital::geo_point p_utma{ loc3a, crs_utm_18n };
+  geo_point p_lla{ loc1a, crs_ll };
+  geo_point p_utma{ loc3a, crs_utm_18n };
 
   auto const conv_loc_utma = p_lla.location( p_utma.crs() );
   auto const conv_loc_lla = p_utma.location( p_lla.crs() );

--- a/vital/tests/test_geo_polygon.cxx
+++ b/vital/tests/test_geo_polygon.cxx
@@ -299,6 +299,27 @@ TEST_P(geo_polygon_roundtrip, insert_operator)
 }
 
 // ----------------------------------------------------------------------------
+TEST_P(geo_polygon_roundtrip, config_block)
+{
+  auto const expected_loc = GetParam().loc;
+  auto const expected_crs = GetParam().crs;
+
+  auto const config = config_block::empty_config();
+  auto const key = config_block_key_t{ "key" };
+
+  config->set_value( key, geo_polygon{ { expected_loc }, expected_crs } );
+
+  auto const value = config->get_value<geo_polygon>( key );
+  ASSERT_EQ( expected_crs, value.crs() );
+
+  auto const actual_loc = value.polygon( expected_crs ).get_vertices()[0];
+
+  // Successful round-trip?
+  EXPECT_EQ( expected_loc[0], actual_loc[0] );
+  EXPECT_EQ( expected_loc[1], actual_loc[1] );
+}
+
+// ----------------------------------------------------------------------------
 INSTANTIATE_TEST_CASE_P(
   ,
   geo_polygon_roundtrip,

--- a/vital/tests/test_geo_polygon.cxx
+++ b/vital/tests/test_geo_polygon.cxx
@@ -44,6 +44,8 @@
 #include <vital/types/geodesy.h>
 #include <vital/types/polygon.h>
 
+#include <sstream>
+
 using namespace kwiver::vital;
 
 namespace {
@@ -53,6 +55,8 @@ auto const loc_ll = vector_2d{ -149.484444, -17.619482 };
 auto const loc_utm = vector_2d{ 236363.98, 8050181.74 };
 
 auto const loc2_ll = vector_2d{ -73.759291, 42.849631 };
+
+auto const loc_rt = vector_2d{ 0.123456789012345678, -0.987654321098765432 };
 
 auto constexpr crs_ll = SRID::lat_lon_WGS84;
 auto constexpr crs_utm_6s = SRID::UTM_WGS84_south + 6;
@@ -230,3 +234,77 @@ TEST(geo_polygon, config_block_io)
 
   EXPECT_EQ( loc, config->get_value<geo_polygon>( key ).polygon( crs ) );
 }
+
+// ----------------------------------------------------------------------------
+TEST(geo_polygon, insert_operator_empty)
+{
+  geo_polygon p_empty;
+
+  std::stringstream str;
+  str << p_empty;
+
+  EXPECT_EQ( str.str(), "{ empty }" );
+}
+
+
+// ----------------------------------------------------------------------------
+struct roundtrip_test
+{
+  char const* text;
+  vector_2d loc;
+  int crs;
+};
+
+// ----------------------------------------------------------------------------
+void
+PrintTo( roundtrip_test const& v, ::std::ostream* os )
+{
+  (*os) << v.text;
+}
+
+// ----------------------------------------------------------------------------
+class geo_polygon_roundtrip : public ::testing::TestWithParam<roundtrip_test>
+{
+};
+
+// ----------------------------------------------------------------------------
+TEST_P(geo_polygon_roundtrip, insert_operator)
+{
+  auto const expected_loc = GetParam().loc;
+  auto const expected_crs = GetParam().crs;
+
+  geo_polygon p{ { expected_loc }, expected_crs };
+
+  // Write polygon to stream
+  auto s = std::stringstream{};
+  s << p;
+
+  // Read back values
+  double easting, northing;
+  int crs;
+  std::string dummy;
+
+  s >> dummy; // {
+  s >> easting;
+  s >> dummy; // /
+  s >> northing;
+  s >> dummy; // }
+  s >> dummy; // @
+  s >> crs;
+
+  // Successful round-trip?
+  EXPECT_EQ( expected_loc[0], easting );
+  EXPECT_EQ( expected_loc[1], northing );
+  EXPECT_EQ( expected_crs, crs );
+}
+
+// ----------------------------------------------------------------------------
+INSTANTIATE_TEST_CASE_P(
+  ,
+  geo_polygon_roundtrip,
+  ::testing::Values(
+      ( roundtrip_test{ "ll", loc_ll, crs_ll } ),
+      ( roundtrip_test{ "utm", loc_utm, crs_utm_6s } ),
+      ( roundtrip_test{ "2", loc2_ll, crs_ll } ),
+      ( roundtrip_test{ "rt", loc2_ll, 12345 } )
+  ) );

--- a/vital/types/geo_point.cxx
+++ b/vital/types/geo_point.cxx
@@ -37,6 +37,7 @@
 #include "geodesy.h"
 
 #include <iomanip>
+#include <limits>
 #include <stdexcept>
 
 namespace kwiver {
@@ -136,7 +137,7 @@ operator<<( std::ostream& str, vital::geo_point const& obj )
     auto const old_prec = str.precision();
     auto const loc = obj.location();
 
-    str << std::setprecision(22)
+    str << std::setprecision( std::numeric_limits<double>::digits10 + 2 )
         << "[ " << loc[0]
         << ", " << loc[1]
         << ", " << loc[2]

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iomanip>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 
@@ -174,10 +175,12 @@ config_block_set_value_cast( geo_polygon const& value )
     []( double cur, vector_2d const& p ) {
       return std::max( { cur, std::fabs( p[0] ), std::fabs( p[1] ) } );
     });
-  auto const idigits =
+  auto const integer_digits =
     static_cast<int>( std::floor( std::log10( magnitude ) ) ) + 1;
+  auto const total_digits =
+    std::numeric_limits<double>::digits10 + 2;
 
-  str_result.precision( std::max( 0, 20 - idigits ) );
+  str_result.precision( std::max( 0, total_digits - integer_digits ) );
   str_result.setf( std::ios::fixed );
 
   // Write vertex coordinates
@@ -203,7 +206,8 @@ operator<<( std::ostream& str, vital::geo_polygon const& obj )
     auto const old_prec = str.precision();
     auto const verts = obj.polygon();
 
-    str << std::setprecision(22) << "{";
+    str.precision( std::numeric_limits<double>::digits10 + 2 );
+    str << "{";
     for ( size_t n = 0; n < verts.num_vertices(); ++n )
     {
       if ( n ) {


### PR DESCRIPTION
This PR changes the precision of decimal strings handled by the `geo_polygon` and `geo_point` classes. Previously, the precision was 22, which may print "garbage" values due to the inexactness of floating point arithmetic. The precision was changed to 17 to guarantee `double` round-trips, and tests were added.