### PR TITLE
Provide consistent data references in ocv_to_vital's returned image

### DIFF
--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -115,28 +115,25 @@ image_container
   // if the cv::Mat has reference counted memory then wrap it to keep a
   // counted reference too it.  If it doesn't own its memory, then the
   // vital image won't take ownership either
-  image_memory_sptr memory;
-  void* data;
+  cv::Mat img2;
 #ifndef KWIVER_HAS_OPENCV_VER_3
   if ( !img.refcount )
 #else
   if ( !img.u )
 #endif
   {
-    data = img.data;
-    memory = std::make_shared<mat_image_memory>(img);
+    img2 = img;
   }
   else
   {
-    cv::Mat img_clone = img.clone();
-    data = img_clone.data;
-    memory = std::make_shared<mat_image_memory>(img_clone);
+    img2 = img.clone();
   }
 
-  return image(memory, data,
-               img.cols, img.rows, img.channels(),
-               img.channels(), img.step1(), 1,
-               ocv_to_vital(img.type()));
+  image_memory_sptr memory = std::make_shared<mat_image_memory>(img2);
+  return image(memory, img2.data,
+               img2.cols, img2.rows, img2.channels(),
+               img2.channels(), img2.step1(), 1,
+               ocv_to_vital(img2.type()));
 }
 
 

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -116,21 +116,24 @@ image_container
   // counted reference too it.  If it doesn't own its memory, then the
   // vital image won't take ownership either
   image_memory_sptr memory;
+  void* data;
 #ifndef KWIVER_HAS_OPENCV_VER_3
   if ( !img.refcount )
 #else
   if ( !img.u )
 #endif
   {
+    data = img.data;
     memory = std::make_shared<mat_image_memory>(img);
   }
   else
   {
     cv::Mat img_clone = img.clone();
+    data = img_clone.data;
     memory = std::make_shared<mat_image_memory>(img_clone);
   }
 
-  return image(memory, img.data,
+  return image(memory, data,
                img.cols, img.rows, img.channels(),
                img.channels(), img.step1(), 1,
                ocv_to_vital(img.type()));


### PR DESCRIPTION
From the commit:

> If the else block in `ocv_to_vital(const cv::Mat&, ColorMode)` (in `kwiver::arrows::ocv::image_container`) is triggered, then `img.data` no longer points to memory managed by the variable `memory`.  Therefore we use `img_clone.data` in that case instead.

I ran into this when running a debug build of TeleSculptor. As previously created, the returned `image` ran afoul of [this check](https://github.com/vxl/vxl/blob/0bb0ca92867408caec298cef05412ed85c6d56b7/core/vil/vil_image_view.hxx#L85-L86) in VXL because the first pixel pointer was out of range of the data array.

I'm not very familiar with KWIVER's image infrastructure, so it would be good if someone could double-check this.