### PR TITLE
FFMPEG fast frame count

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -638,7 +638,6 @@ public:
       // Add metadata for current frame
       if ( frame_advanced )
       {
-        number_of_frames++;
         this->metadata_map.insert(
           std::make_pair( this->frame_number(), this->current_metadata() ) );
       }
@@ -646,7 +645,6 @@ public:
       // Advance video stream to end
       while ( this->advance() )
       {
-        number_of_frames++;
         this->metadata_map.insert(
           std::make_pair( this->frame_number(), this->current_metadata() ) );
       }
@@ -659,7 +657,6 @@ public:
       unsigned int frame_num = 0;
       while ( frame_num < initial_frame_number && this->advance() )
       {
-        number_of_frames++;
         ++frame_num;
         this->metadata_map.insert(
           std::make_pair( this->frame_number(), this->current_metadata() ) );
@@ -682,7 +679,7 @@ public:
       VITAL_THROW(vital::file_not_read_exception, video_path, "Video not open");
     }
 
-    if (!estimated_num_frames && !collected_all_metadata)
+    if ( !estimated_num_frames )
     {
       std::lock_guard< std::mutex > lock(open_mutex);
 

--- a/doc/release-notes/1.5.0.txt
+++ b/doc/release-notes/1.5.0.txt
@@ -207,6 +207,11 @@ Arrows: CUDA
  * CUDA depth map integration now uses optional weight maps to down-weight
    the contribution of some rays.
 
+Arrows: FFMPEG
+
+ * Optimized the num_frames() call to produce a count of the number of frames
+   in constant time without scanning the entire video and counting all frames.
+
 Arrows: Serialization
 
  * Updated serialization algorithms to use PLUGIN_INFO macro and added


### PR DESCRIPTION
This is one last feature I'd like to get into KWIVER before the next release.  This change allows FFMPEG to provide an accurate frame count quickly (in constant time) without scanning the whole video.  Since we are now trusting the accuracy of seeking we can seek to the last key frame and advance to the end to find the last valid frame.  There are existing tests that compare the output of `num_frames()` to a count of frames by stepping through all frames.  These tests continue to pass.  I've also validated that the frame counts are accurate on several real videos.

This change allows us to open very large videos in TeleSculptor in seconds without waiting minutes or hours to scan the whole video. 