### PR TITLE
Use an avfilter pipeline in the FFMPEG reader

### DIFF
--- a/CMake/FindFFMPEG.cmake
+++ b/CMake/FindFFMPEG.cmake
@@ -64,6 +64,13 @@ else()
     /usr/local/lib64
   )
 
+  find_library( FFMPEG_avfilter_LIBRARY avfilter
+    /usr/lib
+    /usr/local/lib
+    /usr/lib64
+    /usr/local/lib64
+  )
+
   find_library( FFMPEG_swscale_LIBRARY swscale
     /usr/lib
     /usr/local/lib
@@ -78,6 +85,9 @@ else()
     set( FFMPEG_LIBRARIES ${FFMPEG_avformat_LIBRARY} ${FFMPEG_avcodec_LIBRARY} )
     if( FFMPEG_avutil_LIBRARY )
        set( FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} ${FFMPEG_avutil_LIBRARY} )
+    endif()
+    if( FFMPEG_avfilter_LIBRARY )
+       set( FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} ${FFMPEG_avfilter_LIBRARY} )
     endif()
     if( FFMPEG_swscale_LIBRARY )
        set( FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} ${FFMPEG_swscale_LIBRARY} )

--- a/arrows/ffmpeg/ffmpeg_init.cxx
+++ b/arrows/ffmpeg/ffmpeg_init.cxx
@@ -40,6 +40,7 @@
 
 extern "C" {
 #include <libavformat/avformat.h>
+#include <libavfilter/avfilter.h>
 }
 
 #include <vital/logger/logger.h>
@@ -88,6 +89,7 @@ void ffmpeg_init()
   static bool initialized = false;
   if ( ! initialized ) {
     av_register_all();
+    avfilter_register_all();
     av_log_set_callback(ffmpeg_kwiver_log_callback);
     initialized = true;
   }

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -90,6 +90,7 @@ public:
     f_backstep_size(-1),
     f_frame_number_offset(0),
     video_path(""),
+    filter_desc("yadif=deint=1"),
     metadata(0),
     frame_advanced(0),
     end_of_video(true),
@@ -132,6 +133,10 @@ public:
 
   // Name of video we opened
   std::string video_path;
+
+  // FFMPEG filter description string
+  // What you put after -vf in the ffmpeg command line tool
+  std::string filter_desc;
 
   // the buffer of metadata from the data stream
   std::deque<uint8_t> metadata;
@@ -260,7 +265,7 @@ public:
       return false;
     }
 
-    if (!this->init_filters("yadif"))
+    if (!this->init_filters(filter_desc))
     {
       return false;
     }
@@ -916,6 +921,14 @@ ffmpeg_video_input
   // get base config from base class
   vital::config_block_sptr config = vital::algo::video_input::get_configuration();
 
+
+  config->set_value("filter_desc", d->filter_desc,
+    "A string describing the libavfilter pipeline to apply when reading "
+    "the video.  Only filters that operate on each frame independently "
+    "will currently work.  The default \"yadif=deint=1\" filter applies "
+    "deinterlacing only to frames which are interlaced.  "
+    "See details at https://ffmpeg.org/ffmpeg-filters.html");
+
   return config;
 }
 
@@ -931,6 +944,8 @@ ffmpeg_video_input
 
   vital::config_block_sptr config = this->get_configuration();
   config->merge_config(in_config);
+
+  d->filter_desc = config->get_value<std::string>("filter_desc", d->filter_desc);
 }
 
 

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1156,8 +1156,9 @@ ffmpeg_video_input
       av_image_fill_arrays(picture.data, picture.linesize,
                            (uint8_t*)d->current_image_memory->data(),
                            pix_fmt, width, height, 1);
+      auto framedata = const_cast<const uint8_t **>(frame->data);
       av_image_copy(picture.data, picture.linesize,
-                    (const uint8_t **)(frame->data), frame->linesize,
+                    framedata, frame->linesize,
                     pix_fmt, width, height);
     }
     else

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -43,6 +43,11 @@ Arrows: CUDA
 
 Arrows: FFmpeg
 
+ * Added a libavfilter pipeline into the ffmpeg_video_input reader. This
+   allows users to inject filters in the video reader, much the same as
+   is possible in the ffmpeg command line with the -vf option.  The default
+   filter applies deinterlacing to any interlaced frames.
+
 Arrows: GDAL
 
 Arrows: KPF


### PR DESCRIPTION
My motivation for this change was to restore the deinterlacing option that we used to have with older versions of FFMPEG.  This is important for properly reading interlaced video like the VIRAT data.  In modern FFMPEG there is no explicit deinterlacing functions.  Instead there is a generic filtering pipeline with `libavfilter` that includes several different deinterlacing filters to choose from.  The filter pipeline is very similar in concept to Sprokit, but focused on audio and video data only.  So with this change we can now inject  "yadif" (yet another deinterlacing filter) into the decoder which will deinterlace only if interlacing is detected.

This change is much more powerful than just deinterlacing.  The avfilter pipeline has a large pool of filters to choose from (blurring, cropping, flipping, color correction, etc).  You can now easily add a pipeline with any number of these features by setting the `filter_desc` string in the ffmpeg_video_input config.  The video will be filtered as it comes out of the video reader.  For example `yadif=dint=1, hflip, gblur=sigma=3` will deinterlace (the `dint=1` means only if needed), horizontally flip the image, and apply a Gaussian blur with sigma of 3.  We can do all of these things with VXL or OpenCV after reading the image, but we haven't wrapped all of these things as KWIVER algorithms, so the avfilter may be more convenient.

The current limitation of feature is that we are only supporting filters that operate on each frame independently.  Any filters that combine multiple frames or change the temporal frame sampling will not currently work correctly.  These things conflict with our design that focuses on frame accurate video seeking. 