### PR TITLE
Add tests for dev/add-pytorch-arrow (#691)

### DIFF
--- a/python/kwiver/sprokit/processes/pytorch/alexnet_descriptors.py
+++ b/python/kwiver/sprokit/processes/pytorch/alexnet_descriptors.py
@@ -159,7 +159,8 @@ class AlexNetDescriptors(KwiverProcess):
             print( repr( e ) )
             import traceback
             print( traceback.format_exc() )
-            #sys.stdout.flush()
+            sys.stdout.flush()
+            raise
 
     def __del__(self):
         print('!!!!alexnet tracking Deleting python process!!!!')

--- a/python/kwiver/sprokit/processes/pytorch/resnet_augmentation.py
+++ b/python/kwiver/sprokit/processes/pytorch/resnet_augmentation.py
@@ -282,7 +282,8 @@ class DataAugmentation(KwiverProcess):
             print( repr( e ) )
             import traceback
             print( traceback.format_exc() )
-            #sys.stdout.flush()
+            sys.stdout.flush()
+            raise
 
     def __del__(self):
         print('!!!!Deleting augmentation python process!!!!')

--- a/python/kwiver/sprokit/processes/pytorch/resnet_descriptors.py
+++ b/python/kwiver/sprokit/processes/pytorch/resnet_descriptors.py
@@ -163,7 +163,8 @@ class ResnetDescriptors(KwiverProcess):
             print( repr( e ) )
             import traceback
             print( traceback.format_exc() )
-            #sys.stdout.flush()
+            sys.stdout.flush()
+            raise
 
     def __del__(self):
         print('!!!!Resnet tracking Deleting python process!!!!')

--- a/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
@@ -427,7 +427,8 @@ class SRNNTracker(KwiverProcess):
             print( repr( e ) )
             import traceback
             print( traceback.format_exc() )
-            #sys.stdout.flush()
+            sys.stdout.flush()
+            raise
 
 
 # ==================================================================

--- a/python/kwiver/sprokit/tests/processes/CMakeLists.txt
+++ b/python/kwiver/sprokit/tests/processes/CMakeLists.txt
@@ -17,3 +17,7 @@ kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/pythonpath_test_process.py
 kwiver_add_python_module(${CMAKE_CURRENT_SOURCE_DIR}/pythonpath_test_scheduler.py
   sprokit/tests/processes
   pythonpath_test_scheduler)
+
+if(KWIVER_ENABLE_PYTORCH)
+  add_subdirectory( pytorch )
+endif()

--- a/python/kwiver/sprokit/tests/processes/pytorch/CMakeLists.txt
+++ b/python/kwiver/sprokit/tests/processes/pytorch/CMakeLists.txt
@@ -1,0 +1,7 @@
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+  sprokit/tests/processes/pytorch
+  __init__ )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/test_processes.py
+  sprokit/tests/processes/pytorch
+  test_processes )

--- a/python/kwiver/sprokit/tests/processes/pytorch/test_processes.py
+++ b/python/kwiver/sprokit/tests/processes/pytorch/test_processes.py
@@ -1,0 +1,154 @@
+"""Tests for the processes in kwiver.sprokit.processes.pytorch
+
+As a minor issue, all the code to be tested here is in KWIVER
+processes, which would make KWIVER's embedded pipeline functionality
+the preferred way to test them.  However, said functionality isn't yet
+wrapped for Python, so we're left invoking "kwiver runner" as a
+subprocess.
+
+"""
+
+import itertools
+import os.path
+import subprocess
+import tempfile
+import textwrap
+
+from PIL import Image
+import torch
+import torchvision
+
+from kwiver.sprokit.processes.pytorch.utils import models
+
+
+def run_pipeline_in_dir(dir_path, pipeline):
+    """Run the provided pipeline file contents with the provided directory
+    as current
+
+    """
+    f = tempfile.NamedTemporaryFile('w', suffix='.pipe', delete=False)
+    try:
+        with f:
+            f.write(pipeline)
+        args = ["kwiver", "runner", f.name]
+        return subprocess.run(args, cwd=dir_path, check=True)
+    finally:
+        os.remove(f.name)
+
+
+DESCRIPTOR_PIPELINE_TEMPLATE = textwrap.dedent("""
+    config _scheduler
+        type = pythread_per_process
+
+    process images :: frame_list_input
+        image_list_file = image_list.txt
+        image_reader:type = ocv
+
+    process detections :: image_object_detector
+        detector:type = example_detector
+        block detector:example_detector
+            dx = 50
+            dy = 30
+        endblock
+
+    process descriptors :: {process}
+        gpu_list = None
+        {network}_model_path = model.pt
+
+    connect from images.image to detections.image
+    connect from images.image to descriptors.image
+    connect from detections.detected_object_set
+            to descriptors.detected_object_set
+""")
+
+
+def build_descriptor_pipeline(process, network, timestamp=True):
+    DPT = DESCRIPTOR_PIPELINE_TEMPLATE
+    return DPT.format(process=process, network=network) + (
+        "connect from images.timestamp to descriptors.timestamp\n"
+        if timestamp else ''
+    )
+
+
+def create_test_image_list(dir_path):
+    """Create image.png and image_list.txt that references it in the given
+    directory
+
+    """
+    im = Image.effect_mandelbrot((800, 600), (-2.23845, -1.1538375, 0.83845, 1.1538375), 64)
+    im.save(os.path.join(dir_path, 'image.png'))
+    with open(os.path.join(dir_path, 'image_list.txt'), 'w') as f:
+        f.writelines(itertools.repeat('image.png\n', 10))
+
+
+def _test_descriptors(model_func, *args, **kwargs):
+    """Run a test pipeline for the given type of feature extractor
+
+    See the test_*_descriptors functions for how this is used.
+
+    """
+    with tempfile.TemporaryDirectory() as dir_:
+        def j(*args): return os.path.join(dir_, *args)
+        # Create all files required by the pipeline file
+        torch.save(model_func().state_dict(), j('model.pt'))
+        create_test_image_list(dir_)
+        pipeline = build_descriptor_pipeline(*args, **kwargs)
+        run_pipeline_in_dir(dir_, pipeline)
+
+
+def test_alexnet_descriptors():
+    _test_descriptors(torchvision.models.alexnet, 'alexnet_descriptors', 'alexnet')
+
+
+def test_resnet_descriptors():
+    _test_descriptors(torchvision.models.resnet50, 'resnet_descriptors', 'resnet')
+
+
+def test_resnet_augmentation():
+    # It has the same input interface, so close enough
+    _test_descriptors(torchvision.models.resnet50, 'resnet_augmentation', 'resnet', timestamp=False)
+
+
+TUT_PIPELINE_TEMPLATE = textwrap.dedent("""
+    config _scheduler
+        type = pythread_per_process
+
+    process images :: frame_list_input
+        image_list_file = image_list.txt
+        image_reader:type = ocv
+
+    process detections :: image_object_detector
+        detector:type = example_detector
+        block detector:example_detector
+            dx = 50
+            dy = 30
+        endblock
+
+    process tracker :: srnn_tracker
+        gpu_list = None
+        siamese_model_path = siamese_model.pt
+        targetRNN_AIM_model_path = lstm_model.pt
+        targetRNN_AIM_V_model_path = lstm_model.pt
+        IOU_tracker_flag = {iou_tracking}
+
+    connect from images.image to detections.image
+    connect from images.image to tracker.image
+    connect from detections.detected_object_set
+            to tracker.detected_object_set
+    connect from images.timestamp to tracker.timestamp
+""")
+
+
+def test_srnn_tracker():
+    with tempfile.TemporaryDirectory() as dir_:
+        def j(*args): return os.path.join(dir_, *args)
+        # Create all files required by the pipeline file
+        sm = torch.nn.DataParallel(models.Siamese())
+        torch.save(dict(state_dict=sm.state_dict()), j('siamese_model.pt'))
+        lm = models.TargetLSTM()
+        torch.save(dict(state_dict=lm.state_dict()), j('lstm_model.pt'))
+        del sm, lm
+        create_test_image_list(dir_)
+        for iou_tracking in [True, False]:
+            pipe = TUT_PIPELINE_TEMPLATE.format(iou_tracking=iou_tracking)
+            run_pipeline_in_dir(dir_, pipe)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,10 @@
 numpy==1.13.0
+opencv-python==3.4.2.17
 pillow==7.1.0
 six==1.10.0
 scipy
+torch==1.4.0
+torchvision==0.5.0
 
 # For Testing
 nose==1.3.7

--- a/python/setup.py
+++ b/python/setup.py
@@ -53,6 +53,7 @@ setup(
         install_requires=[
                           'numpy',
                           'pillow',
+                          'scipy',
                           'six',
                          ],
         tests_require=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -52,9 +52,12 @@ setup(
                        ],
         install_requires=[
                           'numpy',
+                          'opencv-python',
                           'pillow',
                           'scipy',
                           'six',
+                          'torch',
+                          'torchvision',
                          ],
         tests_require=[
                         'nose',
@@ -68,6 +71,7 @@ setup(
                     '-DKWIVER_BUILD_SHARED=OFF',
                     '-DKWIVER_ENABLE_C_BINDINGS=ON',
                     '-DKWIVER_ENABLE_PYTHON=ON',
+                    '-DKWIVER_ENABLE_PYTORCH=ON',
                     '-DKWIVER_PYTHON_MAJOR_VERSION=3',
                     '-DPYBIND11_PYTHON_VERSION=3',
                     '-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON',


### PR DESCRIPTION
This PR has the minimal set of tests I've created for #691. I've created a separate PR to make keeping track of any discussion easier.

All the tests do is make sure that the four processes added by #691 can at least run on dummy input. I'd appreciate some quick feedback on a couple things:
- @as6520 or @tao558, are things correctly set up for the tests to be run?
- @mattdawkins, the `try`-`except` blocks around the processes' `._step` implementations make it harder for the tests to detect errors. I recall you being fine with my removing it in `srnn_tracker.py` at another point; would there be any issue with doing so here as well? (I might elect to keep them around `srnn_tracker.py` though in order to make integrating the more recently released changes easier.)

Thanks!