### PR TITLE
Cleanup and stabilization for TUT tracker

### DIFF
--- a/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
@@ -435,7 +435,7 @@ class SRNNTracker(KwiverProcess):
                                         interaction_feature=grid_feature_list[idx],
                                         app_feature=pt_app_features[idx],
                                         bbox=[int(x) for x in bbox_as_list],
-                                        ref_bbox=[int(x) for x in transform_homog_bbox(homog_src_to_base, bbox_as_list)],
+                                        ref_bbox=transform_homog_bbox(homog_src_to_base, bbox_as_list),
                                         detected_object=d_obj,
                                         sys_frame_id=fid, sys_frame_time=ts)
                     track_state_list.append(cur_ts)

--- a/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
@@ -308,12 +308,12 @@ class SRNNTracker(KwiverProcess):
                 print('!!! No bbox is provided on this frame.  Skipping this frame !!!')
             else:
                 # interaction features
-                grid_feature_list = timing('grid feature', lambda:
-                                           self._grid(im.size, dos, self._gtbbox_flag))
+                grid_feature_list = timing('grid feature', lambda: (
+                    self._grid(im.size, dos, self._gtbbox_flag)))
 
                 # appearance features (format: pytorch tensor)
-                pt_app_features = timing('app feature', lambda:
-                                         self._app_feature_extractor(im, dos, self._gtbbox_flag))
+                pt_app_features = timing('app feature', lambda: (
+                    self._app_feature_extractor(im, dos, self._gtbbox_flag)))
 
                 track_state_list = []
                 next_track_id = int(self._track_set.get_max_track_id()) + 1

--- a/python/kwiver/sprokit/processes/pytorch/utils/iou_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/iou_tracker.py
@@ -48,8 +48,8 @@ class IOUTracker(object):
                 best_iou_score = self._iou_score(track[-1].bbox, best_match.bbox)
                 if best_iou_score >= self._iou_accept_threshold:
                     # if no other bbox with overlap larger than iou_reject_threshold
-                    if (len(sorted_ts_list) >= 2 and
-                        (self._iou_score(track[-1].bbox, sorted_ts_list[1].bbox)
+                    if (len(sorted_ts_list) < 2 or
+                        (self._iou_score(track[-1].bbox, sorted_ts_list[-2].bbox)
                          < self._iou_reject_threshold)):
                         track.updated_flag = True
                         track_set.update_track(track.track_id, best_match)

--- a/python/kwiver/sprokit/processes/pytorch/utils/iou_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/iou_tracker.py
@@ -45,7 +45,8 @@ class IOUTracker(object):
                 # Otherwise do nothing.
 
                 # Get IOUs
-                ious = [self._iou_score(track[-1].bbox, x.bbox) for x in track_state_list]
+                ious = [self._iou_score(track[-1].ref_bbox, x.ref_bbox)
+                        for x in track_state_list]
                 # Get dets with IOU over reject threshold
                 nonreject_dets = [(ts, iou) for ts, iou in zip(track_state_list, ious)
                                   if iou >= self._iou_reject_threshold]

--- a/python/kwiver/sprokit/processes/pytorch/utils/siamese_feature_extractor.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/siamese_feature_extractor.py
@@ -63,7 +63,7 @@ class SiameseDataLoader(data.Dataset):
         return im
 
     def __len__(self):
-        return len(self._bbox_list) if self._mot_flag else  self._bbox_list.size()
+        return len(self._bbox_list) if self._mot_flag else self._bbox_list.size()
 
 
 class SiameseFeatureExtractor(object):
@@ -77,7 +77,7 @@ class SiameseFeatureExtractor(object):
         # load Siamese model
         self._siamese_model = Siamese().to(self._device)
         if use_gpu_flag:
-            self._siamese_model = torch.nn.DataParallel(self._siamese_model, 
+            self._siamese_model = torch.nn.DataParallel(self._siamese_model,
                                                         device_ids=gpu_list)
             snapshot = torch.load(siamese_model_path)
             self._siamese_model.load_state_dict(snapshot['state_dict'])
@@ -85,7 +85,7 @@ class SiameseFeatureExtractor(object):
             snapshot = torch.load(siamese_model_path, map_location='cpu')
             tmp = {self._strip_prefix(k, 'module.'): v
                    for k, v in snapshot['state_dict'].items()}
-            self._siamese_model.load_state_dict( tmp )
+            self._siamese_model.load_state_dict(tmp)
 
         print('Model loaded from {}'.format(siamese_model_path))
         self._siamese_model.train(False)
@@ -93,7 +93,7 @@ class SiameseFeatureExtractor(object):
         self._transform = transforms.Compose([
             transforms.Scale(img_size),
             transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
         ])
         self._img_size = img_size
         self._b_size = batch_size
@@ -101,22 +101,22 @@ class SiameseFeatureExtractor(object):
     @classmethod
     def _strip_prefix(_cls, string, prefix):
         if not string.startswith(prefix):
-            raise ValueError("{!r} was supposed to start with {!r} but does not".\
-                    format(string, prefix))
+            raise ValueError("{!r} was supposed to start with {!r} but does not"
+                             .format(string, prefix))
         return string[len(prefix):]
-    
+
     def __call__(self, frame, bbox_list, mot_flag):
         return self._obtain_features(frame, bbox_list, mot_flag)
 
     def _obtain_features(self, frame, bbox_list, mot_flag):
         kwargs = {'num_workers': 0, 'pin_memory': True}
         if frame is not None:
-            bbox_loader_class = SiameseDataLoader(bbox_list, self._transform, 
+            bbox_loader_class = SiameseDataLoader(bbox_list, self._transform,
                                     frame, self._img_size, mot_flag)
         else:
             raise ValueError("Trying to create SiameseDataLoader without providing frame")
 
-        bbox_loader = torch.utils.data.DataLoader(bbox_loader_class, 
+        bbox_loader = torch.utils.data.DataLoader(bbox_loader_class,
                             batch_size=self._b_size, shuffle=False, **kwargs)
 
         torch.set_grad_enabled(False)

--- a/python/kwiver/sprokit/processes/pytorch/utils/srnn_matching.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/srnn_matching.py
@@ -53,9 +53,9 @@ class TargetRNNDataLoader(data.Dataset):
                         #motion feature and motion target
                         motion_f_tensor = torch.stack([cur_track[i].motion_feature
                                                 for i in range(-g_config.timeStep, 0)])
-                        motion_target_f = (np.asarray(track_state.bbox_center,
+                        motion_target_f = (np.asarray(track_state.ref_point,
                                             dtype=np.float32).reshape(g_config.M_F_num) -
-                                           np.asarray(cur_track[-1].bbox_center,
+                                           np.asarray(cur_track[-1].ref_point,
                                                dtype=np.float32).reshape(g_config.M_F_num))
                         cur_data_item += motion_f_tensor, torch.from_numpy(motion_target_f)
 

--- a/python/kwiver/sprokit/processes/pytorch/utils/srnn_matching.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/srnn_matching.py
@@ -32,17 +32,17 @@ class TargetRNNDataLoader(data.Dataset):
             if _rnnType is self._rnnType:
                 for ts, track_state in enumerate(self._track_state_list):
                     # distance between the two bbox's x instead of center
-                    dis = abs(cur_track[-1].bbox[0] - track_state.bbox[0])
+                    dis = abs(cur_track[-1].ref_bbox[0] - track_state.ref_bbox[0])
 
-                    bbox_area_ratio = (float(cur_track[-1].bbox[2] * cur_track[-1].bbox[3]) /
-                                       float(track_state.bbox[2] * track_state.bbox[3]))
+                    bbox_area_ratio = (float(cur_track[-1].ref_bbox[2] * cur_track[-1].ref_bbox[3]) /
+                                       float(track_state.ref_bbox[2] * track_state.ref_bbox[3]))
                     if bbox_area_ratio < 1.0:
                         bbox_area_ratio = 1.0 / bbox_area_ratio
 
                     # in the search area, we prepare data and calculate the similarity score
-                    if (dis < self._track_search_threshold * cur_track[-1].bbox[2] and         # track dis constraint
-                        dis < self._track_search_threshold * track_state.bbox[2] and           # track_state dis constraint
-                        bbox_area_ratio < self._track_search_threshold):                       # bbox area constraint
+                    if (dis < self._track_search_threshold * cur_track[-1].ref_bbox[2] and         # track dis constraint
+                        dis < self._track_search_threshold * track_state.ref_bbox[2] and           # track_state dis constraint
+                        bbox_area_ratio < self._track_search_threshold):                           # bbox area constraint
                         cur_data_item = []
 
                         #app feature and app target

--- a/python/kwiver/sprokit/processes/pytorch/utils/track.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/track.py
@@ -32,9 +32,11 @@ import torch
 import collections
 
 class track_state(object):
-    def __init__(self, frame_id, bbox_center, interaction_feature, app_feature, bbox, 
-                    detected_object, sys_frame_id, sys_frame_time):
+    def __init__(self, frame_id, bbox_center, ref_point,
+                 interaction_feature, app_feature, bbox,
+                 detected_object, sys_frame_id, sys_frame_time):
         self.bbox_center = bbox_center
+        self.ref_point = ref_point
 
         '''a list [x, y, w, h]'''
         self.bbox = bbox
@@ -79,9 +81,9 @@ class track(object):
         if not self.track_state_list:
             new_track_state.motion_feature = torch.FloatTensor(2).zero_()
         else:
-            pre_bbox_center = np.asarray(self.track_state_list[-1].bbox_center, dtype=np.float32).reshape(2)
-            cur_bbox_center = np.asarray(new_track_state.bbox_center, dtype=np.float32).reshape(2)
-            new_track_state.motion_feature = torch.from_numpy(cur_bbox_center - pre_bbox_center)
+            pre_ref_point = np.asarray(self.track_state_list[-1].ref_point, dtype=np.float32).reshape(2)
+            cur_ref_point = np.asarray(new_track_state.ref_point, dtype=np.float32).reshape(2)
+            new_track_state.motion_feature = torch.from_numpy(cur_ref_point - pre_ref_point)
 
         new_track_state.track_id = self.track_id
         self.track_state_list.append(new_track_state)

--- a/python/kwiver/sprokit/processes/pytorch/utils/track.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/track.py
@@ -33,13 +33,14 @@ import collections
 
 class track_state(object):
     def __init__(self, frame_id, bbox_center, ref_point,
-                 interaction_feature, app_feature, bbox,
+                 interaction_feature, app_feature, bbox, ref_bbox,
                  detected_object, sys_frame_id, sys_frame_time):
         self.bbox_center = bbox_center
         self.ref_point = ref_point
 
         '''a list [x, y, w, h]'''
         self.bbox = bbox
+        self.ref_bbox = ref_bbox
 
         # got required AMI features in torch.tensor format
         self.app_feature = app_feature


### PR DESCRIPTION
This is the first round of changes to the TUT tracker (`srnn_tracker`) extracted from the publicly released code at `dev/tut-tracker-prr-20200716`. The main addition is basic homography-based stabilization, but there's also some reformatting, refactoring, and bug fixes.

The consumer-visible changes are then:
- `srnn_tracker` now has an optional input port `homography_src_to_ref` that it uses to do tracking in a stabilized coordinate space if present
- Tracks should no longer acquire two new states in a single frame under certain circumstances
- The first-pass IoU tracking should now work as intended