### PR TITLE
Convert matlab process to use new registrar approach

### DIFF
--- a/sprokit/processes/matlab/matlab_process.h
+++ b/sprokit/processes/matlab/matlab_process.h
@@ -54,6 +54,9 @@ class KWIVER_PROCESSES_MATLAB_NO_EXPORT matlab_process
   : public sprokit::process
 {
 public:
+  PLUGIN_INFO( "matlab_bridge",
+               "Bridge to process written in matlab." )
+
   matlab_process( kwiver::vital::config_block_sptr const& config );
   virtual ~matlab_process();
 

--- a/sprokit/processes/matlab/register_processes.cxx
+++ b/sprokit/processes/matlab/register_processes.cxx
@@ -44,20 +44,17 @@ extern "C"
 KWIVER_PROCESSES_MATLAB_EXPORT
 void register_factories( kwiver::vital::plugin_loader& vpm )
 {
-  static const auto module_name = kwiver::vital::plugin_manager::module_t( "kwiver_processes_matlab" );
+  using namespace sprokit;
 
-  if ( sprokit::is_process_module_loaded( vpm, module_name ) )
+  process_registrar reg( vpm, "kwiver_processes_matlab" );
+
+  if ( is_process_module_loaded( vpm, reg.module_name() ) )
   {
     return;
   }
 
-  // ----------------------------------------------------------------
-  auto fact = vpm.ADD_PROCESS( kwiver::matlab::matlab_process );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "matlab_bridge" );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Bridge to process written in matlab." );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+  reg.register_process< kwiver::matlab_process >();
 
-  // - - - - - - - - - - - - - - - - - - - - - - -
-  sprokit::mark_process_module_as_loaded( vpm, module_name );
+// - - - - - - - - - - - - - - - - - - - - - - -
+  mark_process_module_as_loaded( vpm, reg.module_name() );
 }


### PR DESCRIPTION
Update matlab process to use the new process registrar to register the process.

This is little used, but it is good to get all process plugins using the registrar pattern.