### PR TITLE
Implement add() method to take shared pointer.

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -13,6 +13,9 @@ Vital Algo
 
 Vital Types
 
+ * Add new method to metadata class to add a metadata item being
+   passed by shared_ptr
+
 Vital Plugin-loader
 
  * Added support for filtering plugins when they are loaded. Filter

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -110,7 +110,7 @@ convert_metadata
                            kwiver::vital::any const& data )
 {
   // If the input data is already in the correct type, just return.
-  if ( metadata::typeid_for_tag( vital_tag ) == data.type() )
+  if ( convert_metadata::typeid_for_tag( vital_tag ) == data.type() )
   {
     return data;
   }
@@ -118,7 +118,7 @@ convert_metadata
   try
   {
     // If destination type is double, then source must be convertable to double
-    if ( metadata::typeid_for_tag( vital_tag ) == typeid( double ) )
+    if ( convert_metadata::typeid_for_tag( vital_tag ) == typeid( double ) )
     {
       kwiver::vital::any converted_data = convert_to_double.convert( data );
       return converted_data;

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -118,7 +118,7 @@ convert_metadata
              << m_metadata_traits.tag_to_symbol( vital_tag ) );
 
   // If the input data is already in the correct type
-  if ( metadata::typeid_for_tag( vital_tag ) == data.type() )
+  if ( convert_metadata::typeid_for_tag( vital_tag ) == data.type() )
   {
     // leave data as is since it already correct type.
     return data;
@@ -126,7 +126,7 @@ convert_metadata
 
 
   // If destination type is double, then source must be convertable to double
-  if ( metadata::typeid_for_tag( vital_tag ) == typeid( double ) )
+  if ( convert_metadata::typeid_for_tag( vital_tag ) == typeid( double ) )
   {
     if ( klv_0601_has_double( tag ) )
     {

--- a/vital/klv/convert_metadata.cxx
+++ b/vital/klv/convert_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -110,6 +110,25 @@ void convert_metadata
     LOG_DEBUG( m_logger, "Unsupported UDS Key: "
               << uds_key << " data size is "
               << klv.value_size() );
+  }
+}
+
+
+// ------------------------------------------------------------------
+std::type_info const&
+convert_metadata
+::typeid_for_tag( vital_metadata_tag tag )
+{
+
+  switch (tag)
+  {
+#define VITAL_META_TRAIT_CASE(TAG, NAME, T, ...) case VITAL_META_ ## TAG: return typeid(T);
+
+    KWIVER_VITAL_METADATA_TAGS( VITAL_META_TRAIT_CASE )
+
+#undef VITAL_META_TRAIT_CASE
+
+  default: return typeid(void);
   }
 }
 

--- a/vital/klv/convert_metadata.h
+++ b/vital/klv/convert_metadata.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017, 2019 by Kitware, Inc.
+ * Copyright 2016-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,6 +72,19 @@ public:
    * @throws metadata_exception When error encountered.
    */
    void convert( klv_data const& klv, metadata& md );
+
+
+  /**
+   * \brief Get type representation for vital metadata tag.
+   *
+   * This method returns the type id string for the specified vital
+   * metadata tag.
+   *
+   * \param tag Code for metadata tag.
+   *
+   * \return Type info for this tag
+   */
+  static std::type_info const& typeid_for_tag( vital_metadata_tag tag );
 
 
   /** Constants used to determine the source of this metadata

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ kwiver_discover_gtests(vital iqr_feedback                   LIBRARIES ${test_lib
 kwiver_discover_gtests(vital iterable                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterator                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital local_cartesian                LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital metadata                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital metadata_io                    LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vital polygon                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital rotation                       LIBRARIES ${test_libraries})

--- a/vital/tests/test_metadata.cxx
+++ b/vital/tests/test_metadata.cxx
@@ -1,0 +1,129 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vital/types/metadata.h>
+#include <vital/types/metadata_traits.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <cstdint>
+
+using namespace ::kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST( metadata, typed_metadata )
+{
+  // create item
+  auto tmds = typed_metadata< VITAL_META_METADATA_ORIGIN, std::string >{
+    "item data", std::string{ "origin" } };
+  auto tmdd = typed_metadata< VITAL_META_PLATFORM_HEADING_ANGLE, double >{
+    std::string{ "test double item" }, 3.14159 };
+  auto tmdi = typed_metadata< VITAL_META_UNIX_TIMESTAMP, uint64_t >{
+    std::string{ "test uint item" }, uint64_t{ 314159 } };
+
+  // test API
+  EXPECT_TRUE( tmds.has_string() );
+  EXPECT_FALSE( tmds.has_double() );
+  EXPECT_FALSE( tmds.has_uint64() );
+  EXPECT_EQ( "origin", tmds.as_string() );
+
+  EXPECT_FALSE( tmdd.has_string() );
+  EXPECT_TRUE( tmdd.has_double() );
+  EXPECT_FALSE( tmdd.has_uint64() );
+  EXPECT_FLOAT_EQ( 3.14159, tmdd.as_double() );
+  EXPECT_EQ( "3.14159", tmdd.as_string() );
+
+  EXPECT_FALSE( tmdi.has_string() );
+  EXPECT_FALSE( tmdi.has_double() );
+  EXPECT_TRUE( tmdi.has_uint64() );
+  EXPECT_EQ( 314159, tmdi.as_uint64() );
+  EXPECT_EQ( "314159", tmdi.as_string() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( metadata, add_metadata )
+{
+  // create item
+  using rmdi_t = typed_metadata< VITAL_META_UNIX_TIMESTAMP, uint64_t >;
+  auto rmdi =
+    std::make_shared< rmdi_t >( "test uint item", uint64_t{ 314159 } );
+
+  using umdd_t = typed_metadata< VITAL_META_PLATFORM_HEADING_ANGLE, double >;
+  auto umdd = std::unique_ptr< umdd_t >{
+    new umdd_t{ "test double item" , 3.14159 } };
+
+  metadata meta_collection;
+
+  meta_collection.add< VITAL_META_METADATA_ORIGIN >( "item data" );
+  meta_collection.add( std::move( umdd ) );
+  meta_collection.add_copy( rmdi );
+
+  {
+    EXPECT_TRUE( meta_collection.has( VITAL_META_METADATA_ORIGIN ) );
+
+    auto const& md = meta_collection.find( VITAL_META_METADATA_ORIGIN );
+    EXPECT_TRUE( md.has_string() );
+    EXPECT_EQ( "item data",  md.as_string() );
+  }
+
+  {
+    EXPECT_TRUE( meta_collection.has( VITAL_META_PLATFORM_HEADING_ANGLE ) );
+
+    auto const& md = meta_collection.find( VITAL_META_PLATFORM_HEADING_ANGLE );
+    EXPECT_TRUE( md.has_double() );
+    EXPECT_FALSE( md.has_string() );
+    EXPECT_FLOAT_EQ( 3.14159, md.as_double() );
+    EXPECT_EQ( "3.14159", md.as_string() );
+  }
+
+  {
+    EXPECT_TRUE( meta_collection.has( VITAL_META_UNIX_TIMESTAMP ) );
+
+    auto const& md = meta_collection.find( VITAL_META_UNIX_TIMESTAMP );
+    EXPECT_FALSE( md.has_string() );
+    EXPECT_FALSE( md.has_double() );
+    EXPECT_TRUE( md.has_uint64() );
+    EXPECT_EQ( 314159, md.as_uint64() );
+    EXPECT_EQ( "314159", md.as_string() );
+  }
+
+  EXPECT_EQ( 3, meta_collection.size() );
+  EXPECT_FALSE( meta_collection.empty() );
+}

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -34,13 +34,11 @@
  */
 
 #include "metadata.h"
-#include "metadata_traits.h"
 
 #include <vital/util/demangle.h>
 
 namespace kwiver {
 namespace vital {
-
 
 // ----------------------------------------------------------------
 /*
@@ -98,14 +96,12 @@ metadata_item
   return true;
 }
 
-
 std::string const&
 metadata_item
 ::name() const
 {
   return this->m_name;
 }
-
 
 kwiver::vital::any
 metadata_item
@@ -114,14 +110,12 @@ metadata_item
   return this->m_data;
 }
 
-
 double
 metadata_item
 ::as_double() const
 {
   return kwiver::vital::any_cast< double > ( this->m_data );
 }
-
 
 bool
 metadata_item
@@ -130,14 +124,12 @@ metadata_item
   return m_data.type() == typeid( double );
 }
 
-
 uint64_t
 metadata_item
 ::as_uint64() const
 {
   return kwiver::vital::any_cast< uint64_t > ( this->m_data );
 }
-
 
 bool
 metadata_item
@@ -146,7 +138,6 @@ metadata_item
   return m_data.type() == typeid( uint64_t );
 }
 
-
 bool
 metadata_item
 ::has_string() const
@@ -154,13 +145,12 @@ metadata_item
   return m_data.type() == typeid( std::string );
 }
 
-
 // ==================================================================
 metadata
 ::metadata()
 { }
 
-// ----------------------------------------------------------------------------
+// ---------------------------------------------------------------------
 void
 metadata
 ::add( std::unique_ptr< metadata_item >&& item )
@@ -178,6 +168,7 @@ metadata
 #endif
 }
 
+// ---------------------------------------------------------------------
 void
 metadata
 ::add_copy( std::shared_ptr<metadata_item const> const& item )
@@ -193,14 +184,13 @@ metadata
   this->m_metadata_map[ item->tag() ] = item_ptr{ item->clone() };
 }
 
-
+// -------------------------------------------------------------------
 bool
 metadata
 ::has( vital_metadata_tag tag ) const
 {
   return m_metadata_map.find( tag ) != m_metadata_map.end();
 }
-
 
 // ------------------------------------------------------------------
 metadata_item const&
@@ -218,7 +208,6 @@ metadata
   return *(it->second);
 }
 
-
 // ------------------------------------------------------------------
 bool
 metadata
@@ -226,7 +215,6 @@ metadata
 {
   return m_metadata_map.erase( tag ) > 0;
 }
-
 
 // ------------------------------------------------------------------
 metadata::const_iterator_t
@@ -236,14 +224,12 @@ metadata
   return m_metadata_map.begin();
 }
 
-
 metadata::const_iterator_t
 metadata
 ::cbegin() const
 {
   return m_metadata_map.cbegin();
 }
-
 
 metadata::const_iterator_t
 metadata
@@ -252,7 +238,6 @@ metadata
   return m_metadata_map.end();
 }
 
-
 metadata::const_iterator_t
 metadata
 ::cend() const
@@ -260,7 +245,7 @@ metadata
   return m_metadata_map.cend();
 }
 
-
+// ---------------------------------------------------------------------
 size_t
 metadata
 ::size() const
@@ -268,14 +253,13 @@ metadata
   return m_metadata_map.size();
 }
 
-
+// ---------------------------------------------------------------------
 bool
 metadata
 ::empty() const
 {
   return m_metadata_map.empty();
 }
-
 
 // ------------------------------------------------------------------
 void
@@ -285,33 +269,13 @@ metadata
   this->m_timestamp = ts;
 }
 
-
+// ---------------------------------------------------------------------
 kwiver::vital::timestamp const&
 metadata
 ::timestamp() const
 {
   return this->m_timestamp;
 }
-
-
-  // ------------------------------------------------------------------
-std::type_info const&
-metadata
-::typeid_for_tag( vital_metadata_tag tag )
-{
-
-  switch (tag)
-  {
-#define VITAL_META_TRAIT_CASE(TAG, NAME, T, ...) case VITAL_META_ ## TAG: return typeid(T);
-
-    KWIVER_VITAL_METADATA_TAGS( VITAL_META_TRAIT_CASE )
-
-#undef VITAL_META_TRAIT_CASE
-
-  default: return typeid(void);
-  }
-}
-
 
 // ------------------------------------------------------------------
 std::string
@@ -357,7 +321,6 @@ metadata
   return ascii;
 }
 
-
 // ------------------------------------------------------------------
 std::ostream& print_metadata( std::ostream& str, metadata const& metadata )
 {
@@ -377,7 +340,6 @@ std::ostream& print_metadata( std::ostream& str, metadata const& metadata )
 
   return str;
 }
-
 
 // ----------------------------------------------------------------------------
 bool test_equal_content( const kwiver::vital::metadata& one,
@@ -403,6 +365,5 @@ bool test_equal_content( const kwiver::vital::metadata& one,
 
   return true;
 }
-
 
 } } // end namespace

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -56,18 +56,16 @@ namespace vital {
       : metadata_item( "Requested metadata item is not in collection", 0, VITAL_META_UNKNOWN )
     { }
 
-    virtual bool is_valid() const { return false; }
-    virtual vital_metadata_tag tag() const { return static_cast< vital_metadata_tag >(0); }
-    virtual std::type_info const& type() const { return typeid( void ); }
-    virtual std::string as_string() const { return "--Unknown metadata item--"; }
-    virtual double as_double() const { return 0; }
-    virtual double as_uint64() const { return 0; }
-    virtual std::ostream& print_value(std::ostream& os) const
+    bool is_valid() const override { return false; }
+    std::type_info const& type() const override { return typeid( void ); }
+    std::string as_string() const override { return "--Unknown metadata item--"; }
+    std::ostream& print_value(std::ostream& os) const override
     {
       os << this->as_string();
       return os;
     }
 
+    metadata_item* clone() const override { return nullptr; } // never used
   }; // end class unknown_metadata_item
 
 // ----------------------------------------------------------------------------
@@ -162,13 +160,6 @@ metadata
 ::metadata()
 { }
 
-
-metadata
-::~metadata()
-{
-
-}
-
 // ----------------------------------------------------------------------------
 void
 metadata
@@ -185,6 +176,21 @@ metadata
 #else
   this->m_metadata_map[ tag ] = item_ptr{ item.release() };
 #endif
+}
+
+void
+metadata
+::add_copy( std::shared_ptr<metadata_item const> const& item )
+{
+  if ( !item )
+  {
+    throw std::invalid_argument{ "null pointer" };
+  }
+
+  // Since the design intent for this map is that the metadata
+  // collection owns the elements, we will clone the item passed in.
+  // The original parameter will be freed eventually.
+  this->m_metadata_map[ item->tag() ] = item_ptr{ item->clone() };
 }
 
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -39,20 +39,19 @@
 #include <vital/vital_export.h>
 
 #include <vital/any.h>
-
-#include <vital/types/timestamp.h>
 #include <vital/exceptions/metadata.h>
 #include <vital/types/metadata_tags.h>
+#include <vital/types/timestamp.h>
 
+#include <iostream>
 #include <map>
-#include <vector>
-#include <string>
-#include <typeinfo>
 #include <memory>
 #include <ostream>
 #include <sstream>
+#include <string>
 #include <type_traits>
-#include <iostream>
+#include <typeinfo>
+#include <vector>
 
 namespace kwiver {
 namespace vital {
@@ -60,8 +59,8 @@ namespace vital {
 template <vital_metadata_tag tag> struct vital_meta_trait;
 
 // -----------------------------------------------------------------
-/// Abstract base class for metadata items
 /**
+ * \brief Abstract base class for metadata items
  * This class is the abstract base class for a single metadata
  * item. This mainly provides the interface for the type specific
  * derived classes.
@@ -74,53 +73,54 @@ class VITAL_EXPORT metadata_item
 public:
   virtual ~metadata_item() = default;
 
-  /// Test if metadata item is valid.
   /**
+   * \brief Test if metadata item is valid.
    * This method tests if this metadata item is valid.
    *
-   * @return \c true if the item is valid, otherwise \c false.
+   * \return \c true if the item is valid, otherwise \c false.
    *
-   * @sa metadata::find
+   * \sa metadata::find
    */
   virtual bool is_valid() const;
 
-  /// @copydoc is_valid
+  /// \copydoc is_valid
   operator bool() const { return this->is_valid(); }
 
-  /// Get name of metadata item.
   /**
+   * \brief Get name of metadata item.
+   *
    * This method returns the descriptive name for this metadata item.
    *
-   * @return Descriptive name of this metadata entry.
+   * \return Descriptive name of this metadata entry.
    */
   std::string const& name() const;
 
-
-  /// Get vital metadata tag.
   /**
+   * \brief Get vital metadata tag.
+   *
    * This method returns the vital metadata tag enum value.
    *
-   * @return Metadata tag value.
+   * \return Metadata tag value.
    */
   vital_metadata_tag tag() const { return m_tag; };
 
-
-  /// Get metadata data type.
-  /**
+    /**
+   * \brief Get metadata data type.
+   *
    * This method returns the type-info for this metadata item.
    *
-   * @return Ty[e info for metadata tag.
+   * \return Ty[e info for metadata tag.
    */
   virtual std::type_info const& type() const = 0;
 
-
-  /// Get actual data for metadata item.
   /**
+   * \brief Get actual data for metadata item.
+   *
    * This method returns the actual raw data for this metadata item as
    * a "any" object. Non-standard data types must be handled through this
    * call.
    *
-   * @return Data for metadata item.
+   * \return Data for metadata item.
    */
   kwiver::vital::any data() const;
 
@@ -139,72 +139,72 @@ public:
     }
   }
 
-  /// Get metadata value as double.
   /**
+   * \brief Get metadata value as double.
+   *
    * This method returns the metadata item value as a double or throws
    * an exception if data is not a double.
    *
-   * @return Data for metadata item as double.
-   * @throws bad_any_cast if data type is not really a double.
+   * \return Data for metadata item as double.
+   * \throws bad_any_cast if data type is not really a double.
    */
   double as_double() const;
 
-
-  /// Does this entry contain double type data?
   /**
+   * \brief Does this entry contain double type data?
    * This method returns \b true if this metadata item contains a data
    * value with double type.
    *
-   * @return \b true if data type is double, \b false otherwise/
+   * \return \b true if data type is double, \b false otherwise/
    */
   bool has_double() const;
 
-
-  /// Get metadata value as uint64.
   /**
+   * \brief Get metadata value as uint64.
+   *
    * This method returns the metadata item value as a uint64 or throws
    * an exception if data is not a uint64.
    *
-   * @return Data for metadata item as uint64.
-   * @throws bad_any_cast if data type is not really a uint64.
+   * \return Data for metadata item as uint64.
+   * \throws bad_any_cast if data type is not really a uint64.
    */
   uint64_t as_uint64() const;
 
-
-  /// Does this entry contain uint64 type data?
   /**
+   * \brief Does this entry contain uint64 type data?
+   *
    * This method returns \b true if this metadata item contains a data
    * value with uint64 type.
    *
-   * @return \b true if data type is uint64, \b false otherwise/
+   * \return \b true if data type is uint64, \b false otherwise/
    */
   bool has_uint64() const;
 
-
-  /// Get metadata value as string.
   /**
+   * \brief Get metadata value as string.
+   *
    * This method returns the metadata item value as a string.  If the
    * data is actually a string (as indicated by has_string() method)
    * the native value is returned. If the data is of another type, it
    * is converted to a string.
    *
-   * @return Data for metadata item as string.
+   * \return Data for metadata item as string.
    */
   virtual std::string as_string() const = 0;
 
-
-  /// Does this entry contain std::string type data?
   /**
+   * \brief dev/metadata-api-change.
+   *
    * This method returns \b true if this metadata item contains a data
    * value with std::string type.
    *
-   * @return \b true if data type is std::string, \b false otherwise/
+   * \return \b true if data type is std::string, \b false otherwise/
    */
   bool has_string() const;
 
-
-  /// Print the value of this item to an output stream
   /**
+   * \brief Print the value of this item to an output stream.
+   *
    * This method is has the advantage over \c as_string() that it allow
    * control over string formatting (e.g. precision of floats).
    */
@@ -222,12 +222,16 @@ protected:
   const kwiver::vital::any m_data;
   const vital_metadata_tag m_tag;
 
+private:
+  friend class metadata;
+  virtual metadata_item* clone() const = 0;
 }; // end class metadata_item
 
 
 // -----------------------------------------------------------------
-/// Class for typed metadata values.
 /**
+ * \brief Class for typed metadata values.
+
  * This class represents a typed metadata item.
  *
  * NOTE: Does it really add any benefit to have the metadata item
@@ -241,8 +245,8 @@ protected:
  * type is known in advance rather than having to handle multiple
  * possibly unknown types at run time.
  *
- * tparam TAG Metadata tag value
- * tparam TYPE Metadata value representation type
+ * \tparam TAG Metadata tag value
+ * \tparam TYPE Metadata value representation type
  */
 template<vital_metadata_tag TAG, typename TYPE>
 class typed_metadata
@@ -275,8 +279,8 @@ public:
 
   virtual ~typed_metadata() = default;
 
-  virtual std::type_info const& type() const override { return typeid( TYPE ); }
-  virtual std::string as_string() const override
+  std::type_info const& type() const override { return typeid( TYPE ); }
+  std::string as_string() const override
   {
     if ( this->has_string() )
     {
@@ -291,20 +295,28 @@ public:
     return ss.str();
   }
 
-  /// Print the value of this item to an output stream
-  std::ostream& print_value(std::ostream& os) const
+  // Print the value of this item to an output stream
+  std::ostream& print_value(std::ostream& os) const override
   {
     TYPE var = kwiver::vital::any_cast< TYPE > ( m_data );
     os << var;
     return os;
   }
 
+private:
+  // Create a copy of this metadata item. This is needed to disconnect
+  // a metadata item from a shared pointer.
+  metadata_item* clone() const override
+  {
+    return new typed_metadata<TAG, TYPE>( *this );
+  }
 }; // end class typed_metadata
 
 
 // -----------------------------------------------------------------
-/// Collection of metadata.
 /**
+ * \brief Collection of metadata.
+ *
  * This class represents a set of metadata items.
  *
  * The concept is to provide a canonical set of useful metadata
@@ -348,27 +360,51 @@ public:
 class VITAL_EXPORT metadata
 {
 public:
+// The design for this collection requires that the elements in the
+// collection are owned by the collection and are only returned by
+// value. This is why the std::unique_ptr is used. Unfortunately, not
+// all stdc implementations support maps with unique_ptrs. The
+// following is done to work around this limitation.
 #ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  typedef std::unique_ptr< metadata_item > item_ptr;
+  using item_ptr = std::unique_ptr< metadata_item >;
 #else
-  typedef std::shared_ptr< metadata_item > item_ptr;
+  using item_ptr = std::shared_ptr< metadata_item >;
 #endif
-  typedef std::map< vital_metadata_tag, item_ptr > metadata_map_t;
-  typedef metadata_map_t::const_iterator const_iterator_t;
+  using metadata_map_t = std::map< vital_metadata_tag, item_ptr >;
+  using const_iterator_t = metadata_map_t::const_iterator;
 
   metadata();
-  ~metadata();
+  ~metadata() = default;
 
-
-  /// Add metadata item to collection.
   /**
-   * This method adds a metadata item to the collection. The collection
-   * takes ownership of the item and managed the memory.
+   * \brief Add metadata item to collection.
    *
-   * @param item New metadata item to be copied into collection.
+   * This method adds a metadata item to the collection. The collection takes
+   * ownership of the \p item.
+   *
+   * \param item New metadata item to be added to the collection.
    */
   void add( std::unique_ptr< metadata_item >&& item );
 
+  /**
+   * \brief Add metadata item to collection.
+   *
+   * This method adds a metadata item to the collection. The collection makes
+   * a copy of the item.
+   *
+   * \param item New metadata item to be copied into the collection.
+   */
+  void add_copy( std::shared_ptr<metadata_item const> const& item );
+
+  //@{
+  /**
+   * \brief  Add metadata item to collection.
+   *
+   * This method creates a new metadata item and adds it to the collection.
+   *
+   * \tparam Tag Metadata tag value.
+   * \param data Metadata value.
+   */
   template < vital_metadata_tag Tag >
   void add( typename vital_meta_trait< Tag >::type&& data )
   {
@@ -386,7 +422,18 @@ public:
     using ptr_t = std::unique_ptr< result_t >;
     this->add( ptr_t{ new result_t{ tag_t::name(), data } } );
   }
+  //@}
 
+  /**
+   * \brief Add metadata item to collection.
+   *
+   * This method creates a new metadata item and adds it to the collection.
+   * Unlike ::add, this method must be used if the \p data is an ::any, as
+   * overload resolution will fail otherwise.
+   *
+   * \tparam Tag Metadata tag value.
+   * \param data Metadata value.
+   */
   template < vital_metadata_tag Tag >
   void add_any( any const& data )
   {
@@ -396,47 +443,49 @@ public:
     this->add( ptr_t{ new result_t{ tag_t::name(), data } } );
   }
 
-  /// Remove metadata item.
   /**
-   * The metadata item that corresponds with the tag is deleted it it
-   * is in the collection.
+   * \brief Remove metadata item.
    *
-   * @param tag Tag of metadata to delete.
+   * The metadata item that corresponds with the tag is deleted if it is in the
+   * collection.
    *
-   * @return \b true if specified item was found and deleted.
+   * \param tag Tag of metadata to delete.
+   *
+   * \return \b true if specified item was found and deleted.
    */
   bool erase( vital_metadata_tag tag );
 
-
-  /// Determine if metadata collection has tag.
   /**
+   * \brief  Determine if metadata collection has tag.
+   *
    * This method determines if the specified tag is in this metadata
    * collection.
    *
-   * @param tag Check for the presence of this tag.
+   * \param tag Check for the presence of this tag.
    *
-   * @return \b true if tag is in metadata collection, \b false otherwise.
+   * \return \b true if tag is in metadata collection, \b false otherwise.
    */
-  bool has( vital_metadata_tag tag ) const; // needs not-found return value
+  bool has( vital_metadata_tag tag ) const;
 
-
-  /// Find metadata entry for specified tag.
   /**
+   * \brief Find metadata entry for specified tag.
+   *
    * This method looks for the metadata entrty corresponding to the supplied
    * tag. If the tag is not present in the collection, the result will be a
    * instance for which metadata_item::is_valid returns \c false and whose
    * behavior otherwise is unspecified.
    *
-   * @param tag Look for this tag in collection of metadata.
+   * \param tag Look for this tag in collection of metadata.
    *
-   * @return metadata item object for tag.
+   * \return metadata item object for tag.
    */
   metadata_item const& find( vital_metadata_tag tag ) const;
 
 
   //@{
-  /// Get starting iterator for collection of metadata items.
   /**
+   * \brief Get starting iterator for collection of metadata items.
+   *
    * This method returns the const iterator to the first element in
    * the collection of metadata items.
    *
@@ -448,15 +497,16 @@ public:
    kwiver::vital::any data = ix->second->data();
    \endcode
    *
-   * @return Iterator pointing to the first element in the collection.
+   * \return Iterator pointing to the first element in the collection.
    */
   const_iterator_t begin() const;
   const_iterator_t cbegin() const;
   //@}
 
   //@{
-  /// Get ending iterator for collection of metadata.
   /**
+   * \brief Get ending iterator for collection of metadata.
+   *
    * This method returns the ending iterator for the collection of
    * metadata items.
    *
@@ -468,56 +518,56 @@ public:
      // process metada items
    }
    \endcode
-   * @return Ending iterator for collection
+   * \return Ending iterator for collection
    */
   const_iterator_t end() const;
   const_iterator_t cend() const;
   //@}
 
-  /// Get the number of metadata items in the collection.
   /**
+   * \brief Get the number of metadata items in the collection.
+   *
    * This method returns the number of elements in the
    * collection. There will usually be at least one element which
    * defines the souce of the metadata items.
    *
-   * @return Number of elements in the collection.
+   * \return Number of elements in the collection.
    */
   size_t size() const;
 
-
-  /// Test whether collection is empty.
   /**
+   * \brief Test whether collection is empty.
+   *
    * This method returns whether the collection is empty
    * (i.e. size() == 0).  There will usually be at least
    * one element which defines
    * the souce of the metadata items.
    *
-   * @return \b true if collection is empty
+   * \return \b true if collection is empty
    */
   bool empty() const;
 
-
-  /// Set timestamp for this metadata set.
   /**
+   * \brief Set timestamp for this metadata set.
+   *
    * This method sets that time stamp for this metadata
    * collection. This time stamp can be used to relate this metada
    * back to other temporal data like a video image stream.
    *
-   * @param ts Time stamp to add to this collection.
+   * \param ts Time stamp to add to this collection.
    */
   void set_timestamp( kwiver::vital::timestamp const& ts );
 
-
-  /// Return timestamp associated with these metadata.
   /**
+   * \brief Return timestamp associated with these metadata.
+   *
    * This method returns the timestamp associated with this collection
    * of metadata. The value may not be meaningful if it has not
    * been set by set_timestamp().
    *
-   * @return Timestamp value.
+   * \return Timestamp value.
    */
   kwiver::vital::timestamp const& timestamp() const;
-
 
   /// Get type representation for vital metadata tag. //+ move to convert_metadata
   /**
@@ -532,16 +582,14 @@ public:
 
   static std::string format_string( std::string const& val );
 
-
 private:
   metadata_map_t m_metadata_map;
   kwiver::vital::timestamp m_timestamp;
 
 }; // end class metadata
 
-typedef std::shared_ptr< metadata > metadata_sptr;
-typedef std::vector< metadata_sptr > metadata_vector;
-
+using metadata_sptr = std::shared_ptr< metadata >;
+using metadata_vector = std::vector< metadata_sptr >;
 
 VITAL_EXPORT std::ostream& print_metadata( std::ostream& str, metadata const& metadata );
 VITAL_EXPORT bool test_equal_content( const kwiver::vital::metadata& one,

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -109,7 +109,7 @@ public:
    *
    * This method returns the type-info for this metadata item.
    *
-   * \return Ty[e info for metadata tag.
+   * \return Type info for metadata tag.
    */
   virtual std::type_info const& type() const = 0;
 
@@ -193,7 +193,7 @@ public:
   virtual std::string as_string() const = 0;
 
   /**
-   * \brief dev/metadata-api-change.
+   * \brief Determine if item has string representation.
    *
    * This method returns \b true if this metadata item contains a data
    * value with std::string type.
@@ -568,17 +568,6 @@ public:
    * \return Timestamp value.
    */
   kwiver::vital::timestamp const& timestamp() const;
-
-  /// Get type representation for vital metadata tag. //+ move to convert_metadata
-  /**
-   * This method returns the type id string for the specified vital
-   * metadata tag.
-   *
-   * @param tag Code for metadata tag.
-   *
-   * @return Type info for this tag
-   */
-  static std::type_info const& typeid_for_tag( vital_metadata_tag tag );
 
   static std::string format_string( std::string const& val );
 

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -123,16 +123,6 @@ metadata_traits
 
 
 // ------------------------------------------------------------------
-std::type_info const&
-metadata_traits
-::typeid_for_tag( vital_metadata_tag tag ) const
-{
-  vital_meta_trait_base const& trait = find( tag );
-  return trait.tag_type();
-}
-
-
-// ------------------------------------------------------------------
 std::string
 metadata_traits
 ::tag_to_symbol( vital_metadata_tag tag ) const

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -122,18 +122,6 @@ public:
   vital_meta_trait_base const& find( vital_metadata_tag tag ) const;
 
 
-  /// Get type representation for vital metadata tag. //+ move to convert_metadata
-  /**
-   * This method returns the type id string for the specified vital
-   * metadata tag.
-   *
-   * @param tag Code for metadata tag.
-   *
-   * @return Type info for this tag
-   */
-  std::type_info const& typeid_for_tag( vital_metadata_tag tag ) const;
-
-
   /// Convert tag value to enum symbol
   /**
    * This method returns the symbol name for the supplied tag.


### PR DESCRIPTION
An additional add_copy() method was needed to support python bindings. Python
manages objects with shared pointers and this collection did not support
that type of reference. An additional complication is that the metadata
collection manages its own elements and can not directly accept an element
managed by a shared_ptr due to the design of the collection. The metadata
item managed by the shared pointer is copied and the copy is added to
the collection. The copy is low overhead since metadata objects are
small, and metadata collections are not created that frequently.