### PR TITLE
Remediating some warnings when using KWIVER_CPP_EXTRA option.

### DIFF
--- a/arrows/core/associate_detections_to_tracks_threshold.cxx
+++ b/arrows/core/associate_detections_to_tracks_threshold.cxx
@@ -38,6 +38,7 @@
 #include <vital/algo/detected_object_filter.h>
 #include <vital/types/object_track_set.h>
 #include <vital/exceptions/algorithm.h>
+#include <vital/vital_config.h>
 
 #include <string>
 #include <vector>
@@ -125,7 +126,7 @@ associate_detections_to_tracks_threshold
 
 bool
 associate_detections_to_tracks_threshold
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/close_loops_appearance_indexed.cxx
+++ b/arrows/core/close_loops_appearance_indexed.cxx
@@ -640,8 +640,8 @@ kwiver::vital::feature_track_set_sptr
 close_loops_appearance_indexed
 ::stitch(kwiver::vital::frame_id_t frame_number,
   kwiver::vital::feature_track_set_sptr input,
-  kwiver::vital::image_container_sptr image,
-  kwiver::vital::image_container_sptr mask) const
+  VITAL_UNUSED kwiver::vital::image_container_sptr image,
+  VITAL_UNUSED kwiver::vital::image_container_sptr mask) const
 {
   return d_->detect(input, frame_number);
 }

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -272,14 +272,14 @@ close_loops_keyframe
     all_matches[*f] = pool.enqueue(match_func, *f);
   }
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    all_matches[*kitr] = pool.enqueue(match_func, *kitr);
+    all_matches[*k_itr] = pool.enqueue(match_func, *k_itr);
   }
 
 
@@ -331,20 +331,20 @@ close_loops_keyframe
     static_cast<unsigned int>(last_frame_itr - frames.rbegin() - 2);
 
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    if (!all_matches[*kitr].valid())
+    if (!all_matches[*k_itr].valid())
     {
       LOG_WARN(logger(), "keyframe match from "<< frame_number << " to "
-                         << *kitr << " not available");
+                         << *k_itr << " not available");
       continue;
     }
-    auto const& matches = all_matches[*kitr].get();
+    auto const& matches = all_matches[*k_itr].get();
     int num_matched = static_cast<int>(matches.size());
     int num_linked = 0;
     if( num_matched >= d_->match_req )
@@ -357,7 +357,7 @@ close_loops_keyframe
         }
       }
     }
-    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *kitr
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *k_itr
                        << " has "<< num_matched << " matches and "
                        << num_linked << " joined tracks");
     if( num_matched > max_keyframe_matched )
@@ -373,7 +373,7 @@ close_loops_keyframe
     {
       break;
     }
-  }
+  } // end for
 
 
   // keep track of frames that matched no keyframes

--- a/arrows/core/compute_association_matrix_from_features.cxx
+++ b/arrows/core/compute_association_matrix_from_features.cxx
@@ -38,6 +38,7 @@
 #include <vital/algo/detected_object_filter.h>
 #include <vital/types/object_track_set.h>
 #include <vital/exceptions/algorithm.h>
+#include <vital/vital_config.h>
 
 #include <string>
 #include <vector>
@@ -139,8 +140,8 @@ compute_association_matrix_from_features
 /// Compute an association matrix given detections and tracks
 bool
 compute_association_matrix_from_features
-::compute( kwiver::vital::timestamp ts,
-           kwiver::vital::image_container_sptr image,
+::compute( VITAL_UNUSED kwiver::vital::timestamp ts,
+           VITAL_UNUSED kwiver::vital::image_container_sptr image,
            kwiver::vital::object_track_set_sptr tracks,
            kwiver::vital::detected_object_set_sptr detections,
            kwiver::vital::matrix_d& matrix,

--- a/arrows/core/depth_utils.cxx
+++ b/arrows/core/depth_utils.cxx
@@ -159,8 +159,8 @@ project_3d_bounds(kwiver::vital::vector_3d const& minpt,
 
   for (vector_3d const& p : points)
   {
-    vector_2d pp = cam.project(p);
-    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(pp[1]);
+    const vector_2d p_p = cam.project(p);
+    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(p_p[1]);
     i0 = std::min(i0, ui);
     j0 = std::min(j0, vi);
     i1 = std::max(i1, ui);

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -38,6 +38,7 @@
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 
 #include <sstream>
 #include <cstdlib>
@@ -121,7 +122,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_csv::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/core/detected_object_set_input_kw18.cxx
+++ b/arrows/core/detected_object_set_input_kw18.cxx
@@ -38,6 +38,7 @@
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 
 #include <map>
 #include <sstream>
@@ -113,7 +114,7 @@ detected_object_set_input_kw18::
 // ------------------------------------------------------------------
 void
 detected_object_set_input_kw18::
-set_configuration(vital::config_block_sptr config)
+set_configuration( VITAL_UNUSED vital::config_block_sptr config )
 {
 }
 
@@ -121,7 +122,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kw18::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -130,7 +131,8 @@ check_configuration(vital::config_block_sptr config) const
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kw18::
-read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name )
+read_set( kwiver::vital::detected_object_set_sptr & set,
+          VITAL_UNUSED std::string& image_name )
 {
   if ( d->m_first )
   {

--- a/arrows/core/detected_object_set_input_simulator.cxx
+++ b/arrows/core/detected_object_set_input_simulator.cxx
@@ -147,7 +147,7 @@ set_configuration(vital::config_block_sptr config_in)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_simulator::
-check_configuration(vital::config_block_sptr config) const
+check_configuration(VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -156,7 +156,7 @@ check_configuration(vital::config_block_sptr config) const
 // ----------------------------------------------------------------------------
 void
 detected_object_set_input_simulator::
-open( std::string const& filename )
+open( VITAL_UNUSED std::string const& filename )
 {
 }
 

--- a/arrows/core/detected_object_set_output_csv.cxx
+++ b/arrows/core/detected_object_set_output_csv.cxx
@@ -89,7 +89,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_csv::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -31,6 +31,7 @@
 #include "detected_object_set_output_kw18.h"
 
 #include <vital/util/tokenize.h>
+#include <vital/vital_config.h>
 
 #include <memory>
 #include <vector>
@@ -148,7 +149,7 @@ get_configuration() const
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_kw18::
-check_configuration( vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   if( d->m_write_tot && d->m_tot_field1_ids.empty() )
   {
@@ -167,7 +168,8 @@ check_configuration( vital::config_block_sptr config ) const
 // ------------------------------------------------------------------
 void
 detected_object_set_output_kw18::
-write_set( const kwiver::vital::detected_object_set_sptr set, std::string const& image_name )
+write_set( const kwiver::vital::detected_object_set_sptr set,
+           VITAL_UNUSED std::string const& image_name )
 {
 
   if (d->m_first)
@@ -233,9 +235,9 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
     double ily = ( bbox.min_y() + bbox.max_y() ) / 2.0;
 
     static std::atomic<unsigned> id_counter( 0 );
-    const unsigned id = id_counter++;
+    const unsigned l_id = id_counter++;
 
-    stream() << id                  // 1: track id
+    stream() << l_id                  // 1: track id
              << " 1 "               // 2: track length
              << d->m_frame_number-1 // 3: frame number / set number
              << " 0 "               // 4: tracking plane x
@@ -270,6 +272,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
           f1 = std::max( f1, clf->score( id ) );
         }
       }
+
       for( const std::string id : d->m_parsed_tot_ids2 )
       {
         if( clf->has_class_name( id ) )
@@ -280,7 +283,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
 
       f3 = 1.0 - f2 - f1;
 
-      (*d->m_tot_writer) << id << " " << f1 << " " << f2 << " " << f3 << std::endl;
+      (*d->m_tot_writer) << l_id << " " << f1 << " " << f2 << " " << f3 << std::endl;
 
     } // end write_tot
   } // end foreach

--- a/arrows/core/dynamic_config_none.cxx
+++ b/arrows/core/dynamic_config_none.cxx
@@ -35,6 +35,8 @@
 
 #include "dynamic_config_none.h"
 
+#include <vital/vital_config.h>
+
 namespace kwiver {
 namespace arrows {
 namespace core {
@@ -49,14 +51,14 @@ dynamic_config_none()
 // ------------------------------------------------------------------
 void
 dynamic_config_none::
-set_configuration( kwiver::vital::config_block_sptr config )
+set_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config )
 { }
 
 
 // ------------------------------------------------------------------
 bool
 dynamic_config_none::
-check_configuration( kwiver::vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/estimate_canonical_transform.cxx
+++ b/arrows/core/estimate_canonical_transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,7 +133,7 @@ estimate_canonical_transform
 // Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_canonical_transform
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
  return true;
 }

--- a/arrows/core/example_detector.cxx
+++ b/arrows/core/example_detector.cxx
@@ -35,6 +35,7 @@
 
 #include "example_detector.h"
 
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -118,7 +119,7 @@ set_configuration(vital::config_block_sptr config_in)
 // ------------------------------------------------------------------
 bool
 example_detector::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -127,11 +128,11 @@ check_configuration(vital::config_block_sptr config) const
 // ------------------------------------------------------------------
 kwiver::vital::detected_object_set_sptr
 example_detector::
-detect( vital::image_container_sptr image_data) const
+detect( VITAL_UNUSED vital::image_container_sptr image_data) const
 {
   auto detected_set = std::make_shared< kwiver::vital::detected_object_set>();
 
-  const double ct = (double)d->m_frame_ct;
+  const double ct { static_cast<double>(d->m_frame_ct) };
 
   kwiver::vital::bounding_box_d bbox(
           d->m_center_x + ct*d->m_dx - d->m_width/2.0,

--- a/arrows/core/feature_descriptor_io.cxx
+++ b/arrows/core/feature_descriptor_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,7 @@
 #include <fstream>
 
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 #include <cereal/archives/portable_binary.hpp>
 
 
@@ -116,7 +117,7 @@ feature_descriptor_io
 // Check that the algorithm's currently configuration is valid
 bool
 feature_descriptor_io
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -215,7 +216,7 @@ read_descriptors(Archive & ar, size_t num_desc)
 
   std::vector<descriptor_sptr> descriptors;
   descriptors.reserve(num_desc);
-  for( size_t i=0; i<num_desc; ++i )
+  for( size_t i = 0; i < num_desc; ++i )
   {
     std::shared_ptr<descriptor_array_of<T> > d;
     // allocate fixed vectors for common dimensions
@@ -231,7 +232,7 @@ read_descriptors(Archive & ar, size_t num_desc)
         d = std::make_shared<descriptor_dynamic<T> >(dim);
     }
     T* data = d->raw_data();
-    for(unsigned i=0; i<dim; ++i, ++data)
+    for(unsigned x = 0; x < dim; ++x, ++data)
     {
       ar( *data );
     }

--- a/arrows/core/filter_features_nonmax.cxx
+++ b/arrows/core/filter_features_nonmax.cxx
@@ -208,10 +208,10 @@ public:
     Eigen::AlignedBox<double, 1> scale_box;
     for (unsigned int i = 0; i < feat_vec.size(); i++)
     {
-      auto const& feat = feat_vec[i];
-      indices.push_back(std::make_pair(i, feat->magnitude()));
-      bbox.extend(feat->loc());
-      scale_box.extend(Eigen::Matrix<double,1,1>(feat->scale()));
+      auto const& l_feat = feat_vec[i];
+      indices.push_back(std::make_pair(i, l_feat->magnitude()));
+      bbox.extend(l_feat->loc());
+      scale_box.extend(Eigen::Matrix<double,1,1>(l_feat->scale()));
     }
 
     const double scale_min = std::log2(scale_box.min()[0]);

--- a/arrows/core/initialize_cameras_landmarks.cxx
+++ b/arrows/core/initialize_cameras_landmarks.cxx
@@ -1028,8 +1028,8 @@ initialize_cameras_landmarks
 
     // find existing landmarks for tracks also having features on the other frame
     map_landmark_t flms;
-    std::vector<track_sptr> trks = ftracks->active_tracks(static_cast<int>(other_frame));
-    for(const track_sptr& t : trks)
+    std::vector<track_sptr> ftrks = ftracks->active_tracks(static_cast<int>(other_frame));
+    for(const track_sptr& t : ftrks)
     {
       map_landmark_t::const_iterator li = lms.find(t->id());
       if( li != lms.end() )
@@ -1087,9 +1087,9 @@ initialize_cameras_landmarks
       camera_map::map_camera_t opt_cam_map;
       opt_cam_map[f] = cams[f];
       camera_map_sptr opt_cams = std::make_shared<simple_camera_map>(opt_cam_map);
-      landmark_map_sptr landmarks = std::make_shared<simple_landmark_map>(flms);
-      auto tracks = std::make_shared<feature_track_set>(trks);
-      d_->camera_optimizer->optimize(opt_cams, tracks, landmarks, constraints);
+      landmark_map_sptr landmarks_map = std::make_shared<simple_landmark_map>(flms);
+      auto ftracks = std::make_shared<feature_track_set>(trks);
+      d_->camera_optimizer->optimize(opt_cams, ftracks, landmarks_map, constraints);
       cams[f] = opt_cams->cameras()[f];
     }
 

--- a/arrows/core/initialize_cameras_landmarks_keyframe.cxx
+++ b/arrows/core/initialize_cameras_landmarks_keyframe.cxx
@@ -43,26 +43,27 @@
 #include <fstream>
 #include <ctime>
 
-#include <vital/math_constants.h>
 #include <vital/exceptions.h>
 #include <vital/io/eigen_io.h>
+#include <vital/math_constants.h>
+#include <vital/vital_config.h>
 
-#include <vital/algo/estimate_essential_matrix.h>
-#include <vital/algo/triangulate_landmarks.h>
 #include <vital/algo/bundle_adjust.h>
-#include <vital/algo/optimize_cameras.h>
 #include <vital/algo/estimate_canonical_transform.h>
-#include <vital/algo/estimate_similarity_transform.h>
-
-#include <arrows/core/triangulate_landmarks.h>
-#include <arrows/core/epipolar_geometry.h>
-#include <arrows/core/metrics.h>
-#include <arrows/core/match_matrix.h>
-#include <arrows/core/necker_reverse.h>
-#include <arrows/core/triangulate.h>
-#include <arrows/core/transform.h>
+#include <vital/algo/estimate_essential_matrix.h>
 #include <vital/algo/estimate_pnp.h>
+#include <vital/algo/estimate_similarity_transform.h>
+#include <vital/algo/optimize_cameras.h>
+#include <vital/algo/triangulate_landmarks.h>
+
+#include <arrows/core/epipolar_geometry.h>
+#include <arrows/core/match_matrix.h>
+#include <arrows/core/metrics.h>
+#include <arrows/core/necker_reverse.h>
 #include <arrows/core/sfm_utils.h>
+#include <arrows/core/transform.h>
+#include <arrows/core/triangulate.h>
+#include <arrows/core/triangulate_landmarks.h>
 
 using namespace kwiver::vital;
 
@@ -1064,12 +1065,11 @@ initialize_cameras_landmarks_keyframe::priv
   unsigned frames_skip = std::max(1u, static_cast<unsigned>(frames.size() / 2));
 
   do {
-
-    std::vector<frame_id_t> m_kf_mm_frames;
+    std::vector<frame_id_t> m_kf_mm_frames; //+ shadows member @mleotta is this correct
     int fid_idx = 0;
     for(auto fid: frames)
     {
-      if (fid_idx%frames_skip == 0)
+      if (fid_idx % frames_skip == 0)
       {
         m_kf_mm_frames.push_back(fid);
       }
@@ -1864,7 +1864,7 @@ void initialize_cameras_landmarks_keyframe::priv
   landmark_map_sptr& landmarks,
   feature_track_set_sptr tracks,
   sfm_constraints_sptr constraints,
-  frame_id_t target_frame)
+  VITAL_UNUSED frame_id_t target_frame)
 {
 
   if (m_track_map.empty())
@@ -2069,8 +2069,8 @@ initialize_cameras_landmarks_keyframe::priv
 feature_track_set_changes_sptr
 initialize_cameras_landmarks_keyframe::priv
 ::get_feature_track_changes(
-  feature_track_set_sptr tracks,
-  const simple_camera_perspective_map &cams) const
+  VITAL_UNUSED feature_track_set_sptr tracks,
+  VITAL_UNUSED const simple_camera_perspective_map &cams) const
 {
   auto chgs = std::make_shared<feature_track_set_changes>();
   /*
@@ -2255,13 +2255,13 @@ initialize_cameras_landmarks_keyframe::priv
                          << after_new_cam_rmse);
 
     }
-    int num_constraints_used;
+    int constraints_used;
     ba_constraints = nullptr;
     m_solution_was_fit_to_constraints = false;
     if (fit_reconstruction_to_constraints(cams, lms, tracks,
-                                          constraints, num_constraints_used))
+                                          constraints, constraints_used))
     {
-      if (num_constraints_used > 2)
+      if (constraints_used > 2)
       {
         ba_constraints = constraints;
         m_solution_was_fit_to_constraints = true;
@@ -2909,7 +2909,7 @@ initialize_cameras_landmarks_keyframe::priv
 std::set<landmark_id_t>
 initialize_cameras_landmarks_keyframe::priv
 ::find_visible_landmarks_in_frames(
-  const map_landmark_t &lmks,
+  VITAL_UNUSED const map_landmark_t &lmks,
   feature_track_set_sptr tracks,
   const std::set<frame_id_t> &frames)
 {

--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -42,6 +42,7 @@
 #include "vital_kpf_adapters.h"
 
 #include <vital/util/data_stream_reader.h>
+#include <vital/vital_config.h>
 #include <vital/exceptions.h>
 
 #include <map>
@@ -95,14 +96,14 @@ detected_object_set_input_kpf::
 // ------------------------------------------------------------------
 void
 detected_object_set_input_kpf::
-set_configuration(vital::config_block_sptr config)
+set_configuration( VITAL_UNUSED vital::config_block_sptr config)
 { }
 
 
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kpf::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/kpf/detected_object_set_output_kpf.cxx
+++ b/arrows/kpf/detected_object_set_output_kpf.cxx
@@ -30,9 +30,9 @@
 
 #include "detected_object_set_output_kpf.h"
 
+#include <vital/vital_config.h>
 #include <arrows/kpf/yaml/kpf_canonical_io_adapter.h>
 #include <arrows/kpf/yaml/kpf_yaml_writer.h>
-
 #include <arrows/kpf/vital_kpf_adapters.h>
 
 #include <memory>
@@ -114,7 +114,7 @@ get_configuration() const
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_kpf::
-check_configuration( vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -122,7 +122,8 @@ check_configuration( vital::config_block_sptr config ) const
 // ------------------------------------------------------------------
 void
 detected_object_set_output_kpf::
-write_set( const kwiver::vital::detected_object_set_sptr set, std::string const& image_name )
+write_set( const kwiver::vital::detected_object_set_sptr set,
+           VITAL_UNUSED std::string const& image_name )
 {
   KPF::record_yaml_writer w(stream());
   size_t line_count = 0;

--- a/arrows/serialize/json/activity.cxx
+++ b/arrows/serialize/json/activity.cxx
@@ -59,14 +59,14 @@ std::shared_ptr< std::string >
 activity::
 serialize( const kwiver::vital::any& element )
 {
-  kwiver::vital::activity activity =
+  kwiver::vital::activity l_activity =
     kwiver::vital::any_cast< kwiver::vital::activity > ( element );
 
   std::stringstream msg;
   msg << "activity ";
   {
     cereal::JSONOutputArchive ar( msg );
-    save( ar, activity );
+    save( ar, l_activity );
   }
 
   return std::make_shared< std::string > ( msg.str() );
@@ -77,7 +77,7 @@ kwiver::vital::any activity::
 deserialize( const std::string& message )
 {
   std::stringstream msg(message);
-  kwiver::vital::activity activity;
+  kwiver::vital::activity l_activity;
   std::string tag;
   msg >> tag;
 
@@ -89,10 +89,10 @@ deserialize( const std::string& message )
   else
   {
     cereal::JSONInputArchive ar( msg );
-    load( ar, activity );
+    load( ar, l_activity );
   }
 
-  return kwiver::vital::any( activity );
+  return kwiver::vital::any( l_activity );
 }
 
 } } } }

--- a/arrows/serialize/json/activity.h
+++ b/arrows/serialize/json/activity.h
@@ -46,8 +46,7 @@ namespace serialize {
 namespace json {
 
 class KWIVER_SERIALIZE_JSON_EXPORT activity
-  : public vital::algorithm_impl< activity,
-           vital::algo::data_serializer >
+  : public vital::algo::data_serializer
 {
 public:
   // Type name this class supports and description
@@ -60,9 +59,9 @@ public:
   activity();
   virtual ~activity();
 
-  virtual std::shared_ptr< std::string >
+  std::shared_ptr< std::string >
     serialize( const kwiver::vital::any& element ) override;
-  virtual kwiver::vital::any deserialize( const std::string& message ) override;
+  kwiver::vital::any deserialize( const std::string& message ) override;
 };
 
 } } } }

--- a/arrows/serialize/json/activity_type.h
+++ b/arrows/serialize/json/activity_type.h
@@ -45,10 +45,8 @@ namespace arrows {
 namespace serialize {
 namespace json {
 
-
 class KWIVER_SERIALIZE_JSON_EXPORT activity_type
-  : public vital::algorithm_impl< activity_type,
-           vital::algo::data_serializer >
+  : public vital::algo::data_serializer
 {
 public:
   // Type name this class supports and description
@@ -61,9 +59,9 @@ public:
   activity_type();
   virtual ~activity_type();
 
-  virtual std::shared_ptr< std::string >
+  std::shared_ptr< std::string >
     serialize( const kwiver::vital::any& element ) override;
-  virtual kwiver::vital::any deserialize( const std::string& message ) override;
+  kwiver::vital::any deserialize( const std::string& message ) override;
 };
 
 } } } }

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -134,7 +134,6 @@ void convert_protobuf( const ::kwiver::vital::activity& act,
   *proto_act.mutable_start_frame() = proto_start_frame;
   *proto_act.mutable_end_frame() = proto_end_frame;
 
-  auto at_sptr = act.type();
   // Now check if optional fields can be set
   if ( auto at_sptr = act.type() )
   {

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -395,7 +395,7 @@ TEST( convert_protobuf, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -745,7 +745,7 @@ TEST( convert_protobuf, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -895,7 +895,7 @@ TEST( convert_protobuf, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -424,7 +424,7 @@ TEST( serialize, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto deser_it = deser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( deser_it->second, deser_it->second );
@@ -676,7 +676,7 @@ TEST( serialize, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *( ser_it->first ), *( ser_it->first ) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -840,7 +840,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -31,6 +31,7 @@
 #include "logger_process_instrumentation.h"
 
 #include <sprokit/pipeline/process.h>
+#include <vital/vital_config.h>
 #include <vital/config/config_difference.h>
 #include <vital/util/enum_converter.h>
 #include <vital/util/string.h>
@@ -58,7 +59,7 @@ logger_process_instrumentation()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-  start_init_processing( std::string const& data )
+  start_init_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_init_processing" );
 }
@@ -76,7 +77,7 @@ stop_init_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-  start_finalize_processing( std::string const& data )
+  start_finalize_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_finalize_processing" );
 }
@@ -94,7 +95,7 @@ stop_finalize_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_reset_processing( std::string const& data )
+start_reset_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": stop_init_processing" );
 }
@@ -112,7 +113,7 @@ stop_reset_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_flush_processing( std::string const& data )
+start_flush_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_reset_processing" );
 }
@@ -130,7 +131,7 @@ stop_flush_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_step_processing( std::string const& data )
+start_step_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_step_processing" );
 }
@@ -148,7 +149,7 @@ stop_step_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_configure_processing( std::string const& data )
+start_configure_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_configure_processing" );
 }
@@ -166,7 +167,7 @@ stop_configure_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_reconfigure_processing( std::string const& data )
+start_reconfigure_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_reconfigure_processing" );
 }
@@ -229,6 +230,7 @@ void logger_process_instrumentation
     break;
 
   default:
+  case kvll::LEVEL_NONE:
   case kvll::LEVEL_INFO:
     LOG_INFO( m_logger, data );
     break;
@@ -238,6 +240,7 @@ void logger_process_instrumentation
     break;
 
   case kvll::LEVEL_ERROR:
+  case kvll::LEVEL_FATAL:
     LOG_ERROR( m_logger, data );
     break;
 

--- a/extras/process_instrumentation/timing_process_instrumentation.cxx
+++ b/extras/process_instrumentation/timing_process_instrumentation.cxx
@@ -30,6 +30,7 @@
 
 #include "timing_process_instrumentation.h"
 
+#include <vital/vital_config.h>
 #include <vital/util/enum_converter.h>
 
 #include <sprokit/pipeline/process.h>
@@ -79,7 +80,7 @@ timing_process_instrumentation::
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_init_processing( std::string const& data )
+start_init_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -101,7 +102,7 @@ stop_init_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_finalize_processing( std::string const& data )
+start_finalize_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -123,7 +124,7 @@ stop_finalize_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_reset_processing( std::string const& data )
+start_reset_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -142,7 +143,7 @@ stop_reset_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_flush_processing( std::string const& data )
+start_flush_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -161,7 +162,7 @@ stop_flush_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_step_processing( std::string const& data )
+start_step_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -182,7 +183,7 @@ stop_step_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_configure_processing( std::string const& data )
+start_configure_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -201,7 +202,7 @@ stop_configure_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_reconfigure_processing( std::string const& data )
+start_reconfigure_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -239,6 +240,9 @@ configure( kwiver::vital::config_block_sptr const conf )
   case timer_type::timer_cpu:
     m_timer = std::make_shared<kwiver::vital::cpu_timer>();
     type_name = "cpu_clock_duration";
+    break;
+
+  default:
     break;
   } // end switch
 

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -39,16 +39,15 @@
 #include <vital/config/config_block.h>
 #include <vital/logger/logger.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <sprokit/pipeline_util/pipeline_builder.h>
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/datum.h>
 #include <sprokit/pipeline/scheduler.h>
 #include <sprokit/pipeline/scheduler_factory.h>
-
 #include <sprokit/processes/adapters/input_adapter.h>
 #include <sprokit/processes/adapters/input_adapter_process.h>
-
 #include <sprokit/processes/adapters/output_adapter.h>
 #include <sprokit/processes/adapters/output_adapter_process.h>
 
@@ -483,7 +482,7 @@ embedded_pipeline
 // ----------------------------------------------------------------------------
 void
 embedded_pipeline::
-update_config( kwiver::vital::config_block_sptr config )
+update_config( VITAL_UNUSED kwiver::vital::config_block_sptr config )
 {
 }
 

--- a/sprokit/processes/adapters/embedded_pipeline_extension.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.cxx
@@ -29,6 +29,7 @@
  */
 
 #include "embedded_pipeline_extension.h"
+#include <vital/vital_config.h>
 
 namespace kwiver {
 
@@ -40,7 +41,7 @@ embedded_pipeline_extension()
 // ----------------------------------------------------------------------------
 void
 embedded_pipeline_extension::
-configure( kwiver::vital::config_block_sptr const conf )
+configure( VITAL_UNUSED kwiver::vital::config_block_sptr const conf )
 { }
 
 

--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -84,7 +84,7 @@ public:
    *
    * @param ctxt The calling context.
    */
-  virtual void pre_setup( context& ctxt ) { };
+  virtual void pre_setup( context& /* ctxt */ ) { };
 
   /**
    * @brief pipeline post-setup hook
@@ -94,7 +94,7 @@ public:
    *
    * @param ctxt The calling context.
    */
-  virtual void post_setup( context& ctxt ) { };
+  virtual void post_setup( context& /* ctxt */ ) { };
 
   /**
    * @brief End of data received from pipeline.
@@ -106,7 +106,7 @@ public:
    *
    * @param ctxt The calling context
    */
-  virtual void end_of_output( context& ctxt ) { };
+  virtual void end_of_output( context& /* ctxt */ ) { };
 
   /**
    * @brief Configure provider.
@@ -119,7 +119,7 @@ public:
    *
    * @param conf Configuration block.
    */
-  virtual void configure( kwiver::vital::config_block_sptr const conf );
+  virtual void configure( kwiver::vital::config_block_sptr const /* conf */ );
 
   /**
    * @brief Get default configuration block.
@@ -156,9 +156,9 @@ class embedded_pipeline_extension_registrar
   : public plugin_registrar
 {
 public:
-  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl,
-                    const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl_,
+                    const std::string& mod_name_ )
+    : plugin_registrar( vpl_, mod_name_ )
   {
   }
 

--- a/sprokit/processes/adapters/epx_test.cxx
+++ b/sprokit/processes/adapters/epx_test.cxx
@@ -33,6 +33,7 @@
 #include <vital/plugin_loader/plugin_loader.h>
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/config/config_block_formatter.h>
+#include <vital/vital_config.h>
 
 #include <sstream>
 #include <iostream>
@@ -63,7 +64,7 @@ pre_setup( context& ctxt )
 // ----------------------------------------------------------------------------
 void
 epx_test::
-end_of_output( context& ctxt )
+end_of_output( VITAL_UNUSED context& ctxt )
 {
   std::cout << "exp_test End_Of_Output called\n";
 }

--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -77,16 +77,16 @@ kwiver::adapter::ports_info_t
 input_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t port_info;
+  kwiver::adapter::ports_info_t l_port_info;
 
   // formulate list of current input ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    port_info[port] = this->input_port_info( port );
+    l_port_info[port] = this->input_port_info( port );
   }
 
-  return port_info;
+  return l_port_info;
 }
 
 

--- a/sprokit/processes/adapters/tests/test_non_blocking.cxx
+++ b/sprokit/processes/adapters/tests/test_non_blocking.cxx
@@ -120,7 +120,7 @@ main(int argc, char* argv[])
 }
 
 // ==================================================================
-IMPLEMENT_TEST(non_blocking)
+IMPLEMENT_TEST(nonblocking)
 {
   std::stringstream pipeline_desc;
   pipeline_desc

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -33,6 +33,7 @@
 #include <kwiver_type_traits.h>
 
 #include <vital/types/timestamp.h>
+#include <vital/vital_config.h>
 
 namespace kwiver
 {
@@ -50,7 +51,7 @@ public:
   explicit priv( downsample_process* p );
   ~priv();
 
-  bool skip_frame( vital::timestamp const& ts, double frame_rate );
+  bool skip_frame( VITAL_UNUSED vital::timestamp const& ts, double frame_rate );
 
   downsample_process* parent;
 

--- a/sprokit/processes/core/keyframe_selection_process.cxx
+++ b/sprokit/processes/core/keyframe_selection_process.cxx
@@ -279,7 +279,7 @@ vital::feature_track_set_sptr
 keyframe_selection_process::priv
 ::remove_non_keyframes_between_keyframes(
   vital::feature_track_set_sptr input_tracks,
-  vital::frame_id_t current_frame_number)
+  VITAL_UNUSED vital::frame_id_t current_frame_number)
 {
   bool passed_a_keyframe = false;
   auto afd = input_tracks->all_frame_data();
@@ -344,7 +344,7 @@ vital::feature_track_set_sptr
 keyframe_selection_process::priv
 ::merge_next_tracks_into_loop_back_track(
   vital::feature_track_set_sptr next_tracks,
-  vital::frame_id_t next_tracks_frame_num,
+  VITAL_UNUSED vital::frame_id_t next_tracks_frame_num,
   vital::feature_track_set_sptr loop_back_tracks)
 {
   vital::feature_track_set_sptr curr_tracks = loop_back_tracks;

--- a/sprokit/processes/flow/mux_process.cxx
+++ b/sprokit/processes/flow/mux_process.cxx
@@ -362,9 +362,10 @@ mux_process
           break;
         }
 
-        default:
-          VITAL_THROW( invalid_configuration_exception, name(),
-                       "Invalid option specified for termination_policy." );
+      default:
+      case priv::term_policy_t::skip:
+        VITAL_THROW( invalid_configuration_exception, name(),
+                     "Invalid option specified for termination_policy." );
       } // end switch
 
       continue;

--- a/sprokit/processes/trait_utils.h
+++ b/sprokit/processes/trait_utils.h
@@ -256,7 +256,7 @@ sprokit::process::type_t const PN ## _port_trait::type_name = sprokit::process::
 sprokit::process::port_t const PN ## _port_trait::port_name = sprokit::process::port_t( # PN ); \
 sprokit::process::port_description_t const PN ## _port_trait::description = sprokit::process::port_description_t( DESCRIP ); }
 
-#if VITAL_VARIADAC_MACRO
+#ifdef VITAL_VARIADAC_MACRO
 
 //
 // Substantial macro magic

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -147,5 +147,3 @@ kwiver_install_headers(
   SUBDIR sprokit/pipeline
   NOPATH
   )
-
-sprokit_configure_pkgconfig(sprokit-pipeline)

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -37,6 +37,7 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/string.h>
 #include <vital/optional.h>
+#include <vital/vital_config.h>
 
 #include <boost/assign/ptr_map_inserter.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
@@ -832,7 +833,7 @@ process
 // ------------------------------------------------------------------
 void
 process
-::input_port_undefined( port_t const& port )
+::input_port_undefined( VITAL_UNUSED port_t const& port )
 {
 }
 
@@ -866,7 +867,7 @@ process
 // ------------------------------------------------------------------
 void
 process
-::output_port_undefined( port_t const& port )
+::output_port_undefined( VITAL_UNUSED port_t const& port )
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -237,8 +237,8 @@ public:
   };
 
   process_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& mod_name_ )
+    : plugin_registrar( vpl, mod_name_ )
   {
   }
 

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
@@ -35,6 +35,7 @@
 
 #include "process_instrumentation.h"
 
+#include <vital/vital_config.h>
 #include <sprokit/pipeline/process.h>
 
 namespace sprokit {
@@ -55,7 +56,7 @@ set_process( sprokit::process const& proc )
 
 void
 process_instrumentation::
-configure( kwiver::vital::config_block_sptr const config )
+configure( VITAL_UNUSED kwiver::vital::config_block_sptr const config )
 { }
 
 

--- a/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
@@ -32,6 +32,7 @@
 
 #include <vital/config/config_block.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/scheduler.h>
@@ -181,7 +182,8 @@ IMPLEMENT_TEST(unknown_types)
 
 // ------------------------------------------------------------------
 sprokit::scheduler_t
-null_scheduler(sprokit::pipeline_t const& /*pipeline*/, kwiver::vital::config_block_sptr const& /*config*/)
+null_scheduler_ptr( VITAL_UNUSED sprokit::pipeline_t const& pipeline,
+                    VITAL_UNUSED kwiver::vital::config_block_sptr const& config )
 {
   return sprokit::scheduler_t();
 }

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -157,8 +157,8 @@ class algorithm_registrar
 {
 public:
   algorithm_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& module_name )
+    : plugin_registrar( vpl, module_name )
   {
   }
 

--- a/vital/algo/bundle_adjust.cxx
+++ b/vital/algo/bundle_adjust.cxx
@@ -37,6 +37,7 @@
 #include <vital/algo/bundle_adjust.h>
 #include <vital/algo/algorithm.txx>
 #include <vital/logger/logger.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -62,8 +63,8 @@ bundle_adjust
   kwiver::vital::simple_camera_perspective_map &cameras,
   kwiver::vital::landmark_map::map_landmark_t &landmarks,
   vital::feature_track_set_sptr tracks,
-  const std::set<vital::frame_id_t>& fixed_cameras,
-  const std::set<vital::landmark_id_t>& fixed_landmarks,
+  VITAL_UNUSED const std::set<vital::frame_id_t>& fixed_cameras,
+  VITAL_UNUSED const std::set<vital::landmark_id_t>& fixed_landmarks,
   kwiver::vital::sfm_constraints_sptr constraints) const
 {
   auto cam_map = std::static_pointer_cast<vital::camera_map>(

--- a/vital/algo/image_io.cxx
+++ b/vital/algo/image_io.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
+#include <vital/vital_config.h>
 #include <vital/vital_types.h>
 
 #include <kwiversys/SystemTools.hxx>
@@ -135,7 +136,7 @@ image_io
 
 metadata_sptr
 image_io
-::load_metadata_(std::string const& filename) const
+::load_metadata_(VITAL_UNUSED std::string const& filename) const
 {
   // No metadata-only loading by default.
   return nullptr;

--- a/vital/algo/train_detector.cxx
+++ b/vital/algo/train_detector.cxx
@@ -36,6 +36,7 @@
 #include "train_detector.h"
 
 #include <vital/algo/algorithm.txx>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -50,11 +51,11 @@ train_detector
 void
 train_detector
 ::train_from_disk(
-  vital::category_hierarchy_sptr object_labels,
-  std::vector< std::string > train_image_names,
-  std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
-  std::vector< std::string > test_image_names,
-  std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
+  VITAL_UNUSED vital::category_hierarchy_sptr object_labels,
+  VITAL_UNUSED std::vector< std::string > train_image_names,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
+  VITAL_UNUSED std::vector< std::string > test_image_names,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
 {
   throw std::runtime_error( "Method not implemented" );
 }
@@ -63,11 +64,11 @@ train_detector
 void
 train_detector
 ::train_from_memory(
-  vital::category_hierarchy_sptr object_labels,
-  std::vector< kwiver::vital::image_container_sptr > train_images,
-  std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
-  std::vector< kwiver::vital::image_container_sptr > test_images,
-  std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
+  VITAL_UNUSED vital::category_hierarchy_sptr object_labels,
+  VITAL_UNUSED std::vector< kwiver::vital::image_container_sptr > train_images,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
+  VITAL_UNUSED std::vector< kwiver::vital::image_container_sptr > test_images,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
 {
   throw std::runtime_error( "Method not implemented" );
 }

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -703,8 +703,8 @@ config_block
   // iterate over all strings and convert to target type
   for (std::string str : sv )
   {
-    T val = config_block_get_value_cast<T>( str );
-    val_vector.push_back( val );
+    T l_val = config_block_get_value_cast<T>( str );
+    val_vector.push_back( l_val );
   }
 
   return val_vector;

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/math_constants.h>
 #include <vital/types/metadata_traits.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -301,7 +302,7 @@ bool
 update_camera_from_metadata(metadata const& md,
                             local_geo_cs const& lgcs,
                             simple_camera_perspective& cam,
-                            rotation_d const& rot_offset)
+               VITAL_UNUSED rotation_d const& rot_offset)
 {
   bool rotation_set = false;
   bool translation_set = false;

--- a/vital/io/mesh_io.cxx
+++ b/vital/io/mesh_io.cxx
@@ -325,7 +325,7 @@ read_obj(std::istream& is)
     {
       case 'v': // read a vertex
       {
-        char c2 = (char)is.peek();
+        char c2 = static_cast<char>(is.peek());
         switch (c2)
         {
           case 'n': // read a normal

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -399,6 +399,11 @@ convert_metadata
       raw_target_location[0] = klv_0601_value_double( KLV_0601_TARGET_LOCATION_LONG, data );
       break;
 
+      // And all the others
+    case KLV_0601_UNKNOWN:
+    case KLV_0601_CHECKSUM:
+    case KLV_0601_ENUM_END:
+    case KLV_0601_GENERIC_FLAG_DATA_01:
     default:
       LOG_DEBUG( logger, "KLV 0601 key: " << int(itr->first) << " is not supported." );
       break;

--- a/vital/logger/log4cplus_factory.cxx
+++ b/vital/logger/log4cplus_factory.cxx
@@ -107,6 +107,7 @@ virtual void set_level( log_level_t level )
     break;
 
   default:
+  case LEVEL_NONE:
     // log or throw
     break;
   } // end switch
@@ -281,22 +282,29 @@ virtual void log_message ( log_level_t level, std::string const& msg)
   case LEVEL_TRACE:
     log_trace(msg);
     break;
+
   case LEVEL_DEBUG:
     log_debug(msg);
     break;
+
   case LEVEL_INFO:
     log_info(msg);
     break;
+
   case LEVEL_WARN:
     log_warn(msg);
     break;
+
   case LEVEL_ERROR:
     log_error(msg);
     break;
+
   case LEVEL_FATAL:
     log_fatal(msg);
     break;
+
   default:
+  case LEVEL_NONE:
     break;
   } // end switch
 }
@@ -333,6 +341,7 @@ virtual void log_message ( log_level_t level, std::string const& msg,
     break;
 
   default:
+  case LEVEL_NONE:
     break;
   } // end switch
 }

--- a/vital/plugin_loader/plugin_loader_filter.h
+++ b/vital/plugin_loader/plugin_loader_filter.h
@@ -82,8 +82,8 @@ public:
    *
    * @return \b true if the plugin should be loaded, \b false if plugin should not be loaded
    */
-  virtual bool load_plugin( path_t const& path,
-                            DL::LibraryHandle lib_handle ) const
+  virtual bool load_plugin( path_t const& /* path */,
+                            DL::LibraryHandle /* lib_handle */ ) const
     { return true; }
 
   /**
@@ -107,7 +107,7 @@ public:
    *
    * @return \b true if the plugin should be registered, \b false otherwise.
    */
-  virtual bool add_factory( plugin_factory_handle_t fact ) const
+  virtual bool add_factory( plugin_factory_handle_t /* fact */ ) const
     { return true; }
 
 

--- a/vital/tests/test_estimate_similarity_transform.cxx
+++ b/vital/tests/test_estimate_similarity_transform.cxx
@@ -68,14 +68,14 @@ public:
     : expected_size(0)
   {}
 
-  dummy_est(size_t expected_size)
-    : expected_size(expected_size)
+  dummy_est(size_t expected_size_)
+    : expected_size(expected_size_)
   {}
 
   virtual ~dummy_est() = default;
 
-  void set_configuration(kwiver::vital::config_block_sptr config) {}
-  bool check_configuration(kwiver::vital::config_block_sptr config) const {return true;}
+  void set_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config) {}
+  bool check_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config) const {return true;}
 
   using kwiver::vital::algo::estimate_similarity_transform::estimate_transform;
 

--- a/vital/tests/test_image.cxx
+++ b/vital/tests/test_image.cxx
@@ -38,6 +38,7 @@
 #include <vital/types/image.h>
 #include <vital/types/image_container.h>
 #include <vital/util/transform_image.h>
+#include <vital/vital_config.h>
 
 #include <gtest/gtest.h>
 
@@ -78,7 +79,7 @@ struct val_zero_op
 // ----------------------------------------------------------------------------
 struct val_incr_op
 {
-  byte operator()( byte const &b )
+  byte operator()( VITAL_UNUSED byte const &b )
   {
     return val_incr_op_i++;
   }

--- a/vital/types/descriptor.h
+++ b/vital/types/descriptor.h
@@ -127,7 +127,7 @@ public:
    * to store the node_id.  Derived classes that do store the node_id
    * should return true if it successfully stored.
   */
-  virtual bool set_node_id(unsigned int node_id) { return false; }
+  virtual bool set_node_id( unsigned int /* node_id */ ) { return false; }
 
 };
 

--- a/vital/types/feature_track_set.h
+++ b/vital/types/feature_track_set.h
@@ -65,24 +65,24 @@ class VITAL_EXPORT feature_track_state : public track_state
 public:
   //@{
   /// Constructor
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr const& feature = nullptr,
-                                descriptor_sptr const& descriptor = nullptr,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ feature }
-    , descriptor{ descriptor }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr const& p_feature = nullptr,
+                                descriptor_sptr const& p_descriptor = nullptr,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ p_feature }
+    , descriptor{ p_descriptor }
+    , inlier{ p_inlier }
   {}
 
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr&& feature,
-                                descriptor_sptr&& descriptor,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ std::move( feature ) }
-    , descriptor{ std::move( descriptor ) }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr&& p_feature,
+                                descriptor_sptr&& p_descriptor,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ std::move( p_feature ) }
+    , descriptor{ std::move( p_descriptor ) }
+    , inlier{ p_inlier }
   {}
   //@}
 

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -129,8 +129,8 @@ config_block_get_value_cast( config_block_value_t const& value )
   }
 
   // Set up helper lambda to check for errors
-  auto try_or_die = [&value]( std::istream& s ) {
-    if ( s.fail() ) {
+  auto try_or_die = [&value]( std::istream& s_ ) {
+    if ( s_.fail() ) {
       VITAL_THROW( bad_config_block_cast,
                    "failed to convert from string representation \"" + value + "\"" );
     }

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -68,23 +68,23 @@ namespace vital {
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any const& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ data },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any const& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ p_data },
+      m_tag{ p_tag }
 {
 }
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any&& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ std::move( data ) },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any&& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ std::move( p_data ) },
+      m_tag{ p_tag }
 {
 }
 
@@ -291,15 +291,15 @@ metadata
 
   for (size_t i = 0; i < len; i++)
   {
-    char const byte = val[i];
-    if ( ! isprint( byte ) )
+    char const l_byte = val[i];
+    if ( ! isprint( l_byte ) )
     {
       ascii.append( 1, '.' );
       unprintable_found = true;
     }
     else
     {
-      ascii.append( 1, byte );
+      ascii.append( 1, l_byte );
     }
 
     // format as hex
@@ -308,8 +308,8 @@ metadata
       hex += " ";
     }
 
-    hex += hex_chars[ ( byte & 0xF0 ) >> 4 ];
-    hex += hex_chars[ ( byte & 0x0F ) >> 0 ];
+    hex += hex_chars[ ( l_byte & 0xF0 ) >> 4 ];
+    hex += hex_chars[ ( l_byte & 0x0F ) >> 0 ];
 
   } // end for
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -253,24 +253,24 @@ class typed_metadata
   : public metadata_item
 {
 public:
-  typed_metadata( std::string const& name, TYPE const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, TYPE const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
   }
 
-  typed_metadata( std::string const& name, TYPE&& data )
-    : metadata_item( name, std::move( data ), TAG )
+  typed_metadata( std::string const& p_name, TYPE&& p_data )
+    : metadata_item( p_name, std::move( p_data ), TAG )
   {
   }
 
-  typed_metadata( std::string const& name, kwiver::vital::any const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, kwiver::vital::any const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
-    if ( data.type() != typeid(TYPE) )
+    if ( p_data.type() != typeid(TYPE) )
     {
       std::stringstream msg;
       msg << "Creating typed_metadata object with data type ("
-          << demangle( data.type().name() )
+          << demangle( p_data.type().name() )
           << ") different from type object was created with ("
           << demangle( typeid(TYPE).name() ) << ")";
       VITAL_THROW( metadata_exception, msg.str() );

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -135,7 +135,8 @@ metadata_traits
     KWIVER_VITAL_METADATA_TAGS( TAG_CASE )
 
   default:
-    return "-- unknown tag code --";
+  case VITAL_META_LAST_TAG:
+      return "-- unknown tag code --";
     break;
   } // end switch
 

--- a/vital/types/point.cxx
+++ b/vital/types/point.cxx
@@ -64,6 +64,9 @@ out(std::ostream& str, point< N, T >const& p)
   case 4:
     str << "[ " << v[0] << ", " << v[1] << ", " << v[2] << ", " << v[3] << " ]\n";
     break;
+  default:
+    str << "Unexpected dimension for point.\n";
+    break;
   }
 
   str << " - covariance : ";
@@ -84,6 +87,9 @@ out(std::ostream& str, point< N, T >const& p)
                 << c(1, 0) << ", " << c(1, 1) << ", " << c(1, 2) << ", " << c(1, 3) << "\n                  "
                 << c(2, 0) << ", " << c(2, 1) << ", " << c(2, 2) << ", " << c(2, 3) << "\n                  "
                 << c(3, 0) << ", " << c(3, 1) << ", " << c(3, 2) << ", " << c(3, 3) << " ]\n";
+    break;
+  default:
+    str << "Unexpected dimension for point.\n";
     break;
   }
 

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -144,7 +144,7 @@ rotation_< T >
 ::angle() const
 {
   static const T _pi = static_cast< T > ( pi );
-  static const T two_pi = static_cast< T > ( 2.0 * pi );
+  static const T _two_pi = static_cast< T > ( 2.0 * pi );
 
   const double i = Eigen::Matrix< T, 3, 1 > ( q_.x(), q_.y(), q_.z() ).norm();
   const double r = q_.w();
@@ -154,11 +154,11 @@ rotation_< T >
   // i.e. -pi/2 < a < pi/2
   if ( a >= _pi )
   {
-    a -= two_pi;
+    a -= _two_pi;
   }
   if ( a <= -_pi )
   {
-    a += two_pi;
+    a += _two_pi;
   }
   return a;
 }

--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -60,8 +60,8 @@ class VITAL_EXPORT track_ref : public std::weak_ptr< track >
 {
 public:
   track_ref() = default;
-  track_ref( track_ref const& other ) {}
-  track_ref( track_ref&& other ) {}
+  track_ref( VITAL_UNUSED track_ref const& other ) {}
+  track_ref( VITAL_UNUSED track_ref&& other ) {}
 
   track_ref& operator= ( track_ref const& rhs ) = delete;
   track_ref& operator= ( track_ref&& rhs ) = delete;

--- a/vital/util/string.cxx
+++ b/vital/util/string.cxx
@@ -45,7 +45,8 @@ namespace vital {
 std::string
 string_format( const std::string fmt_str, ... )
 {
-  int final_n, n = ( (int)fmt_str.size() ) * 2; /* Reserve two times as much as the length of the fmt_str */
+  int final_n;
+  int n = static_cast<int>(fmt_str.size() ) * 2; /* Reserve two times as much as the length of the fmt_str */
   std::string str;
   std::unique_ptr< char[] > formatted;
   va_list ap;

--- a/vital/util/token_expander.cxx
+++ b/vital/util/token_expander.cxx
@@ -158,7 +158,8 @@ expand_token( std::string const& initial_string )
 // ------------------------------------------------------------------
 bool
 token_expander::
-handle_missing_entry( const std::string& provider, const std::string& entry )
+handle_missing_entry( VITAL_UNUSED std::string const& provider,
+                      VITAL_UNUSED std::string const& entry )
 {
   // default is to insert unresolved text
   return true;
@@ -168,7 +169,8 @@ handle_missing_entry( const std::string& provider, const std::string& entry )
 // ------------------------------------------------------------------
 bool
 token_expander::
-handle_missing_provider( const std::string& provider, const std::string& entry )
+handle_missing_provider( VITAL_UNUSED std::string const& provider,
+                         VITAL_UNUSED std::string const& entry )
 {
   // default is to insert unresolved text
   return true;

--- a/vital/util/whereami.c
+++ b/vital/util/whereami.c
@@ -306,13 +306,12 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 
             if (dirname_length)
             {
-              int i;
-
-              for (i = length - 1; i >= 0; --i)
+              int ii;
+              for (ii = length - 1; ii >= 0; --ii)
               {
-                if (out[i] == '/')
+                if (out[ii] == '/')
                 {
-                  *dirname_length = i;
+                  *dirname_length = ii;
                   break;
                 }
               }


### PR DESCRIPTION
Specifically addressing 
- unused parameters
- shadowed variables
- Missing case elements of a switch