### PR TITLE
Patch to support JSON serialization of boolean metadata

### DIFF
--- a/arrows/serialize/json/load_save_metadata.cxx
+++ b/arrows/serialize/json/load_save_metadata.cxx
@@ -91,10 +91,13 @@ struct meta_item
     {
       // bool metadata passes the is_integral() check but cannot be cast
       // to uint64_t
-      if ( trait.tag_type() == typeid( bool ) ) {
+      if ( trait.tag_type() == typeid( bool ) )
+      {
         const bool value = kwiver::vital::any_cast< bool > ( this->item_value );
         archive( CEREAL_NVP( value ) );
-      } else {
+      }
+      else
+      {
         const uint64_t value = kwiver::vital::any_cast< uint64_t > ( this->item_value );
         archive( CEREAL_NVP( value ) );
       }

--- a/arrows/serialize/json/load_save_metadata.cxx
+++ b/arrows/serialize/json/load_save_metadata.cxx
@@ -81,7 +81,7 @@ struct meta_item
     archive(  ::cereal::make_nvp( "type", item_value.type_name() ) );
     archive(  ::cereal::make_nvp( "name", trait.name() ) );
 
-    // This si a switch on the item data type
+    // This is a switch on the item data type
     if ( trait.is_floating_point() )
     {
       const double value = kwiver::vital::any_cast< double > ( this->item_value );
@@ -89,8 +89,15 @@ struct meta_item
     }
     else if ( trait.is_integral() )
     {
-      const uint64_t value = kwiver::vital::any_cast< uint64_t > ( this->item_value );
-      archive( CEREAL_NVP( value ) );
+      // bool metadata passes the is_integral() check but cannot be cast
+      // to uint64_t
+      if ( trait.tag_type() == typeid( bool ) ) {
+        const bool value = kwiver::vital::any_cast< bool > ( this->item_value );
+        archive( CEREAL_NVP( value ) );
+      } else {
+        const uint64_t value = kwiver::vital::any_cast< uint64_t > ( this->item_value );
+        archive( CEREAL_NVP( value ) );
+      }
     }
     else if ( trait.tag_type() == typeid( std::string ) )
     {

--- a/arrows/serialize/json/load_save_metadata.cxx
+++ b/arrows/serialize/json/load_save_metadata.cxx
@@ -145,9 +145,19 @@ struct meta_item
     }
     else if ( trait.is_integral() )
     {
-      uint64_t value;
-      archive( CEREAL_NVP( value ) );
-      this->item_value = kwiver::vital::any( value );
+      // is_integral() returns true for a bool, which needs to be handled differently
+      if ( trait.tag_type() == typeid( bool ) )
+      {
+        bool value;
+        archive( CEREAL_NVP( value ) );
+        this->item_value = kwiver::vital::any( value );
+      }
+      else
+      {
+        uint64_t value;
+        archive( CEREAL_NVP( value ) );
+        this->item_value = kwiver::vital::any( value );
+      }
     }
     else if ( trait.tag_type() == typeid( std::string ) )
     {

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -227,7 +227,7 @@ kwiver::vital::metadata create_meta_collection()
   }
 
   {
-    const auto& info = traits.find( kwiver::vital::VIDEO_KEY_FRAME );
+    const auto& info = traits.find( kwiver::vital::VITAL_VIDEO_KEY_FRAME );
     auto* item = info.create_metadata_item( kwiver::vital::any(true ) );
     meta.add( item );
   }

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -227,7 +227,7 @@ kwiver::vital::metadata create_meta_collection()
   }
 
   {
-    const auto& info = traits.find( kwiver::vital::VITAL_VIDEO_KEY_FRAME );
+    const auto& info = traits.find( kwiver::vital::VITAL_META_VIDEO_KEY_FRAME );
     auto* item = info.create_metadata_item( kwiver::vital::any(true ) );
     meta.add( item );
   }

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -227,6 +227,12 @@ kwiver::vital::metadata create_meta_collection()
   }
 
   {
+    const auto& info = traits.find( kwiver::vital::VIDEO_KEY_FRAME );
+    auto* item = info.create_metadata_item( kwiver::vital::any(true ) );
+    meta.add( item );
+  }
+
+  {
     const auto& info = traits.find( kwiver::vital::VITAL_META_UNIX_TIMESTAMP );
     auto* item = info.create_metadata_item( kwiver::vital::any((uint64_t)12345678) );
     meta.add( item );

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -52,3 +52,8 @@ Arrows: OpenCV
    A workaround was previously added that forced a deep copy, but this created
    another bug resulting in images with invalid first_pixel() values.
    Both of these issues have been addressed.
+
+Arrows: Serialize
+
+ * Fixed a bug in the JSON serializer for metadata where bool fields caused a
+   runtime error.


### PR DESCRIPTION
For reference, here is a snippet of the serialized data taken from [here](https://data.kitware.com/#item/56f580488d777f753209c72f).

`{
            "tag": 16,
            "type": "bool",
            "name": "Is frame a key frame",
            "value": false
        },
`