### PR TITLE
Improve metadata API

### DIFF
--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -622,7 +622,7 @@ video_input_image_list::priv
     md = std::make_shared< kv::metadata >();
   }
 
-  md->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI, file ) );
+  md->add< vital::VITAL_META_IMAGE_URI >( file );
 
   m_metadata_by_path[ file ] = md;
   return md;

--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2019 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,8 +92,7 @@ public:
     // Include the path to the image
     if ( metadata )
     {
-      metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
-                                        paths.first) );
+      metadata->add< vital::VITAL_META_IMAGE_URI >( paths.first );
     }
 
     // Return timestamp
@@ -313,8 +312,8 @@ video_input_pos
   if ( d->d_metadata )
   {
     d->d_metadata->set_timestamp( ts );
-    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
-                                           d->d_current_files->first ) );
+    d->d_metadata->add< vital::VITAL_META_IMAGE_URI >(
+      d->d_current_files->first );
   }
 
   return true;
@@ -362,8 +361,8 @@ video_input_pos
   if ( d->d_metadata )
   {
     d->d_metadata->set_timestamp( ts );
-    d->d_metadata->add( NEW_METADATA_ITEM( vital::VITAL_META_IMAGE_URI,
-                                           d->d_current_files->first ) );
+    d->d_metadata->add< vital::VITAL_META_IMAGE_URI >(
+      d->d_current_files->first );
   }
 
   return true;

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -554,16 +554,16 @@ public:
     md->set_timestamp( ts );
 
     // Add file name/uri
-    md->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_URI, video_path ) );
+    md->add< vital::VITAL_META_VIDEO_URI >( video_path );
 
     // Mark whether the frame is a key frame
     if ( this->f_frame->key_frame > 0 )
     {
-      md->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_KEY_FRAME, true ) );
+      md->add< vital::VITAL_META_VIDEO_KEY_FRAME >( true );
     }
     else
     {
-      md->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_KEY_FRAME, false ) );
+      md->add< vital::VITAL_META_VIDEO_KEY_FRAME >( false );
     }
   }
 

--- a/arrows/gdal/image_container.cxx
+++ b/arrows/gdal/image_container.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018-2019 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,19 +63,17 @@ void add_rpc_metadata(char* raw_md, vital::metadata_sptr md)
     return;
   }
 
-#define MAP_METADATA_SCALAR( GN, KN )                       \
-if ( key == #GN)                                            \
-{                                                           \
-  md->add( NEW_METADATA_ITEM(                               \
-    vital::VITAL_META_RPC_ ## KN, std::stod( value ) ) ) ;  \
-}                                                           \
+#define MAP_METADATA_SCALAR( GN, KN )                             \
+if ( key == #GN )                                                 \
+{                                                                 \
+  md->add< vital::VITAL_META_RPC_ ## KN >( std::stod( value ) );  \
+}
 
-#define MAP_METADATA_COEFF( GN, KN )          \
-if ( key == #GN)                              \
-{                                             \
-  md->add( NEW_METADATA_ITEM(                 \
-    vital::VITAL_META_RPC_ ## KN, value ) );  \
-}                                             \
+#define MAP_METADATA_COEFF( GN, KN )                \
+if ( key == #GN )                                   \
+{                                                   \
+  md->add< vital::VITAL_META_RPC_ ## KN >( value ); \
+}
 
   MAP_METADATA_SCALAR( HEIGHT_OFF,   HEIGHT_OFFSET )
   MAP_METADATA_SCALAR( HEIGHT_SCALE, HEIGHT_SCALE )
@@ -115,12 +113,11 @@ void add_nitf_metadata(char* raw_md, vital::metadata_sptr md)
     return;
   }
 
-#define MAP_METADATA_COEFF( GN, KN )          \
-if ( key == #GN)                              \
-{                                             \
-  md->add( NEW_METADATA_ITEM(                 \
-    vital::VITAL_META_NITF_ ## KN, value ) );  \
-}                                             \
+#define MAP_METADATA_COEFF( GN, KN )                  \
+if ( key == #GN )                                     \
+{                                                     \
+  md->add< vital::VITAL_META_NITF_ ## KN >( value );  \
+}
 
   MAP_METADATA_COEFF( NITF_IDATIM, IDATIM )
   MAP_METADATA_COEFF( NITF_BLOCKA_FRFC_LOC_01, BLOCKA_FRFC_LOC_01 )
@@ -208,8 +205,7 @@ image_container
 
   vital::metadata_sptr md = std::make_shared<vital::metadata>();
 
-  md->add( NEW_METADATA_ITEM(
-    kwiver::vital::VITAL_META_IMAGE_URI, filename ) );
+  md->add< kwiver::vital::VITAL_META_IMAGE_URI >( filename );
 
   // Get geotransform and calculate corner points
   double geo_transform[6];
@@ -229,8 +225,8 @@ image_container
     points.push_back( apply_geo_transform(geo_transform, w, 0) );
     points.push_back( apply_geo_transform(geo_transform, w, h ) );
 
-    md->add( NEW_METADATA_ITEM( vital::VITAL_META_CORNER_POINTS,
-      vital::geo_polygon( points, atoi( osrs.GetAuthorityCode("GEOGCS") ) ) ) );
+    md->add< vital::VITAL_META_CORNER_POINTS >(
+      vital::geo_polygon( points, atoi( osrs.GetAuthorityCode("GEOGCS") ) ) );
   }
 
   // Get RPC metadata

--- a/arrows/ocv/image_io.cxx
+++ b/arrows/ocv/image_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2015, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ image_io
 ::load_(const std::string& filename) const
 {
   auto md = std::make_shared<kwiver::vital::metadata>();
-  md->add(NEW_METADATA_ITEM(kwiver::vital::VITAL_META_IMAGE_URI, filename));
+  md->add<kwiver::vital::VITAL_META_IMAGE_URI>(filename);
 
   cv::Mat img = cv::imread(filename.c_str(), -1);
   auto img_ptr = vital::image_container_sptr(new ocv::image_container(img, ocv::image_container::BGR_COLOR));
@@ -91,7 +91,7 @@ image_io
 ::load_metadata_(const std::string& filename) const
 {
   auto md = std::make_shared<kwiver::vital::metadata>();
-  md->add(NEW_METADATA_ITEM(kwiver::vital::VITAL_META_IMAGE_URI, filename));
+  md->add<kwiver::vital::VITAL_META_IMAGE_URI>(filename);
   return md;
 }
 

--- a/arrows/serialize/json/load_save_metadata.cxx
+++ b/arrows/serialize/json/load_save_metadata.cxx
@@ -233,9 +233,8 @@ void load( ::cereal::JSONInputArchive& archive, kwiver::vital::metadata& meta )
   for ( const auto & it : meta_vect )
   {
     const auto& trait = meta_traits.find( it.tag );
-    auto* item = trait.create_metadata_item( it.item_value );
-    meta.add( item );
-  } // end for
+    meta.add( trait.create_metadata_item( it.item_value ) );
+  }
 }
 
 } // end namespace

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -222,36 +222,36 @@ kwiver::vital::metadata create_meta_collection()
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_METADATA_ORIGIN );
-    auto* item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_UNIX_TIMESTAMP );
-    auto* item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_SENSOR_VERTICAL_FOV );
-    auto* item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_FRAME_CENTER );
     kwiver::vital::geo_point::geo_2d_point_t geo( 42.50, 73.54 );
     kwiver::vital::geo_point pt ( geo, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(pt) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_FRAME_CENTER );
     kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
     kwiver::vital::geo_point pt ( geo, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(pt) );
+    meta.add( std::move( item ) );
   }
 
   {
@@ -263,8 +263,8 @@ kwiver::vital::metadata create_meta_collection()
     raw_obj.push_back( 100, 400 );
 
     kwiver::vital::geo_polygon poly( raw_obj, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(poly) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(poly) );
+    meta.add( std::move( item ) );
   }
 
   return meta;

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -364,20 +364,20 @@ TEST( convert_protobuf, metadata )
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_METADATA_ORIGIN );
-    auto* item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_UNIX_TIMESTAMP );
-    auto* item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
+    meta.add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_SENSOR_VERTICAL_FOV );
-    auto* item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
+    meta.add( std::move( item ) );
   }
 
   {
@@ -385,8 +385,8 @@ TEST( convert_protobuf, metadata )
 
     kwiver::vital::geo_point::geo_2d_point_t geo_2d( 42.50, 73.54 );
     kwiver::vital::geo_point pt ( geo_2d, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(pt) );
+    meta.add( std::move( item ) );
   }
 
   {
@@ -394,8 +394,8 @@ TEST( convert_protobuf, metadata )
 
     kwiver::vital::geo_point::geo_3d_point_t geo( 42.50, 73.54, 16.33 );
     kwiver::vital::geo_point pt ( geo, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(pt) );
+    meta.add( std::move( item ) );
   }
 
   {
@@ -407,8 +407,8 @@ TEST( convert_protobuf, metadata )
     raw_obj.push_back( 100, 400 );
 
     kwiver::vital::geo_polygon poly( raw_obj, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(poly) );
-    meta.add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(poly) );
+    meta.add( std::move( item ) );
   }
 
   kwiver::protobuf::metadata obj_proto;

--- a/arrows/serialize/protobuf/tests/test_serialize_metadata.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize_metadata.cxx
@@ -71,20 +71,20 @@ TEST( serialize_metadata, metadata )
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_METADATA_ORIGIN );
-    auto* item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
-    meta_sptr->add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(std::string ("test-source")) );
+    meta_sptr->add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_UNIX_TIMESTAMP );
-    auto* item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
-    meta_sptr->add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
+    meta_sptr->add( std::move( item ) );
   }
 
   {
     const auto& info = traits.find( kwiver::vital::VITAL_META_SENSOR_VERTICAL_FOV );
-    auto* item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
-    meta_sptr->add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any((double)12345.678) );
+    meta_sptr->add( std::move( item ) );
   }
 
   {
@@ -92,8 +92,8 @@ TEST( serialize_metadata, metadata )
 
     kwiver::vital::geo_point::geo_3d_point_t geo_3d( 42.50, 73.54, 100 );
     kwiver::vital::geo_point pt (  geo_3d, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(pt) );
-    meta_sptr->add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(pt) );
+    meta_sptr->add( std::move( item ) );
   }
 
   {
@@ -105,8 +105,8 @@ TEST( serialize_metadata, metadata )
     raw_obj.push_back( 100, 400 );
 
     kwiver::vital::geo_polygon poly( raw_obj, kwiver::vital::SRID::lat_lon_WGS84 );
-    auto* item = info.create_metadata_item( kwiver::vital::any(poly) );
-    meta_sptr->add( item );
+    auto item = info.create_metadata_item( kwiver::vital::any(poly) );
+    meta_sptr->add( std::move( item ) );
   }
 
   kasp::metadata meta_ser;      // The serializer

--- a/arrows/vxl/image_io.cxx
+++ b/arrows/vxl/image_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2018 by Kitware, Inc.
+ * Copyright 2013-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -318,7 +318,7 @@ image_io
   LOG_DEBUG( logger(), "Loading image from file: " << filename );
 
   auto md = std::shared_ptr<kwiver::vital::metadata>( new kwiver::vital::metadata() );
-  md->add( NEW_METADATA_ITEM( kwiver::vital::VITAL_META_IMAGE_URI, filename) );
+  md->add< kwiver::vital::VITAL_META_IMAGE_URI >( filename );
 
   vil_image_resource_sptr img_rsc = vil_load_image_resource(filename.c_str());
 
@@ -476,7 +476,7 @@ image_io
 ::load_metadata_(const std::string& filename) const
 {
   auto md = std::make_shared<kwiver::vital::metadata>();
-  md->add( NEW_METADATA_ITEM( kwiver::vital::VITAL_META_IMAGE_URI, filename) );
+  md->add< kwiver::vital::VITAL_META_IMAGE_URI >( filename );
   return md;
 }
 

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2019 by Kitware, Inc.
+ * Copyright 2016-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -227,8 +227,7 @@ public:
 
         meta->set_timestamp( ts );
 
-        meta->add( NEW_METADATA_ITEM( vital::VITAL_META_VIDEO_URI,
-                                      video_path ) );
+        meta->add< vital::VITAL_META_VIDEO_URI>( video_path );
         retval.push_back( meta );
       } // end valid metadata packet.
     } // end while
@@ -248,8 +247,7 @@ public:
 
       meta->set_timestamp(ts);
 
-      meta->add(NEW_METADATA_ITEM(vital::VITAL_META_VIDEO_URI,
-        video_path));
+      meta->add< vital::VITAL_META_VIDEO_URI >( video_path );
 
       retval.push_back(meta);
     }

--- a/vital/any.h
+++ b/vital/any.h
@@ -34,9 +34,9 @@
 #include <vital/vital_config.h>
 #include <vital/util/demangle.h>
 
-#include <algorithm>
 #include <memory>
 #include <typeinfo>
+#include <type_traits>
 
 #include <cstring>
 
@@ -149,10 +149,9 @@ public:
   /**
    * @brief Determine if this object has a value.
    *
-   * This method returns \b true if this object has not been assigned
-   * a value.
+   * This method returns \c true if this object has not been assigned a value.
    *
-   * @return \b true if no value in object, \b false if there is a
+   * @return \c true if no value in object, \c false if there is a
    * value.
    */
   bool empty() const noexcept
@@ -175,12 +174,11 @@ public:
   /**
    * @brief Get typeid for current value.
    *
-   * This method returns the std::type_info for the item contained in
-   * this object. If this object is empty(), then the type info for \b
-   * void is returned.
+   * This method returns the std::type_info for the item contained in this
+   * object. If this object is empty(), the type info for \c void is returned.
    *
-   * You can get the type name string from the following, but the name
-   * string may not be all that helpful.
+   * You can get the type name string from the following, but the name string
+   * may not be all that helpful.
    *
    \code
    kwiver::vital::any any_double(3.14159);
@@ -195,10 +193,26 @@ public:
   }
 
   /**
+   * @brief Test type of current value.
+   *
+   * This method returns \c true if this object's value is of the type
+   * specified by the template parameter.
+   */
+  template < typename T >
+  bool is_type() const
+  {
+    if ( m_content )
+    {
+      auto const& my_type = this->m_content->type();
+      return std::strcmp( typeid( T ).name(), my_type.name() ) == 0;
+    }
+    return std::is_same< T, void >::value;
+  }
+
+  /**
    * @brief Return demangled name of type contained in this object.
    *
-   * This method returns the demangled name of type contained in this
-   * object.
+   * This method returns the demangled name of type contained in this object.
    *
    * @return Demangled type name string.
    */
@@ -250,18 +264,30 @@ private:
   template < typename T >
   friend T any_cast( any const& aval );
 
+  template < typename T >
+  internal_typed< T >* content()
+  {
+    return static_cast< internal_typed< T >* >( this->m_content.get() );
+  }
+
+  template < typename T >
+  internal_typed< T > const* content() const
+  {
+    return static_cast< internal_typed< T >* >( this->m_content.get() );
+  }
+
   std::unique_ptr< internal > m_content;
 };
-
 
 // ============================================================================
 class bad_any_cast : public std::bad_cast
 {
 public:
 
-  /// Create bad cast exception;
   /**
-   * This is the constructor for the bnad any cast exception. A message is
+   * @brief Create bad cast exception;
+   *
+   * This is the constructor for the bad any cast exception. A message is
    * created from the supplied mangled type names.
    *
    * @param from_type Mangled type name.
@@ -271,7 +297,7 @@ public:
                 std::string const& to_type )
   {
     // Construct helpful message
-    if( from_type != "")
+    if( !from_type.empty() )
     {
       m_message = "vital::bad_any_cast: failed conversion using kwiver::vital::any_cast from type \""
         + demangle( from_type ) + "\" to type \"" + demangle( to_type ) + "\"";
@@ -282,8 +308,8 @@ public:
     }
   }
 
-  virtual ~bad_any_cast() noexcept {}
-  virtual const char * what() const noexcept
+  virtual ~bad_any_cast() noexcept {};
+  char const* what() const noexcept override
   {
     return m_message.c_str();
   }
@@ -292,55 +318,64 @@ private:
   std::string m_message;
 };
 
+///////////////////////////////////////////////////////////////////////////////
 
-// ==================================================================
-// Casting functions
-//
-/// Get value from a container.
+//BEGIN Casting functions
+
+// ----------------------------------------------------------------------------
 /**
- * This method returns a typed value from the any container. If the
- * conversion can not be completed, then an exception is thrown.
+ * @brief Get value pointer from a container.
+ *
+ * This method returns a typed pointer to the value from the ::any container.
+ * If the types are incompatible, \c nullptr is returned.
  *
  * @param aval Object that has the value.
  *
- * @return Value from object as specified type.
+ * @return Pointer to the value from the object as specified type,
+ *         or \c nullptr if the conversion failed.
  */
 template < typename T >
 inline T*
 any_cast( any* operand ) noexcept
 {
-  if ( operand && ( operand->type() == typeid( T ) ) )
+  if ( operand && ( operand->is_type< T >() ) )
   {
-    return &static_cast< any::internal_typed< T >* > ( operand->m_content )->m_any_data;
+    return &( operand->content< T >()->m_any_data );
   }
-
-  return 0;
+  return nullptr;
 }
 
 
-// ------------------------------------------------------------------
-/// Get value from a container.
+// ----------------------------------------------------------------------------
 /**
- * This method returns a typed value from the any container. If the
- * conversion can not be completed, then an exception is thrown.
+ * @brief Get value pointer from a container.
+ *
+ * This method returns a typed pointer to the value from the ::any container.
+ * If the types are incompatible, \c nullptr is returned.
  *
  * @param aval Object that has the value.
  *
- * @return Value from object as specified type.
+ * @return Pointer to the value from the object as specified type,
+ *         or \c nullptr if the conversion failed.
  */
 template < typename T >
 inline const T*
 any_cast( any const* operand ) noexcept
 {
-  return any_cast< T > ( const_cast< any* > ( operand ) );
+  if ( operand && ( operand->is_type< T >() ) )
+  {
+    return &( operand->content< T >()->m_any_data );
+  }
+  return nullptr;
 }
 
 
-// ------------------------------------------------------------------
-/// Get value from a container.
+// ----------------------------------------------------------------------------
 /**
- * This method returns a typed value from the any container. If the
- * conversion can not be completed, then an exception is thrown.
+ * @brief Get value from a container.
+ *
+ * This method returns a typed value from the any container. If the types are
+ * incompatible, an exception is thrown.
  *
  * @param aval Object that has the value.
  *
@@ -350,13 +385,11 @@ template < typename T >
 inline T
 any_cast( any const& aval )
 {
-  // Is the type requested compatible with the type represented.
   if ( aval.m_content )
   {
-    if ( std::strcmp( typeid( T ).name(), aval.m_content->type().name() ) == 0  )
+    if ( aval.is_type< T >() )
     {
-      auto* const adata = aval.m_content.get();
-      return static_cast< any::internal_typed< T >* >( adata )->m_any_data;
+      return aval.content< T >()->m_any_data;
     }
 
     throw bad_any_cast( aval.m_content->type().name(), typeid( T ).name() );
@@ -365,6 +398,10 @@ any_cast( any const& aval )
   throw bad_any_cast( "", typeid( T ).name() );
 }
 
-} }  // end namespace
+} // namespace vital
 
-#endif /* KWIVER_VITAL_ANY_H */
+} // namespace kwiver
+
+//END Casting functions
+
+#endif

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018-2019 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -430,9 +430,9 @@ update_metadata_from_camera(simple_camera_perspective const& cam,
     yaw *= rad_to_deg;
     pitch *= rad_to_deg;
     roll *= rad_to_deg;
-    md.add(NEW_METADATA_ITEM(VITAL_META_SENSOR_YAW_ANGLE, yaw));
-    md.add(NEW_METADATA_ITEM(VITAL_META_SENSOR_PITCH_ANGLE, pitch));
-    md.add(NEW_METADATA_ITEM(VITAL_META_SENSOR_ROLL_ANGLE, roll));
+    md.add<VITAL_META_SENSOR_YAW_ANGLE>(yaw);
+    md.add<VITAL_META_SENSOR_PITCH_ANGLE>(pitch);
+    md.add<VITAL_META_SENSOR_ROLL_ANGLE>(roll);
   }
 
   if (md.has(VITAL_META_SENSOR_LOCATION))
@@ -441,7 +441,7 @@ update_metadata_from_camera(simple_camera_perspective const& cam,
     const vector_3d loc = cam.get_center() + lgcs.origin().location();
     geo_point gc(loc, lgcs.origin().crs());
 
-    md.add(NEW_METADATA_ITEM(VITAL_META_SENSOR_LOCATION, gc));
+    md.add<VITAL_META_SENSOR_LOCATION>(gc);
   }
 }
 

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2019 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,22 +128,22 @@ read_pos_file( path_t const& file_path )
 
   // make a new metadata container.
   auto md = std::make_shared<metadata>();
-  md->add( NEW_METADATA_ITEM( VITAL_META_METADATA_ORIGIN, std::string( "POS-file") ) );
+  md->add< VITAL_META_METADATA_ORIGIN >( "POS-file" );
 
   if ( tokens.size() == 15 )
   {
     base = 1;
-    md->add( NEW_METADATA_ITEM( VITAL_META_IMAGE_SOURCE_SENSOR, tokens[0] ) );
+    md->add< VITAL_META_IMAGE_SOURCE_SENSOR >( tokens[0] );
   }
   else
   {
     // Set name to "KWIVER"
-    md->add( NEW_METADATA_ITEM( VITAL_META_IMAGE_SOURCE_SENSOR, std::string( "KWIVER" ) ) );
+    md->add< VITAL_META_IMAGE_SOURCE_SENSOR >( "KWIVER" );
   }
 
-  md->add( NEW_METADATA_ITEM( VITAL_META_SENSOR_YAW_ANGLE, std::stod( tokens[base + 0] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_SENSOR_PITCH_ANGLE, std::stod( tokens[ base + 1] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_SENSOR_ROLL_ANGLE, std::stod( tokens[base + 2] ) ) );
+  md->add< VITAL_META_SENSOR_YAW_ANGLE >( std::stod( tokens[base + 0] ) );
+  md->add< VITAL_META_SENSOR_PITCH_ANGLE >( std::stod( tokens[ base + 1] ) );
+  md->add< VITAL_META_SENSOR_ROLL_ANGLE >( std::stod( tokens[base + 2] ) );
 
   // altitude is in feet in a POS file and needs to be converted to meters
   constexpr double feet2meters = 0.3048;
@@ -152,16 +152,16 @@ read_pos_file( path_t const& file_path )
                                     std::stod( tokens[ base + 3 ] ),
                                     altitude };
   kwiver::vital::geo_point geo_pt{ raw_geo, SRID::lat_lon_WGS84 };
-  md->add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, geo_pt) );
+  md->add< VITAL_META_SENSOR_LOCATION >( geo_pt );
 
-  md->add( NEW_METADATA_ITEM( VITAL_META_GPS_SEC, std::stod( tokens[base + 6] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_GPS_WEEK, std::stoi( tokens[base + 7] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_NORTHING_VEL, std::stod( tokens[base + 8] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_EASTING_VEL, std::stod( tokens[base + 9] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_UP_VEL, std::stod( tokens[base + 10] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_IMU_STATUS, std::stoi( tokens[base + 11] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_LOCAL_ADJ, std::stoi( tokens[base + 12] ) ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_DST_FLAGS, std::stoi( tokens[base + 13] ) ) );
+  md->add< VITAL_META_GPS_SEC >( std::stod( tokens[base + 6] ) );
+  md->add< VITAL_META_GPS_WEEK >( std::stoi( tokens[base + 7] ) );
+  md->add< VITAL_META_NORTHING_VEL >( std::stod( tokens[base + 8] ) );
+  md->add< VITAL_META_EASTING_VEL >( std::stod( tokens[base + 9] ) );
+  md->add< VITAL_META_UP_VEL >( std::stod( tokens[base + 10] ) );
+  md->add< VITAL_META_IMU_STATUS >( std::stoi( tokens[base + 11] ) );
+  md->add< VITAL_META_LOCAL_ADJ >( std::stoi( tokens[base + 12] ) );
+  md->add< VITAL_META_DST_FLAGS >( std::stoi( tokens[base + 13] ) );
 
   return md;
 }

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017, 2019 by Kitware, Inc.
+ * Copyright 2016-2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,7 +163,7 @@ void convert_metadata
   // Add our "origin" tag to indicate that the source of this metadata
   // collection is from a 0104 spec packet.
   //
-  md.add( NEW_METADATA_ITEM( VITAL_META_METADATA_ORIGIN, MISB_0104 ) );
+  md.add< VITAL_META_METADATA_ORIGIN >( MISB_0104 );
 
   for ( auto itr = uds.begin(); itr != uds.end(); ++itr )
   {
@@ -195,15 +195,15 @@ void convert_metadata
     switch (tag)
     {
 // Refine simple case to a define
-#define CASE(N)                                           \
-case klv_0104::N:                                         \
-  md.add( NEW_METADATA_ITEM( VITAL_META_ ## N, data ) );  \
+#define CASE(N)                           \
+case klv_0104::N:                         \
+  md.add_any< VITAL_META_ ## N >( data ); \
   break
 
-#define CASE2(KN,MN)                                         \
-      case klv_0104::KN:                                     \
-    md.add( NEW_METADATA_ITEM( VITAL_META_ ## MN, data ) );  \
-    break
+#define CASE2(KN,MN)                        \
+case klv_0104::KN:                          \
+  md.add_any< VITAL_META_ ## MN >( data );  \
+  break
 
       CASE( UNIX_TIMESTAMP );
       CASE( MISSION_ID );
@@ -311,7 +311,7 @@ case klv_0104::N:                                         \
     {
       vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], raw_sensor_location[2]);
       auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
+      md.add< VITAL_META_SENSOR_LOCATION >( sensor_location );
     }
   }
 
@@ -324,7 +324,7 @@ case klv_0104::N:                                         \
     else
     {
       auto const frame_center = geo_point{ raw_frame_center, SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_FRAME_CENTER, frame_center ) );
+      md.add< VITAL_META_FRAME_CENTER >( frame_center );
     }
   }
 
@@ -374,7 +374,7 @@ case klv_0104::N:                                         \
       raw_corners.push_back( raw_corner_pt4 );
 
       kwiver::vital::geo_polygon corners{ raw_corners, kwiver::vital::SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_CORNER_POINTS, corners ) );
+      md.add< VITAL_META_CORNER_POINTS >( corners );
     }
   }
 }

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017, 2019 by Kitware, Inc.
+ * Copyright 2016-2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -168,7 +168,7 @@ convert_metadata
 {
   static kwiver::vital::logger_handle_t logger( kwiver::vital::get_logger( "vital.convert_metadata" ) );
 
-  md.add( NEW_METADATA_ITEM( VITAL_META_METADATA_ORIGIN, MISB_0601 ) );
+  md.add< VITAL_META_METADATA_ORIGIN >( MISB_0601 );
 
   //
   // Data items that are used to collect multi-value metadataa items such as
@@ -204,21 +204,21 @@ convert_metadata
     switch (tag)
     {
 // Refine simple case to a define
-#define CASE(N)                                                         \
-  case KLV_0601_ ## N:                                                  \
-    md.add( NEW_METADATA_ITEM( VITAL_META_ ## N,                        \
-      normalize_0601_tag_data( KLV_0601_ ## N, VITAL_META_ ## N, data ) ) ); \
+#define CASE(N)                                                             \
+  case KLV_0601_ ## N:                                                      \
+    md.add_any< VITAL_META_ ## N >(                                         \
+      normalize_0601_tag_data( KLV_0601_ ## N, VITAL_META_ ## N, data ) );  \
     break
 
-#define CASE_COPY(N)                                                    \
-  case KLV_0601_ ## N:                                                  \
-    md.add( NEW_METADATA_ITEM( VITAL_META_ ## N, data ) );              \
+#define CASE_COPY(N)                        \
+  case KLV_0601_ ## N:                      \
+    md.add_any< VITAL_META_ ## N >( data ); \
     break
 
-#define CASE2(KN,VN)                                                    \
-  case KLV_0601_ ## KN:                                                 \
-    md.add( NEW_METADATA_ITEM( VITAL_META_ ## VN,                       \
-      normalize_0601_tag_data( KLV_0601_ ## KN, VITAL_META_ ## VN, data ) ) ); \
+#define CASE2(KN,VN)                                                          \
+  case KLV_0601_ ## KN:                                                       \
+    md.add_any< VITAL_META_ ## VN >(                                          \
+      normalize_0601_tag_data( KLV_0601_ ## KN, VITAL_META_ ## VN, data ) );  \
     break
 
       CASE( UNIX_TIMESTAMP );
@@ -418,7 +418,7 @@ convert_metadata
     {
       vector_3d sensor_loc(raw_sensor_location[0], raw_sensor_location[1], raw_sensor_location[2]);
       auto const sensor_location = geo_point{ sensor_loc, SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_SENSOR_LOCATION, sensor_location ) );
+      md.add< VITAL_META_SENSOR_LOCATION >( sensor_location );
     }
   }
 
@@ -431,7 +431,7 @@ convert_metadata
     else
     {
       auto const frame_center = geo_point{ raw_frame_center, SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_FRAME_CENTER, frame_center ) );
+      md.add< VITAL_META_FRAME_CENTER >( frame_center );
     }
   }
 
@@ -444,7 +444,7 @@ convert_metadata
     else
     {
       auto const target_location = geo_point{ raw_target_location, SRID::lat_lon_WGS84 };
-      md.add( NEW_METADATA_ITEM( VITAL_META_TARGET_LOCATION, target_location ) );
+      md.add< VITAL_META_TARGET_LOCATION >( target_location );
     }
   }
 
@@ -500,7 +500,7 @@ convert_metadata
         raw_corners.push_back( raw_corner_pt4 + rfc );
 
         kwiver::vital::geo_polygon corners{ raw_corners, kwiver::vital::SRID::lat_lon_WGS84 };
-        md.add( NEW_METADATA_ITEM( VITAL_META_CORNER_POINTS, corners ) );
+        md.add< VITAL_META_CORNER_POINTS >( corners );
       }
     }
   } // corner points are empty

--- a/vital/tests/test_camera_from_metadata.cxx
+++ b/vital/tests/test_camera_from_metadata.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -93,22 +93,22 @@ metadata_sptr generate_metadata()
 
   // sample RPC metadata read by GDAL from the following 2016 MVS Benchmark image
   // 01SEP15WV031000015SEP01135603-P1BS-500497284040_01_P001_________AAE_0AAAAABPABP0.NTF
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_HEIGHT_OFFSET, HEIGHT_OFFSET ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_HEIGHT_SCALE, HEIGHT_SCALE ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_LAT_OFFSET, LAT_OFFSET ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_LAT_SCALE, LAT_SCALE ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_LONG_OFFSET, LONG_OFFSET ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_LONG_SCALE, LONG_SCALE ) );
+  md->add< VITAL_META_RPC_HEIGHT_OFFSET >( HEIGHT_OFFSET );
+  md->add< VITAL_META_RPC_HEIGHT_SCALE >( HEIGHT_SCALE );
+  md->add< VITAL_META_RPC_LAT_OFFSET >( LAT_OFFSET );
+  md->add< VITAL_META_RPC_LAT_SCALE >( LAT_SCALE );
+  md->add< VITAL_META_RPC_LONG_OFFSET >( LONG_OFFSET );
+  md->add< VITAL_META_RPC_LONG_SCALE >( LONG_SCALE );
 
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_ROW_OFFSET, ROW_OFFSET ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_ROW_SCALE, ROW_SCALE ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_COL_OFFSET, COL_OFFSET ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_COL_SCALE, COL_SCALE ) );
+  md->add< VITAL_META_RPC_ROW_OFFSET >( ROW_OFFSET );
+  md->add< VITAL_META_RPC_ROW_SCALE >( ROW_SCALE );
+  md->add< VITAL_META_RPC_COL_OFFSET >( COL_OFFSET );
+  md->add< VITAL_META_RPC_COL_SCALE >( COL_SCALE );
 
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_ROW_NUM_COEFF, row_num_coeff ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_ROW_DEN_COEFF, row_den_coeff ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_COL_NUM_COEFF, col_num_coeff ) );
-  md->add( NEW_METADATA_ITEM( VITAL_META_RPC_COL_DEN_COEFF, col_den_coeff ) );
+  md->add< VITAL_META_RPC_ROW_NUM_COEFF >( row_num_coeff );
+  md->add< VITAL_META_RPC_ROW_DEN_COEFF >( row_den_coeff );
+  md->add< VITAL_META_RPC_COL_NUM_COEFF >( col_num_coeff );
+  md->add< VITAL_META_RPC_COL_DEN_COEFF >( col_den_coeff );
 
   return md;
 }

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,8 +69,12 @@ struct vital_meta_trait_object
     virtual bool is_integral() const override { return std::is_integral<T>::value; } \
     virtual bool is_floating_point() const override { return std::is_floating_point<T>::value; } \
     virtual vital_metadata_tag tag() const override { return VITAL_META_ ## TAG; } \
-    virtual metadata_item* create_metadata_item ( const kwiver::vital::any& data ) const override \
-    { return new kwiver::vital::typed_metadata< VITAL_META_ ## TAG, T > ( NAME, data ); } \
+    virtual std::unique_ptr<metadata_item> create_metadata_item ( const kwiver::vital::any& data ) const override \
+    { \
+      return std::unique_ptr<metadata_item>{ \
+        new kwiver::vital::typed_metadata< VITAL_META_ ## TAG, T > ( NAME, data ) \
+      }; \
+    } \
   };
 
 #endif

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017, 2019 by Kitware, Inc.
+ * Copyright 2016-2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ struct vital_meta_trait_base
   virtual bool is_integral() const = 0;
   virtual bool is_floating_point() const = 0;
   virtual vital_metadata_tag tag() const = 0;
-  virtual metadata_item* create_metadata_item( const kwiver::vital::any& data ) const = 0;
+  virtual std::unique_ptr<metadata_item> create_metadata_item( const kwiver::vital::any& data ) const = 0;
 };
 
 
@@ -72,8 +72,6 @@ struct vital_meta_trait_base
 // vital meta compile time traits
 //
 //
-template <vital_metadata_tag tag> struct vital_meta_trait;
-
 
 // Macro to define basic metadata trait
 // This macro is available for others to create separate sets of traits.
@@ -183,10 +181,5 @@ private:
 }; // end class metadata_traits
 
 } } // end namespace
-
-// usage for creating metadata items
-#define NEW_METADATA_ITEM( TAG, DATA )                                  \
-  new kwiver::vital::typed_metadata< TAG, kwiver::vital::vital_meta_trait<TAG>::type > \
-  ( kwiver::vital::vital_meta_trait<TAG>::name(), DATA )
 
 #endif


### PR DESCRIPTION
Modify `metadata_map::add` to take a `unique_ptr` rather than a raw pointer to make it clear that the map takes ownership of the item. Add overloads to create the item, replacing the ugly `NEW_METADATA_ITEM` macro. Replace uses of said macro with the new methods.

This is also somewhat more type-safe, as the new method requires that the data being added is of the correct type. (An `add_any` method is provided for users that need to be able to add items without static type checking.)

Additionally, add move operations to `vital::any` and clean up the code style and documentation therein.

See also #1011.