### PR TITLE
Add dep on config with vital-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,19 +224,6 @@ endif ()
 #---------------------------------------------------------------------
 #
 
-# Use Git (if available) to add Git hash info to the version header
-set(kwiver_configure_with_git on)
-kwiver_configure_file(version.h
-  "${CMAKE_CURRENT_SOURCE_DIR}/vital/version.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/vital/version.h"
-  KWIVER_VERSION_MAJOR
-  KWIVER_VERSION_MINOR
-  KWIVER_VERSION_PATCH
-  KWIVER_VERSION
-  KWIVER_SOURCE_DIR
-  )
-set(kwiver_configure_with_git)
-
 
 set( LIB_SUFFIX "" CACHE STRING
   "Library directory suffix. e.g. suffix=\"kwiver\" will install libraries in \"libkwiver\" rather than \"lib\"")
@@ -272,6 +259,22 @@ add_subdirectory( vital )
 
 # this is where the algorithm default configuration files live
 add_subdirectory(config)
+
+
+# Use Git (if available) to add Git hash info to the version header
+set(kwiver_configure_with_git on)
+kwiver_configure_file(version.h
+  "${CMAKE_CURRENT_SOURCE_DIR}/vital/version.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/vital/version.h"
+  KWIVER_VERSION_MAJOR
+  KWIVER_VERSION_MINOR
+  KWIVER_VERSION_PATCH
+  KWIVER_VERSION
+  KWIVER_SOURCE_DIR
+  )
+set(kwiver_configure_with_git)
+
+
 
 if(MSVC)
   # Generate files to inform msvc of the kwiver runtime environment

--- a/vital/config/CMakeLists.txt
+++ b/vital/config/CMakeLists.txt
@@ -49,6 +49,8 @@ kwiver_add_library( vital_config
   ${CMAKE_CURRENT_BINARY_DIR}/vital_config_export.h
   )
 
+add_dependencies (vital_config kwiver_configure)
+
 target_link_libraries( vital_config
   PUBLIC               vital_exceptions
   PRIVATE              kwiversys


### PR DESCRIPTION
This PR fixes a sporadic failure in Visual Studio, where the vital_config library tries to build before the vital/version.h is configured and 'installed'. It sets a dependency on the vital_config to the kwiver_config custom target.