### PR TITLE
Add callbacks for detected_object_type type names

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -72,12 +72,14 @@ set( vital_public_headers
   algorithm_capabilities.h
   any.h
   attribute_set.h
+  context.h
   exceptions.h
   iterator.h
   math_constants.h
   noncopyable.h
   optional.h
   set.h
+  signal.h
 
   io/camera_from_metadata.h
   io/camera_io.h
@@ -159,6 +161,7 @@ set( vital_public_headers
 set( vital_sources
   algorithm_capabilities.cxx
   attribute_set.cxx
+  context.cxx
 
   io/camera_from_metadata.cxx
   io/camera_io.cxx

--- a/vital/context.cxx
+++ b/vital/context.cxx
@@ -1,0 +1,105 @@
+/*ckwg +30
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <vital/context.h>
+#include <vital/signal.h>
+
+#include <thread>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+context
+::context()
+{
+}
+
+// ----------------------------------------------------------------------------
+context::~context()
+{
+  // Disconnect from all connected signals
+  std::unique_lock< std::mutex > lock{ this->m_mutex };
+  while ( !this->m_connections.empty() )
+  {
+    auto failed = false;
+    auto iter = this->m_connections.begin();
+    while ( iter != this->m_connections.end() )
+    {
+      // Attempt to disconnect; if the signal is being emitted or destroyed, we
+      // will not be able to get the mutex, so skip it and try again after
+      // dropping our own lock to allow the signal to finish what it's doing
+      auto* const connection = *iter;
+      std::unique_lock< std::mutex > connection_lock{
+        connection->m_mutex, std::try_to_lock };
+      if ( connection_lock.owns_lock() )
+      {
+        connection->disconnect( this );
+        iter = this->m_connections.erase( iter );
+      }
+      else
+      {
+        failed = true;
+        ++iter;
+      }
+    }
+    if ( failed )
+    {
+      // Need to back off our lock to let a connected signal do something
+      lock.unlock();
+      std::this_thread::yield();
+      lock.lock();
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+context
+::connect( signal_base* signal )
+{
+  std::lock_guard< std::mutex > lock{ this->m_mutex };
+  this->m_connections.emplace( signal );
+}
+
+// ----------------------------------------------------------------------------
+void
+context
+::disconnect( signal_base* signal )
+{
+  std::lock_guard< std::mutex > lock{ this->m_mutex };
+  this->m_connections.erase( signal );
+}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/context.h
+++ b/vital/context.h
@@ -1,0 +1,87 @@
+/*ckwg +30
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for context class
+ */
+
+#ifndef VITAL_CONTEXT_H_
+#define VITAL_CONTEXT_H_
+
+#include <vital/vital_export.h>
+
+#include <memory>
+#include <mutex>
+#include <unordered_set>
+
+namespace kwiver {
+
+namespace vital {
+
+class signal_base;
+
+template < typename... Args > class signal;
+
+// ----------------------------------------------------------------------------
+/**
+ * \brief Slot execution context.
+ *
+ * This class represents a context for a slot connected to a ::signal. The
+ * context is used to manage resources that may be required by slots. When the
+ * context is destroyed, any connections associated with the context will be
+ * disconnected.
+ *
+ * \warning
+ * Destroying a context from within a connected slot is a logic error and will
+ * likely cause the program to deadlock or exhibit undefined behavior.
+ */
+class VITAL_EXPORT context
+{
+public:
+  context();
+  ~context();
+
+private:
+  template < typename... Args > friend class signal;
+
+  void connect( signal_base* signal );
+  void disconnect( signal_base* signal );
+
+  std::mutex m_mutex;
+  std::unordered_set< signal_base* > m_connections;
+};
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/vital/signal.h
+++ b/vital/signal.h
@@ -1,0 +1,166 @@
+/*ckwg +30
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief Interface for signal class
+ */
+
+#ifndef VITAL_SIGNAL_H_
+#define VITAL_SIGNAL_H_
+
+#include <vital/context.h>
+
+#include <functional>
+#include <unordered_map>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/**
+ * \brief Base class for ::signal.
+ *
+ * This class encapsulates some functionality used by ::signal which must not
+ * be templated. This class is an implemenation detail and should not be used
+ * directly.
+ */
+class signal_base
+{
+protected:
+  friend class context;
+
+  inline signal_base() = default;
+  inline ~signal_base() = default;
+
+  signal_base( signal_base const& ) = delete;
+  signal_base& operator=( signal_base const& ) = delete;
+
+  virtual void disconnect( context* ctx ) = 0;
+
+  std::mutex m_mutex;
+};
+
+// ----------------------------------------------------------------------------
+/**
+ * \brief Encapsulation class for an event signal.
+ *
+ * This class represents a signal which may be emitted when an event occurs.
+ * Signals provide a mechanism by which interested listeners may connect to
+ * the signal in order to receive notification of the event. Because connected
+ * slots are executed synchronously, it is generally recommended such slots
+ * execute as quickly as possible.
+ *
+ * The thread on which connected slots will be invoked is specified by the
+ * logic which emits the signal, and in general should be considered as
+ * unspecified. The order in which connected slots are executed is also
+ * unspecified and may change between program executions or when the set of
+ * connected slots changes.
+ *
+ * Concurrent emission of a signal from multiple threads is not currently
+ * supported.
+ *
+ * Currently, slots must have an associated ::context. This is used to ensure
+ * that the slot is not executed after its required resources are destroyed.
+ * Users should ensure that the associated ::context is destroyed before any
+ * resources required by the slot are destroyed.
+ */
+template < typename... Args >
+class signal : protected signal_base
+{
+public:
+  using slot_t = std::function< void ( Args... ) >;
+
+  signal() = default;
+  ~signal()
+  {
+    std::lock_guard< std::mutex > lock{ this->m_mutex };
+    for ( auto const& iter : m_slots )
+    {
+      iter.first->disconnect( this );
+    }
+  }
+
+  /**
+   * \brief Emit the signal.
+   *
+   * This method triggers emission of this signal. The supplied arguments are
+   * passed to any connected slots.
+   */
+  void
+  operator()( Args... args )
+  {
+    std::lock_guard< std::mutex > lock{ this->m_mutex };
+    for ( auto const& iter : m_slots )
+    {
+      iter.second( args... );
+    }
+  }
+
+  /**
+   * \brief Connect a slot to this signal.
+   *
+   * This method connects the specified \p slot, which is owned by the
+   * specified ::context \p ctx, to this signal. The slot will be called when
+   * the signal is emitted, and will be disconnected when its associated
+   * context is destroyed.
+   *
+   * \warning
+   * Destruction of the ::context during the execution of this method will
+   * result in undefined behavior and may cause the program to deadlock or
+   * crash.
+   */
+  void
+  connect( context* ctx, slot_t&& slot )
+  {
+    std::lock_guard< std::mutex > lock{ this->m_mutex };
+    this->m_slots.emplace( ctx, std::move( slot ) );
+    ctx->connect( this );
+  }
+
+protected:
+  void
+  disconnect( context* ctx ) final
+  {
+    // WARNING: This must be called with m_mutex already locked
+    m_slots.erase( ctx );
+  }
+
+private:
+  std::unordered_map< context*, slot_t > m_slots;
+};
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ kwiver_discover_gtests(vital local_cartesian                LIBRARIES ${test_lib
 kwiver_discover_gtests(vital metadata_io                    LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vital polygon                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital rotation                       LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital signal                         LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital similarity                     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital timestamp                      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital track                          LIBRARIES ${test_libraries})

--- a/vital/tests/test_signal.cxx
+++ b/vital/tests/test_signal.cxx
@@ -1,0 +1,174 @@
+/*ckwg +30
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/**
+ * \file
+ * \brief core signal/context tests
+ */
+
+#include <vital/signal.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <thread>
+
+namespace kv = kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char* argv[] )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(signal, basic)
+{
+  kv::signal< int > signal;
+  kv::context ctx;
+
+  auto result = int{ 0 };
+
+  signal.connect( &ctx, [ & ]( int value ){ result = value; } );
+
+  signal( 42 );
+  EXPECT_EQ( 42, result );
+
+  signal( 17 );
+  EXPECT_EQ( 17, result );
+}
+
+// ----------------------------------------------------------------------------
+TEST(signal, multiple_slots)
+{
+  kv::signal< int > signal;
+
+  auto result1 = int{ 0 };
+  auto result2 = int{ 0 };
+  auto result3 = int{ 1 };
+
+  auto ctx1 = std::unique_ptr< kv::context >{ new kv::context };
+  signal.connect( ctx1.get(), [ & ]( int value ){ result1 = value; } );
+
+  auto ctx2 = std::unique_ptr< kv::context >{ new kv::context };
+  signal.connect( ctx2.get(), [ & ]( int value ){ result2 += value; } );
+
+  auto ctx3 = std::unique_ptr< kv::context >{ new kv::context };
+  signal.connect( ctx3.get(), [ & ]( int value ){ result3 *= value; } );
+
+  signal( 42 );
+  EXPECT_EQ( 42, result1 );
+  EXPECT_EQ( 42, result2 );
+  EXPECT_EQ( 42, result3 );
+
+  signal( 17 );
+  EXPECT_EQ( 17, result1 );
+  EXPECT_EQ( 59, result2 );
+  EXPECT_EQ( 714, result3 );
+
+  ctx3.reset();
+
+  signal( 42 );
+  EXPECT_EQ( 42, result1 );
+  EXPECT_EQ( 101, result2 );
+  EXPECT_EQ( 714, result3 );
+}
+
+// ----------------------------------------------------------------------------
+TEST(signal, races)
+{
+  // This test merits some explanation. The goal of this test is to verify that
+  // a context can be destroyed without racing the emission or destruction of a
+  // signal. The first is relatively easy to force, but for the second, we can
+  // only rely on running the test many times and hoping for lucky scheduling.
+  //
+  // To execute the test, we create a context in a separate thread, notify that
+  // the thread is running, and wait for the signal to be raised. Meanwhile, on
+  // the original/main thread, we wait for the notification, then raise the
+  // signal. The slot fires in the main thread, notifies that it is running,
+  // and immediately goes to sleep so that the signal will be "busy". Back on
+  // the second thread, upon receiving the notification, we try to destroy the
+  // context, which will block because the signal is "busy".
+  //
+  // Finally, in the original/main thread, once the signal finishes executing
+  // the slot, we immediately destroy the signal. Depending on timing, this may
+  // or may not happen before the context is destroyed. Running the test
+  // repeatedly should exercise both possibilities.
+
+  auto signal = std::unique_ptr< kv::signal<> >{ new kv::signal<> };
+  std::atomic< kv::context* > ctxp{ nullptr };
+  std::atomic< bool > cond{ false };
+
+  auto thread = std::thread{
+    [ & ]{
+      auto ctx = std::unique_ptr< kv::context >{ new kv::context };
+
+      signal->connect(
+        ctx.get(),
+        [ & ]{
+          // Notify that the signal is executing
+          cond = false;
+
+          // Go to sleep so that the secondary thread will start to tear down
+          // the context; note that this slot is executing in the original/main
+          // thread, since that is where the signal is raised
+          std::this_thread::sleep_for( std::chrono::milliseconds{ 250 } );
+        });
+
+      // Notify that we are ready for the signal to be raised, then wait
+      cond = true;
+      while ( cond.load() )
+      {
+        std::this_thread::yield();
+      }
+
+      // Destroy our context
+      ctx.reset();
+    }};
+
+  // Wait until thread is executing
+  while ( !cond.load() )
+  {
+    std::this_thread::yield();
+  }
+
+  // Raise the signal
+  ( *signal )();
+
+  // Destroy the signal, hopefully while the context is still being destroyed
+  signal.reset();
+
+  // Wait for thread to terminate
+  thread.join();
+}

--- a/vital/types/detected_object_type.cxx
+++ b/vital/types/detected_object_type.cxx
@@ -42,7 +42,8 @@ namespace vital {
 
 const double detected_object_type::INVALID_SCORE = std::numeric_limits< double >::min();
 
-// Master list of all class_names
+// Master list of all type names, and members associated with the same
+signal< std::string const& > detected_object_type::class_name_added;
 std::set< std::string > detected_object_type::s_master_name_set;
 std::mutex detected_object_type::s_table_mutex;
 
@@ -189,11 +190,12 @@ detected_object_type
 {
   // Check to see if class_name is in the master set.
   // If not, add it
-  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
+  std::lock_guard< std::mutex > lock{ s_table_mutex };
   auto it = s_master_name_set.find( class_name );
   if ( it == s_master_name_set.end() )
   {
     auto result = s_master_name_set.insert( class_name );
+    class_name_added( class_name );
     it = result.first;
   }
 
@@ -314,7 +316,7 @@ const std::string*
 detected_object_type
 ::find_string( const std::string& str ) const
 {
-  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
+  std::lock_guard< std::mutex > lock{ s_table_mutex };
   auto it = s_master_name_set.find( str );
   if ( it == s_master_name_set.end() )
   {
@@ -328,14 +330,13 @@ detected_object_type
 }
 
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 std::vector< std::string >
 detected_object_type
 ::all_class_names()
 {
-  std::lock_guard< std::mutex > lock( detected_object_type::s_table_mutex );
-  std::vector< std::string > names( s_master_name_set.begin(), s_master_name_set.end() );
-  return names;
+  std::lock_guard< std::mutex > lock{ s_table_mutex };
+  return { s_master_name_set.begin(), s_master_name_set.end() };
 }
 
 } } // end namespace

--- a/vital/types/detected_object_type.h
+++ b/vital/types/detected_object_type.h
@@ -36,13 +36,15 @@
 #ifndef VITAL_DETECTED_OBJECT_TYPE_H_
 #define VITAL_DETECTED_OBJECT_TYPE_H_
 
+#include <vital/signal.h>
 #include <vital/vital_export.h>
 
-#include <vector>
+#include <functional>
 #include <map>
-#include <set>
 #include <memory>
 #include <mutex>
+#include <set>
+#include <vector>
 
 namespace kwiver {
 namespace vital {
@@ -269,6 +271,23 @@ public:
    * @return Vector of class names.
    */
   static std::vector < std::string > all_class_names();
+
+  /**
+   * @brief Signal emitted when a new type name is created.
+   *
+   * This signal is emitted whenever a new type name is seen for the first
+   * time. Applications which need to perform some function when this occurs
+   * may do so by connecting to this signal. The name of the new type is passed
+   * to the slot.
+   *
+   * @warning
+   * Connected slots execute on whichever thread caused the creation of a new
+   * detected object type name. This thread should generally be treated as
+   * arbitrary, and the slot coded accordingly. Note also that it may be
+   * important for performance that the slot does not take a long time to
+   * execute.
+   */
+  static signal< std::string const& > class_name_added;
 
 private:
   const std::string* find_string( const std::string& str ) const;


### PR DESCRIPTION
Add (static) methods to `detected_object_type` to allow registering a callback to be called when a new type name is first seen. This is useful if users need to execute some logic when this occurs, e.g. for [an application](/Kitware/SEAL-TK) that needs to persistently display all known type names.