### PR TITLE
Remove the usage of boost in darknet arrow

### DIFF
--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018, 2020 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
-
-#include <boost/filesystem.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <string>
 #include <sstream>
@@ -239,14 +234,13 @@ train_from_disk(
   if( !d->m_skip_format )
   {
     // Delete and reset folder contents
-    if( boost::filesystem::exists( d->m_train_directory ) &&
-        boost::filesystem::is_directory( d->m_train_directory ) )
+    if( kwiversys::SystemTools::FileExists( d->m_train_directory, false ) &&
+        kwiversys::SystemTools::FileIsDirectory( d->m_train_directory ) )
     {
-      boost::filesystem::remove_all( d->m_train_directory );
+      kwiversys::SystemTools::RemoveADirectory( d->m_train_directory );
     }
 
-    boost::filesystem::path dir( d->m_train_directory );
-    boost::filesystem::create_directories( dir );
+    kwiversys::SystemTools::MakeDirectory( d->m_train_directory );
 
     // Format train images
     std::vector< std::string > train_list, test_list;
@@ -290,7 +284,7 @@ train_from_disk(
 #else
   std::string darknet_cmd = "darknet";
 #endif
-  std::string darknet_args = "-i " + boost::lexical_cast< std::string >( d->m_gpu_index ) +
+  std::string darknet_args = "-i " + std::to_string( d->m_gpu_index ) +
     " detector train " + d->m_train_directory + "/yolo_v2.data "
                        + d->m_train_directory + "/yolo_v2.cfg ";
 
@@ -322,11 +316,8 @@ format_images( std::string folder, std::string prefix,
   std::string image_folder = folder + "/" + prefix + "_images";
   std::string label_folder = folder + "/" + prefix + "_labels";
 
-  boost::filesystem::path image_dir( image_folder );
-  boost::filesystem::path label_dir( label_folder );
-
-  boost::filesystem::create_directories( image_dir );
-  boost::filesystem::create_directories( label_dir );
+  kwiversys::SystemTools::MakeDirectory( image_folder );
+  kwiversys::SystemTools::MakeDirectory( label_folder );
 
   for( unsigned fid = 0; fid < image_names.size(); ++fid )
   {
@@ -501,11 +492,11 @@ print_detections(
 
       std::string line = category + " ";
 
-      line += boost::lexical_cast< std::string >( 0.5 * ( min_x + max_x ) / width ) + " ";
-      line += boost::lexical_cast< std::string >( 0.5 * ( min_y + max_y ) / height ) + " ";
+      line += std::to_string( 0.5 * ( min_x + max_x ) / width ) + " ";
+      line += std::to_string( 0.5 * ( min_y + max_y ) / height ) + " ";
 
-      line += boost::lexical_cast< std::string >( overlap.width() / width ) + " ";
-      line += boost::lexical_cast< std::string >( overlap.height() / height );
+      line += std::to_string( overlap.width() / width ) + " ";
+      line += std::to_string( overlap.height() / height );
 
       to_write.push_back( line );
     }


### PR DESCRIPTION
PR replaces boost::lexical_cast with std::to_string and boost::filesystem with kwiversys. The related boost libraries are removed in a follow-up branch since I fixed some other library issues at the same time.