### PR TITLE
"Suppress" warnings from Eigen

### DIFF
--- a/CMake/kwiver-depends-Eigen.cmake
+++ b/CMake/kwiver-depends-Eigen.cmake
@@ -1,4 +1,4 @@
 # Required Eigen external dependency
 
 find_package(Eigen3 REQUIRED)
-include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})


### PR DESCRIPTION
Include Eigen headers as system headers so that the compiler won't emit warnings from them. (There are quite a few such warnings, and it's unlikely we would try to address them, at least directly, in a third-party package, so they don't really contribute anything except noise, and make it more difficult to sort out genuine warnings in our code.)