### PR TITLE
Refactor python sprokit tests

### DIFF
--- a/CMake/utils/kwiver-utils-tests-python.cmake
+++ b/CMake/utils/kwiver-utils-tests-python.cmake
@@ -65,16 +65,8 @@ endfunction ()
 #
 function (kwiver_add_python_test group instance)
   string(TOLOWER "${CMAKE_PROJECT_NAME}" project_name)
-  set(python_module_path    "${kwiver_python_output_path}/${python_sitename}")
-  set(python_chdir          ".")
 
-  if (CMAKE_CONFIGURATION_TYPES)
-    set(python_module_path      "${kwiver_python_output_path}/$<CONFIGURATION>/${python_sitename}")
-    set(python_chdir           "$<CONFIGURATION>")
-  endif ()
-
-  kwiver_add_test(python-${group} ${instance}
-    "${python_chdir}" "${python_module_path}" ${ARGN})
+  kwiver_add_test(python-${group} ${instance} ${ARGN})
 endfunction ()
 
 

--- a/python/kwiver/sprokit/tests/modules/test-pymodules.py
+++ b/python/kwiver/sprokit/tests/modules/test-pymodules.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2012-2013 by Kitware, Inc.
+# Copyright 2012-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -77,19 +78,12 @@ def test_extra_modules():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/modules/test-pymodules.py
+++ b/python/kwiver/sprokit/tests/modules/test-pymodules.py
@@ -80,7 +80,7 @@ def test_extra_modules():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
@@ -28,6 +28,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
+
 def test_import():
     try:
         import kwiver.sprokit.adapters.adapter_data_set
@@ -245,19 +247,12 @@ def test_iter():
             test_error("unknown port: {}".format(port))
 
 if __name__ == "__main__":
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
@@ -249,7 +249,7 @@ def test_iter():
 if __name__ == "__main__":
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import(pipeline_dir):
     try:
@@ -135,18 +136,12 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if not len(sys.argv) == 5:
+    if not len(sys.argv) == 3:
         test_error("Expected three arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
 
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    pipeline_dir = sys.argv[4]
-
-    from kwiver.sprokit.util.test import *
+    pipeline_dir = sys.argv[2]
 
     run_test(testname, find_tests(locals()), pipeline_dir)

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if not len(sys.argv) == 3:
+    if len(sys.argv) != 3:
         test_error("Expected three arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -124,19 +125,13 @@ def test_error_():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
 
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
@@ -127,7 +127,7 @@ def test_error_():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-edge.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-edge.py
@@ -122,7 +122,7 @@ def test_datum_api_calls():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-edge.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-edge.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -119,19 +120,12 @@ def test_datum_api_calls():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-pipeline.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-pipeline.py
@@ -132,7 +132,7 @@ def test_api_calls():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-pipeline.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-pipeline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -129,19 +130,12 @@ def test_api_calls():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013, 2019 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import expect_exception, find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -271,19 +272,12 @@ def test_peek_at_datum_on_port():
         test_error("Datum mismatch: expected a complete datum, got {0}".format(receiver_datum_type))
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments( test-name, data-dir, path")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process.py
@@ -274,7 +274,7 @@ def test_peek_at_datum_on_port():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_cluster.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_cluster.py
@@ -74,7 +74,7 @@ def test_api_calls():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_cluster.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_cluster.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2012-2013 by Kitware, Inc.
+# Copyright 2012-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -71,19 +72,12 @@ def test_api_calls():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_registry.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_registry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013, 2020 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import expect_exception, find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -358,19 +359,12 @@ def test_wrapper_api():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_registry.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-process_registry.py
@@ -361,7 +361,7 @@ def test_wrapper_api():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-run.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-run.py
@@ -386,7 +386,7 @@ def test_python_via_cpp(sched_type):
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-run.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013, 2020 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from kwiver.sprokit.util.test import expect_exception, find_tests, run_test, test_error
 
 cpp_scheds = ["sync","thread_per_process"] # One shop stop if we add any more c++ schedulers to the tests
 
@@ -382,19 +384,12 @@ def test_python_via_cpp(sched_type):
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments. \"name-of-test\" \"new cwd\" \"python path to add\"")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     (testname, sched_type) = tuple(sys.argv[1].split('-', 1))
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()), sched_type)

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -37,19 +38,12 @@ def test_import():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler.py
@@ -40,7 +40,7 @@ def test_import():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler_registry.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler_registry.py
@@ -173,7 +173,7 @@ def test_wrapper_api():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler_registry.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-scheduler_registry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -170,19 +171,12 @@ def test_wrapper_api():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-stamp.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-stamp.py
@@ -66,7 +66,7 @@ def test_api_calls():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-stamp.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-stamp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -63,19 +64,12 @@ def test_api_calls():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-utils.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-utils.py
@@ -46,7 +46,7 @@ def test_name_thread():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-utils.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -43,19 +44,12 @@ def test_name_thread():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-version.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2012-2013 by Kitware, Inc.
+# Copyright 2012-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import():
     try:
@@ -61,19 +62,12 @@ def test_api_calls():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-version.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-version.py
@@ -64,7 +64,7 @@ def test_api_calls():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-bake.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-bake.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
+
 def test_import(path_unused):
     try:
         import kwiver.sprokit.pipeline_util.bake
@@ -81,19 +84,14 @@ def test_cluster_multiplier(path):
 if __name__ == '__main__':
     import os
     import sys
-    from kwiver.sprokit.util.test import *
 
-    if not len(sys.argv) == 5:
-        test_error("Expected four arguments")
+    if not len(sys.argv) == 3:
+        test_error("Expected three arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
 
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    pipeline_dir = sys.argv[4]
+    pipeline_dir = sys.argv[2]
 
     path = os.path.join(pipeline_dir, '%s.pipe' % testname)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-bake.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-bake.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     import os
     import sys
 
-    if not len(sys.argv) == 3:
+    if len(sys.argv) != 3:
         test_error("Expected three arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-export_.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-export_.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import(path_unused):
     try:
@@ -65,18 +66,13 @@ if __name__ == '__main__':
     import os
     import sys
 
-    from kwiver.sprokit.util.test import *
-    if not len(sys.argv) == 5:
-        test_error("Expected four arguments")
+    if not len(sys.argv) == 3:
+        test_error("Expected three arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
 
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    pipeline_dir = sys.argv[4]
+    pipeline_dir = sys.argv[2]
 
     path = os.path.join(pipeline_dir, '%s.pipe' % testname)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-export_.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-export_.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
     import os
     import sys
 
-    if not len(sys.argv) == 3:
+    if len(sys.argv) != 3:
         test_error("Expected three arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-load.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-load.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2011-2013 by Kitware, Inc.
+# Copyright 2011-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
 def test_import(path_unused):
     try:
@@ -207,21 +208,14 @@ if __name__ == '__main__':
     import os
     import sys
 
-    from kwiver.sprokit.util.test import *
-
-    if not len(sys.argv) == 5:
-        test_error("Expected four arguments")
+    if not len(sys.argv) == 3:
+        test_error("Expected three arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
 
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    pipeline_dir = sys.argv[4]
+    pipeline_dir = sys.argv[2]
 
     path = os.path.join(pipeline_dir, '{0}.pipe'.format(testname))
-
 
     run_test(testname, find_tests(locals()), path)

--- a/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-load.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline_util/test-load.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
     import os
     import sys
 
-    if not len(sys.argv) == 3:
+    if len(sys.argv) != 3:
         test_error("Expected three arguments")
         sys.exit(1)
 

--- a/python/kwiver/sprokit/tests/test/test-test.py
+++ b/python/kwiver/sprokit/tests/test/test-test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #ckwg +28
-# Copyright 2012-2013 by Kitware, Inc.
+# Copyright 2012-2020 by Kitware, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from kwiver.sprokit.util.test import expect_exception, find_tests, run_test, test_error
 
 # TEST_PROPERTY(WILL_FAIL, TRUE)
 def test_return_code():
@@ -96,19 +97,12 @@ def test_environment():
 
 
 if __name__ == '__main__':
-    import os
     import sys
 
-    if not len(sys.argv) == 4:
-        test_error("Expected three arguments")
+    if not len(sys.argv) == 2:
+        test_error("Expected two arguments")
         sys.exit(1)
 
     testname = sys.argv[1]
-
-    os.chdir(sys.argv[2])
-
-    sys.path.append(sys.argv[3])
-
-    from kwiver.sprokit.util.test import *
 
     run_test(testname, find_tests(locals()))

--- a/python/kwiver/sprokit/tests/test/test-test.py
+++ b/python/kwiver/sprokit/tests/test/test-test.py
@@ -99,7 +99,7 @@ def test_environment():
 if __name__ == '__main__':
     import sys
 
-    if not len(sys.argv) == 2:
+    if len(sys.argv) != 2:
         test_error("Expected two arguments")
         sys.exit(1)
 


### PR DESCRIPTION
This branch refactors the sprokit python tests. There were unused arguments being passed to each test through sys.argv, as well as imports in main, instead of the top of the module