### PR TITLE
Partially revert FFMPEG timestamp rescaling changes.

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -286,12 +286,10 @@ public:
         return false;
     }
 
-    auto seek_timestamp = av_rescale_q( 0, av_get_time_base_q(),
-                                        this->f_video_stream->time_base );
     // Now seek back to the start of the video
     auto seek_rslt = av_seek_frame( this->f_format_context,
                                     this->f_video_index,
-                                    seek_timestamp,
+                                    0,
                                     AVSEEK_FLAG_BACKWARD );
     avcodec_flush_buffers( this->f_video_encoding );
     if (seek_rslt < 0 )
@@ -458,10 +456,8 @@ public:
     bool advance_successful = false;
     do
     {
-      auto rescaled_frame_ts = av_rescale_q( frame_ts, av_get_time_base_q(),
-                                          this->f_video_stream->time_base );
       auto seek_rslt = av_seek_frame( this->f_format_context,
-                                      this->f_video_index, rescaled_frame_ts,
+                                      this->f_video_index, frame_ts,
                                       AVSEEK_FLAG_BACKWARD );
       avcodec_flush_buffers( this->f_video_encoding );
 


### PR DESCRIPTION
Previous changes (branch #859) added scaling of timestamps before
seeking which appear to be incorrect and resulted in significant performance
degradation.  This commit reverts those changes, but keeps an unrelated
change that uses 0 rather than INT64_MIN as a seeking target to seek back to
the start of a video.

Revert "Don't use AV_TIME_BASE_Q"
This reverts commit 07a929effdfb9d80b595430bea03b766fdab18ec.

Revert "Dev/rescale timestamp (#859)"
This reverts commit 78568e03fa286d971743a7831363a1006dc2690e.