### PR TITLE
Add recommendations for commits to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,6 +63,32 @@ a PR until it conforms to the requirements described here (e.g.
 coding style, release notes, etc.) and it is confirmed that the code
 has sufficient unit tests and does not break any existing unit tests.
 
+Commits
+-------
+
+While not a strict requirement, it is beneficial for commits to record a set of
+separate, logical changes.  Ideally, each commit should compile and have
+correct code style (this is partly enforced by our workflow tools, and such
+enforcement may be expanded in the future).  "Fixup" commits only serve to
+clutter the history and make it harder to understand what changed.  Judicious
+use of amend and rebase is encouraged.
+
+Additionally, commits should follow the accepted conventions for git commit
+messages.  In short:
+
+- Use proper spelling and grammar; avoid "twitter speak".
+- Use complete sentences (including the first line) and appropriate
+  capitalization.  Use imperative mood.
+- Try to limit the subject line to 50 characters.  *Don't* end with a period.
+- Limit body lines (when necessary; occasionally just a subject is enough) to
+  72 characters (unless this is impossible e.g. due to a long URL).
+
+For further reading, see:
+
+- https://chris.beams.io/posts/git-commit/
+- https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/
+- https://medium.com/@steveamaza/how-to-write-a-proper-git-commit-message-e028865e5791
+
 
 Coding Style
 ============


### PR DESCRIPTION
Add a short section on best practices for commits/history and commit messages to `CONTRIBUTING.rst`.

Note that the goal here isn't to beat people over the head with these policies, but rather to have a statement somewhere that we can easily reference as to our preferences and additional resources. (In particular, so I don't have to keep running the same Google search whenever it comes up :slightly_smiling_face:.)