### PR TITLE
Examples require opencv

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,23 +1,27 @@
 
-set(SOURCE "main.cpp"
-           "how_to_part_01_images.cpp"
-           "how_to_part_02_detections.cpp"
-)
+if (KWIVER_ENABLE_OPENCV AND KWIVER_ENABLE_VXL)
+  set(SOURCE "main.cpp"
+    "how_to_part_01_images.cpp"
+    "how_to_part_02_detections.cpp"
+    )
 
-set(kwiver_examples_libraries vital_algo
-                              kwiver_algo_ocv
-                              kwiver_algo_vxl
-                              kwiversys )
+  set(kwiver_examples_libraries vital_algo
+    kwiver_algo_ocv
+    kwiver_algo_vxl
+    kwiversys )
 
-if(KWIVER_ENABLE_KPF)
-  add_subdirectory( kpf )
+  if(KWIVER_ENABLE_KPF)
+    add_subdirectory( kpf )
 
-  list(APPEND kwiver_examples_libraries kwiver_algo_kpf kpf_yaml ${YAML_CPP_LIBRARIES})
-  if(WIN32)
-    set(kwiver_examples_flags YAML_CPP_DLL)
+    list(APPEND kwiver_examples_libraries kwiver_algo_kpf kpf_yaml ${YAML_CPP_LIBRARIES})
+    if(WIN32)
+      set(kwiver_examples_flags YAML_CPP_DLL)
+    endif()
   endif()
-endif()
 
-add_executable(kwiver_examples ${SOURCE})
-target_link_libraries(kwiver_examples ${kwiver_examples_libraries})
-target_compile_definitions(kwiver_examples PRIVATE ${kwiver_examples_flags})
+  add_executable(kwiver_examples ${SOURCE})
+  target_link_libraries(kwiver_examples ${kwiver_examples_libraries})
+  target_compile_definitions(kwiver_examples PRIVATE ${kwiver_examples_flags})
+else()
+  message(SEND_ERROR " Building examples requires enabling VXL and OpenCV")
+endif()


### PR DESCRIPTION
Examples used OpenCV but didn't have any checks to protect when it wasn't enabled. Fixes issue #1039 