### PR TITLE
Downgrade message to Warning.

### DIFF
--- a/vital/logger/kwiver_logger_manager.cxx
+++ b/vital/logger/kwiver_logger_manager.cxx
@@ -130,7 +130,7 @@ kwiver_logger_manager
     // Only give error if the environment specified logger could not be found
     if ( ! try_default )
     {
-      std::cerr << "ERROR: Could not load logger factory \"" << factory_name
+      std::cerr << "WARNING: Could not load logger factory \"" << factory_name
                 << "\" as specified in environment variable \""
                 << PLUGIN_ENV_VAR "\"\n"
                 << "Defaulting to built-in logger.\n"


### PR DESCRIPTION
This message should be a warning since it can proceed with the default logger when the specified back end can not be loaded. The "ERROR" in the message would cause testing failures due to the testing framework looking for that keyword.