### PR TITLE
Kwiver support vs2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,11 @@ mark_as_advanced(KWIVER_DEFAULT_LIBRARY_DIR)
 
 #
 # kwiver module config file.
-set(KWIVER_CONFIG_FILE          "${KWIVER_BINARY_DIR}/kwiver-config.cmake")
+set(KWIVER_CONFIG_FILE "${KWIVER_BINARY_DIR}/kwiver-config.cmake")
 if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
- if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.10)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.20)
+    set(_vcVersion vc16)
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.10)
     set(_vcVersion vc15)
   elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19)
     set(_vcVersion vc14)

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -7,6 +7,10 @@ v1.5.0 release.
 Bug Fixes since v1.5.0
 ----------------------
 
+Config
+
+ * Add support for Visual Studio 2019 in the setup_KWIVER.bat
+
 Vital
 
  * Added a missing include file in track.cxx required to build on MSVC 2019.


### PR DESCRIPTION
Force kwiver to recognize Visual Studio 2019 and apply that to its setup_KWIVER.bat. Without it, some tests are failing to run during the build since the can't find OpenCV.