### PR TITLE
Rework docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # Install KWIVER to /opt/kitware/kwiver
 # Use latest Fletch as base image (Ubuntu 18.04)
 
-FROM kitware/fletch:latest-ubuntu16.04-py2-cuda8.0-cudnn5-devel
+FROM kitware/fletch:latest-ubuntu18.04-py3-cuda10.0-cudnn7-devel
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-                          python3-dev \
-                          python3-pip
+ && apt-get install -y --no-install-recommends \
+                    python3-dev \
+                    python3-pip \
+ && pip3 install setuptools \
+                 scipy \
+                 six
 
 #
 # Build KWIVER
@@ -37,6 +40,13 @@ RUN cd /kwiver \
     -DKWIVER_PYTHON_MAJOR_VERSION=3 \
     -DKWIVER_USE_BUILD_TREE=ON \
   && make -j$(nproc) -k \
-  && make install
+  && make install \
+  && chmod +x setup_KWIVER.sh
 
-CMD [ "bash" ]
+# Configure entrypoint
+RUN echo 'source /kwiver/build/setup_KWIVER.sh' >> entrypoint.sh \
+ && echo 'kwiver $@' >> entrypoint.sh \
+ && chmod +x entrypoint.sh
+
+ENTRYPOINT [ "bash", "/entrypoint.sh" ]
+CMD [ "help" ]

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The Dockerfile used to build the image can be found `here <dockerfile>`_.
 
 Pull the image from Dockerhub::
 
- "docker pull kitware/kwiver:master" (latest master)
+ "docker pull kitware/kwiver:latest" (latest master)
 
  "docker pull kitware/kwiver:release" (latest release)
 


### PR DESCRIPTION
- Renames dockerfile to Dockerfile (docker standard)

- Updates readme to point to tag `latest` instead of `master` (docker standard)

- Updates the default Fletch base image from:
`kitware/fletch:latest-ubuntu16.04-py2-cuda8.0-cudnn5-devel`
to
`kitware/fletch:latest-ubuntu18.04-py3-cuda10.0-cudnn7-devel`

- Change entrypoint to `kwiver` from `bash`

- Fixes the errors: 
```
ModuleNotFoundError: No module named 'pkg_resources'
WARNING kwiver.vital.modules.loaders(155): Could not import: kwiver.sprokit.processes.simple_homog_tracker, Reason: No module named scipy
WARNING kwiver.vital.modules.loaders(155): Could not import: kwiver.sprokit.processes.apply_descriptor, Reason: No module named six
```
That occurs when calling `kwiver` inside the current docker container. The fix is to install `setuptools`, `six`, and `scipy`.
