### PR TITLE
Fix inconsistent python install paths

### DIFF
--- a/CMake/kwiver-setup-python.cmake
+++ b/CMake/kwiver-setup-python.cmake
@@ -51,6 +51,11 @@
 #      the value of `kwiver_python_subdir`.
 #      (e.g. build/lib/python2.7, build/lib/python3.5m)
 #
+#    kwiver_python_install_path
+#      The base location in the install tree where python files/modules are
+#      to be installed.
+#      (e.g. ${CMAKE_INSTALL_PREFIX}/lib/python3)
+#
 #    sprokit_python_output_path
 #      Similar to `kwiver_python_output_path`. Used by sprokit to define extra
 #      python output paths. This may be removed in the future.
@@ -146,11 +151,16 @@ include_directories(SYSTEM ${PYTHON_INCLUDE_DIR})
 #
 _pycmd(python_site_packages "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
 message(STATUS "python_site_packages = ${python_site_packages}")
+
 # Current usage determines most of the path in alternate ways.
 # All we need to supply is the '*-packages' directory name.
 # Customers could be converted to accept a larger part of the path from this function.
 get_filename_component(python_sitename ${python_site_packages} NAME)
 
+###
+# Python install path
+set(kwiver_python_install_path "${CMAKE_INSTALL_PREFIX}/${python_site_packages}")
+message(STATUS "kwiver_python_install_path = ${kwiver_python_install_path}")
 
 ###
 # Python major/minor version
@@ -233,6 +243,9 @@ PYTHON_CONFIG_STATUS
   * python_sitename = \"${python_sitename}\"
 
   * kwiver_python_subdir = \"${kwiver_python_subdir}\"
+  * kwiver_python_install_path = \"${kwiver_python_install_path}\"
   * kwiver_python_output_path = \"${kwiver_python_output_path}\"
   * sprokit_python_output_path = \"${sprokit_python_output_path}\"
 ")
+
+message(STATUS "${PYTHON_CONFIG_STATUS}")

--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -123,16 +123,11 @@ function (kwiver_add_python_module path     modpath    module)
   if (WIN32)
     if (python_noarch)
       return ()
-    else ()
-      set(python_install_path lib)
     endif ()
   else ()
     if (python_noarch)
       set(python_noarchdir /noarch)
-      set(python_install_path lib)
       set(python_arch u)
-    else ()
-      set(python_install_path "lib${LIB_SUFFIX}")
     endif ()
   endif ()
 
@@ -145,8 +140,6 @@ function (kwiver_add_python_module path     modpath    module)
 
   set(pyfile_src "${path}")
   set(pyfile_dst "${kwiver_python_output_path}${python_noarchdir}/${python_sitename}/${modpath}/${module}.py")
-  # installation path for this module
-  set(pypkg_install_path "${python_install_path}/${kwiver_python_subdir}/${python_sitename}/${modpath}")
 
   # copy and configure the source file into the binary directory
   if (KWIVER_SYMLINK_PYTHON)
@@ -164,7 +157,7 @@ function (kwiver_add_python_module path     modpath    module)
   # install the configured binary to the kwiver python install path
   kwiver_install(
     FILES       "${pyfile_dst}"
-    DESTINATION "${pypkg_install_path}"
+    DESTINATION "${kwiver_python_install_path}/${modpath}"
     COMPONENT   runtime)
 
   add_dependencies(python
@@ -231,9 +224,8 @@ function (kwiver_create_python_init    modpath)
   endif()
 
   # Installation __init__
-  set ( install_path "${CMAKE_INSTALL_PREFIX}/${python_site_packages}/${modpath}")
   kwiver_install(
     FILES       "${init_path}"
-    DESTINATION "${install_path}"
+    DESTINATION "${kwiver_python_install_path}/${modpath}"
     COMPONENT   runtime)
 endfunction ()

--- a/arrows/python/CMakeLists.txt
+++ b/arrows/python/CMakeLists.txt
@@ -1,13 +1,5 @@
 
-set(kwiver_python_subdir "python${PYTHON_VERSION}${PYTHON_ABIFLAGS}")
-set(kwiver_python_output_path "${KWIVER_BINARY_DIR}/lib/${kwiver_python_subdir}")
-
 kwiver_create_python_init(kwiver/arrows/python)
 kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/simple_image_detector.py
                         kwiver/arrows/python
                         simple_image_detector)
-
-
-
-
-

--- a/vital/algo/refine_detections.h
+++ b/vital/algo/refine_detections.h
@@ -48,7 +48,7 @@ namespace algo {
 
 // ----------------------------------------------------------------
 /**
- * @brief Image object detector base class/
+ * @brief Case class for refining detected object sets.
  *
  */
 class VITAL_ALGO_EXPORT refine_detections


### PR DESCRIPTION
There are two different ways of composing the python install path in the kwiver-utils-python.cmake  file and they are different. Usually this does not cause a problem, but sometimes it does. In any event, why are there two different ways of composing this path? One approach uses platform specific logic to determine components of the path, the other does not. If all this additional logic is needed, then it should be refactored so both places can benefit.

This change centralizes the install path creation. 