### PR TITLE
Fix reliability of OpenCV Estimate PNP 

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -14,3 +14,9 @@ Arrows: Core
    was also metadata useful for determining focal length.  Distortion
    parameters were also not properly preserved in this initialization
    and this has also been resolved.
+
+Arrows: OpenCV
+
+ * Fixed improper use of RANSAC in the OpenCV estimate_pnp algorithm.
+   This algorithm was producing a lower then expected success rate when
+   resectioning cameras.


### PR DESCRIPTION
There was an outlier RANSAC loop around the OpenCV RANSAC PNP algorithm.  Letting OpenCV handle the RANSAC by itself produces better results and the code is much simpler.  Run time seems about the same.