### PR TITLE
Transfer bbox with depth map -- OpenCV quickfix

### DIFF
--- a/arrows/core/tests/test_transfer_bbox_with_depth_map.cxx
+++ b/arrows/core/tests/test_transfer_bbox_with_depth_map.cxx
@@ -34,9 +34,6 @@
 
 #include <arrows/core/transfer_bbox_with_depth_map.h>
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-
 using namespace kwiver::vital;
 
 path_t g_data_dir;


### PR DESCRIPTION
This PR removes the extraneous OpenCV dependency in the tests for `transfer_bbox_with_depth_map` in the Core arrow.  This issue was raised in the now merged PR: #958.

(PS. I haven't been able to replicate the build failure prior to changes requested here, though I'm building inside of a Docker which is sitting on top of the latest Fletch build, which I believe comes with OpenCV)

@mwoehlke-kitware could you at least confirm that the lines removed here are consistent with the changes you needed to make locally to build successfully?  Thanks in advance.