### PR TITLE
Dev/finish activity serialization

### DIFF
--- a/arrows/serialize/json/load_save.cxx
+++ b/arrows/serialize/json/load_save.cxx
@@ -664,17 +664,14 @@ void load( cereal::JSONInputArchive& archive,
   // Optional parameters aren't supported
   // for JSON. activity_type and participants may or may not exist,
   // so we check if an exception is thrown when we look for them.
-  // If an exception is thrown, we don't set those fields.
-  bool has_act_type = true;
-  bool has_participants = true;
-
+  // If an exception is thrown, we set those fields to null.
   try
   {
     load( archive, *act_type );
   }
   catch( cereal::Exception& )
   {
-    has_act_type = false;
+    act_type = nullptr;
   }
 
   try
@@ -683,26 +680,11 @@ void load( cereal::JSONInputArchive& archive,
   }
   catch( cereal::Exception& )
   {
-    has_participants = false;
+    participants = nullptr;
   }
 
-  if ( has_act_type )
-  {
-    activity.set_activity_type( act_type );
-  }
-  else
-  {
-    activity.set_activity_type( nullptr );
-  }
-
-  if ( has_participants )
-  {
-    activity.set_participants( participants );
-  }
-  else
-  {
-    activity.set_participants( nullptr );
-  }
+  activity.set_activity_type( act_type );
+  activity.set_participants( participants );
 }
 
 } // end namespace

--- a/arrows/serialize/json/load_save.cxx
+++ b/arrows/serialize/json/load_save.cxx
@@ -669,7 +669,7 @@ void load( cereal::JSONInputArchive& archive,
   {
     load( archive, *act_type );
   }
-  catch( cereal::Exception& )
+  catch( cereal::Exception const& )
   {
     act_type = nullptr;
   }
@@ -678,7 +678,7 @@ void load( cereal::JSONInputArchive& archive,
   {
     load( archive, *participants );
   }
-  catch( cereal::Exception& )
+  catch( cereal::Exception const& )
   {
     participants = nullptr;
   }

--- a/arrows/serialize/json/load_save.cxx
+++ b/arrows/serialize/json/load_save.cxx
@@ -629,10 +629,14 @@ void save( cereal::JSONOutputArchive& archive,
 
     // These may be null
     if ( activity.activity_type() )
+    {
       save( archive, *activity.activity_type());
+    }
 
     if ( activity.participants() )
+    {
       save( archive, *activity.participants() );
+    }
 }
 
 void load( cereal::JSONInputArchive& archive,
@@ -683,14 +687,22 @@ void load( cereal::JSONInputArchive& archive,
   }
 
   if ( has_act_type )
+  {
     activity.set_activity_type( act_type );
+  }
   else
+  {
     activity.set_activity_type( nullptr );
+  }
 
   if ( has_participants )
+  {
     activity.set_participants( participants );
+  }
   else
+  {
     activity.set_participants( nullptr );
+  }
 }
 
 } // end namespace

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -77,7 +77,7 @@ TEST( load_save, activity_default )
 {
   // This tests the behavior when participants
   // and class_map are set to NULL
-  kwiver::vital::activity act;
+  auto const act = kwiver::vital::activity{};
   std::stringstream msg;
   {
     cereal::JSONOutputArchive ar( msg );
@@ -94,7 +94,8 @@ TEST( load_save, activity_default )
   auto const end_in = kwiver::vital::timestamp { 2, 2 };
   auto const part_in = std::make_shared< kwiver::vital::object_track_set >();
 
-  auto act_dser = kwiver::vital::activity { 5, "label", 3.14, cm_in, start_in, end_in, part_in };
+  auto act_dser =
+    kwiver::vital::activity { 5, "label", 3.14, cm_in, start_in, end_in, part_in };
   {
     cereal::JSONInputArchive ar( msg );
     cereal::load( ar, act_dser );
@@ -108,10 +109,10 @@ TEST( load_save, activity_default )
   EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
 
   // Timestamps are invalid so can't do a direct comparison
-  auto start = act.start();
-  auto end = act.end();
-  auto start_dser = act_dser.start();
-  auto end_dser = act_dser.end();
+  auto const start = act.start();
+  auto const end = act.end();
+  auto const start_dser = act_dser.start();
+  auto const end_dser = act_dser.end();
 
   EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
   EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
@@ -136,23 +137,32 @@ TEST( load_save, activity )
   track_sptr->set_id( 1 );
   for ( int i = 0; i < 10; i++ )
   {
-    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto const bbox =
+      kwiver::vital::bounding_box_d{ 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+
     auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
     dobj_cm_sptr->set_score( "key", i / 10.0 );
-    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
-    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
+    auto const dobj_sptr =
+      std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+
+    auto const ots_sptr =
+      std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
     track_sptr->append( ots_sptr );
   }
 
-  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
-  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+  auto const tracks = std::vector< kwiver::vital::track_sptr >{ track_sptr };
+  auto const obj_trk_set_sptr =
+    std::make_shared< kwiver::vital::object_track_set >( tracks );
 
   // Now both timestamps
-  kwiver::vital::timestamp start { 1, 1 } ;
-  kwiver::vital::timestamp end { 2, 2 };
+  auto const start = kwiver::vital::timestamp{ 1, 1 };
+  auto const end = kwiver::vital::timestamp{ 2, 2 };
 
   // Now construct activity
-  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+  auto const act =
+    kwiver::vital::activity{ 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr };
 
   std::stringstream msg;
   {
@@ -164,7 +174,7 @@ TEST( load_save, activity )
   std::cout << "activity as json - " << msg.str() << std::endl;
   #endif
 
-  kwiver::vital::activity act_dser;
+  auto act_dser = kwiver::vital::activity{};
   {
     cereal::JSONInputArchive ar( msg );
     cereal::load( ar, act_dser );
@@ -197,25 +207,26 @@ TEST( load_save, activity )
   // Iterate over the track_states
   for ( int i = 0; i < 10; i++ )
   {
-    auto trk_state_sptr = *trk->find( i );
-    auto trk_state_dser_sptr = *trk_dser->find( i );
+    auto const trk_state_sptr = *trk->find( i );
+    auto const trk_state_dser_sptr = *trk_dser->find( i );
 
     EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
 
-    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
-    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
-                                                      downcast( trk_state_dser_sptr );
+    auto const obj_trk_state_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto const obj_trk_state_dser_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_dser_sptr );
 
     EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
 
-    auto do_ser_sptr = obj_trk_state_sptr->detection();
-    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+    auto const do_ser_sptr = obj_trk_state_sptr->detection();
+    auto const do_dser_sptr = obj_trk_state_dser_sptr->detection();
 
     EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
     EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
 
-    auto cm_ser_sptr = do_ser_sptr->type();
-    auto cm_dser_sptr = do_dser_sptr->type();
+    auto const cm_ser_sptr = do_ser_sptr->type();
+    auto const cm_dser_sptr = do_dser_sptr->type();
 
     if ( cm_ser_sptr )
     {

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include <vital/types/activity.h>
 #include <vital/types/bounding_box.h>
 #include <vital/types/class_map.h>
 #include <vital/types/covariance.h>
@@ -69,6 +70,159 @@ int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST( load_save, activity_default )
+{
+  // This tests the behavior when participants
+  // and class_map are set to NULL
+  kwiver::vital::activity act;
+  std::stringstream msg;
+  {
+    cereal::JSONOutputArchive ar( msg );
+    cereal::save( ar, act );
+  }
+
+  #ifndef NDEBUG
+  std::cout << "default activity as json - " << msg.str() << std::endl;
+  #endif
+
+  // Set some data to check that fields are overwritten
+  auto const cm_in = std::make_shared< kwiver::vital::class_map >();
+  auto const start_in = kwiver::vital::timestamp { 1, 1 };
+  auto const end_in = kwiver::vital::timestamp { 2, 2 };
+  auto const part_in = std::make_shared< kwiver::vital::object_track_set >();
+
+  auto act_dser = kwiver::vital::activity { 5, "label", 3.14, cm_in, start_in, end_in, part_in };
+  {
+    cereal::JSONInputArchive ar( msg );
+    cereal::load( ar, act_dser );
+  }
+
+  // Check members
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_EQ( act.activity_type(), act_dser.activity_type() );
+  EXPECT_EQ( act.participants(), act_dser.participants() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+
+  // Timestamps are invalid so can't do a direct comparison
+  auto start = act.start();
+  auto end = act.end();
+  auto start_dser = act_dser.start();
+  auto end_dser = act_dser.end();
+
+  EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
+  EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
+  EXPECT_EQ( start.get_time_domain_index(), start_dser.get_time_domain_index() );
+
+  EXPECT_EQ( end.get_time_seconds(), end_dser.get_time_seconds() );
+  EXPECT_EQ( end.get_frame(), end_dser.get_frame() );
+  EXPECT_EQ( end.get_time_domain_index(), end_dser.get_time_domain_index() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( load_save, activity )
+{
+  auto cm_sptr = std::make_shared< kwiver::vital::class_map >();
+  cm_sptr->set_score( "first", 1 );
+  cm_sptr->set_score( "second", 10 );
+  cm_sptr->set_score( "third", 101 );
+
+  // Create object_track_set consisting of
+  // 1 track_sptr with 10 track states
+  auto track_sptr = kwiver::vital::track::create();
+  track_sptr->set_id( 1 );
+  for ( int i = 0; i < 10; i++ )
+  {
+    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
+    dobj_cm_sptr->set_score( "key", i / 10.0 );
+    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+    track_sptr->append( ots_sptr );
+  }
+
+  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
+  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+
+  // Now both timestamps
+  kwiver::vital::timestamp start { 1, 1 } ;
+  kwiver::vital::timestamp end { 2, 2 };
+
+  // Now construct activity
+  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+
+  std::stringstream msg;
+  {
+    cereal::JSONOutputArchive ar( msg );
+    cereal::save( ar, act );
+  }
+
+  #ifndef NDEBUG
+  std::cout << "activity as json - " << msg.str() << std::endl;
+  #endif
+
+  kwiver::vital::activity act_dser;
+  {
+    cereal::JSONInputArchive ar( msg );
+    cereal::load( ar, act_dser );
+  }
+
+  // Now check equality
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+  EXPECT_EQ( act.start(), act_dser.start() );
+  EXPECT_EQ( act.end(), act_dser.end() );
+
+  // Check values in the retrieved class map
+  auto const act_type = act.activity_type();
+  auto const act_type_dser = act_dser.activity_type();
+  EXPECT_EQ( act_type->size(), act_type_dser->size() );
+  EXPECT_DOUBLE_EQ( act_type->score( "first" ),  act_type_dser->score( "first" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "second" ), act_type_dser->score( "second" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "third" ),  act_type_dser->score( "third" ) );
+
+  // Now the object_track_set
+  auto const parts = act.participants();
+  auto const parts_dser = act_dser.participants();
+
+  EXPECT_EQ( parts->size(), parts_dser->size() );
+
+  auto const trk = parts->get_track( 1 );
+  auto const trk_dser = parts_dser->get_track( 1 );
+
+  // Iterate over the track_states
+  for ( int i = 0; i < 10; i++ )
+  {
+    auto trk_state_sptr = *trk->find( i );
+    auto trk_state_dser_sptr = *trk_dser->find( i );
+
+    EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
+
+    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
+                                                      downcast( trk_state_dser_sptr );
+
+    EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
+
+    auto do_ser_sptr = obj_trk_state_sptr->detection();
+    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+
+    EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
+    EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
+
+    auto cm_ser_sptr = do_ser_sptr->type();
+    auto cm_dser_sptr = do_dser_sptr->type();
+
+    if ( cm_ser_sptr )
+    {
+      EXPECT_EQ( cm_ser_sptr->size(), cm_dser_sptr->size() );
+      EXPECT_EQ( cm_ser_sptr->score( "key" ), cm_dser_sptr->score( "key" ) );
+    }
+  }
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include <vital/types/activity.h>
 #include <vital/types/bounding_box.h>
 #include <vital/types/class_map.h>
 #include <vital/types/detected_object.h>
@@ -44,6 +45,7 @@
 #include <vital/types/track.h>
 #include <vital/types/object_track_set.h>
 
+#include <arrows/serialize/json/activity.h>
 #include <arrows/serialize/json/bounding_box.h>
 #include <arrows/serialize/json/class_map.h>
 #include <arrows/serialize/json/detected_object.h>
@@ -68,6 +70,137 @@ int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST( serialize, activity_default )
+{
+  // This tests the behavior when participants
+  // and class_map are set to NULL
+  kwiver::vital::activity act;
+  kasj::activity act_ser;
+
+  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+
+  auto dser = act_ser.deserialize( *mes );
+  kwiver::vital::activity act_dser =
+    kwiver::vital::any_cast< kwiver::vital::activity >( dser );
+
+  // Check members
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_EQ( act.activity_type(), act_dser.activity_type() );
+  EXPECT_EQ( act.participants(), act_dser.participants() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+
+  // Timestamps are invalid so can't do a direct comparison
+  auto start = act.start();
+  auto end = act.end();
+  auto start_dser = act_dser.start();
+  auto end_dser = act_dser.end();
+
+  EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
+  EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
+  EXPECT_EQ( start.get_time_domain_index(), start_dser.get_time_domain_index() );
+
+  EXPECT_EQ( end.get_time_seconds(), end_dser.get_time_seconds() );
+  EXPECT_EQ( end.get_frame(), end_dser.get_frame() );
+  EXPECT_EQ( end.get_time_domain_index(), end_dser.get_time_domain_index() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( serialize, activity )
+{
+  auto cm_sptr = std::make_shared< kwiver::vital::class_map >();
+  cm_sptr->set_score( "first", 1 );
+  cm_sptr->set_score( "second", 10 );
+  cm_sptr->set_score( "third", 101 );
+
+  // Create object_track_set consisting of
+  // 1 track_sptr with 10 track states
+  auto track_sptr = kwiver::vital::track::create();
+  track_sptr->set_id( 1 );
+  for ( int i = 0; i < 10; i++ )
+  {
+    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
+    dobj_cm_sptr->set_score( "key", i / 10.0 );
+    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+    track_sptr->append( ots_sptr );
+  }
+
+  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
+  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+
+  // Now both timestamps
+  kwiver::vital::timestamp start { 1, 1 } ;
+  kwiver::vital::timestamp end { 2, 2 };
+
+  // Now construct activity
+  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+
+  kasj::activity act_ser;
+
+  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+
+  auto dser = act_ser.deserialize( *mes );
+  kwiver::vital::activity act_dser =
+    kwiver::vital::any_cast< kwiver::vital::activity >( dser );
+
+  // Now check equality
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+  EXPECT_EQ( act.start(), act_dser.start() );
+  EXPECT_EQ( act.end(), act_dser.end() );
+
+  // Check values in the retrieved class map
+  auto const act_type = act.activity_type();
+  auto const act_type_dser = act_dser.activity_type();
+  EXPECT_EQ( act_type->size(), act_type_dser->size() );
+  EXPECT_DOUBLE_EQ( act_type->score( "first" ),  act_type_dser->score( "first" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "second" ), act_type_dser->score( "second" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "third" ),  act_type_dser->score( "third" ) );
+
+  // Now the object_track_set
+  auto const parts = act.participants();
+  auto const parts_dser = act_dser.participants();
+
+  EXPECT_EQ( parts->size(), parts_dser->size() );
+
+  auto const trk = parts->get_track( 1 );
+  auto const trk_dser = parts_dser->get_track( 1 );
+
+  // Iterate over the track_states
+  for ( int i = 0; i < 10; i++ )
+  {
+    auto trk_state_sptr = *trk->find( i );
+    auto trk_state_dser_sptr = *trk_dser->find( i );
+
+    EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
+
+    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
+                                                      downcast( trk_state_dser_sptr );
+
+    EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
+
+    auto do_ser_sptr = obj_trk_state_sptr->detection();
+    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+
+    EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
+    EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
+
+    auto cm_ser_sptr = do_ser_sptr->type();
+    auto cm_dser_sptr = do_dser_sptr->type();
+
+    if ( cm_ser_sptr )
+    {
+      EXPECT_EQ( cm_ser_sptr->size(), cm_dser_sptr->size() );
+      EXPECT_EQ( cm_ser_sptr->score( "key" ), cm_dser_sptr->score( "key" ) );
+    }
+  }
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -269,8 +269,8 @@ TEST( serialize, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
-    o_it++;
-    d_it++;
+    ++o_it;
+    ++d_it;
   }
 }
 
@@ -339,8 +339,8 @@ TEST( serialize, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
-      o_it++;
-      d_it++;
+      ++o_it;
+      ++d_it;
     }
   }
 }
@@ -403,8 +403,8 @@ TEST( serialize, detected_object_set )
       {
         EXPECT_EQ( *(o_it->first), *(d_it->first) );
         EXPECT_EQ( o_it->second, d_it->second );
-        o_it++;
-        d_it++;
+        ++o_it;
+        ++d_it;
       }
     }
   }

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -259,6 +259,8 @@ TEST( serialize, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
+    o_it++;
+    d_it++;
   }
 }
 
@@ -327,6 +329,8 @@ TEST( serialize, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
+      o_it++;
+      d_it++;
     }
   }
 }
@@ -389,6 +393,8 @@ TEST( serialize, detected_object_set )
       {
         EXPECT_EQ( *(o_it->first), *(d_it->first) );
         EXPECT_EQ( o_it->second, d_it->second );
+        o_it++;
+        d_it++;
       }
     }
   }

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -77,13 +77,13 @@ TEST( serialize, activity_default )
 {
   // This tests the behavior when participants
   // and class_map are set to NULL
-  kwiver::vital::activity act;
-  kasj::activity act_ser;
+  auto const act = kwiver::vital::activity{};
+  auto act_ser = kasj::activity{};
 
-  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+  auto const mes = act_ser.serialize( kwiver::vital::any( act ) );
 
-  auto dser = act_ser.deserialize( *mes );
-  kwiver::vital::activity act_dser =
+  auto const dser = act_ser.deserialize( *mes );
+  auto const act_dser =
     kwiver::vital::any_cast< kwiver::vital::activity >( dser );
 
   // Check members
@@ -94,10 +94,10 @@ TEST( serialize, activity_default )
   EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
 
   // Timestamps are invalid so can't do a direct comparison
-  auto start = act.start();
-  auto end = act.end();
-  auto start_dser = act_dser.start();
-  auto end_dser = act_dser.end();
+  auto const start = act.start();
+  auto const end = act.end();
+  auto const start_dser = act_dser.start();
+  auto const end_dser = act_dser.end();
 
   EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
   EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
@@ -122,30 +122,39 @@ TEST( serialize, activity )
   track_sptr->set_id( 1 );
   for ( int i = 0; i < 10; i++ )
   {
-    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto const bbox =
+      kwiver::vital::bounding_box_d{ 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+
     auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
     dobj_cm_sptr->set_score( "key", i / 10.0 );
-    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
-    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
+    auto const dobj_sptr =
+      std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+
+    auto const ots_sptr =
+      std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
     track_sptr->append( ots_sptr );
   }
 
-  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
-  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+  auto const tracks = std::vector< kwiver::vital::track_sptr >{ track_sptr };
+  auto const obj_trk_set_sptr =
+    std::make_shared< kwiver::vital::object_track_set >( tracks );
 
   // Now both timestamps
-  kwiver::vital::timestamp start { 1, 1 } ;
-  kwiver::vital::timestamp end { 2, 2 };
+  auto const start = kwiver::vital::timestamp{ 1, 1 };
+  auto const end = kwiver::vital::timestamp{ 2, 2 };
 
   // Now construct activity
-  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+  auto const act =
+    kwiver::vital::activity{ 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr };
 
-  kasj::activity act_ser;
+  auto act_ser = kasj::activity{};
 
-  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+  auto const mes = act_ser.serialize( kwiver::vital::any( act ) );
 
-  auto dser = act_ser.deserialize( *mes );
-  kwiver::vital::activity act_dser =
+  auto const dser = act_ser.deserialize( *mes );
+  auto const act_dser =
     kwiver::vital::any_cast< kwiver::vital::activity >( dser );
 
   // Now check equality
@@ -175,25 +184,26 @@ TEST( serialize, activity )
   // Iterate over the track_states
   for ( int i = 0; i < 10; i++ )
   {
-    auto trk_state_sptr = *trk->find( i );
-    auto trk_state_dser_sptr = *trk_dser->find( i );
+    auto const trk_state_sptr = *trk->find( i );
+    auto const trk_state_dser_sptr = *trk_dser->find( i );
 
     EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
 
-    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
-    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
-                                                      downcast( trk_state_dser_sptr );
+    auto const obj_trk_state_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto const obj_trk_state_dser_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_dser_sptr );
 
     EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
 
-    auto do_ser_sptr = obj_trk_state_sptr->detection();
-    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+    auto const do_ser_sptr = obj_trk_state_sptr->detection();
+    auto const do_dser_sptr = obj_trk_state_dser_sptr->detection();
 
     EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
     EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
 
-    auto cm_ser_sptr = do_ser_sptr->type();
-    auto cm_dser_sptr = do_dser_sptr->type();
+    auto const cm_ser_sptr = do_ser_sptr->type();
+    auto const cm_dser_sptr = do_dser_sptr->type();
 
     if ( cm_ser_sptr )
     {

--- a/arrows/serialize/protobuf/CMakeLists.txt
+++ b/arrows/serialize/protobuf/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set( headers_public
   convert_protobuf.h
   convert_protobuf_point.h
+  activity.h
   bounding_box.h
   class_map.h
   detected_object.h
@@ -29,6 +30,7 @@ set( headers_public
 set( sources
   convert_protobuf.cxx
   convert_protobuf_point.cxx
+  activity.cxx
   bounding_box.cxx
   class_map.cxx
   detected_object.cxx

--- a/arrows/serialize/protobuf/activity.cxx
+++ b/arrows/serialize/protobuf/activity.cxx
@@ -1,0 +1,112 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "activity.h"
+#include "convert_protobuf.h"
+
+#include <vital/types/activity.h>
+#include <vital/types/protobuf/activity.pb.h>
+#include <vital/exceptions.h>
+
+namespace kwiver {
+namespace arrows {
+namespace serialize {
+namespace protobuf {
+
+// ----------------------------------------------------------------------------
+activity::
+activity()
+{
+  // Verify that the version of the library that we linked against is
+  // compatible with the version of the headers we compiled against.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+}
+
+
+activity::
+~activity()
+{ }
+
+// ----------------------------------------------------------------------------
+std::shared_ptr< std::string >
+activity::
+serialize( const vital::any& element )
+{
+  kwiver::vital::activity act =
+    kwiver::vital::any_cast< kwiver::vital::activity > ( element );
+
+  std::ostringstream msg;
+  msg << "activity "; // add type tag
+
+  kwiver::protobuf::activity proto_act;
+  convert_protobuf( act, proto_act );
+
+  if ( ! proto_act.SerializeToOstream( &msg ) )
+  {
+    VITAL_THROW( kwiver::vital::serialization_exception,
+                 "Error serializing activity from protobuf" );
+  }
+
+  return std::make_shared< std::string > ( msg.str() );
+}
+
+// ----------------------------------------------------------------------------
+vital::any activity::
+deserialize( const std::string& message )
+{
+  kwiver::vital::activity act;
+  std::istringstream msg( message );
+
+  std::string tag;
+  msg >> tag;
+  msg.get();  // Eat delimiter
+
+  if ( tag != "activity" )
+  {
+    LOG_ERROR( logger(), "Invalid data type tag received. Expected \"activity\", received \""
+               << tag << "\". Message dropped." );
+  }
+  else
+  {
+    // define our protobuf
+    kwiver::protobuf::activity proto_act;
+    if ( ! proto_act.ParseFromIstream( &msg ) )
+    {
+      VITAL_THROW( kwiver::vital::serialization_exception,
+                   "Error deserializing detected_type from protobuf" );
+    }
+
+    convert_protobuf( proto_act, act );
+  }
+
+  return kwiver::vital::any(act);
+}
+
+} } } } // end namespace

--- a/arrows/serialize/protobuf/activity.h
+++ b/arrows/serialize/protobuf/activity.h
@@ -1,0 +1,58 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ARROWS_SERIALIZATION_PROTO_ACTIVITY_H
+#define ARROWS_SERIALIZATION_PROTO_ACTIVITY_H
+
+#include <arrows/serialize/protobuf/kwiver_serialize_protobuf_export.h>
+#include <vital/algo/data_serializer.h>
+
+namespace kwiver {
+namespace arrows {
+namespace serialize {
+namespace protobuf {
+
+class KWIVER_SERIALIZE_PROTOBUF_EXPORT activity
+  : public vital::algo::data_serializer
+{
+public:
+  PLUGIN_INFO( "kwiver:activity",
+               "Serializes a activity using protobuf notation. " );
+
+  activity();
+  virtual ~activity();
+
+  std::shared_ptr< std::string > serialize( const vital::any& element ) override;
+  vital::any deserialize( const std::string& message ) override;
+};
+
+} } } }       // end namespace kwiver
+
+#endif // ARROWS_SERIALIZATION_PROTO_ACTIVITY_H

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -46,6 +46,7 @@
 #include <vital/exceptions.h>
 #include <vital/vital_types.h>
 
+#include <vital/types/protobuf/activity.pb.h>
 #include <vital/types/protobuf/bounding_box.pb.h>
 #include <vital/types/protobuf/class_map.pb.h>
 #include <vital/types/protobuf/detected_object.pb.h>
@@ -67,6 +68,7 @@
 #include <zlib.h>
 #include <cstddef>
 #include <cstring>
+#include <memory>
 #include <sstream>
 
 namespace kwiver {
@@ -75,7 +77,79 @@ namespace serialize {
 namespace protobuf {
 
 // ----------------------------------------------------------------------------
-void convert_protobuf( const ::kwiver::protobuf::bounding_box&  proto_bbox,
+KWIVER_SERIALIZE_PROTOBUF_EXPORT
+void convert_protobuf( const ::kwiver::protobuf::activity& proto_act,
+                       ::kwiver::vital::activity&          act )
+{
+  act = ::kwiver::vital::activity();
+
+  // First convert required params from protobuf
+  ::kwiver::vital::timestamp start_frame;
+  convert_protobuf( proto_act.start_frame(), start_frame );
+
+  ::kwiver::vital::timestamp end_frame;
+  convert_protobuf( proto_act.end_frame(), end_frame );
+
+  // Set required params
+  act.set_id( proto_act.id() );
+  act.set_label( proto_act.label() );
+  act.set_confidence( proto_act.confidence() );
+  act.set_start( start_frame );
+  act.set_end( end_frame );
+
+  // Now get the optional params, if they exist, and set
+  if ( proto_act.has_classifications() )
+  {
+    auto cm_sptr = std::make_shared< ::kwiver::vital::class_map >();
+    convert_protobuf( proto_act.classifications(), *cm_sptr );
+    act.set_activity_type( cm_sptr );
+  }
+
+  if ( proto_act.has_participants() )
+  {
+    auto obj_trk_set_sptr = std::make_shared< ::kwiver::vital::object_track_set >();
+    convert_protobuf( proto_act.participants(), obj_trk_set_sptr );
+    act.set_participants( obj_trk_set_sptr );
+  }
+}
+
+// ----------------------------------------------------------------------------
+KWIVER_SERIALIZE_PROTOBUF_EXPORT
+void convert_protobuf( const ::kwiver::vital::activity& act,
+                       ::kwiver::protobuf::activity&    proto_act )
+{
+  // Again retrieve required params and convert to protobuf
+  ::kwiver::protobuf::timestamp proto_start_frame;
+  convert_protobuf( act.start(), proto_start_frame );
+
+  ::kwiver::protobuf::timestamp proto_end_frame;
+  convert_protobuf( act.end(), proto_end_frame );
+
+  // Set required fields
+  proto_act.set_id( act.id() );
+  proto_act.set_label( act.label() );
+  proto_act.set_confidence( act.confidence() );
+  *proto_act.mutable_start_frame() = proto_start_frame;
+  *proto_act.mutable_end_frame() = proto_end_frame;
+
+  // Now check if optional fields can be set
+  if ( auto cm_sptr = act.activity_type() )
+  {
+    ::kwiver::protobuf::class_map proto_cm;
+    convert_protobuf( *cm_sptr, proto_cm );
+    *proto_act.mutable_classifications() = proto_cm;
+  }
+
+  if ( auto obj_trk_set_sptr = act.participants() )
+  {
+    ::kwiver::protobuf::object_track_set proto_obj_trk_set;
+    convert_protobuf( obj_trk_set_sptr, proto_obj_trk_set );
+    *proto_act.mutable_participants() = proto_obj_trk_set;
+  }
+}
+
+// ----------------------------------------------------------------------------
+void convert_protobuf( const ::kwiver::protobuf::bounding_box& proto_bbox,
                   ::kwiver::vital::bounding_box_d& bbox )
  {
    bbox = ::kwiver::vital::bounding_box_d( proto_bbox.xmin(),

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -132,14 +132,14 @@ void convert_protobuf( const ::kwiver::vital::activity& act,
   *proto_act.mutable_start_frame() = proto_start_frame;
   *proto_act.mutable_end_frame() = proto_end_frame;
 
-  // auto cm_sptr = act.activity_type();
-  // // Now check if optional fields can be set
-  // if ( auto cm_sptr = act.activity_type() )
-  // {
-  //   ::kwiver::protobuf::class_map proto_cm;
-  //   convert_protobuf( *cm_sptr, proto_cm );
-  //   *proto_act.mutable_classifications() = proto_cm;
-  // }
+  auto cm_sptr = act.activity_type();
+  // Now check if optional fields can be set
+  if ( auto cm_sptr = act.activity_type() )
+  {
+    ::kwiver::protobuf::class_map proto_cm;
+    convert_protobuf( *cm_sptr, proto_cm );
+    *proto_act.mutable_classifications() = proto_cm;
+  }
 
   if ( auto obj_trk_set_sptr = act.participants() )
   {

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -98,10 +98,10 @@ void convert_protobuf( const ::kwiver::protobuf::activity& proto_act,
   act.set_end( end_frame );
 
   // Now get the optional params, if they exist, and set
-  if ( proto_act.has_classifications() )
+  if ( proto_act.has_activity_type() )
   {
     auto cm_sptr = std::make_shared< ::kwiver::vital::class_map >();
-    convert_protobuf( proto_act.classifications(), *cm_sptr );
+    convert_protobuf( proto_act.activity_type(), *cm_sptr );
     act.set_activity_type( cm_sptr );
   }
 
@@ -138,7 +138,7 @@ void convert_protobuf( const ::kwiver::vital::activity& act,
   {
     ::kwiver::protobuf::class_map proto_cm;
     convert_protobuf( *cm_sptr, proto_cm );
-    *proto_act.mutable_classifications() = proto_cm;
+    *proto_act.mutable_activity_type() = proto_cm;
   }
 
   if ( auto obj_trk_set_sptr = act.participants() )

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -132,13 +132,14 @@ void convert_protobuf( const ::kwiver::vital::activity& act,
   *proto_act.mutable_start_frame() = proto_start_frame;
   *proto_act.mutable_end_frame() = proto_end_frame;
 
-  // Now check if optional fields can be set
-  if ( auto cm_sptr = act.activity_type() )
-  {
-    ::kwiver::protobuf::class_map proto_cm;
-    convert_protobuf( *cm_sptr, proto_cm );
-    *proto_act.mutable_classifications() = proto_cm;
-  }
+  // auto cm_sptr = act.activity_type();
+  // // Now check if optional fields can be set
+  // if ( auto cm_sptr = act.activity_type() )
+  // {
+  //   ::kwiver::protobuf::class_map proto_cm;
+  //   convert_protobuf( *cm_sptr, proto_cm );
+  //   *proto_act.mutable_classifications() = proto_cm;
+  // }
 
   if ( auto obj_trk_set_sptr = act.participants() )
   {

--- a/arrows/serialize/protobuf/convert_protobuf.h
+++ b/arrows/serialize/protobuf/convert_protobuf.h
@@ -33,6 +33,7 @@
 
 #include <arrows/serialize/protobuf/kwiver_serialize_protobuf_export.h>
 
+#include <vital/types/activity.h>
 #include <vital/types/metadata.h>
 #include <vital/types/bounding_box.h>
 #include <vital/types/image_container.h>
@@ -57,6 +58,7 @@ namespace vital {
 namespace kwiver {
 namespace protobuf {
 
+  class activity;
   class bounding_box;
   class class_map;
   class detected_object;
@@ -82,6 +84,15 @@ namespace kwiver {
 namespace arrows {
 namespace serialize {
 namespace protobuf {
+
+// ---- activity
+KWIVER_SERIALIZE_PROTOBUF_EXPORT
+void convert_protobuf( const ::kwiver::protobuf::activity& proto_act,
+                       ::kwiver::vital::activity&          act );
+
+KWIVER_SERIALIZE_PROTOBUF_EXPORT
+void convert_protobuf( const ::kwiver::vital::activity& act,
+                       ::kwiver::protobuf::activity&    proto_act );
 
 // ---- bounding_box
 KWIVER_SERIALIZE_PROTOBUF_EXPORT

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -87,8 +87,8 @@ TEST( convert_protobuf, activity_default )
 {
   // This tests the behavior when participants
   // and class_map are set to NULL
-  kwiver::vital::activity act;
-  kwiver::protobuf::activity act_proto;
+  auto const act = kwiver::vital::activity{};
+  auto act_proto = kwiver::protobuf::activity{};
 
   // Set some data to check that fields are overwritten
   auto const cm_in = std::make_shared< kwiver::vital::class_map >();
@@ -96,7 +96,8 @@ TEST( convert_protobuf, activity_default )
   auto const end_in = kwiver::vital::timestamp { 2, 2 };
   auto const part_in = std::make_shared< kwiver::vital::object_track_set >();
 
-  auto act_dser = kwiver::vital::activity { 5, "label", 3.14, cm_in, start_in, end_in, part_in };
+  auto act_dser =
+    kwiver::vital::activity{ 5, "label", 3.14, cm_in, start_in, end_in, part_in };
 
   kasp::convert_protobuf( act, act_proto );
   kasp::convert_protobuf( act_proto, act_dser );
@@ -109,10 +110,10 @@ TEST( convert_protobuf, activity_default )
   EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
 
   // Timestamps are invalid so can't do a direct comparison
-  auto start = act.start();
-  auto end = act.end();
-  auto start_dser = act_dser.start();
-  auto end_dser = act_dser.end();
+  auto const start = act.start();
+  auto const end = act.end();
+  auto const start_dser = act_dser.start();
+  auto const end_dser = act_dser.end();
 
   EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
   EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
@@ -137,26 +138,35 @@ TEST( convert_protobuf, activity )
   track_sptr->set_id( 1 );
   for ( int i = 0; i < 10; i++ )
   {
-    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto const bbox =
+      kwiver::vital::bounding_box_d{ 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+
     auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
     dobj_cm_sptr->set_score( "key", i / 10.0 );
-    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
-    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
+    auto const dobj_sptr =
+      std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+
+    auto const ots_sptr =
+      std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
     track_sptr->append( ots_sptr );
   }
 
-  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
-  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+  auto const tracks = std::vector< kwiver::vital::track_sptr >{ track_sptr };
+  auto const obj_trk_set_sptr =
+    std::make_shared< kwiver::vital::object_track_set >( tracks );
 
   // Now both timestamps
-  kwiver::vital::timestamp start { 1, 1 } ;
-  kwiver::vital::timestamp end { 2, 2 };
+  auto const start = kwiver::vital::timestamp{ 1, 1 };
+  auto const end = kwiver::vital::timestamp{ 2, 2 };
 
   // Now construct activity
-  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+  auto const act =
+    kwiver::vital::activity{ 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr };
 
-  kwiver::protobuf::activity act_proto;
-  kwiver::vital::activity act_dser;
+  auto act_proto = kwiver::protobuf::activity{};
+  auto act_dser = kwiver::vital::activity{};
 
   kasp::convert_protobuf( act, act_proto );
   kasp::convert_protobuf( act_proto, act_dser );
@@ -188,25 +198,26 @@ TEST( convert_protobuf, activity )
   // Iterate over the track_states
   for ( int i = 0; i < 10; i++ )
   {
-    auto trk_state_sptr = *trk->find( i );
-    auto trk_state_dser_sptr = *trk_dser->find( i );
+    auto const trk_state_sptr = *trk->find( i );
+    auto const trk_state_dser_sptr = *trk_dser->find( i );
 
     EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
 
-    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
-    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
-                                                      downcast( trk_state_dser_sptr );
+    auto const obj_trk_state_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto const obj_trk_state_dser_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_dser_sptr );
 
     EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
 
-    auto do_ser_sptr = obj_trk_state_sptr->detection();
-    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+    auto const do_ser_sptr = obj_trk_state_sptr->detection();
+    auto const do_dser_sptr = obj_trk_state_dser_sptr->detection();
 
     EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
     EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
 
-    auto cm_ser_sptr = do_ser_sptr->type();
-    auto cm_dser_sptr = do_dser_sptr->type();
+    auto const cm_ser_sptr = do_ser_sptr->type();
+    auto const cm_dser_sptr = do_dser_sptr->type();
 
     if ( cm_ser_sptr )
     {

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -255,6 +255,8 @@ TEST( convert_protobuf, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
+    o_it++;
+    d_it++;
   }
 }
 
@@ -297,6 +299,8 @@ TEST( convert_protobuf, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
+      o_it++;
+      d_it++;
     }
   }
 }

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -266,8 +266,8 @@ TEST( convert_protobuf, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
-    o_it++;
-    d_it++;
+    ++o_it;
+    ++d_it;
   }
 }
 
@@ -310,8 +310,8 @@ TEST( convert_protobuf, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
-      o_it++;
-      d_it++;
+      ++o_it;
+      ++d_it;
     }
   }
 }

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include <arrows/serialize/protobuf/activity.h>
 #include <arrows/serialize/protobuf/bounding_box.h>
 #include <arrows/serialize/protobuf/class_map.h>
 #include <arrows/serialize/protobuf/detected_object.h>
@@ -49,6 +50,7 @@
 #include <arrows/serialize/protobuf/object_track_set.h>
 #include <arrows/serialize/protobuf/convert_protobuf.h>
 
+#include <vital/types/activity.h>
 #include <vital/types/bounding_box.h>
 #include <vital/types/detected_object_set.h>
 #include <vital/types/class_map.h>

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -76,13 +76,13 @@ TEST( serialize, activity_default )
 {
   // This tests the behavior when participants
   // and class_map are set to NULL
-  kwiver::vital::activity act;
-  kasp::activity act_ser;
+  auto const act = kwiver::vital::activity{};
+  auto act_ser = kasp::activity{};
 
-  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+  auto const mes = act_ser.serialize( kwiver::vital::any( act ) );
 
-  auto dser = act_ser.deserialize( *mes );
-  kwiver::vital::activity act_dser =
+  auto const dser = act_ser.deserialize( *mes );
+  auto const act_dser =
     kwiver::vital::any_cast< kwiver::vital::activity >( dser );
 
   // Check members
@@ -93,10 +93,10 @@ TEST( serialize, activity_default )
   EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
 
   // Timestamps are invalid so can't do a direct comparison
-  auto start = act.start();
-  auto end = act.end();
-  auto start_dser = act_dser.start();
-  auto end_dser = act_dser.end();
+  auto const start = act.start();
+  auto const end = act.end();
+  auto const start_dser = act_dser.start();
+  auto const end_dser = act_dser.end();
 
   EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
   EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
@@ -121,30 +121,39 @@ TEST( serialize, activity )
   track_sptr->set_id( 1 );
   for ( int i = 0; i < 10; i++ )
   {
-    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto const bbox =
+      kwiver::vital::bounding_box_d{ 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+
     auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
     dobj_cm_sptr->set_score( "key", i / 10.0 );
-    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
-    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
+    auto const dobj_sptr =
+      std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+
+    auto const ots_sptr =
+      std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+
     track_sptr->append( ots_sptr );
   }
 
-  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
-  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+  auto const tracks = std::vector< kwiver::vital::track_sptr >{ track_sptr };
+  auto const obj_trk_set_sptr =
+    std::make_shared< kwiver::vital::object_track_set >( tracks );
 
   // Now both timestamps
-  kwiver::vital::timestamp start { 1, 1 } ;
-  kwiver::vital::timestamp end { 2, 2 };
+  auto const start = kwiver::vital::timestamp{ 1, 1 };
+  auto const end = kwiver::vital::timestamp{ 2, 2 };
 
   // Now construct activity
-  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+  auto const act =
+    kwiver::vital::activity{ 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr };
 
-  kasp::activity act_ser;
+  auto act_ser = kasp::activity{};
 
-  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+  auto const mes = act_ser.serialize( kwiver::vital::any( act ) );
 
-  auto dser = act_ser.deserialize( *mes );
-  kwiver::vital::activity act_dser =
+  auto const dser = act_ser.deserialize( *mes );
+  auto const act_dser =
     kwiver::vital::any_cast< kwiver::vital::activity >( dser );
 
   // Now check equality
@@ -174,25 +183,26 @@ TEST( serialize, activity )
   // Iterate over the track_states
   for ( int i = 0; i < 10; i++ )
   {
-    auto trk_state_sptr = *trk->find( i );
-    auto trk_state_dser_sptr = *trk_dser->find( i );
+    auto const trk_state_sptr = *trk->find( i );
+    auto const trk_state_dser_sptr = *trk_dser->find( i );
 
     EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
 
-    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
-    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
-                                                      downcast( trk_state_dser_sptr );
+    auto const obj_trk_state_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto const obj_trk_state_dser_sptr =
+      kwiver::vital::object_track_state::downcast( trk_state_dser_sptr );
 
     EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
 
-    auto do_ser_sptr = obj_trk_state_sptr->detection();
-    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+    auto const do_ser_sptr = obj_trk_state_sptr->detection();
+    auto const do_dser_sptr = obj_trk_state_dser_sptr->detection();
 
     EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
     EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
 
-    auto cm_ser_sptr = do_ser_sptr->type();
-    auto cm_dser_sptr = do_dser_sptr->type();
+    auto const cm_ser_sptr = do_ser_sptr->type();
+    auto const cm_dser_sptr = do_dser_sptr->type();
 
     if ( cm_ser_sptr )
     {

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -687,7 +687,7 @@ TEST( serialize, track )
 }
 
 // ---------------------------------------------------------------------------
-TEST( convert_protobuf, track_set )
+TEST( serialize, track_set )
 {
   auto trk_set_sptr = std::make_shared< kwiver::vital::track_set >();
   for ( kwiver::vital::track_id_t trk_id=1; trk_id<5; ++trk_id )

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -262,8 +262,8 @@ TEST( serialize, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
-    o_it++;
-    d_it++;
+    ++o_it;
+    ++d_it;
   }
 }
 
@@ -335,8 +335,8 @@ TEST( serialize, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
-      o_it++;
-      d_it++;
+      ++o_it;
+      ++d_it;
     }
   }
 }

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -252,6 +252,8 @@ TEST( serialize, class_map )
   {
     EXPECT_EQ( *(o_it->first), *(d_it->first) );
     EXPECT_EQ( o_it->second, d_it->second );
+    o_it++;
+    d_it++;
   }
 }
 
@@ -323,6 +325,8 @@ TEST( serialize, detected_object )
     {
       EXPECT_EQ( *(o_it->first), *(d_it->first) );
       EXPECT_EQ( o_it->second, d_it->second );
+      o_it++;
+      d_it++;
     }
   }
 }

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -72,6 +72,137 @@ int main(int argc, char** argv)
 }
 
 // ----------------------------------------------------------------------------
+TEST( serialize, activity_default )
+{
+  // This tests the behavior when participants
+  // and class_map are set to NULL
+  kwiver::vital::activity act;
+  kasp::activity act_ser;
+
+  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+
+  auto dser = act_ser.deserialize( *mes );
+  kwiver::vital::activity act_dser =
+    kwiver::vital::any_cast< kwiver::vital::activity >( dser );
+
+  // Check members
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_EQ( act.activity_type(), act_dser.activity_type() );
+  EXPECT_EQ( act.participants(), act_dser.participants() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+
+  // Timestamps are invalid so can't do a direct comparison
+  auto start = act.start();
+  auto end = act.end();
+  auto start_dser = act_dser.start();
+  auto end_dser = act_dser.end();
+
+  EXPECT_EQ( start.get_time_seconds(), start_dser.get_time_seconds() );
+  EXPECT_EQ( start.get_frame(), start_dser.get_frame() );
+  EXPECT_EQ( start.get_time_domain_index(), start_dser.get_time_domain_index() );
+
+  EXPECT_EQ( end.get_time_seconds(), end_dser.get_time_seconds() );
+  EXPECT_EQ( end.get_frame(), end_dser.get_frame() );
+  EXPECT_EQ( end.get_time_domain_index(), end_dser.get_time_domain_index() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( serialize, activity )
+{
+  auto cm_sptr = std::make_shared< kwiver::vital::class_map >();
+  cm_sptr->set_score( "first", 1 );
+  cm_sptr->set_score( "second", 10 );
+  cm_sptr->set_score( "third", 101 );
+
+  // Create object_track_set consisting of
+  // 1 track_sptr with 10 track states
+  auto track_sptr = kwiver::vital::track::create();
+  track_sptr->set_id( 1 );
+  for ( int i = 0; i < 10; i++ )
+  {
+    kwiver::vital::bounding_box_d bbox { 10.0 + i, 10.0 + i, 20.0 + i, 20.0 + i };
+    auto dobj_cm_sptr = std::make_shared< kwiver::vital::class_map >();
+    dobj_cm_sptr->set_score( "key", i / 10.0 );
+    auto dobj_sptr = std::make_shared< kwiver::vital::detected_object >( bbox, i / 10.0, dobj_cm_sptr );
+    auto ots_sptr = std::make_shared< kwiver::vital::object_track_state >( i, i, dobj_sptr );
+    track_sptr->append( ots_sptr );
+  }
+
+  std::vector< kwiver::vital::track_sptr > tracks = { track_sptr };
+  auto obj_trk_set_sptr = std::make_shared< kwiver::vital::object_track_set >( tracks );
+
+  // Now both timestamps
+  kwiver::vital::timestamp start { 1, 1 } ;
+  kwiver::vital::timestamp end { 2, 2 };
+
+  // Now construct activity
+  kwiver::vital::activity act( 5, "test_label", 3.1415, cm_sptr, start, end, obj_trk_set_sptr );
+
+  kasp::activity act_ser;
+
+  auto mes = act_ser.serialize( kwiver::vital::any( act ) );
+
+  auto dser = act_ser.deserialize( *mes );
+  kwiver::vital::activity act_dser =
+    kwiver::vital::any_cast< kwiver::vital::activity >( dser );
+
+  // Now check equality
+  EXPECT_EQ( act.id(), act_dser.id() );
+  EXPECT_EQ( act.label(), act_dser.label() );
+  EXPECT_DOUBLE_EQ( act.confidence(), act_dser.confidence() );
+  EXPECT_EQ( act.start(), act_dser.start() );
+  EXPECT_EQ( act.end(), act_dser.end() );
+
+  // Check values in the retrieved class map
+  auto const act_type = act.activity_type();
+  auto const act_type_dser = act_dser.activity_type();
+  EXPECT_EQ( act_type->size(), act_type_dser->size() );
+  EXPECT_DOUBLE_EQ( act_type->score( "first" ),  act_type_dser->score( "first" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "second" ), act_type_dser->score( "second" ) );
+  EXPECT_DOUBLE_EQ( act_type->score( "third" ),  act_type_dser->score( "third" ) );
+
+  // Now the object_track_set
+  auto const parts = act.participants();
+  auto const parts_dser = act_dser.participants();
+
+  EXPECT_EQ( parts->size(), parts_dser->size() );
+
+  auto const trk = parts->get_track( 1 );
+  auto const trk_dser = parts_dser->get_track( 1 );
+
+  // Iterate over the track_states
+  for ( int i = 0; i < 10; i++ )
+  {
+    auto trk_state_sptr = *trk->find( i );
+    auto trk_state_dser_sptr = *trk_dser->find( i );
+
+    EXPECT_EQ( trk_state_sptr->frame(), trk_state_dser_sptr->frame() );
+
+    auto obj_trk_state_sptr = kwiver::vital::object_track_state::downcast( trk_state_sptr );
+    auto obj_trk_state_dser_sptr = kwiver::vital::object_track_state::
+                                                      downcast( trk_state_dser_sptr );
+
+    EXPECT_EQ( obj_trk_state_sptr->time(), obj_trk_state_dser_sptr->time() );
+
+    auto do_ser_sptr = obj_trk_state_sptr->detection();
+    auto do_dser_sptr = obj_trk_state_dser_sptr->detection();
+
+    EXPECT_EQ( do_ser_sptr->bounding_box(), do_dser_sptr->bounding_box() );
+    EXPECT_EQ( do_ser_sptr->confidence(), do_dser_sptr->confidence() );
+
+    auto cm_ser_sptr = do_ser_sptr->type();
+    auto cm_dser_sptr = do_dser_sptr->type();
+
+    if ( cm_ser_sptr )
+    {
+      EXPECT_EQ( cm_ser_sptr->size(), cm_dser_sptr->size() );
+      EXPECT_EQ( cm_ser_sptr->score( "key" ), cm_dser_sptr->score( "key" ) );
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
 TEST( serialize, bounding_box )
 {
   kasp::bounding_box bbox_ser;

--- a/vital/types/activity.cxx
+++ b/vital/types/activity.cxx
@@ -85,7 +85,7 @@ namespace vital {
 
   class_map_sptr activity::activity_type() const
   {
-    return std::make_shared< class_map >( *m_class_map );
+    return m_class_map;
   }
 
   void activity::set_activity_type( class_map_sptr class_map )

--- a/vital/types/protobuf/CMakeLists.txt
+++ b/vital/types/protobuf/CMakeLists.txt
@@ -5,6 +5,7 @@
 find_package( Protobuf REQUIRED 3 )
 
 set( proto_files
+  activity.proto
   bounding_box.proto
   covariance.proto
   detected_object.proto

--- a/vital/types/protobuf/activity.proto
+++ b/vital/types/protobuf/activity.proto
@@ -1,0 +1,47 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+syntax = "proto2";
+
+package kwiver.protobuf;
+
+import "class_map.proto";
+import "object_track_set.proto";
+import "timestamp.proto";
+
+message activity {
+  required int64 id = 1;
+  required string label = 2;
+  optional class_map classifications = 3;
+  required double confidence = 4;
+  optional object_track_set participants = 5;
+  required timestamp start_frame = 6;
+  required timestamp end_frame = 7;
+}

--- a/vital/types/protobuf/activity.proto
+++ b/vital/types/protobuf/activity.proto
@@ -39,7 +39,7 @@ import "timestamp.proto";
 message activity {
   required int64 id = 1;
   required string label = 2;
-  optional class_map classifications = 3;
+  optional class_map activity_type = 3;
   required double confidence = 4;
   optional object_track_set participants = 5;
   required timestamp start_frame = 6;


### PR DESCRIPTION
This PR adds protobuf serialization for the vital type "activity". Tests for the JSON and protobuf serialization are also added.

In order for the JSON tests to pass, the implementations of load and save for an activity were modified. Activity has two fields that are pointers, and in the previous implementation, it was assumed that they were always non-null. When one of these fields was null, a null pointer was dereferenced which caused a seg-fault.

Other small improvements were made as well:
1.) In a few unrelated tests, iterators were not being incremented.
2.) Renamed a misnamed unrelated test