### PR TITLE
Improve code style in video_input_image_list

### DIFF
--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -1,5 +1,5 @@
-/*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+/*ckwg +30
+ * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -12,9 +12,9 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -23,182 +23,193 @@
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
  */
 
 #include "video_input_image_list.h"
 
-#include <vital/vital_types.h>
-#include <vital/types/timestamp.h>
-#include <vital/types/image_container.h>
-#include <vital/types/image.h>
-#include <vital/types/metadata_traits.h>
 #include <vital/algo/image_io.h>
-#include <vital/exceptions.h>
+
 #include <vital/util/data_stream_reader.h>
 #include <vital/util/tokenize.h>
+
+#include <vital/types/image.h>
+#include <vital/types/image_container.h>
+#include <vital/types/metadata_traits.h>
+#include <vital/types/timestamp.h>
+
+#include <vital/exceptions.h>
+#include <vital/vital_types.h>
+
+#include <vital/range/iota.h>
 
 #include <kwiversys/Directory.hxx>
 #include <kwiversys/SystemTools.hxx>
 
 #include <algorithm>
+#include <fstream>
 #include <string>
 #include <vector>
-#include <stdint.h>
-#include <fstream>
+
+#include <cstdint>
+
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+using ksst = kwiversys::SystemTools;
+
+using kv::algo::video_input;
+using kv::algo::image_io;
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
 
+// ----------------------------------------------------------------------------
 class video_input_image_list::priv
 {
 public:
   priv( video_input_image_list* parent )
-  : m_parent( parent )
-  , m_current_file( m_files.end() )
-  , m_frame_number( 0 )
-  , m_image( nullptr )
-  , m_have_metadata_map( false )
+    : m_parent{ parent },
+      m_current_file{ m_files.end() }
   {}
 
-  video_input_image_list* m_parent;
+  video_input_image_list* const m_parent;
 
   // Configuration values
   std::vector< std::string > c_search_path;
   std::vector< std::string > c_allowed_extensions;
 
-  // local state
-  std::vector < kwiver::vital::path_t > m_files;
-  std::vector < kwiver::vital::path_t >::const_iterator m_current_file;
-  kwiver::vital::frame_id_t m_frame_number;
-  kwiver::vital::image_container_sptr m_image;
+  // Local state
+  std::vector< kv::path_t > m_files;
+  std::vector< kv::path_t >::const_iterator m_current_file;
+  kv::frame_id_t m_frame_number = 0;
+  kv::image_container_sptr m_image;
 
-  // metadata map
-  bool m_have_metadata_map;
+  // Metadata map
+  bool m_have_metadata_map = false;
   vital::metadata_map::map_metadata_t m_metadata_map;
-  std::map< kwiver::vital::path_t, kwiver::vital::metadata_sptr > m_metadata_by_path;
+  std::map< kv::path_t, kv::metadata_sptr > m_metadata_by_path;
 
-  // processing classes
+  // Processing classes
   vital::algo::image_io_sptr m_image_reader;
 
   void read_from_file( std::string const& filename );
   void read_from_directory( std::string const& dirname );
   vital::metadata_sptr frame_metadata(
-    const kwiver::vital::path_t& file,
-    kwiver::vital::image_container_sptr image = nullptr );
+    kv::path_t const& file, kv::image_container_sptr image = nullptr );
 };
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 video_input_image_list
 ::video_input_image_list()
   : d( new video_input_image_list::priv( this ) )
 {
   attach_logger( "arrows.core.video_input_image_list" );
 
-  set_capability( vital::algo::video_input::HAS_EOV, true );
-  set_capability( vital::algo::video_input::HAS_FRAME_NUMBERS, true );
-  set_capability( vital::algo::video_input::HAS_FRAME_DATA, true );
-  set_capability( vital::algo::video_input::HAS_METADATA, true );
+  set_capability( video_input::HAS_EOV, true );
+  set_capability( video_input::HAS_FRAME_NUMBERS, true );
+  set_capability( video_input::HAS_FRAME_DATA, true );
+  set_capability( video_input::HAS_METADATA, true );
 
-  set_capability( vital::algo::video_input::HAS_FRAME_TIME, false );
-  set_capability( vital::algo::video_input::HAS_ABSOLUTE_FRAME_TIME, false );
-  set_capability( vital::algo::video_input::HAS_TIMEOUT, false );
-  set_capability( vital::algo::video_input::IS_SEEKABLE, true );
+  set_capability( video_input::HAS_FRAME_TIME, false );
+  set_capability( video_input::HAS_ABSOLUTE_FRAME_TIME, false );
+  set_capability( video_input::HAS_TIMEOUT, false );
+  set_capability( video_input::IS_SEEKABLE, true );
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 video_input_image_list
 ::~video_input_image_list()
 {
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 vital::config_block_sptr
 video_input_image_list
 ::get_configuration() const
 {
-  // get base config from base class
-  vital::config_block_sptr config = vital::algo::video_input::get_configuration();
+  // Get base configuration from base class
+  auto const& config = video_input::get_configuration();
 
-  config->set_value( "path", "",
-                     "Path to search for image file. "
-                     "If a file name is not absolute, this list of directories is scanned to find the file. "
-                     "The current directory '.' is automatically appended to the end of the path. "
-                     "The format of this path is the same as the standard "
-                     "path specification, a set of directories separated by a colon (':')" );
-  config->set_value( "allowed_extensions", "",
-                     "Semicolon-separated list of allowed file extensions. "
-                     "Leave empty to allow all file extensions." );
+  config->set_value(
+    "path", "",
+    "Path to search for image file. "
+    "If a file name is not absolute, this list of directories is scanned "
+    "to find the file. The current directory '.' is automatically appended "
+    "to the end of the path. "
+    "The format of this path is the same as the standard path specification, "
+    "a set of directories separated by a colon (':')" );
+  config->set_value(
+    "allowed_extensions", "",
+    "Semicolon-separated list of allowed file extensions. "
+    "Leave empty to allow all file extensions." );
 
-  vital::algo::image_io::
-    get_nested_algo_configuration( "image_reader", config, d->m_image_reader );
+  image_io::get_nested_algo_configuration(
+    "image_reader", config, d->m_image_reader );
 
   return config;
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void
 video_input_image_list
 ::set_configuration( vital::config_block_sptr in_config )
 {
-  vital::config_block_sptr config = this->get_configuration();
-  config->merge_config(in_config);
+  auto const& config = this->get_configuration();
+  config->merge_config( in_config );
 
   // Extract string and create vector of directories
-  std::string path = config->get_value<std::string>( "path", "" );
-  kwiver::vital::tokenize( path, d->c_search_path, ":", kwiver::vital::TokenizeTrimEmpty );
-  d->c_search_path.push_back( "." ); // add current directory
+  auto const& path = config->get_value< std::string >( "path", {} );
+  kv::tokenize( path, d->c_search_path, ":", kv::TokenizeTrimEmpty );
+  d->c_search_path.push_back( "." ); // Add current directory
 
   // Create vector of allowed file extensions
-  std::string extensions = config->get_value<std::string>( "allowed_extensions", "" );
-  kwiver::vital::tokenize( extensions, d->c_allowed_extensions, ";", kwiver::vital::TokenizeTrimEmpty );
+  auto const& extensions =
+    config->get_value< std::string >( "allowed_extensions", {} );
+  kv::tokenize( extensions, d->c_allowed_extensions, ";",
+                kv::TokenizeTrimEmpty );
 
   // Setup actual reader algorithm
-  vital::algo::image_io::
-    set_nested_algo_configuration( "image_reader", config, d->m_image_reader );
+  image_io::set_nested_algo_configuration(
+    "image_reader", config, d->m_image_reader );
 
   // Check capabilities of image reader
-  set_capability( vital::algo::video_input::HAS_FRAME_TIME,
-    d->m_image_reader->get_implementation_capabilities().capability(
-      vital::algo::image_io::HAS_TIME ) );
+  auto const& reader_capabilities =
+    d->m_image_reader->get_implementation_capabilities();
+  set_capability( HAS_FRAME_TIME,
+                  reader_capabilities.capability( image_io::HAS_TIME ) );
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
 ::check_configuration( vital::config_block_sptr config ) const
 {
   // Check the reader configuration.
-  return vital::algo::image_io::
-    check_nested_algo_configuration( "image_reader", config );
+  return image_io::check_nested_algo_configuration( "image_reader", config );
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void
 video_input_image_list
 ::open( std::string list_name )
 {
-  typedef kwiversys::SystemTools ST;
-
-  // close the video in case already open
+  // Close the video in case already open
   this->close();
 
-  if ( ! d->m_image_reader )
+  if ( !d->m_image_reader )
   {
-    VITAL_THROW( kwiver::vital::algorithm_configuration_exception, type_name(), impl_name(),
-          "invalid image_reader." );
+    VITAL_THROW( kv::algorithm_configuration_exception,
+                 type_name(), impl_name(), "invalid image_reader." );
   }
 
-  if( ST::FileIsDirectory( list_name ) )
+  if ( ksst::FileIsDirectory( list_name ) )
   {
     d->read_from_directory( list_name );
   }
@@ -211,8 +222,7 @@ video_input_image_list
   d->m_frame_number = 0;
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void
 video_input_image_list
 ::close()
@@ -223,8 +233,7 @@ video_input_image_list
   d->m_image = nullptr;
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
 ::end_of_video() const
@@ -232,16 +241,15 @@ video_input_image_list
   return ( d->m_current_file == d->m_files.end() );
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
 ::good() const
 {
-  return d->m_frame_number > 0 && ! this->end_of_video();
+  return d->m_frame_number > 0 && !this->end_of_video();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
 ::seekable() const
@@ -249,7 +257,7 @@ video_input_image_list
   return true;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 size_t
 video_input_image_list
 ::num_frames() const
@@ -257,25 +265,22 @@ video_input_image_list
   return d->m_files.size();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
-::next_frame( kwiver::vital::timestamp& ts,
-              uint32_t                  timeout )
+::next_frame( kv::timestamp& ts, uint32_t /*timeout*/ )
 {
-  // returns timestamp
-  // does not support timeout
   if ( this->end_of_video() )
   {
     return false;
   }
 
-  // clear the last loaded image
+  // Clear the last loaded image
   d->m_image = nullptr;
 
-  // If this is the first call to next_frame() then
-  // do not increment the file iteration.
-  // next_frame() must be called once before accessing the first frame.
+  // If this is the first call to next_frame(), do not increment
+  // the file iteration; next_frame() must be called once
+  // before accessing the first frame
   if ( d->m_frame_number > 0 )
   {
     ++d->m_current_file;
@@ -286,45 +291,46 @@ video_input_image_list
   // Return timestamp
   ts = this->frame_timestamp();
 
-  return ! this->end_of_video();
+  return !this->end_of_video();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 bool
 video_input_image_list
-::seek_frame( kwiver::vital::timestamp& ts,   // returns timestamp
-              kwiver::vital::timestamp::frame_t frame_number,
-              uint32_t                  timeout )
+::seek_frame( kv::timestamp& ts,
+              kv::timestamp::frame_t frame_number,
+              uint32_t /*timeout*/ )
 {
   // Check if requested frame exists
-  if (frame_number > static_cast<int>( d->m_files.size() ) || frame_number <= 0)
+  auto const max_frame_number =
+    static_cast< kv::timestamp::frame_t >( d->m_files.size() );
+  if ( frame_number > max_frame_number || frame_number <= 0 )
   {
     return false;
   }
 
   // Adjust frame number if this is the first call to seek_frame or next_frame
-  if (d->m_frame_number == 0)
+  if ( d->m_frame_number == 0 )
   {
     d->m_frame_number = 1;
   }
 
   // Calculate distance to new frame
-  kwiver::vital::timestamp::frame_t frame_diff =
-    frame_number - d->m_frame_number;
+  auto const frame_diff = frame_number - d->m_frame_number;
   d->m_current_file += frame_diff;
   d->m_frame_number = frame_number;
 
-  // clear the last loaded image
+  // Clear the last loaded image
   d->m_image = nullptr;
 
   // Return timestamp
   ts = this->frame_timestamp();
 
-  return ! this->end_of_video();
+  return !this->end_of_video();
 }
 
-// ------------------------------------------------------------------
-kwiver::vital::timestamp
+// ----------------------------------------------------------------------------
+kv::timestamp
 video_input_image_list
 ::frame_timestamp() const
 {
@@ -333,17 +339,18 @@ video_input_image_list
     return {};
   }
 
-  kwiver::vital::timestamp ts;
+  kv::timestamp ts;
 
   ts.set_frame( d->m_frame_number );
 
-  if ( d->m_image_reader->get_implementation_capabilities().capability(
-      kwiver::vital::algo::image_io::HAS_TIME ) )
+  auto const& reader_capabilities =
+    d->m_image_reader->get_implementation_capabilities();
+  if ( reader_capabilities.capability( image_io::HAS_TIME ) )
   {
-    auto md = d->frame_metadata( *d->m_current_file, d->m_image );
+    auto const& md = d->frame_metadata( *d->m_current_file, d->m_image );
     if ( md )
     {
-      auto mdts = md->timestamp();
+      auto const& mdts = md->timestamp();
       if ( mdts.has_valid_time() )
       {
         ts.set_time_usec( mdts.get_time_usec() );
@@ -354,169 +361,164 @@ video_input_image_list
   return ts;
 }
 
-
-// ------------------------------------------------------------------
-kwiver::vital::image_container_sptr
+// ----------------------------------------------------------------------------
+kv::image_container_sptr
 video_input_image_list
 ::frame_image()
 {
   if ( !d->m_image && this->good() )
   {
-    LOG_DEBUG( logger(), "reading image from file \"" << *d->m_current_file << "\"" );
+    LOG_DEBUG( logger(),
+               "reading image from file \"" << *d->m_current_file << "\"" );
 
-    // read image file
+    // Read image file
     //
-    // This call returns a *new* image container. This is good since
-    // we are going to pass it downstream using the sptr.
+    // This call returns a *new* image container; this is good since
+    // we are going to pass it downstream using the sptr
     d->m_image = d->m_image_reader->load( *d->m_current_file );
   }
   return d->m_image;
 }
 
-
-// ------------------------------------------------------------------
-kwiver::vital::metadata_vector
+// ----------------------------------------------------------------------------
+kv::metadata_vector
 video_input_image_list
 ::frame_metadata()
 {
-  if ( ! this->good() )
+  if ( !this->good() )
   {
-    return vital::metadata_vector();
+    return {};
   }
-  auto md = d->frame_metadata( *d->m_current_file, d->m_image );
-  vital::metadata_vector mdv(1, md);
-  return mdv;
+
+  return { 1, d->frame_metadata( *d->m_current_file, d->m_image ) };
 }
 
-
-// ------------------------------------------------------------------
-kwiver::vital::metadata_map_sptr
+// ----------------------------------------------------------------------------
+kv::metadata_map_sptr
 video_input_image_list
 ::metadata_map()
 {
   if ( !d->m_have_metadata_map )
   {
-    kwiver::vital::timestamp::frame_t fn = 0;
-    for (const auto& f: d->m_files)
+    auto fn = kv::timestamp::frame_t{ 0 };
+    for ( auto const& f : d->m_files )
     {
-      ++fn;
-      auto md = d->frame_metadata( f );
-      vital::metadata_vector mdv(1, md);
-      d->m_metadata_map[fn] = mdv;
+      auto mdv = vital::metadata_vector{ 1, d->frame_metadata( f ) };
+      d->m_metadata_map.emplace( ++fn, std::move( mdv ) );
     }
 
     d->m_have_metadata_map = true;
   }
 
-  return std::make_shared<kwiver::vital::simple_metadata_map>(d->m_metadata_map);
+  return std::make_shared< kv::simple_metadata_map >( d->m_metadata_map );
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void
 video_input_image_list::priv
 ::read_from_file( std::string const& filename )
 {
-  typedef kwiversys::SystemTools ST;
-
-  // open file and read lines
+  // Open file and read lines
   std::ifstream ifs( filename.c_str() );
-  if ( ! ifs )
+  if ( !ifs )
   {
-    VITAL_THROW( kwiver::vital::invalid_file, filename, "Could not open file" );
+    VITAL_THROW( kv::invalid_file, filename, "Could not open file" );
   }
 
   // Add directory that contains the list file to the path
-  std::string list_path = ST::GetFilenamePath( filename );
-  if ( ! list_path.empty() )
+  auto const& list_path = ksst::GetFilenamePath( filename );
+  if ( !list_path.empty() )
   {
     this->c_search_path.push_back( list_path );
   }
 
-  kwiver::vital::data_stream_reader stream_reader( ifs );
+  kv::data_stream_reader stream_reader( ifs );
 
-  // verify and get file names in a list
-  std::string data_dir = "";
-  std::string line;
+  // Verify and get file names in a list
+  auto data_dir = std::string{};
+  auto line = std::string{};
+
   // Read the first line and determine to file location
   if ( stream_reader.getline( line ) )
   {
-    std::string resolved_file = line;
-    if ( ! ST::FileExists( resolved_file ) )
+    auto resolved_file = line;
+    if ( !ksst::FileExists( resolved_file ) )
     {
       // Resolve against specified path
-      resolved_file = ST::FindFile( line, this->c_search_path, true );
+      resolved_file = ksst::FindFile( line, this->c_search_path, true );
       if ( resolved_file.empty() )
       {
-        VITAL_THROW( kwiver::vital::
-          file_not_found_exception, line, "could not locate file in path" );
+        VITAL_THROW( kv:: file_not_found_exception, line,
+                     "could not locate file in path" );
       }
-      if( ST::StringEndsWith( resolved_file.c_str(), line.c_str() ) )
+      if ( ksst::StringEndsWith( resolved_file.c_str(), line.c_str() ) )
       {
         // extract the prefix added to get the full path
-        data_dir = resolved_file.substr(0, resolved_file.size() - line.size() );
+        data_dir =
+          resolved_file.substr( 0, resolved_file.size() - line.size() );
       }
     }
     this->m_files.push_back( resolved_file );
   }
+
   // Read the rest of the file and validate paths
   // Only check the same data_dir used to resolve the first frame
   while ( stream_reader.getline( line ) )
   {
-    std::string resolved_file = line;
-    if ( ! ST::FileExists( resolved_file ) )
+    auto resolved_file = line;
+    if ( !ksst::FileExists( resolved_file ) )
     {
       resolved_file = data_dir + line;
-      if ( ! ST::FileExists( resolved_file ) )
+      if ( !ksst::FileExists( resolved_file ) )
       {
-        VITAL_THROW( kwiver::vital::
-          file_not_found_exception, line,
-              "could not locate file relative to \"" + data_dir + "\"" );
+        VITAL_THROW( kv::file_not_found_exception, line,
+                     "could not locate file relative to \"" +
+                     data_dir + "\"" );
       }
     }
 
     this->m_files.push_back( resolved_file );
-  } // end while
+  }
 }
 
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void
 video_input_image_list::priv
 ::read_from_directory( std::string const& dirname )
 {
-  typedef kwiversys::SystemTools ST;
-
   // Open the directory and read the entries
   kwiversys::Directory directory;
-  if( ! directory.Load( dirname ) )
+  if ( !directory.Load( dirname ) )
   {
-    VITAL_THROW( kwiver::vital::invalid_file, dirname, "Could not open directory" );
+    VITAL_THROW( kv::invalid_file, dirname,
+                 "Could not open directory" );
   }
 
   // Read each entry
-  for( unsigned long i = 0; i < directory.GetNumberOfFiles(); i++ )
+  for ( auto const i : kvr::iota( directory.GetNumberOfFiles() ) )
   {
-    std::string filename = directory.GetFile( i );
-    std::string resolved_file = dirname + "/" + filename;
-    if( ! ST::FileExists( resolved_file ) )
+    auto const filename = std::string{ directory.GetFile( i ) };
+    auto const& resolved_file = dirname + "/" + filename;
+
+    if ( !ksst::FileExists( resolved_file ) )
     {
-      VITAL_THROW( kwiver::vital::
-        file_not_found_exception, filename, "could not locate file in path" );
+      VITAL_THROW( kv::file_not_found_exception, filename,
+                   "could not locate file in path" );
     }
-    if( ! ST::FileIsDirectory( resolved_file ) )
+    if ( !ksst::FileIsDirectory( resolved_file ) )
     {
-      if( this->c_allowed_extensions.empty() )
+      if ( this->c_allowed_extensions.empty() )
       {
         this->m_files.push_back( resolved_file );
       }
       else
       {
-        for( auto const& extension: this->c_allowed_extensions )
+        for ( auto const& extension : this->c_allowed_extensions )
         {
-          std::string resolved_lower = ST::LowerCase( resolved_file );
-          std::string extension_lower = ST::LowerCase( extension );
-          if( ST::StringEndsWith( resolved_lower, extension_lower.c_str() ) )
+          std::string resolved_lower = ksst::LowerCase( resolved_file );
+          std::string extension_lower = ksst::LowerCase( extension );
+          if ( ksst::StringEndsWith( resolved_lower,
+                                     extension_lower.c_str() ) )
           {
             this->m_files.push_back( resolved_file );
             break;
@@ -530,12 +532,11 @@ video_input_image_list::priv
   std::sort( this->m_files.begin(), this->m_files.end() );
 }
 
-
-// ------------------------------------------------------------------
-kwiver::vital::metadata_sptr
+// ----------------------------------------------------------------------------
+kv::metadata_sptr
 video_input_image_list::priv
-::frame_metadata( const kwiver::vital::path_t& file,
-                  kwiver::vital::image_container_sptr image )
+::frame_metadata( kv::path_t const& file,
+                  kv::image_container_sptr image )
 {
   auto it = m_metadata_by_path.find( file );
   if ( it != m_metadata_by_path.end() )
@@ -543,24 +544,28 @@ video_input_image_list::priv
     return it->second;
   }
 
-  kwiver::vital::metadata_sptr md;
+  kv::metadata_sptr md;
   if ( image )
   {
     md = image->get_metadata();
   }
-  if ( ! md )
+  if ( !md )
   {
     md = m_image_reader->load_metadata( file );
   }
-  if ( ! md )
+  if ( !md )
   {
-    md = std::make_shared<kwiver::vital::metadata>();
+    md = std::make_shared< kv::metadata >();
   }
 
   md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI, file ) );
 
-  m_metadata_by_path[file] = md;
+  m_metadata_by_path[ file ] = md;
   return md;
 }
 
-} } }     // end namespace
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/video_input_image_list.h
+++ b/arrows/core/video_input_image_list.h
@@ -1,4 +1,4 @@
-/*ckwg +29
+/*ckwg +30
  * Copyright 2017-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
@@ -12,9 +12,9 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -23,9 +23,10 @@
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
  */
 
 #ifndef ARROWS_CORE_VIDEO_INPUT_IMAGE_LIST_H
@@ -36,15 +37,18 @@
 #include <arrows/core/kwiver_algo_core_export.h>
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
 
-/// Video input using list of images.
-// ----------------------------------------------------------------
+// ----------------------------------------------------------------------------
 /**
- * This class implements a video input algorithm using a list of
- * images to simulate a video. Only the images are returned. This
- * algorithm produces no metadata.
+ * \brief Video input using list of images.
+ *
+ * This class implements a video input algorithm using a list of images
+ * to simulate a video. Only the images are returned.
+ * This algorithm produces no metadata.
  *
  * Example config:
  *   # select reader type
@@ -61,53 +65,65 @@ public:
                " in the \"image_reader\" config block."
                " Read an image list as a video stream." )
 
-  /// Constructor
   video_input_image_list();
   virtual ~video_input_image_list();
 
-  /// Get this algorithm's \link vital::config_block configuration block \endlink
-  virtual vital::config_block_sptr get_configuration() const;
-
-  /// Set this algorithm's properties via a config block
-  virtual void set_configuration(vital::config_block_sptr config);
-
-  /// Check that the algorithm's currently configuration is valid
-  virtual bool check_configuration(vital::config_block_sptr config) const;
+  /**
+   * \brief Get this algorithm's
+   * \link vital::config_block configuration block \endlink.
+   */
+  vital::config_block_sptr get_configuration() const override;
 
   /**
-   * @brief Open a list of images.
+   * \brief Set this algorithm's properties via a
+   * \link vital::config_block configuration block \endlink.
+   */
+  void set_configuration( vital::config_block_sptr config ) override;
+
+  /// Check that the algorithm's currently configuration is valid.
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  /**
+   * \brief Open a list of images.
    *
    * This method opens the file that contains the list of images. Each
    * image verified to exist at this time.
    *
-   * @param list_name Name of file that contains list of images.
+   * \param list_name Name of file that contains list of images.
    */
-  virtual void open( std::string list_name );
-  virtual void close();
+  void open( std::string list_name ) override;
+  void close() override;
 
-  virtual bool end_of_video() const;
-  virtual bool good() const;
-  virtual bool seekable() const;
-  virtual size_t num_frames() const;
+  bool end_of_video() const override;
+  bool good() const override;
+  bool seekable() const override;
+  size_t num_frames() const override;
 
-  virtual bool next_frame( kwiver::vital::timestamp& ts,
-                           uint32_t timeout = 0 );
+  bool next_frame( kwiver::vital::timestamp& ts,
+                   uint32_t timeout = 0 ) override;
 
-  virtual bool seek_frame( kwiver::vital::timestamp& ts,
-                           kwiver::vital::timestamp::frame_t frame_number,
-                           uint32_t timeout = 0 );
+  bool seek_frame( kwiver::vital::timestamp& ts,
+                   kwiver::vital::timestamp::frame_t frame_number,
+                   uint32_t timeout = 0 ) override;
 
-  virtual kwiver::vital::timestamp frame_timestamp() const;
-  virtual kwiver::vital::image_container_sptr frame_image();
-  virtual kwiver::vital::metadata_vector frame_metadata();
-  virtual kwiver::vital::metadata_map_sptr metadata_map();
+  kwiver::vital::timestamp frame_timestamp() const override;
+  kwiver::vital::image_container_sptr frame_image() override;
+  kwiver::vital::metadata_vector frame_metadata() override;
+  kwiver::vital::metadata_map_sptr metadata_map() override;
 
 private:
-  /// private implementation class
+  /**
+   * \brief Private implementation class.
+   */
   class priv;
-  const std::unique_ptr<priv> d;
+
+  std::unique_ptr< priv > const d;
 };
 
-} } } // end namespace
+} // namespace core
 
-#endif // ARROWS_CORE_VIDEO_INPUT_IMAGE_LIST_H
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Aggressively reformat the code of `video_input_image_list` to conform with our "official" style, and to improve overall consistency. This should not produce any API changes, although some places (building the initial metadata map, in particular) have been tweaked slightly to improve performance (mostly by avoiding unnecessary copies and temporaries).

This is a first step at rectifying #959 and #1007, both of which include varying amounts of similar cleanup. The goal is to do all possibly cleanup first, in a separate PR for ease of review, so that PR replacing or superseding #959/#1007 can have only functional changes (again, for ease of review).