### PR TITLE
Let kwiver recognize Visual Studio 2019 in its setup_KWIVER.bat file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,11 @@ mark_as_advanced(KWIVER_DEFAULT_LIBRARY_DIR)
 
 #
 # kwiver module config file.
-set(KWIVER_CONFIG_FILE          "${KWIVER_BINARY_DIR}/kwiver-config.cmake")
+set(KWIVER_CONFIG_FILE "${KWIVER_BINARY_DIR}/kwiver-config.cmake")
 if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
- if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.10)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.20)
+    set(_vcVersion vc16)
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.10)
     set(_vcVersion vc15)
   elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19)
     set(_vcVersion vc14)


### PR DESCRIPTION
Kwiver needs to recognize Visual Studio 2019 or it sets up the wrong PATH in the setup_KWIVER.bat file. That causes some of the dashboard tests to fail to build because they can't find OpenCV.