### PR TITLE
Cleanup plugin path generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,10 @@ else()  # Other Unix systems
   set(path_sep "\\072")
 endif()
 
+set(KWIVER_DEFAULT_MODULE_PATHS ""
+  CACHE STRING "The default paths for module scanning. Separate paths with ';' character." FORCE)
+mark_as_advanced( KWIVER_DEFAULT_MODULE_PATHS )
+
 # add all user supplied paths to the property
 foreach( p IN LISTS KWIVER_DEFAULT_MODULE_PATHS )
   kwiver_add_module_path( ${p} )

--- a/arrows/core/applets/CMakeLists.txt
+++ b/arrows/core/applets/CMakeLists.txt
@@ -20,12 +20,6 @@ set( headers
 # Add our plugin path to the default list
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
-###
-# Add path to applets so plugin loader can find them
-if(NOT SKBUILD)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_applets_subdir} )
-  kwiver_add_module_path( ${kwiver_module_path_result} )
-endif()
 # Add applet plugin
 kwiver_add_plugin( kwiver_algo_core_applets
   SUBDIR       ${kwiver_plugin_applets_subdir}

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -56,23 +56,6 @@ set(pipeline_headers
 
 set(pipeline_private_headers)
 
-if(NOT SKBUILD)
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_process_subdir} )
-set( sprokit_default_module_paths ${kwiver_module_path_result} )
-
-if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${sprokit_output_dir} ${kwiver_plugin_process_subdir} )
-  list( INSERT sprokit_default_module_paths 0 "${kwiver_module_path_result}" )
-endif ()
-
-set(SPROKIT_DEFAULT_MODULE_PATHS "${sprokit_default_module_paths}"
-  CACHE STRING "The default paths to search for modules in" FORCE)
-
-# add all paths to the property
-foreach( p IN LISTS   SPROKIT_DEFAULT_MODULE_PATHS )
-  kwiver_add_module_path( ${p} )
-endforeach(p)
-endif()
 ##
 set(utils_build_options)
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -266,41 +266,6 @@ endif ()
 option(KWIVER_USE_CONFIGURATION_SUBDIRECTORY
   "Look in the configuration's subdirectory for each module path (e.g. debug, release, ...)" ${default})
 
-if (WIN32)
-  set(path_sep "\\073")
-else()  # Other Unix systems
-  set(path_sep "\\072")
-endif()
-
-# Build a default set of plugin path dirs
-# Provide that list as the default value for the path option.
-if( NOT SKBUILD )
-kwiver_make_module_path( ${CMAKE_INSTALL_PREFIX} ${kwiver_plugin_module_subdir} )
-set( vital_default_module_path ${kwiver_module_path_result} )
-
-if (KWIVER_USE_BUILD_TREE)
-  kwiver_make_module_path( ${KWIVER_BINARY_DIR} ${kwiver_plugin_module_subdir} )
-  set( vital_default_module_path ${kwiver_module_path_result} ${vital_default_module_path} )
-endif()
-
-set(KWIVER_DEFAULT_MODULE_PATHS "${vital_default_module_path}"
-  CACHE STRING "The default paths for module scanning. Separate paths with ';' character." FORCE)
-mark_as_advanced( KWIVER_DEFAULT_MODULE_PATHS )
-
-# add all paths to the property
-foreach( p IN LISTS KWIVER_DEFAULT_MODULE_PATHS )
-  kwiver_add_module_path( ${p} )
-endforeach(p)
-endif()
-# need to retrieve the GLOBAL PROPERTY kwiver_plugin_path and
-# formulate the default module path
-get_property(plugin_path GLOBAL PROPERTY kwiver_plugin_path)
-
-# convert list to path string using the system specific path separator
-foreach( p IN LISTS plugin_path )
-  set( VITAL_MODULE_PATH "${VITAL_MODULE_PATH}${path_sep}${p}" )
-endforeach(p)
-
 ###
 # configure our compiler options
 configure_file(


### PR DESCRIPTION
The plugin path only points to the base directory for all the
plugin types. This shortens the path considerably.