### PR TITLE
Add missing header needed for MSVC 2019

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -7,6 +7,10 @@ v1.5.0 release.
 Bug Fixes since v1.5.0
 ----------------------
 
+Vital
+
+ * Added a missing include file in track.cxx required to build on MSVC 2019.
+
 Arrows: Core
 
  * Fixed a bug in initialize_cameras_landmarks_keyframe in which the

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -36,6 +36,7 @@
 #include "track.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 #include <vital/exceptions.h>
 


### PR DESCRIPTION
This fix addresses #1021 