### PR TITLE
Clean arrows library links

### DIFF
--- a/arrows/ceres/CMakeLists.txt
+++ b/arrows/ceres/CMakeLists.txt
@@ -39,7 +39,7 @@ kwiver_add_library( kwiver_algo_ceres
   ${ceres_sources}
   )
 target_link_libraries( kwiver_algo_ceres
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
   PRIVATE              ceres
   )
 if(NOT CERES_USES_MINIGLOG)

--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ project(arrows_test_ceres)
 
 include(kwiver-test-setup)
 
-set(test_libraries    kwiver_algo_ceres)
+set(test_libraries    kwiver_algo_ceres kwiver_algo_core)
 
 # we need to link tests to GLog becuase they instantiate Ceres templates which
 # use GLog.  If Ceres was built with MiniGlog, link to ceres instead to get

--- a/arrows/cuda/CMakeLists.txt
+++ b/arrows/cuda/CMakeLists.txt
@@ -25,8 +25,17 @@ kwiver_install_headers(
   NOPATH   SUBDIR     arrows/cuda
   )
 
-kwiver_add_library(kwiver_algo_cuda ${header_files} ${private_header_files} ${cxx_files} ${CUDA_COMPILE_O})
-target_link_libraries(kwiver_algo_cuda kwiver_algo_core ${CUDA_LIBRARIES}
+kwiver_add_library( kwiver_algo_cuda
+  ${header_files}
+  ${private_header_files}
+  ${cxx_files}
+  ${CUDA_COMPILE_O}
+  )
+
+target_link_libraries( kwiver_algo_cuda
+  PUBLIC               vital_algo
+  PRIVATE              kwiver_algo_core
+                       ${CUDA_LIBRARIES}
 )
 
 algorithms_create_plugin( kwiver_algo_cuda

--- a/arrows/dbow2/CMakeLists.txt
+++ b/arrows/dbow2/CMakeLists.txt
@@ -49,7 +49,7 @@ kwiver_add_library( kwiver_algo_dbow2
   ${dbow2_sources}
   )
 target_link_libraries( kwiver_algo_dbow2
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
                        ${OpenCV_LIBS}
   PRIVATE              kwiversys
   )

--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -50,7 +50,7 @@ if(fletch_ENABLED_ZLib)
 endif()
 
 target_link_libraries( kwiver_algo_ffmpeg
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
   PRIVATE              vital_klv kwiversys
                        ${FFMPEG_LIBRARIES}
                        ${ZLIB_LIBRARIES}

--- a/arrows/ffmpeg/tests/CMakeLists.txt
+++ b/arrows/ffmpeg/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ project(arrows_test_ffmpeg)
 
 include(kwiver-test-setup)
 
-set(test_libraries     kwiver_algo_ffmpeg)
+set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_core)
 
 ##############################
 # Algorithms ffmpeg tests

--- a/arrows/gdal/CMakeLists.txt
+++ b/arrows/gdal/CMakeLists.txt
@@ -26,7 +26,7 @@ kwiver_add_library( kwiver_algo_gdal
   ${gdal_sources}
   )
 target_link_libraries( kwiver_algo_gdal
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
   PRIVATE              ${GDAL_LIBRARY}
   )
 

--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -108,9 +108,10 @@ kwiver_add_library( kwiver_algo_ocv
   ${ocv_sources}
   )
 target_link_libraries( kwiver_algo_ocv
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
                        ${OpenCV_LIBS}
   PRIVATE              kwiversys
+                       kwiver_algo_core
   )
 
 algorithms_create_plugin( kwiver_algo_ocv

--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -11,9 +11,12 @@ kwiver_discover_gtests(ocv algo_config                 LIBRARIES ${test_librarie
 kwiver_discover_gtests(ocv bounding_box                LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv descriptor_set              LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv distortion                  LIBRARIES ${test_libraries})
-kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})
-kwiver_discover_gtests(ocv estimate_pnp                LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv estimate_homography         LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv feature_set                 LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv image                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(ocv match_set                   LIBRARIES ${test_libraries})
+
+# additional tests that also depend on the core arrow
+list(APPEND test_libraries kwiver_algo_core)
+kwiver_discover_gtests(ocv estimate_fundamental_matrix LIBRARIES ${test_libraries})
+kwiver_discover_gtests(ocv estimate_pnp                LIBRARIES ${test_libraries})

--- a/arrows/proj/CMakeLists.txt
+++ b/arrows/proj/CMakeLists.txt
@@ -24,7 +24,7 @@ kwiver_add_library( kwiver_algo_proj
   )
 
 target_link_libraries( kwiver_algo_proj
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
                        ${PROJ_LIBRARY}
   )
 

--- a/arrows/qt/CMakeLists.txt
+++ b/arrows/qt/CMakeLists.txt
@@ -37,7 +37,7 @@ kwiver_add_library( kwiver_algo_qt
   ${qt_sources}
   )
 target_link_libraries( kwiver_algo_qt
-  PUBLIC  kwiver_algo_core
+  PUBLIC  vital_algo
           Qt5::Gui
           Qt5::Core
   )

--- a/arrows/super3d/CMakeLists.txt
+++ b/arrows/super3d/CMakeLists.txt
@@ -30,9 +30,15 @@ kwiver_install_headers(
   NOPATH   SUBDIR     arrows/super3d
   )
 
-kwiver_add_library(kwiver_algo_super3d ${header_files} ${cxx_files})
-target_link_libraries(kwiver_algo_super3d kwiver_algo_core kwiver_algo_vxl
-  vil vpgl vnl vul vil_algo vgl_algo vbl
+kwiver_add_library(kwiver_algo_super3d
+  ${header_files}
+  ${cxx_files}
+  )
+target_link_libraries(kwiver_algo_super3d
+  PUBLIC              vital_algo
+                      vil vpgl vnl vgl_algo
+  PRIVATE             kwiver_algo_vxl
+                      vil_algo vbl
   )
 
 algorithms_create_plugin( kwiver_algo_super3d

--- a/arrows/viscl/CMakeLists.txt
+++ b/arrows/viscl/CMakeLists.txt
@@ -42,7 +42,7 @@ kwiver_add_library( kwiver_algo_viscl
   )
 
 target_link_libraries( kwiver_algo_viscl
-  PUBLIC           kwiver_algo_core
+  PUBLIC           vital_algo
                    viscl_core viscl_tasks viscl_vxl
   )
 

--- a/arrows/vxl/CMakeLists.txt
+++ b/arrows/vxl/CMakeLists.txt
@@ -61,9 +61,10 @@ kwiver_add_library( kwiver_algo_vxl
   ${vxl_sources}
   )
 target_link_libraries( kwiver_algo_vxl
-  PUBLIC               kwiver_algo_core
+  PUBLIC               vital_algo
                        vil vpgl vgl
   PRIVATE              vital_klv
+                       kwiver_algo_core
                        rrel rsdl
                        vnl
                        vidl

--- a/arrows/vxl/tests/CMakeLists.txt
+++ b/arrows/vxl/tests/CMakeLists.txt
@@ -8,20 +8,21 @@ set(test_libraries     kwiver_algo_vxl)
 # Algorithms VXL tests
 ##############################
 kwiver_discover_gtests(vxl bounding_box                LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl bundle_adjust               LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl camera                      LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl estimate_essential_matrix   LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl estimate_fundamental_matrix LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl estimate_homography         LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl estimate_similarity         LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl image                       LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl optimize_cameras            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl polygon                     LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl triangulate_landmarks       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl vidl_ffmpeg_video_input     LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
+
+# additional tests that also depend on the core arrow
+list(APPEND test_libraries kwiver_algo_core)
+kwiver_discover_gtests(vxl bundle_adjust               LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vxl estimate_essential_matrix   LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vxl estimate_fundamental_matrix LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vxl optimize_cameras            LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vxl triangulate_landmarks       LIBRARIES ${test_libraries})
 
 # This test is really for an algorithm in core, but it's here
 # because the test depends on availability of VXL sub-algorithms
-set(test_libraries     kwiver_algo_vxl kwiver_algo_core)
-
 kwiver_discover_gtests(vxl initialize_cameras_landmarks LIBRARIES ${test_libraries})

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -45,6 +45,9 @@ Vital Bindings
 
 Arrows
 
+ * Cleaned up arrows library links.  Many arrows linked to the core arrow
+   when really only needed to link directly to vital libraries.
+
 Arrows: Core
 
 Arrows: Ceres


### PR DESCRIPTION
Most arrows were linking the core arrow (kwiver_algo_core) when they did not use any symbols from core arrow.  Instead they needed to only link to vital_algo.  In some cases private linkage to core was required, and in several cases only some tests needed to link to core.