### PR TITLE
Dev/config debug

### DIFF
--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -69,7 +69,7 @@ namespace algo = kwiver::vital::algo;
 namespace kwiver {
 
 // (config-key, value-type, default-value, description )
-create_config_trait( error_mode, std::string, "fail",
+create_config_trait( error_mode, std::string, "abort",
                      "How to handle file not found errors. Options are 'abort' and 'skip'. "
                      "Specifying 'fail' will cause an exception to be thrown. "
                      "The 'pass' option will only log a warning and wait for the next file name." );
@@ -275,6 +275,7 @@ void image_file_reader_process
   declare_config_using_trait( error_mode );
   declare_config_using_trait( path );
   declare_config_using_trait( image_reader );
+  declare_config_using_trait( frame_time );
 }
 
 

--- a/sprokit/src/applets/pipeline_runner.cxx
+++ b/sprokit/src/applets/pipeline_runner.cxx
@@ -31,6 +31,7 @@
 #include "pipeline_runner.h"
 
 #include <vital/config/config_block.h>
+#include <vital/config/config_block_formatter.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
 #include <sprokit/pipeline/scheduler.h>
@@ -76,7 +77,10 @@ add_command_options()
       cxxopts::value<std::vector<std::string>>() )
     ( "I,include", "A directory to be added to configuration include path. Can occur multiple times.",
       cxxopts::value<std::vector<std::string>>()  )
-    ( "S,scheduler", "Scheduler type to use.", cxxopts::value<std::string>() );
+    ( "S,scheduler", "Scheduler type to use.", cxxopts::value<std::string>() )
+    ( "D,dump-config", "Dump final pipeline configuration. This is useful for "
+      "debugging config related problems." )
+    ;
 
     // positional parameters
   m_cmd_options->add_options()
@@ -152,12 +156,20 @@ run()
   // get handle to config block
   kwiver::vital::config_block_sptr const conf = builder.config();
 
+  // nice to dump config at this point
+  if ( cmd_args["dump-config"].as<bool>() )
+  {
+    ::kwiver::vital::config_block_formatter fmt( conf );
+    fmt.print( std::cout, "tree" );
+  }
+
   if (!pipe)
   {
     std::cerr << "Error: Unable to bake pipeline" << std::endl;
     return EXIT_FAILURE;
   }
 
+  // Get pipeline ready to run
   pipe->setup_pipeline();
 
   //

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.h
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.h
@@ -71,7 +71,6 @@ public:
   class config_info_t
   {
   public:
-
     config_info_t( const kwiver::vital::config_block_value_t&           val,
                    bool                                  ro,
                    bool                                  relative_path,
@@ -94,11 +93,9 @@ public:
   process_decls_t m_processes;
   process::connections_t m_connections;
 
-
   // Static methods
   static kwiver::vital::config_block_key_t flatten_keys(kwiver::vital::config_block_keys_t const& keys);
   static kwiver::vital::config_block_sptr extract_configuration_from_decls( bakery_base::config_decls_t& configs );
-
 
   // static data
   static config_flag_t const flag_read_only;
@@ -111,7 +108,6 @@ protected:
                               config_value_t const&                     value );
 
 private:
-
   // macro provider
   std::shared_ptr< kwiver::vital::token_expander > m_token_expander;
   kwiver::vital::token_type_symtab* m_symtab;

--- a/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
+++ b/sprokit/src/sprokit/pipeline_util/pipeline_builder.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2018 by Kitware, Inc.
+ * Copyright 2011-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -166,6 +166,7 @@ void
 pipeline_builder
 ::add_setting( std::string const& setting )
 {
+  static auto command_line_src = std::make_shared< std::string >( "Command Line" );
   size_t const split_pos = setting.find(split_str);
 
   if (split_pos == std::string::npos)
@@ -194,13 +195,15 @@ pipeline_builder
   sprokit::config_value_t value;
   value.key_path.push_back(keys.back());
   value.value = setting_value;
-
+  value.loc = ::kwiver::vital::source_location( command_line_src, 1 );
   keys.pop_back();
 
   sprokit::config_pipe_block block;
   block.key = keys;
   block.values.push_back(value);
+  block.loc = ::kwiver::vital::source_location( command_line_src, 1 );
 
+  // Add to pipe blocks
   m_blocks.push_back(block);
 }
 

--- a/vital/config/format_config_block_plugin.cxx
+++ b/vital/config/format_config_block_plugin.cxx
@@ -241,7 +241,6 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_ORGANIZATION, "Kitware Inc." )
     ;
 
-
   fact = vpm.ADD_FACTORY( kwiver::vital::format_config_block, kwiver::vital::format_config_block_tree );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "tree")
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name )


### PR DESCRIPTION
Upgraded the handling of config parameters that are supplied with the kwiver runner command by the --settings parameter. The origin of these values is specified as being from the command line. 

Added a new parameter to the kwiver runner applet to display the final resolved configuration to the pipeline as a aid to diagnosing configuration related problems.

Fixed configuration related problem in file_image_reader_process where parameters were not handled correctly.