### PR TITLE
Remove warnings

### DIFF
--- a/arrows/ceres/optimize_cameras.cxx
+++ b/arrows/ceres/optimize_cameras.cxx
@@ -302,8 +302,7 @@ optimize_cameras
   }
 
   // add costs for priors
-  int num_position_priors_applied =
-    d_->add_position_prior_cost(problem, camera_params, constraints);
+  d_->add_position_prior_cost(problem, camera_params, constraints);
 
   d_->add_intrinsic_priors_cost(problem, camera_intr_params);
 

--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@
 // kwiver includes
 #include <vital/util/cpu_timer.h>
 #include <vital/config/config_block_formatter.h>
+#include <vital/types/detected_object_set_util.h>
 
 #include <arrows/ocv/image_container.h>
 #include <kwiversys/SystemTools.hxx>
@@ -311,7 +312,7 @@ detect( vital::image_container_sptr image_data ) const
     detections = d->process_image( cv_resized_image );
 
     // rescales output detections if required
-    detections->scale( 1.0 / scale_factor );
+    scale_detections( detections, 1.0 / scale_factor );
   }
   else
   {
@@ -334,9 +335,9 @@ detect( vital::image_container_sptr image_data ) const
 
         vital::detected_object_set_sptr new_dets = d->process_image( scaled_crop );
 
-        new_dets->scale( 1.0 / scaled_crop_scale );
-        new_dets->shift( li, lj );
-        new_dets->scale( 1.0 / scale_factor );
+        scale_detections( new_dets, 1.0 / scaled_crop_scale );
+        shift_detections( new_dets, li, lj );
+        scale_detections( new_dets, 1.0 / scale_factor );
 
         detections->add( new_dets );
       }
@@ -352,7 +353,7 @@ detect( vital::image_container_sptr image_data ) const
 
       vital::detected_object_set_sptr new_dets = d->process_image( scaled_original );
 
-      new_dets->scale( 1.0 / scaled_original_scale );
+      scale_detections( new_dets, 1.0 / scaled_original_scale );
 
       detections->add( new_dets );
     }

--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #include "darknet_custom_resize.h"
 
 #include <vital/util/cpu_timer.h>
+#include <vital/types/detected_object_set_util.h>
 
 #include <arrows/ocv/image_container.h>
 #include <kwiversys/SystemTools.hxx>
@@ -355,7 +356,7 @@ format_images( std::string folder, std::string prefix,
     {
       resized_scale = format_image( original_image, resized_image,
         m_resize_option, m_scale, m_resize_i, m_resize_j );
-      scaled_detections_ptr->scale( resized_scale );
+      scale_detections( scaled_detections_ptr, resized_scale );
     }
     else
     {
@@ -429,7 +430,7 @@ format_images( std::string folder, std::string prefix,
           scaled_original, m_resize_i, m_resize_j );
 
         kwiver::vital::detected_object_set_sptr scaled_original_dets_ptr = groundtruth[fid]->clone();
-        scaled_original_dets_ptr->scale( scaled_original_scale );
+        scale_detections( scaled_original_dets_ptr, scaled_original_scale );
 
         std::string img_file, gt_file;
         generate_fn( image_folder, label_folder, img_file, gt_file );


### PR DESCRIPTION
Delete unused variables, replace deprecated methods
with utility functions for scaling detection sets.