### PR TITLE
ugrade pillow to 6.2.2

### DIFF
--- a/vital/bindings/python/requirements.txt
+++ b/vital/bindings/python/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.13.0
-pillow==6.2.0
+pillow==6.2.2
 six==1.10.0
 
 # For Testing


### PR DESCRIPTION
This PR resolves the Dependabot vulnerability warnings below:

<img width="758" alt="Screen Shot 2020-06-09 at 8 58 27 AM" src="https://user-images.githubusercontent.com/19600828/84150102-643b1580-aa2f-11ea-900b-dc2b114c1426.png">
