### PR TITLE
Dev/reduce warnings

### DIFF
--- a/CMake/kwiver-flags-gnu.cmake
+++ b/CMake/kwiver-flags-gnu.cmake
@@ -16,6 +16,8 @@ kwiver_check_compiler_flag( -Werror=reorder )
 kwiver_check_compiler_flag( -Werror=overloaded-virtual )
 kwiver_check_compiler_flag( -Werror=cast-qual )
 kwiver_check_compiler_flag( -Werror=vla )
+kwiver_check_compiler_flag( -Wshadow )
+kwiver_check_compiler_flag( -Wunused-parameter )
 
 # to slience this warning
 kwiver_check_compiler_flag( -Wno-unknown-pragmas )
@@ -54,8 +56,6 @@ if (KWIVER_CPP_EXTRA)
 
   # TODO: Python triggers warnings with this
   kwiver_check_compiler_flag(-Wold-style-cast)
-  # Variable naming warnings
-  kwiver_check_compiler_flag(-Wshadow)
   # Exception warnings
   kwiver_check_compiler_flag(-Wnoexcept)
   # Miscellaneous warnings

--- a/arrows/ceres/bundle_adjust.cxx
+++ b/arrows/ceres/bundle_adjust.cxx
@@ -40,6 +40,8 @@
 #include <unordered_set>
 
 #include <vital/io/eigen_io.h>
+#include <vital/vital_config.h>
+
 #include <arrows/ceres/reprojection_error.h>
 #include <arrows/ceres/types.h>
 #include <arrows/ceres/options.h>
@@ -63,7 +65,7 @@ public:
   explicit StateCallback(bundle_adjust* b = NULL)
     : bap(b) {}
 
-  ::ceres::CallbackReturnType operator() (const ::ceres::IterationSummary& summary)
+  ::ceres::CallbackReturnType operator() ( VITAL_UNUSED const ::ceres::IterationSummary& summary)
   {
     return ( bap && !bap->trigger_callback() )
            ? ::ceres::SOLVER_TERMINATE_SUCCESSFULLY
@@ -208,7 +210,7 @@ bundle_adjust
 // Check that the algorithm's currently configuration is valid
 bool
 bundle_adjust
-::check_configuration(config_block_sptr config) const
+::check_configuration( VITAL_UNUSED config_block_sptr config ) const
 {
   std::string msg;
   if( !d_->options.IsValid(&msg) )

--- a/arrows/ceres/optimize_cameras.cxx
+++ b/arrows/ceres/optimize_cameras.cxx
@@ -37,14 +37,13 @@
 #include <arrows/ceres/options.h>
 #include <arrows/ceres/reprojection_error.h>
 #include <vital/exceptions.h>
-
+#include <vital/vital_config.h>
 
 using namespace kwiver::vital;
 
 namespace kwiver {
 namespace arrows {
 namespace ceres {
-
 
 // Private implementation class
 class optimize_cameras::priv
@@ -157,7 +156,7 @@ optimize_cameras
 // Check that the algorithm's currently configuration is valid
 bool
 optimize_cameras
-::check_configuration(config_block_sptr config) const
+::check_configuration( VITAL_UNUSED config_block_sptr config) const
 {
   std::string msg;
   if( !d_->options.IsValid(&msg) )
@@ -334,7 +333,7 @@ optimize_cameras
 ::optimize(vital::camera_perspective_sptr& camera,
            const std::vector<vital::feature_sptr>& features,
            const std::vector<vital::landmark_sptr>& landmarks,
-           kwiver::vital::sfm_constraints_sptr constraints) const
+           VITAL_UNUSED kwiver::vital::sfm_constraints_sptr constraints) const
 {
   // extract camera parameters to optimize
   const unsigned int ndp = num_distortion_params(d_->lens_distortion_type);

--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -678,17 +678,17 @@ camera_options
     const double scale = constraints.size() / sum_dist;
     auto scaled_loss = new ::ceres::ScaledLoss(NULL, weight,
                            ::ceres::Ownership::TAKE_OWNERSHIP);
-    for (auto curr_cam : constraints)
+    for (auto curr_cam_constr : constraints)
     {
-      auto prev_cam = curr_cam - 1;
-      double inv_dist = 1.0 / static_cast<double>(curr_cam->first -
-                                                  prev_cam->first);
+      auto p_cam = curr_cam_constr - 1;
+      double inv_dist = 1.0 / static_cast<double>(curr_cam_constr->first -
+                                                  p_cam->first);
       ::ceres::CostFunction* fwd_mo_cost =
         camera_limit_forward_motion::create(scale * inv_dist);
       problem.AddResidualBlock(fwd_mo_cost,
                                scaled_loss,
-                               prev_cam->second,
-                               curr_cam->second);
+                               p_cam->second,
+                               curr_cam_constr->second);
     }
   }
 }

--- a/arrows/core/associate_detections_to_tracks_threshold.cxx
+++ b/arrows/core/associate_detections_to_tracks_threshold.cxx
@@ -38,6 +38,7 @@
 #include <vital/algo/detected_object_filter.h>
 #include <vital/types/object_track_set.h>
 #include <vital/exceptions/algorithm.h>
+#include <vital/vital_config.h>
 
 #include <string>
 #include <vector>
@@ -125,7 +126,7 @@ associate_detections_to_tracks_threshold
 
 bool
 associate_detections_to_tracks_threshold
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/close_loops_appearance_indexed.cxx
+++ b/arrows/core/close_loops_appearance_indexed.cxx
@@ -640,8 +640,8 @@ kwiver::vital::feature_track_set_sptr
 close_loops_appearance_indexed
 ::stitch(kwiver::vital::frame_id_t frame_number,
   kwiver::vital::feature_track_set_sptr input,
-  kwiver::vital::image_container_sptr image,
-  kwiver::vital::image_container_sptr mask) const
+  VITAL_UNUSED kwiver::vital::image_container_sptr image,
+  VITAL_UNUSED kwiver::vital::image_container_sptr mask) const
 {
   return d_->detect(input, frame_number);
 }

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -272,14 +272,14 @@ close_loops_keyframe
     all_matches[*f] = pool.enqueue(match_func, *f);
   }
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    all_matches[*kitr] = pool.enqueue(match_func, *kitr);
+    all_matches[*k_itr] = pool.enqueue(match_func, *k_itr);
   }
 
 
@@ -331,20 +331,20 @@ close_loops_keyframe
     static_cast<unsigned int>(last_frame_itr - frames.rbegin() - 2);
 
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    if (!all_matches[*kitr].valid())
+    if (!all_matches[*k_itr].valid())
     {
       LOG_WARN(logger(), "keyframe match from "<< frame_number << " to "
-                         << *kitr << " not available");
+                         << *k_itr << " not available");
       continue;
     }
-    auto const& matches = all_matches[*kitr].get();
+    auto const& matches = all_matches[*k_itr].get();
     int num_matched = static_cast<int>(matches.size());
     int num_linked = 0;
     if( num_matched >= d_->match_req )
@@ -357,7 +357,7 @@ close_loops_keyframe
         }
       }
     }
-    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *kitr
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *k_itr
                        << " has "<< num_matched << " matches and "
                        << num_linked << " joined tracks");
     if( num_matched > max_keyframe_matched )
@@ -373,7 +373,7 @@ close_loops_keyframe
     {
       break;
     }
-  }
+  } // end for
 
 
   // keep track of frames that matched no keyframes

--- a/arrows/core/compute_association_matrix_from_features.cxx
+++ b/arrows/core/compute_association_matrix_from_features.cxx
@@ -38,6 +38,7 @@
 #include <vital/algo/detected_object_filter.h>
 #include <vital/types/object_track_set.h>
 #include <vital/exceptions/algorithm.h>
+#include <vital/vital_config.h>
 
 #include <string>
 #include <vector>
@@ -139,8 +140,8 @@ compute_association_matrix_from_features
 /// Compute an association matrix given detections and tracks
 bool
 compute_association_matrix_from_features
-::compute( kwiver::vital::timestamp ts,
-           kwiver::vital::image_container_sptr image,
+::compute( VITAL_UNUSED kwiver::vital::timestamp ts,
+           VITAL_UNUSED kwiver::vital::image_container_sptr image,
            kwiver::vital::object_track_set_sptr tracks,
            kwiver::vital::detected_object_set_sptr detections,
            kwiver::vital::matrix_d& matrix,

--- a/arrows/core/depth_utils.cxx
+++ b/arrows/core/depth_utils.cxx
@@ -159,8 +159,8 @@ project_3d_bounds(kwiver::vital::vector_3d const& minpt,
 
   for (vector_3d const& p : points)
   {
-    vector_2d pp = cam.project(p);
-    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(pp[1]);
+    const vector_2d p_p = cam.project(p);
+    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(p_p[1]);
     i0 = std::min(i0, ui);
     j0 = std::min(j0, vi);
     i1 = std::max(i1, ui);

--- a/arrows/core/detected_object_set_input_csv.cxx
+++ b/arrows/core/detected_object_set_input_csv.cxx
@@ -38,6 +38,7 @@
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 
 #include <sstream>
 #include <cstdlib>
@@ -121,7 +122,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_csv::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/core/detected_object_set_input_kw18.cxx
+++ b/arrows/core/detected_object_set_input_kw18.cxx
@@ -38,6 +38,7 @@
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 
 #include <map>
 #include <sstream>
@@ -113,7 +114,7 @@ detected_object_set_input_kw18::
 // ------------------------------------------------------------------
 void
 detected_object_set_input_kw18::
-set_configuration(vital::config_block_sptr config)
+set_configuration( VITAL_UNUSED vital::config_block_sptr config )
 {
 }
 
@@ -121,7 +122,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kw18::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -130,7 +131,8 @@ check_configuration(vital::config_block_sptr config) const
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kw18::
-read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name )
+read_set( kwiver::vital::detected_object_set_sptr & set,
+          VITAL_UNUSED std::string& image_name )
 {
   if ( d->m_first )
   {

--- a/arrows/core/detected_object_set_input_simulator.cxx
+++ b/arrows/core/detected_object_set_input_simulator.cxx
@@ -147,7 +147,7 @@ set_configuration(vital::config_block_sptr config_in)
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_simulator::
-check_configuration(vital::config_block_sptr config) const
+check_configuration(VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -156,7 +156,7 @@ check_configuration(vital::config_block_sptr config) const
 // ----------------------------------------------------------------------------
 void
 detected_object_set_input_simulator::
-open( std::string const& filename )
+open( VITAL_UNUSED std::string const& filename )
 {
 }
 

--- a/arrows/core/detected_object_set_output_csv.cxx
+++ b/arrows/core/detected_object_set_output_csv.cxx
@@ -89,7 +89,7 @@ set_configuration(vital::config_block_sptr config)
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_csv::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -31,6 +31,7 @@
 #include "detected_object_set_output_kw18.h"
 
 #include <vital/util/tokenize.h>
+#include <vital/vital_config.h>
 
 #include <memory>
 #include <vector>
@@ -148,7 +149,7 @@ get_configuration() const
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_kw18::
-check_configuration( vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   if( d->m_write_tot && d->m_tot_field1_ids.empty() )
   {
@@ -167,7 +168,8 @@ check_configuration( vital::config_block_sptr config ) const
 // ------------------------------------------------------------------
 void
 detected_object_set_output_kw18::
-write_set( const kwiver::vital::detected_object_set_sptr set, std::string const& image_name )
+write_set( const kwiver::vital::detected_object_set_sptr set,
+           VITAL_UNUSED std::string const& image_name )
 {
 
   if (d->m_first)
@@ -233,9 +235,9 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
     double ily = ( bbox.min_y() + bbox.max_y() ) / 2.0;
 
     static std::atomic<unsigned> id_counter( 0 );
-    const unsigned id = id_counter++;
+    const unsigned l_id = id_counter++;
 
-    stream() << id                  // 1: track id
+    stream() << l_id                  // 1: track id
              << " 1 "               // 2: track length
              << d->m_frame_number-1 // 3: frame number / set number
              << " 0 "               // 4: tracking plane x
@@ -270,6 +272,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
           f1 = std::max( f1, clf->score( id ) );
         }
       }
+
       for( const std::string id : d->m_parsed_tot_ids2 )
       {
         if( clf->has_class_name( id ) )
@@ -280,7 +283,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set, std::string const&
 
       f3 = 1.0 - f2 - f1;
 
-      (*d->m_tot_writer) << id << " " << f1 << " " << f2 << " " << f3 << std::endl;
+      (*d->m_tot_writer) << l_id << " " << f1 << " " << f2 << " " << f3 << std::endl;
 
     } // end write_tot
   } // end foreach

--- a/arrows/core/dynamic_config_none.cxx
+++ b/arrows/core/dynamic_config_none.cxx
@@ -35,6 +35,8 @@
 
 #include "dynamic_config_none.h"
 
+#include <vital/vital_config.h>
+
 namespace kwiver {
 namespace arrows {
 namespace core {
@@ -49,14 +51,14 @@ dynamic_config_none()
 // ------------------------------------------------------------------
 void
 dynamic_config_none::
-set_configuration( kwiver::vital::config_block_sptr config )
+set_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config )
 { }
 
 
 // ------------------------------------------------------------------
 bool
 dynamic_config_none::
-check_configuration( kwiver::vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/estimate_canonical_transform.cxx
+++ b/arrows/core/estimate_canonical_transform.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
+ * Copyright 2015-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,7 +133,7 @@ estimate_canonical_transform
 // Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_canonical_transform
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
  return true;
 }

--- a/arrows/core/example_detector.cxx
+++ b/arrows/core/example_detector.cxx
@@ -35,6 +35,7 @@
 
 #include "example_detector.h"
 
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -118,7 +119,7 @@ set_configuration(vital::config_block_sptr config_in)
 // ------------------------------------------------------------------
 bool
 example_detector::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -127,11 +128,11 @@ check_configuration(vital::config_block_sptr config) const
 // ------------------------------------------------------------------
 kwiver::vital::detected_object_set_sptr
 example_detector::
-detect( vital::image_container_sptr image_data) const
+detect( VITAL_UNUSED vital::image_container_sptr image_data) const
 {
   auto detected_set = std::make_shared< kwiver::vital::detected_object_set>();
 
-  const double ct = (double)d->m_frame_ct;
+  const double ct { static_cast<double>(d->m_frame_ct) };
 
   kwiver::vital::bounding_box_d bbox(
           d->m_center_x + ct*d->m_dx - d->m_width/2.0,

--- a/arrows/core/feature_descriptor_io.cxx
+++ b/arrows/core/feature_descriptor_io.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,7 @@
 #include <fstream>
 
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 #include <cereal/archives/portable_binary.hpp>
 
 
@@ -116,7 +117,7 @@ feature_descriptor_io
 // Check that the algorithm's currently configuration is valid
 bool
 feature_descriptor_io
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -215,7 +216,7 @@ read_descriptors(Archive & ar, size_t num_desc)
 
   std::vector<descriptor_sptr> descriptors;
   descriptors.reserve(num_desc);
-  for( size_t i=0; i<num_desc; ++i )
+  for( size_t i = 0; i < num_desc; ++i )
   {
     std::shared_ptr<descriptor_array_of<T> > d;
     // allocate fixed vectors for common dimensions
@@ -231,7 +232,7 @@ read_descriptors(Archive & ar, size_t num_desc)
         d = std::make_shared<descriptor_dynamic<T> >(dim);
     }
     T* data = d->raw_data();
-    for(unsigned i=0; i<dim; ++i, ++data)
+    for(unsigned x = 0; x < dim; ++x, ++data)
     {
       ar( *data );
     }

--- a/arrows/core/filter_features_nonmax.cxx
+++ b/arrows/core/filter_features_nonmax.cxx
@@ -208,10 +208,10 @@ public:
     Eigen::AlignedBox<double, 1> scale_box;
     for (unsigned int i = 0; i < feat_vec.size(); i++)
     {
-      auto const& feat = feat_vec[i];
-      indices.push_back(std::make_pair(i, feat->magnitude()));
-      bbox.extend(feat->loc());
-      scale_box.extend(Eigen::Matrix<double,1,1>(feat->scale()));
+      auto const& l_feat = feat_vec[i];
+      indices.push_back(std::make_pair(i, l_feat->magnitude()));
+      bbox.extend(l_feat->loc());
+      scale_box.extend(Eigen::Matrix<double,1,1>(l_feat->scale()));
     }
 
     const double scale_min = std::log2(scale_box.min()[0]);
@@ -269,12 +269,12 @@ public:
       for (auto const& p : indices)
       {
         unsigned int index = p.first;
-        auto const& feat = feat_vec[index];
-        if (suppressor.cover(*feat))
+        auto const& f = feat_vec[index];
+        if (suppressor.cover(*f))
         {
           // add this feature to the accepted list
           ind.push_back(index);
-          filtered.push_back(feat);
+          filtered.push_back(f);
         }
       }
       // if not using a target number of features, keep this result

--- a/arrows/core/match_features_fundamental_matrix.cxx
+++ b/arrows/core/match_features_fundamental_matrix.cxx
@@ -251,9 +251,9 @@ match_features_fundamental_matrix
   auto f2 = feat2->features();
   std::vector<double> dists;
   dists.reserve(inlier_m.size());
-  for (auto const& m : inlier_m)
+  for (auto const& i_m : inlier_m)
   {
-    vector_2d dist = f1[m.first]->loc() - f2[m.second]->loc();
+    vector_2d dist = f1[i_m.first]->loc() - f2[i_m.second]->loc();
     dists.push_back(dist.norm());
   }
   double max_dist = 2.0 * percentile(dists, d_->motion_filter_percentile);

--- a/arrows/core/read_object_track_set_kw18.cxx
+++ b/arrows/core/read_object_track_set_kw18.cxx
@@ -37,7 +37,7 @@
 
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
-
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -119,7 +119,7 @@ read_object_track_set_kw18
 // -------------------------------------------------------------------------------
 void
 read_object_track_set_kw18
-::set_configuration(vital::config_block_sptr config)
+::set_configuration( vital::config_block_sptr config )
 {
   d->m_delim = config->get_value<std::string>( "delimiter", d->m_delim );
   d->m_batch_load = config->get_value<bool>( "batch_load", d->m_batch_load );
@@ -129,7 +129,7 @@ read_object_track_set_kw18
 // -------------------------------------------------------------------------------
 bool
 read_object_track_set_kw18
-::check_configuration( vital::config_block_sptr config ) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/read_track_descriptor_set_csv.cxx
+++ b/arrows/core/read_track_descriptor_set_csv.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/util/tokenize.h>
 #include <vital/util/data_stream_reader.h>
+#include <vital/vital_config.h>
 
 #include <string>
 
@@ -116,7 +117,7 @@ read_track_descriptor_set_csv
 // -------------------------------------------------------------------------------
 bool
 read_track_descriptor_set_csv
-::check_configuration( vital::config_block_sptr config ) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/tests/test_feature_descriptor_io.cxx
+++ b/arrows/core/tests/test_feature_descriptor_io.cxx
@@ -126,11 +126,11 @@ make_n_descriptors(size_t num_desc, size_t dim)
                     ? static_cast<double>(std::numeric_limits<T>::max()) : 1.0;
   const double scale = (tmax - tmin) / rmax;
 
-  for(unsigned i=0; i<num_desc; ++i)
+  for(unsigned i = 0; i < num_desc; ++i)
   {
     auto d = std::make_shared<descriptor_dynamic<T> >(dim);
     T* data = d->raw_data();
-    for(unsigned i=0; i<dim; ++i, ++data)
+    for(unsigned j = 0; j < dim; ++j, ++data)
     {
       *data = static_cast<T>(rand() * scale + tmin );
     }

--- a/arrows/core/tests/test_video_input_image_list.cxx
+++ b/arrows/core/tests/test_video_input_image_list.cxx
@@ -39,6 +39,7 @@
 #include <arrows/tests/test_video_input.h>
 #include <vital/algo/algorithm_factory.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <memory>
 #include <string>
@@ -78,7 +79,8 @@ TEST_F(video_input_image_list, create)
 // ----------------------------------------------------------------------------
 static
 bool
-set_config(kwiver::vital::config_block_sptr config, std::string const& data_dir)
+set_config(kwiver::vital::config_block_sptr config,
+           VITAL_UNUSED std::string const& data_dir)
 {
   if ( kwiver::vital::has_algorithm_impl_name( "image_io", "ocv" ) )
   {

--- a/arrows/core/tests/test_video_input_splice.cxx
+++ b/arrows/core/tests/test_video_input_splice.cxx
@@ -37,9 +37,11 @@
 
 #include <arrows/core/video_input_splice.h>
 #include <arrows/tests/test_video_input.h>
+
 #include <vital/algo/algorithm_factory.h>
 #include <vital/io/metadata_io.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <memory>
 #include <string>
@@ -79,7 +81,8 @@ TEST_F(video_input_splice, create)
 // ----------------------------------------------------------------------------
 static
 bool
-set_config(kwiver::vital::config_block_sptr config, std::string const& data_dir)
+set_config(kwiver::vital::config_block_sptr config,
+           VITAL_UNUSED std::string const& data_dir)
 {
   for ( int n = 1; n < 4; ++n )
   {

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -221,14 +221,14 @@ box_around_box3d( kwiver::vital::camera_perspective_sptr const camera,
 // ---------------------------------------------------------------------------
 vital::bounding_box<double>
 transform_detected_object_set::
-view_to_view( kwiver::vital::camera_perspective_sptr const src_camera,
-              kwiver::vital::camera_perspective_sptr const dest_camera,
+view_to_view( kwiver::vital::camera_perspective_sptr const src_camera_,
+              kwiver::vital::camera_perspective_sptr const dest_camera_,
               vital::bounding_box<double> const& bbox ) const
 {
   Eigen::Matrix<double, 8, 3> box3d =
-    this->backproject_bbox( src_camera, bbox );
+    this->backproject_bbox( src_camera_, bbox );
 
-  return this->box_around_box3d( dest_camera, box3d );
+  return this->box_around_box3d( dest_camera_, box3d );
 }
 
 // ---------------------------------------------------------------------------

--- a/arrows/core/uv_unwrap_mesh.cxx
+++ b/arrows/core/uv_unwrap_mesh.cxx
@@ -39,7 +39,9 @@
 #include <iostream>
 #include <numeric>
 #include <Eigen/Dense>
+
 #include <vital/exceptions.h>
+#include <vital/vital_config.h>
 
 using namespace kwiver::vital;
 
@@ -66,11 +68,13 @@ class uv_unwrap_mesh::priv
 {
 public:
   /// Constructor
-  priv() : spacing(0.005)
+  priv()
+    : spacing(0.005)
   {
   }
 
-  priv(const priv& other)
+  // Not clear why this copy constructor is non-functional
+  priv( VITAL_UNUSED const priv& other )
   {
   }
 

--- a/arrows/core/video_input_pos.cxx
+++ b/arrows/core/video_input_pos.cxx
@@ -30,14 +30,14 @@
 
 #include "video_input_pos.h"
 
-#include <vital/vital_types.h>
+#include <vital/exceptions.h>
+#include <vital/io/metadata_io.h>
 #include <vital/types/metadata.h>
 #include <vital/types/metadata_traits.h>
 #include <vital/types/timestamp.h>
-#include <vital/exceptions.h>
 #include <vital/util/data_stream_reader.h>
-
-#include <vital/io/metadata_io.h>
+#include <vital/vital_config.h>
+#include <vital/vital_types.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -177,7 +177,7 @@ video_input_pos
 // ------------------------------------------------------------------
 bool
 video_input_pos
-::check_configuration( vital::config_block_sptr config ) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -274,7 +274,7 @@ video_input_pos
 bool
 video_input_pos
 ::next_frame( kwiver::vital::timestamp& ts,   // returns timestamp
-              uint32_t                  timeout ) // not supported
+              VITAL_UNUSED uint32_t     timeout ) // not supported
 {
   // reset current metadata packet and timestamp
   d->d_metadata = nullptr;
@@ -324,7 +324,7 @@ bool
 video_input_pos
 ::seek_frame( kwiver::vital::timestamp& ts,   // returns timestamp
               kwiver::vital::timestamp::frame_t frame_number,
-              uint32_t                  timeout )
+              VITAL_UNUSED uint32_t             timeout )
 {
   // reset current metadata packet and timestamp
   d->d_metadata = nullptr;

--- a/arrows/core/video_input_splice.cxx
+++ b/arrows/core/video_input_splice.cxx
@@ -30,6 +30,7 @@
 
 #include "video_input_splice.h"
 
+#include <vital/vital_config.h>
 #include <vital/vital_types.h>
 #include <vital/exceptions.h>
 #include <vital/util/data_stream_reader.h>
@@ -392,7 +393,7 @@ bool
 video_input_splice
 ::seek_frame( kwiver::vital::timestamp& ts,   // returns timestamp
               kwiver::vital::timestamp::frame_t frame_number,
-              uint32_t                  timeout )
+              VITAL_UNUSED uint32_t             timeout )
 {
   using frame_t = kwiver::vital::timestamp::frame_t;
   bool status = false;

--- a/arrows/core/write_object_track_set_kw18.cxx
+++ b/arrows/core/write_object_track_set_kw18.cxx
@@ -35,6 +35,8 @@
 
 #include "write_object_track_set_kw18.h"
 
+#include <vital/vital_config.h>
+
 #include <time.h>
 
 namespace kwiver {
@@ -153,7 +155,7 @@ write_object_track_set_kw18
 // -------------------------------------------------------------------------------
 bool
 write_object_track_set_kw18
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/core/write_track_descriptor_set_csv.cxx
+++ b/arrows/core/write_track_descriptor_set_csv.cxx
@@ -35,6 +35,8 @@
 
 #include "write_track_descriptor_set_csv.h"
 
+#include <vital/vital_config.h>
+
 #include <time.h>
 
 
@@ -96,7 +98,7 @@ write_track_descriptor_set_csv
 // -------------------------------------------------------------------------------
 bool
 write_track_descriptor_set_csv
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -33,6 +33,7 @@
 
 #include <vital/util/cpu_timer.h>
 #include <vital/types/detected_object_set_util.h>
+#include <vital/vital_config.h>
 
 #include <arrows/ocv/image_container.h>
 #include <kwiversys/SystemTools.hxx>
@@ -521,7 +522,8 @@ print_detections(
 void
 darknet_trainer::priv::
 generate_fn( std::string image_folder, std::string gt_folder,
-  std::string& image, std::string& gt, const int len )
+             std::string& image, std::string& gt,
+             VITAL_UNUSED const int len )
 {
   static int sample_counter = 0;
 

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -44,6 +44,7 @@
 #include <vital/klv/klv_data.h>
 #include <vital/util/tokenize.h>
 #include <vital/types/image_container.h>
+#include <vital/vital_config.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -955,7 +956,7 @@ ffmpeg_video_input
 // ------------------------------------------------------------------
 bool
 ffmpeg_video_input
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   bool retcode(true); // assume success
 
@@ -1013,7 +1014,7 @@ ffmpeg_video_input
 bool
 ffmpeg_video_input
 ::next_frame( kwiver::vital::timestamp& ts,
-              uint32_t timeout )
+              VITAL_UNUSED uint32_t timeout )
 {
   if (!d->is_opened())
   {
@@ -1154,7 +1155,7 @@ ffmpeg_video_input
 
       AVFrame picture;
       av_image_fill_arrays(picture.data, picture.linesize,
-                           (uint8_t*)d->current_image_memory->data(),
+                           static_cast<uint8_t *>(d->current_image_memory->data() ),
                            pix_fmt, width, height, 1);
       auto framedata = const_cast<const uint8_t **>(frame->data);
       av_image_copy(picture.data, picture.linesize,
@@ -1181,7 +1182,7 @@ ffmpeg_video_input
 
       AVFrame rgb_frame;
       av_image_fill_arrays(rgb_frame.data, rgb_frame.linesize,
-                           (uint8_t*)d->current_image_memory->data(),
+                           static_cast<uint8_t*>(d->current_image_memory->data()),
                            AV_PIX_FMT_RGB24, width, height, 1);
 
       sws_scale(d->f_software_context,

--- a/arrows/gdal/image_io.cxx
+++ b/arrows/gdal/image_io.cxx
@@ -38,6 +38,7 @@
 #include <arrows/gdal/image_container.h>
 
 #include <vital/exceptions/algorithm.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -63,8 +64,8 @@ image_io
  */
 void
 image_io
-::save_(const std::string& filename,
-       vital::image_container_sptr data) const
+::save_( VITAL_UNUSED const std::string& filename,
+         VITAL_UNUSED vital::image_container_sptr data) const
 {
   VITAL_THROW( vital::algorithm_exception, this->type_name(), this->impl_name(),
                "Saving to file not supported." );

--- a/arrows/kpf/detected_object_set_input_kpf.cxx
+++ b/arrows/kpf/detected_object_set_input_kpf.cxx
@@ -42,6 +42,7 @@
 #include "vital_kpf_adapters.h"
 
 #include <vital/util/data_stream_reader.h>
+#include <vital/vital_config.h>
 #include <vital/exceptions.h>
 
 #include <map>
@@ -95,14 +96,14 @@ detected_object_set_input_kpf::
 // ------------------------------------------------------------------
 void
 detected_object_set_input_kpf::
-set_configuration(vital::config_block_sptr config)
+set_configuration( VITAL_UNUSED vital::config_block_sptr config)
 { }
 
 
 // ------------------------------------------------------------------
 bool
 detected_object_set_input_kpf::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/kpf/detected_object_set_output_kpf.cxx
+++ b/arrows/kpf/detected_object_set_output_kpf.cxx
@@ -30,9 +30,9 @@
 
 #include "detected_object_set_output_kpf.h"
 
+#include <vital/vital_config.h>
 #include <arrows/kpf/yaml/kpf_canonical_io_adapter.h>
 #include <arrows/kpf/yaml/kpf_yaml_writer.h>
-
 #include <arrows/kpf/vital_kpf_adapters.h>
 
 #include <memory>
@@ -114,7 +114,7 @@ get_configuration() const
 // ------------------------------------------------------------------
 bool
 detected_object_set_output_kpf::
-check_configuration( vital::config_block_sptr config ) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -122,7 +122,8 @@ check_configuration( vital::config_block_sptr config ) const
 // ------------------------------------------------------------------
 void
 detected_object_set_output_kpf::
-write_set( const kwiver::vital::detected_object_set_sptr set, std::string const& image_name )
+write_set( const kwiver::vital::detected_object_set_sptr set,
+           VITAL_UNUSED std::string const& image_name )
 {
   KPF::record_yaml_writer w(stream());
   size_t line_count = 0;

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -461,9 +461,9 @@ parse_activity( const YAML::Node& n, KPF::packet_buffer_t& local_packet_buffer )
       }
       else if (h.style == KPF::packet_style::EVAL)
       {
-        KPF::packet_t p(h);
-        if ( ! parse_packet( i, p )) return false;
-        act.evals.push_back ( {p.eval, p.header.domain} );
+        KPF::packet_t pp(h);
+        if ( ! parse_packet( i, pp )) return false;
+        act.evals.push_back ( {p.eval, pp.header.domain} );
       }
       else if (h.style == KPF::packet_style::ACT)
       {

--- a/arrows/mvg/algo/initialize_cameras_landmarks.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks.cxx
@@ -43,17 +43,18 @@
 #include <fstream>
 #include <ctime>
 
-#include <vital/math_constants.h>
 #include <vital/exceptions.h>
 #include <vital/io/eigen_io.h>
+#include <vital/math_constants.h>
+#include <vital/vital_config.h>
 
-#include <vital/algo/estimate_essential_matrix.h>
-#include <vital/algo/triangulate_landmarks.h>
 #include <vital/algo/bundle_adjust.h>
-#include <vital/algo/optimize_cameras.h>
 #include <vital/algo/estimate_canonical_transform.h>
+#include <vital/algo/estimate_essential_matrix.h>
 #include <vital/algo/estimate_pnp.h>
 #include <vital/algo/estimate_similarity_transform.h>
+#include <vital/algo/optimize_cameras.h>
+#include <vital/algo/triangulate_landmarks.h>
 
 #include <arrows/mvg/algo/triangulate_landmarks.h>
 #include <arrows/mvg/epipolar_geometry.h>
@@ -401,7 +402,6 @@ public:
   std::set<rel_pose> m_rel_poses;
   std::set<frame_id_t> m_keyframes;
   Eigen::SparseMatrix<unsigned int> m_kf_match_matrix;
-  std::vector<frame_id_t> m_kf_mm_frames;
   std::set<frame_id_t> m_frames_removed_from_sfm_solution;
   vital::track_map_t m_track_map;
   std::random_device m_rd;     // only used once to initialise (seed) engine
@@ -1064,19 +1064,18 @@ initialize_cameras_landmarks::priv
   unsigned frames_skip = std::max(1u, static_cast<unsigned>(frames.size() / 2));
 
   do {
-
-    std::vector<frame_id_t> m_kf_mm_frames;
+    std::vector<frame_id_t> kf_mm_frames;
     int fid_idx = 0;
     for(auto fid: frames)
     {
-      if (fid_idx%frames_skip == 0)
+      if (fid_idx % frames_skip == 0)
       {
-        m_kf_mm_frames.push_back(fid);
+        kf_mm_frames.push_back(fid);
       }
       ++fid_idx;
     }
 
-    m_kf_match_matrix = match_matrix(tracks, m_kf_mm_frames);
+    m_kf_match_matrix = match_matrix(tracks, kf_mm_frames);
 
     const int cols = static_cast<int>(m_kf_match_matrix.cols());
 
@@ -1090,8 +1089,8 @@ initialize_cameras_landmarks::priv
       {
         if (it.row() > k && it.value() > min_matches)
         {
-          auto fid_0 = m_kf_mm_frames[it.row()];
-          auto fid_1 = m_kf_mm_frames[k];
+          auto fid_0 = kf_mm_frames[it.row()];
+          auto fid_1 = kf_mm_frames[k];
           if (fid_0 > fid_1)
           {
             std::swap(fid_0, fid_1);
@@ -1862,8 +1861,8 @@ void initialize_cameras_landmarks::priv
   simple_camera_perspective_map_sptr cams,
   landmark_map_sptr& landmarks,
   feature_track_set_sptr tracks,
-  sfm_constraints_sptr constraints,
-  frame_id_t target_frame)
+  VITAL_UNUSED sfm_constraints_sptr constraints,
+  VITAL_UNUSED frame_id_t target_frame)
 {
 
   if (m_track_map.empty())
@@ -2068,8 +2067,8 @@ initialize_cameras_landmarks::priv
 feature_track_set_changes_sptr
 initialize_cameras_landmarks::priv
 ::get_feature_track_changes(
-  feature_track_set_sptr tracks,
-  const simple_camera_perspective_map &cams) const
+  VITAL_UNUSED feature_track_set_sptr tracks,
+  VITAL_UNUSED const simple_camera_perspective_map &cams) const
 {
   auto chgs = std::make_shared<feature_track_set_changes>();
   /*
@@ -2127,9 +2126,9 @@ initialize_cameras_landmarks::priv
     return false;
   }
 
-  int num_constraints_used;
+  int l_num_constraints_used;
   if (fit_reconstruction_to_constraints(cams, lms, tracks,
-                                        constraints, num_constraints_used))
+                                        constraints, l_num_constraints_used))
   {
     std::set<frame_id_t> fixed_cams_empty;
     std::set<landmark_id_t> fixed_lms_empty;
@@ -2254,13 +2253,13 @@ initialize_cameras_landmarks::priv
                          << after_new_cam_rmse);
 
     }
-    int num_constraints_used;
+    int constraints_used;
     ba_constraints = nullptr;
     m_solution_was_fit_to_constraints = false;
     if (fit_reconstruction_to_constraints(cams, lms, tracks,
-                                          constraints, num_constraints_used))
+                                          constraints, constraints_used))
     {
-      if (num_constraints_used > 2)
+      if (constraints_used > 2)
       {
         ba_constraints = constraints;
         m_solution_was_fit_to_constraints = true;
@@ -2906,7 +2905,7 @@ initialize_cameras_landmarks::priv
 std::set<landmark_id_t>
 initialize_cameras_landmarks::priv
 ::find_visible_landmarks_in_frames(
-  const map_landmark_t &lmks,
+  VITAL_UNUSED const map_landmark_t &lmks,
   feature_track_set_sptr tracks,
   const std::set<frame_id_t> &frames)
 {

--- a/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
@@ -1028,8 +1028,8 @@ initialize_cameras_landmarks_basic
 
     // find existing landmarks for tracks also having features on the other frame
     map_landmark_t flms;
-    std::vector<track_sptr> trks = ftracks->active_tracks(static_cast<int>(other_frame));
-    for(const track_sptr& t : trks)
+    std::vector<track_sptr> ftrks = ftracks->active_tracks(static_cast<int>(other_frame));
+    for(const track_sptr& t : ftrks)
     {
       map_landmark_t::const_iterator li = lms.find(t->id());
       if( li != lms.end() )
@@ -1087,9 +1087,9 @@ initialize_cameras_landmarks_basic
       camera_map::map_camera_t opt_cam_map;
       opt_cam_map[f] = cams[f];
       camera_map_sptr opt_cams = std::make_shared<simple_camera_map>(opt_cam_map);
-      landmark_map_sptr landmarks = std::make_shared<simple_landmark_map>(flms);
-      auto tracks = std::make_shared<feature_track_set>(trks);
-      d_->camera_optimizer->optimize(opt_cams, tracks, landmarks, constraints);
+      landmark_map_sptr landmarks_map = std::make_shared<simple_landmark_map>(flms);
+      auto f_tracks = std::make_shared<feature_track_set>(trks);
+      d_->camera_optimizer->optimize(opt_cams, f_tracks, landmarks_map, constraints);
       cams[f] = opt_cams->cameras()[f];
     }
 

--- a/arrows/mvg/algo/triangulate_landmarks.cxx
+++ b/arrows/mvg/algo/triangulate_landmarks.cxx
@@ -43,6 +43,7 @@
 #include <arrows/mvg/triangulate.h>
 
 #include <vital/math_constants.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -204,7 +205,7 @@ triangulate_landmarks
 // Check that the algorithm's currently configuration is valid
 bool
 triangulate_landmarks
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/mvg/transform.cxx
+++ b/arrows/mvg/transform.cxx
@@ -92,13 +92,13 @@ void transform_inplace(vital::landmark_map::map_landmark_t& landmarks,
 {
   for (vital::landmark_map::map_landmark_t::value_type& p : landmarks)
   {
-    if (vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(p.second.get()))
+    if (vital::landmark_d* vlm_d = dynamic_cast<vital::landmark_d*>(p.second.get()))
     {
-      transform_inplace(*vlm, xform);
+      transform_inplace(*vlm_d, xform);
     }
-    else if (vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(p.second.get()))
+    else if (vital::landmark_f* vlm_f = dynamic_cast<vital::landmark_f*>(p.second.get()))
     {
-      transform_inplace(*vlm, vital::similarity_f(xform));
+      transform_inplace(*vlm_f, vital::similarity_f(xform));
     }
   }
 }
@@ -184,13 +184,13 @@ vital::landmark_sptr transform(vital::landmark_sptr lm,
     return vital::landmark_sptr();
   }
   lm = lm->clone();
-  if( vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(lm.get()) )
+  if( vital::landmark_d* vlm_d = dynamic_cast<vital::landmark_d*>(lm.get()) )
   {
-    transform_inplace(*vlm, xform);
+    transform_inplace(*vlm_d, xform);
   }
-  else if( vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(lm.get()) )
+  else if( vital::landmark_f* vlm_f = dynamic_cast<vital::landmark_f*>(lm.get()) )
   {
-    transform_inplace(*vlm, vital::similarity_f(xform));
+    transform_inplace(*vlm_f, vital::similarity_f(xform));
   }
   else
   {

--- a/arrows/ocv/analyze_tracks.cxx
+++ b/arrows/ocv/analyze_tracks.cxx
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include <arrows/core/track_set_impl.h>
+#include <vital/vital_config.h>
 
 #include <opencv2/core/core.hpp>
 using namespace kwiver::vital;
@@ -157,7 +158,7 @@ analyze_tracks
 /// Check that the algorithm's currently configuration is valid
 bool
 analyze_tracks
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/ocv/detect_features_GFTT.cxx
+++ b/arrows/ocv/detect_features_GFTT.cxx
@@ -35,6 +35,8 @@
 
 #include "detect_features_GFTT.h"
 
+#include <vital/vital_config.h>
+
 using namespace kwiver::vital;
 
 namespace kwiver {
@@ -163,7 +165,7 @@ detect_features_GFTT
 
 bool
 detect_features_GFTT
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   // Nothing to explicitly check
   return true;

--- a/arrows/ocv/detect_features_MSD.cxx
+++ b/arrows/ocv/detect_features_MSD.cxx
@@ -35,6 +35,8 @@
 
 #include "detect_features_MSD.h"
 
+#include <vital/vital_config.h>
+
 // Only available in OpenCV 3.x xfeatures2d
 #ifdef HAVE_OPENCV_XFEATURES2D
 
@@ -102,8 +104,8 @@ public:
   }
 
   /// Check config parameter values
-  bool check_config( vital::config_block_sptr const &config,
-                     logger_handle_t const &logger ) const
+  bool check_config( VITAL_UNUSED vital::config_block_sptr const &config,
+                     VITAL_UNUSED logger_handle_t const &logger ) const
   {
     return true;
   }

--- a/arrows/ocv/detect_features_STAR.cxx
+++ b/arrows/ocv/detect_features_STAR.cxx
@@ -37,6 +37,8 @@
 
 #if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
+#include <vital/vital_config.h>
+
 #if KWIVER_OPENCV_VERSION_MAJOR < 3
 typedef cv::StarDetector cv_STAR_t;
 #else
@@ -157,7 +159,7 @@ detect_features_STAR
 
 bool
 detect_features_STAR
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/ocv/detect_features_simple_blob.cxx
+++ b/arrows/ocv/detect_features_simple_blob.cxx
@@ -35,6 +35,8 @@
 
 #include "detect_features_simple_blob.h"
 
+#include <vital/vital_config.h>
+
 using namespace kwiver::vital;
 
 namespace kwiver {
@@ -188,7 +190,7 @@ detect_features_simple_blob
 
 bool
 detect_features_simple_blob
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/ocv/detect_motion_3frame_differencing.cxx
+++ b/arrows/ocv/detect_motion_3frame_differencing.cxx
@@ -40,6 +40,7 @@
 #include <kwiversys/SystemTools.hxx>
 #include <vital/exceptions.h>
 #include <vital/types/matrix.h>
+#include <vital/vital_config.h>
 
 #include <arrows/ocv/image_container.h>
 
@@ -397,7 +398,7 @@ detect_motion_3frame_differencing
 
 bool
 detect_motion_3frame_differencing
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -406,7 +407,7 @@ detect_motion_3frame_differencing
 /// Detect motion from a sequence of images
 image_container_sptr
 detect_motion_3frame_differencing
-::process_image( const timestamp& ts,
+::process_image( VITAL_UNUSED const timestamp& ts,
                  const image_container_sptr image,
                  bool reset_model)
 {

--- a/arrows/ocv/detect_motion_mog2.cxx
+++ b/arrows/ocv/detect_motion_mog2.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/exceptions.h>
 #include <vital/types/matrix.h>
+#include <vital/vital_config.h>
 
 #include <arrows/ocv/image_container.h>
 
@@ -193,7 +194,7 @@ detect_motion_mog2
 
 bool
 detect_motion_mog2
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/ocv/draw_detected_object_set.cxx
+++ b/arrows/ocv/draw_detected_object_set.cxx
@@ -35,6 +35,7 @@
 
 #include "draw_detected_object_set.h"
 
+#include <vital/vital_config.h>
 #include <vital/vital_types.h>
 #include <vital/util/tokenize.h>
 #include <vital/util/string.h>
@@ -438,7 +439,7 @@ set_configuration(vital::config_block_sptr config_in)
 // ------------------------------------------------------------------
 bool
 draw_detected_object_set::
-check_configuration(vital::config_block_sptr config) const
+check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   // This can be called before the config is "set". A more robust way
   // of determining validity should be used.

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -38,6 +38,7 @@
 #include <vital/exceptions/io.h>
 #include <vital/types/feature_track_set.h>
 #include <vital/util/string.h>
+#include <vital/vital_config.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -220,7 +221,7 @@ draw_tracks
 /// Check that the algorithm's currently configuration is valid
 bool
 draw_tracks
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }

--- a/arrows/ocv/extract_descriptors_DAISY.cxx
+++ b/arrows/ocv/extract_descriptors_DAISY.cxx
@@ -131,10 +131,10 @@ public:
   {
     bool valid = true;
 
-    int norm = config->get_value<int>( "norm" );
-    if( ! check_norm_type( norm ) )
+    int n = config->get_value<int>( "norm" );
+    if( ! check_norm_type( n ) )
     {
-      LOG_ERROR( log, "Invalid norm option '" << norm << "'. Valid choices "
+      LOG_ERROR( log, "Invalid norm option '" << n << "'. Valid choices "
                       "are: " << list_norm_options() );
       valid = false;
     }

--- a/arrows/ocv/extract_descriptors_FREAK.cxx
+++ b/arrows/ocv/extract_descriptors_FREAK.cxx
@@ -37,6 +37,8 @@
 
 #if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
+#include <vital/vital_config.h>
+
 // typedef FREAK into a common symbol
 #if KWIVER_OPENCV_VERSION_MAJOR < 3
 typedef cv::FREAK cv_FREAK_t;
@@ -48,7 +50,6 @@ typedef cv::xfeatures2d::FREAK cv_FREAK_t;
 namespace kwiver {
 namespace arrows {
 namespace ocv {
-
 
 class extract_descriptors_FREAK::priv
 {
@@ -161,7 +162,7 @@ extract_descriptors_FREAK
 
 bool
 extract_descriptors_FREAK
-::check_configuration(vital::config_block_sptr in_config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr in_config ) const
 {
   return true;
 }

--- a/arrows/ocv/extract_descriptors_LATCH.cxx
+++ b/arrows/ocv/extract_descriptors_LATCH.cxx
@@ -81,17 +81,17 @@ public:
     bool valid = true;
 
     // Bytes can only be one of the following values
-    int bytes = config->get_value<int>( "bytes" );
-    if( ! ( bytes == 1 ||
-            bytes == 2 ||
-            bytes == 4 ||
-            bytes == 8 ||
-            bytes == 16 ||
-            bytes == 32 ||
-            bytes == 64 ) )
+    int bytes_ = config->get_value<int>( "bytes" );
+    if( ! ( bytes_ == 1 ||
+            bytes_ == 2 ||
+            bytes_ == 4 ||
+            bytes_ == 8 ||
+            bytes_ == 16 ||
+            bytes_ == 32 ||
+            bytes_ == 64 ) )
     {
       LOG_ERROR( log, "bytes value must be one of [1, 2, 4, 8, 16, 32, 64]. "
-                      "Given: " << bytes );
+                      "Given: " << bytes_ );
       valid = false;
     }
 

--- a/arrows/ocv/extract_descriptors_LUCID.cxx
+++ b/arrows/ocv/extract_descriptors_LUCID.cxx
@@ -35,6 +35,8 @@
 
 #include "extract_descriptors_LUCID.h"
 
+#include <vital/vital_config.h>
+
 #ifdef HAVE_OPENCV_XFEATURES2D
 
 #include <opencv2/xfeatures2d.hpp>
@@ -118,11 +120,10 @@ void extract_descriptors_LUCID
 
 bool
 extract_descriptors_LUCID
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
-
 
 } // end namespace ocv
 } // end namespace arrows

--- a/arrows/ocv/feature_detect_extract_BRISK.cxx
+++ b/arrows/ocv/feature_detect_extract_BRISK.cxx
@@ -35,6 +35,8 @@
 
 #include "feature_detect_extract_BRISK.h"
 
+#include <vital/vital_config.h>
+
 using namespace kwiver::vital;
 
 namespace kwiver {
@@ -151,7 +153,7 @@ detect_features_BRISK
 
 bool
 detect_features_BRISK
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -195,7 +197,7 @@ extract_descriptors_BRISK
 
 bool
 extract_descriptors_BRISK
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/ocv/feature_detect_extract_ORB.cxx
+++ b/arrows/ocv/feature_detect_extract_ORB.cxx
@@ -165,9 +165,9 @@ public:
     bool valid = true;
 
     // Must be one of the enumeration values
-    int score_type = config->get_value<int>( "score_type" );
-    if( ! ( score_type == cv::ORB::HARRIS_SCORE ||
-            score_type == cv::ORB::FAST_SCORE ) )
+    int temp = config->get_value<int>( "score_type" );
+    if( ! ( temp == cv::ORB::HARRIS_SCORE ||
+            temp == cv::ORB::FAST_SCORE ) )
     {
       LOG_ERROR( logger, "Score type not a valid enumeration value. Must be "
         "either " << cv::ORB::HARRIS_SCORE << " for cv::ORB::HARRIS_SCORE or "

--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -35,6 +35,8 @@
 
 #include "feature_detect_extract_SIFT.h"
 
+#include <vital/vital_config.h>
+
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
 // Include the correct file and unify different namespace locations of SIFT type
@@ -206,7 +208,7 @@ detect_features_SIFT
 
 bool
 detect_features_SIFT
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -254,7 +256,7 @@ extract_descriptors_SIFT
 
 bool
 extract_descriptors_SIFT
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -35,6 +35,8 @@
 
 #include "feature_detect_extract_SURF.h"
 
+#include <vital/vital_config.h>
+
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
 // Include the correct file and unify different namespace locations of SURF type
@@ -198,7 +200,7 @@ detect_features_SURF
 
 bool
 detect_features_SURF
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }
@@ -249,7 +251,7 @@ extract_descriptors_SURF
 
 bool
 extract_descriptors_SURF
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -35,6 +35,8 @@
 
 #include "image_container.h"
 
+#include <vital/vital_config.h>
+
 #include <arrows/ocv/mat_image_memory.h>
 #include <opencv2/imgproc/imgproc.hpp>
 
@@ -110,7 +112,8 @@ image_container
 /// Convert an OpenCV cv::Mat to a VITAL image
 image
 image_container
-::ocv_to_vital(const cv::Mat& img, ColorMode cm)
+::ocv_to_vital(const cv::Mat& img,
+               VITAL_UNUSED ColorMode cm)
 {
   // if the cv::Mat has reference counted memory then wrap it to keep a
   // counted reference too it.  If it doesn't own its memory, then the

--- a/arrows/ocv/match_features.cxx
+++ b/arrows/ocv/match_features.cxx
@@ -37,6 +37,8 @@
 
 #include <vector>
 
+#include <vital/vital_config.h>
+
 #include <arrows/ocv/descriptor_set.h>
 #include <arrows/ocv/match_set.h>
 
@@ -50,8 +52,10 @@ namespace ocv {
 /// Match one set of features and corresponding descriptors to another
 vital::match_set_sptr
 match_features
-::match(vital::feature_set_sptr feat1, vital::descriptor_set_sptr desc1,
-        vital::feature_set_sptr feat2, vital::descriptor_set_sptr desc2) const
+::match( VITAL_UNUSED vital::feature_set_sptr feat1,
+         vital::descriptor_set_sptr desc1,
+         VITAL_UNUSED vital::feature_set_sptr feat2,
+         vital::descriptor_set_sptr desc2) const
 {
   // Return empty match set pointer if either of the input sets were empty
   // pointers

--- a/arrows/ocv/match_features_bruteforce.cxx
+++ b/arrows/ocv/match_features_bruteforce.cxx
@@ -43,10 +43,10 @@ namespace ocv {
 class match_features_bruteforce::priv
 {
 public:
-  priv(int norm_type=cv::NORM_L2, bool cross_check=false)
-      : norm_type( norm_type ),
-        cross_check( cross_check ),
-        matcher( new cv::BFMatcher(norm_type, cross_check) )
+  priv(int n_type = cv::NORM_L2, bool c_check = false)
+      : norm_type( n_type ),
+        cross_check( c_check ),
+        matcher( new cv::BFMatcher(n_type, cross_check) )
   {
   }
 

--- a/arrows/ocv/refine_detections_write_to_disk.cxx
+++ b/arrows/ocv/refine_detections_write_to_disk.cxx
@@ -137,7 +137,7 @@ refine_detections_write_to_disk
 // Check that the algorithm's currently configuration is valid
 bool
 refine_detections_write_to_disk
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/serialize/json/activity.cxx
+++ b/arrows/serialize/json/activity.cxx
@@ -59,14 +59,14 @@ std::shared_ptr< std::string >
 activity::
 serialize( const kwiver::vital::any& element )
 {
-  kwiver::vital::activity activity =
+  kwiver::vital::activity l_activity =
     kwiver::vital::any_cast< kwiver::vital::activity > ( element );
 
   std::stringstream msg;
   msg << "activity ";
   {
     cereal::JSONOutputArchive ar( msg );
-    save( ar, activity );
+    save( ar, l_activity );
   }
 
   return std::make_shared< std::string > ( msg.str() );
@@ -77,7 +77,7 @@ kwiver::vital::any activity::
 deserialize( const std::string& message )
 {
   std::stringstream msg(message);
-  kwiver::vital::activity activity;
+  kwiver::vital::activity l_activity;
   std::string tag;
   msg >> tag;
 
@@ -89,10 +89,10 @@ deserialize( const std::string& message )
   else
   {
     cereal::JSONInputArchive ar( msg );
-    load( ar, activity );
+    load( ar, l_activity );
   }
 
-  return kwiver::vital::any( activity );
+  return kwiver::vital::any( l_activity );
 }
 
 } } } }

--- a/arrows/serialize/json/activity.h
+++ b/arrows/serialize/json/activity.h
@@ -46,8 +46,7 @@ namespace serialize {
 namespace json {
 
 class KWIVER_SERIALIZE_JSON_EXPORT activity
-  : public vital::algorithm_impl< activity,
-           vital::algo::data_serializer >
+  : public vital::algo::data_serializer
 {
 public:
   // Type name this class supports and description
@@ -60,9 +59,9 @@ public:
   activity();
   virtual ~activity();
 
-  virtual std::shared_ptr< std::string >
+  std::shared_ptr< std::string >
     serialize( const kwiver::vital::any& element ) override;
-  virtual kwiver::vital::any deserialize( const std::string& message ) override;
+  kwiver::vital::any deserialize( const std::string& message ) override;
 };
 
 } } } }

--- a/arrows/serialize/json/activity_type.h
+++ b/arrows/serialize/json/activity_type.h
@@ -45,10 +45,8 @@ namespace arrows {
 namespace serialize {
 namespace json {
 
-
 class KWIVER_SERIALIZE_JSON_EXPORT activity_type
-  : public vital::algorithm_impl< activity_type,
-           vital::algo::data_serializer >
+  : public vital::algo::data_serializer
 {
 public:
   // Type name this class supports and description
@@ -61,9 +59,9 @@ public:
   activity_type();
   virtual ~activity_type();
 
-  virtual std::shared_ptr< std::string >
+  std::shared_ptr< std::string >
     serialize( const kwiver::vital::any& element ) override;
-  virtual kwiver::vital::any deserialize( const std::string& message ) override;
+  kwiver::vital::any deserialize( const std::string& message ) override;
 };
 
 } } } }

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -786,7 +786,7 @@ TEST( load_save, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -692,7 +692,7 @@ TEST(serialize , track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -848,7 +848,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -134,7 +134,6 @@ void convert_protobuf( const ::kwiver::vital::activity& act,
   *proto_act.mutable_start_frame() = proto_start_frame;
   *proto_act.mutable_end_frame() = proto_end_frame;
 
-  auto at_sptr = act.type();
   // Now check if optional fields can be set
   if ( auto at_sptr = act.type() )
   {

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -395,7 +395,7 @@ TEST( convert_protobuf, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -745,7 +745,7 @@ TEST( convert_protobuf, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -895,7 +895,7 @@ TEST( convert_protobuf, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -424,7 +424,7 @@ TEST( serialize, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto deser_it = deser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( deser_it->second, deser_it->second );
@@ -676,7 +676,7 @@ TEST( serialize, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *( ser_it->first ), *( ser_it->first ) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -689,9 +689,9 @@ TEST( serialize, track )
   // test track with track state
   auto trk = kwiver::vital::track::create();
   trk->set_id( 2 );
-  for ( int i=0; i<10; i++ )
+  for ( int ii = 0; ii < 10; ii++ )
   {
-    auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( i );
+    auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( ii );
     bool insert_success = trk->insert( trk_state_sptr );
     if ( !insert_success )
     {
@@ -840,7 +840,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/super3d/compute_depth.cxx
+++ b/arrows/super3d/compute_depth.cxx
@@ -34,19 +34,20 @@
 */
 
 #include <arrows/super3d/compute_depth.h>
-#include <arrows/vxl/image_container.h>
-#include <vital/types/landmark.h>
-#include <vital/util/transform_image.h>
+
 #include <arrows/vxl/camera.h>
-#include <vnl/vnl_double_3.h>
+#include <arrows/vxl/image_container.h>
 #include <vil/algo/vil_threshold.h>
-#include <vil/vil_image_view.h>
-#include <vil/vil_math.h>
 #include <vil/vil_convert.h>
 #include <vil/vil_crop.h>
+#include <vil/vil_image_view.h>
+#include <vil/vil_math.h>
 #include <vil/vil_plane.h>
-#include <vpgl/vpgl_perspective_camera.h>
 #include <vital/types/bounding_box.h>
+#include <vital/types/landmark.h>
+#include <vital/vital_config.h>
+#include <vnl/vnl_double_3.h>
+#include <vpgl/vpgl_perspective_camera.h>
 
 #include <sstream>
 #include <memory>
@@ -88,7 +89,7 @@ public:
 
   std::unique_ptr<world_space> compute_world_space_roi(vpgl_perspective_camera<double> &cam,
                                                        vil_image_view<double> &frame,
-                                                       double depth_min, double depth_max,
+                                                       double d_min, double d_max,
                                                        vital::bounding_box<int> const& roi);
 
   double theta0;
@@ -195,7 +196,7 @@ compute_depth::set_configuration(vital::config_block_sptr in_config)
 
 /// Check that the algorithm's currently configuration is valid
 bool
-compute_depth::check_configuration(vital::config_block_sptr config) const
+compute_depth::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -207,14 +208,14 @@ std::unique_ptr<world_space>
 compute_depth::priv
 ::compute_world_space_roi(vpgl_perspective_camera<double> &cam,
                           vil_image_view<double> &frame,
-                          double depth_min, double depth_max,
+                          double d_min, double d_max,
                           vital::bounding_box<int> const& roi)
 {
   frame = vil_crop(frame, roi.min_x(), roi.width(), roi.min_y(), roi.height());
   cam = crop_camera(cam, roi.min_x(), roi.min_y());
 
   return std::unique_ptr<world_space>(new world_angled_frustum(cam, world_plane_normal,
-                                                                depth_min, depth_max, roi.width(), roi.height()));
+                                                                d_min, d_max, roi.width(), roi.height()));
 }
 
 //*****************************************************************************

--- a/arrows/super3d/cost_volume.cxx
+++ b/arrows/super3d/cost_volume.cxx
@@ -50,6 +50,7 @@
 #include <limits>
 
 #include <vital/logger/logger.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -164,10 +165,10 @@ compute_world_cost_volume(const std::vector<vil_image_view<double> > &frames,
 //Compute gradient weighting
 void
 compute_g(const vil_image_view<double> &ref_img,
-  vil_image_view<double> &g,
-  double alpha,
-  double beta,
-  vil_image_view<bool> *mask)
+          vil_image_view<double> &g,
+          double alpha,
+          VITAL_UNUSED double beta,
+          vil_image_view<bool> *mask)
 {
   g.set_size(ref_img.ni(), ref_img.nj(), 1);
 

--- a/arrows/super3d/tv_refine_search.cxx
+++ b/arrows/super3d/tv_refine_search.cxx
@@ -265,8 +265,8 @@ min_search_bound(vil_image_view<double> &a,
         {
           continue;
         }
-        const double diff = dij - k;
-        const double e = coeff*diff*diff + (*cost);
+        const double dd = dij - k;
+        const double e = coeff * dd * dd + (*cost);
         if (e < best_e)
         {
           best_e = e;

--- a/arrows/super3d/world_space.cxx
+++ b/arrows/super3d/world_space.cxx
@@ -33,7 +33,6 @@
  * \brief Source file for world_space
  */
 
-
 #include "world_space.h"
 
 #include <vgl/algo/vgl_h_matrix_2d_compute_4point.h>
@@ -42,6 +41,7 @@
 #include <vil/vil_math.h>
 #include <vgl/vgl_box_2d.h>
 
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace arrows {
@@ -59,7 +59,7 @@ world_space::world_space(unsigned int pixel_width, unsigned int pixel_height)
 std::vector<vpgl_perspective_camera<double> >
 world_space
 ::warp_cams(const std::vector<vpgl_perspective_camera<double> > &cameras,
-            int ref_frame) const
+            VITAL_UNUSED int ref_frame) const
 {
   return cameras;
 }
@@ -72,7 +72,9 @@ template<typename PixT>
 void world_space::warp_image_to_depth(const vil_image_view<PixT> &in,
                                       vil_image_view<PixT> &out,
                                       const vpgl_perspective_camera<double> &cam,
-                                      double depth_slice, int f, PixT fill)
+                                      double depth_slice,
+                                      VITAL_UNUSED int f,
+                                      PixT fill)
 {
   wip.set_unmapped_value(fill);
   std::vector<vnl_double_3> wpts = this->get_slice(depth_slice);
@@ -133,5 +135,3 @@ template void world_space::warp_image_to_depth(const vil_image_view<bool> &in,
 } // end namespace super3d
 } // end namespace arrows
 } // end namespace kwiver
-
-

--- a/arrows/vxl/bundle_adjust.cxx
+++ b/arrows/vxl/bundle_adjust.cxx
@@ -38,10 +38,10 @@
 #include <iostream>
 #include <set>
 
-#include <vital/util/cpu_timer.h>
-
 #include <arrows/vxl/camera_map.h>
 #include <vital/io/eigen_io.h>
+#include <vital/util/cpu_timer.h>
+#include <vital/vital_config.h>
 
 #include <vpgl/algo/vpgl_bundle_adjust.h>
 
@@ -183,7 +183,7 @@ bundle_adjust
 /// Check that the algorithm's currently configuration is valid
 bool
 bundle_adjust
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
   return true;
 }
@@ -256,15 +256,15 @@ bundle_adjust
       }
       super_map_inner_t frame_lm2feature_map;
 
-      for(const track_sptr& t : ftracks)
+      for(const track_sptr& tt : ftracks)
       {
-        const track_id_t id = t->id();
+        const track_id_t id = tt->id();
         // make sure the track id has an associated landmark
 
         if( lms.find(id) != lms.end() )
         {
           auto fts = std::dynamic_pointer_cast<feature_track_state>(
-                          *t->find(frame) );
+                          *tt->find(frame) );
           if( fts && fts->feature )
           {
             frame_lm2feature_map[id] = fts->feature;

--- a/arrows/vxl/close_loops_homography_guided.cxx
+++ b/arrows/vxl/close_loops_homography_guided.cxx
@@ -45,6 +45,8 @@
 
 #include <vital/algo/compute_ref_homography.h>
 #include <vital/algo/match_features.h>
+#include <vital/vital_config.h>
+
 #include <arrows/vxl/compute_homography_overlap.h>
 
 using namespace kwiver::vital;
@@ -255,7 +257,7 @@ close_loops_homography_guided
 ::stitch( frame_id_t frame_number,
           feature_track_set_sptr input,
           image_container_sptr image,
-          image_container_sptr mask ) const
+          VITAL_UNUSED image_container_sptr mask ) const
 {
   if( !d_->enabled_ )
   {

--- a/arrows/vxl/estimate_canonical_transform.cxx
+++ b/arrows/vxl/estimate_canonical_transform.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/logger/logger.h>
 #include <vital/types/camera_perspective.h>
+#include <vital/vital_config.h>
 
 #include <algorithm>
 
@@ -271,7 +272,7 @@ estimate_canonical_transform
 // Check that the algorithm's configuration vital::config_block is valid
 bool
 estimate_canonical_transform
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
  return true;
 }

--- a/arrows/vxl/estimate_essential_matrix.cxx
+++ b/arrows/vxl/estimate_essential_matrix.cxx
@@ -38,6 +38,8 @@
 
 
 #include <vital/types/feature.h>
+#include <vital/vital_config.h>
+
 #include <arrows/vxl/camera.h>
 #include <arrows/mvg/epipolar_geometry.h>
 
@@ -119,7 +121,7 @@ estimate_essential_matrix
 /// Check that the algorithm's currently configuration is valid
 bool
 estimate_essential_matrix
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/vxl/estimate_fundamental_matrix.cxx
+++ b/arrows/vxl/estimate_fundamental_matrix.cxx
@@ -38,6 +38,7 @@
 
 #include <vital/util/enum_converter.h>
 #include <vital/types/feature.h>
+#include <vital/vital_config.h>
 
 #include <arrows/vxl/camera.h>
 #include <arrows/mvg/epipolar_geometry.h>
@@ -135,7 +136,7 @@ estimate_fundamental_matrix
 /// Check that the algorithm's current configuration is valid
 bool
 estimate_fundamental_matrix
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/vxl/image_io.cxx
+++ b/arrows/vxl/image_io.cxx
@@ -39,6 +39,7 @@
 #include <vital/types/vector.h>
 #include <vital/exceptions/image.h>
 #include <vital/types/metadata_traits.h>
+#include <vital/vital_config.h>
 
 #include <arrows/vxl/image_container.h>
 
@@ -157,8 +158,10 @@ convert_image_helper(const vil_image_view<bool>& src,
 void
 convert_image_helper(const vil_image_view<bool>& src,
                      vil_image_view<bool>& dest,
-                     bool force_byte, bool auto_stretch,
-                     bool manual_stretch, const vector_2d& intensity_range)
+                     VITAL_UNUSED bool force_byte,
+                     VITAL_UNUSED bool auto_stretch,
+                     VITAL_UNUSED bool manual_stretch,
+                     VITAL_UNUSED const vector_2d& intensity_range)
 {
   // special case for bool because stretch does not make sense for bool to bool conversion
   dest = src;

--- a/arrows/vxl/split_image.h
+++ b/arrows/vxl/split_image.h
@@ -40,6 +40,8 @@
 
 #include <vital/algo/split_image.h>
 
+#include <vital/vital_config.h>
+
 namespace kwiver {
 namespace arrows {
 namespace vxl {
@@ -58,8 +60,8 @@ public:
   /// Destructor
   virtual ~split_image();
 
-  virtual void set_configuration( kwiver::vital::config_block_sptr ) { }
-  virtual bool check_configuration( kwiver::vital::config_block_sptr config) const { return true; }
+  virtual void set_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr ) { }
+  virtual bool check_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config) const { return true; }
 
   /// Split image
   virtual std::vector< kwiver::vital::image_container_sptr >

--- a/arrows/vxl/triangulate_landmarks.cxx
+++ b/arrows/vxl/triangulate_landmarks.cxx
@@ -37,6 +37,7 @@
 
 #include <set>
 
+#include <vital/vital_config.h>
 
 #include <arrows/vxl/camera_map.h>
 
@@ -94,7 +95,7 @@ triangulate_landmarks
 // Set this algorithm's properties via a config block
 void
 triangulate_landmarks
-::set_configuration(vital::config_block_sptr in_config)
+::set_configuration( VITAL_UNUSED vital::config_block_sptr in_config)
 {
 }
 
@@ -103,7 +104,7 @@ triangulate_landmarks
 // Check that the algorithm's currently configuration is valid
 bool
 triangulate_landmarks
-::check_configuration(vital::config_block_sptr config) const
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config) const
 {
   return true;
 }

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -43,6 +43,7 @@
 #include <vital/klv/convert_metadata.h>
 #include <vital/klv/misp_time.h>
 #include <vital/klv/klv_data.h>
+#include <vital/vital_config.h>
 
 #include <arrows/vxl/image_container.h>
 
@@ -788,7 +789,7 @@ vidl_ffmpeg_video_input
 bool
 vidl_ffmpeg_video_input
 ::next_frame( kwiver::vital::timestamp& ts,
-              uint32_t timeout )
+              VITAL_UNUSED uint32_t timeout )
 {
   if (d->d_at_eov)
   {
@@ -843,7 +844,7 @@ bool
 vidl_ffmpeg_video_input
 ::seek_frame( kwiver::vital::timestamp& ts,   // returns timestamp
               kwiver::vital::timestamp::frame_t frame_number,
-              uint32_t                  timeout )
+              VITAL_UNUSED uint32_t                  timeout )
 {
   // is stream open?
   if ( ! d->d_video_stream.is_open() )

--- a/extras/process_instrumentation/logger_process_instrumentation.cxx
+++ b/extras/process_instrumentation/logger_process_instrumentation.cxx
@@ -31,6 +31,7 @@
 #include "logger_process_instrumentation.h"
 
 #include <sprokit/pipeline/process.h>
+#include <vital/vital_config.h>
 #include <vital/config/config_difference.h>
 #include <vital/util/enum_converter.h>
 #include <vital/util/string.h>
@@ -58,7 +59,7 @@ logger_process_instrumentation()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-  start_init_processing( std::string const& data )
+  start_init_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_init_processing" );
 }
@@ -76,7 +77,7 @@ stop_init_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-  start_finalize_processing( std::string const& data )
+  start_finalize_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_finalize_processing" );
 }
@@ -94,7 +95,7 @@ stop_finalize_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_reset_processing( std::string const& data )
+start_reset_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": stop_init_processing" );
 }
@@ -112,7 +113,7 @@ stop_reset_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_flush_processing( std::string const& data )
+start_flush_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_reset_processing" );
 }
@@ -130,7 +131,7 @@ stop_flush_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_step_processing( std::string const& data )
+start_step_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_step_processing" );
 }
@@ -148,7 +149,7 @@ stop_step_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_configure_processing( std::string const& data )
+start_configure_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_configure_processing" );
 }
@@ -166,7 +167,7 @@ stop_configure_processing()
 // ------------------------------------------------------------------
 void
 logger_process_instrumentation::
-start_reconfigure_processing( std::string const& data )
+start_reconfigure_processing( VITAL_UNUSED std::string const& data )
 {
   log_message( process()->name() + ": start_reconfigure_processing" );
 }
@@ -229,6 +230,7 @@ void logger_process_instrumentation
     break;
 
   default:
+  case kvll::LEVEL_NONE:
   case kvll::LEVEL_INFO:
     LOG_INFO( m_logger, data );
     break;
@@ -238,6 +240,7 @@ void logger_process_instrumentation
     break;
 
   case kvll::LEVEL_ERROR:
+  case kvll::LEVEL_FATAL:
     LOG_ERROR( m_logger, data );
     break;
 

--- a/extras/process_instrumentation/timing_process_instrumentation.cxx
+++ b/extras/process_instrumentation/timing_process_instrumentation.cxx
@@ -30,6 +30,7 @@
 
 #include "timing_process_instrumentation.h"
 
+#include <vital/vital_config.h>
 #include <vital/util/enum_converter.h>
 
 #include <sprokit/pipeline/process.h>
@@ -79,7 +80,7 @@ timing_process_instrumentation::
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_init_processing( std::string const& data )
+start_init_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -101,7 +102,7 @@ stop_init_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_finalize_processing( std::string const& data )
+start_finalize_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -123,7 +124,7 @@ stop_finalize_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_reset_processing( std::string const& data )
+start_reset_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -142,7 +143,7 @@ stop_reset_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_flush_processing( std::string const& data )
+start_flush_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -161,7 +162,7 @@ stop_flush_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_step_processing( std::string const& data )
+start_step_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -182,7 +183,7 @@ stop_step_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_configure_processing( std::string const& data )
+start_configure_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -201,7 +202,7 @@ stop_configure_processing()
 // ------------------------------------------------------------------
 void
 timing_process_instrumentation::
-start_reconfigure_processing( std::string const& data )
+start_reconfigure_processing( VITAL_UNUSED std::string const& data )
 {
   m_timer->start();
 }
@@ -239,6 +240,9 @@ configure( kwiver::vital::config_block_sptr const conf )
   case timer_type::timer_cpu:
     m_timer = std::make_shared<kwiver::vital::cpu_timer>();
     type_name = "cpu_clock_duration";
+    break;
+
+  default:
     break;
   } // end switch
 

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -39,16 +39,15 @@
 #include <vital/config/config_block.h>
 #include <vital/logger/logger.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <sprokit/pipeline_util/pipeline_builder.h>
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/datum.h>
 #include <sprokit/pipeline/scheduler.h>
 #include <sprokit/pipeline/scheduler_factory.h>
-
 #include <sprokit/processes/adapters/input_adapter.h>
 #include <sprokit/processes/adapters/input_adapter_process.h>
-
 #include <sprokit/processes/adapters/output_adapter.h>
 #include <sprokit/processes/adapters/output_adapter_process.h>
 
@@ -483,7 +482,7 @@ embedded_pipeline
 // ----------------------------------------------------------------------------
 void
 embedded_pipeline::
-update_config( kwiver::vital::config_block_sptr config )
+update_config( VITAL_UNUSED kwiver::vital::config_block_sptr config )
 {
 }
 

--- a/sprokit/processes/adapters/embedded_pipeline_extension.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.cxx
@@ -29,6 +29,7 @@
  */
 
 #include "embedded_pipeline_extension.h"
+#include <vital/vital_config.h>
 
 namespace kwiver {
 
@@ -40,7 +41,7 @@ embedded_pipeline_extension()
 // ----------------------------------------------------------------------------
 void
 embedded_pipeline_extension::
-configure( kwiver::vital::config_block_sptr const conf )
+configure( VITAL_UNUSED kwiver::vital::config_block_sptr const conf )
 { }
 
 

--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -84,7 +84,7 @@ public:
    *
    * @param ctxt The calling context.
    */
-  virtual void pre_setup( context& ctxt ) { };
+  virtual void pre_setup( context& /* ctxt */ ) { };
 
   /**
    * @brief pipeline post-setup hook
@@ -94,7 +94,7 @@ public:
    *
    * @param ctxt The calling context.
    */
-  virtual void post_setup( context& ctxt ) { };
+  virtual void post_setup( context& /* ctxt */ ) { };
 
   /**
    * @brief End of data received from pipeline.
@@ -106,7 +106,7 @@ public:
    *
    * @param ctxt The calling context
    */
-  virtual void end_of_output( context& ctxt ) { };
+  virtual void end_of_output( context& /* ctxt */ ) { };
 
   /**
    * @brief Configure provider.
@@ -119,7 +119,7 @@ public:
    *
    * @param conf Configuration block.
    */
-  virtual void configure( kwiver::vital::config_block_sptr const conf );
+  virtual void configure( kwiver::vital::config_block_sptr const /* conf */ );
 
   /**
    * @brief Get default configuration block.
@@ -156,9 +156,9 @@ class embedded_pipeline_extension_registrar
   : public plugin_registrar
 {
 public:
-  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl,
-                    const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl_,
+                    const std::string& mod_name_ )
+    : plugin_registrar( vpl_, mod_name_ )
   {
   }
 

--- a/sprokit/processes/adapters/epx_test.cxx
+++ b/sprokit/processes/adapters/epx_test.cxx
@@ -33,6 +33,7 @@
 #include <vital/plugin_loader/plugin_loader.h>
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/config/config_block_formatter.h>
+#include <vital/vital_config.h>
 
 #include <sstream>
 #include <iostream>
@@ -63,7 +64,7 @@ pre_setup( context& ctxt )
 // ----------------------------------------------------------------------------
 void
 epx_test::
-end_of_output( context& ctxt )
+end_of_output( VITAL_UNUSED context& ctxt )
 {
   std::cout << "exp_test End_Of_Output called\n";
 }

--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -77,16 +77,16 @@ kwiver::adapter::ports_info_t
 input_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t port_info;
+  kwiver::adapter::ports_info_t l_port_info;
 
   // formulate list of current input ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    port_info[port] = this->input_port_info( port );
+    l_port_info[port] = this->input_port_info( port );
   }
 
-  return port_info;
+  return l_port_info;
 }
 
 

--- a/sprokit/processes/adapters/output_adapter_process.cxx
+++ b/sprokit/processes/adapters/output_adapter_process.cxx
@@ -101,16 +101,16 @@ kwiver::adapter::ports_info_t
 output_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t port_info;
+  kwiver::adapter::ports_info_t p_info;
 
   // formulate list of current output ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    port_info[port] = this->output_port_info( port );
+    p_info[port] = this->output_port_info( port );
   }
 
-  return port_info;
+  return p_info;
 }
 
 

--- a/sprokit/processes/adapters/tests/test_non_blocking.cxx
+++ b/sprokit/processes/adapters/tests/test_non_blocking.cxx
@@ -120,7 +120,7 @@ main(int argc, char* argv[])
 }
 
 // ==================================================================
-IMPLEMENT_TEST(non_blocking)
+IMPLEMENT_TEST(nonblocking)
 {
   std::stringstream pipeline_desc;
   pipeline_desc

--- a/sprokit/processes/core/compute_association_matrix_process.cxx
+++ b/sprokit/processes/core/compute_association_matrix_process.cxx
@@ -124,9 +124,9 @@ compute_association_matrix_process
 ::_step()
 {
   // Check for end of video since we're in manual management mode
-  auto port_info = peek_at_port_using_trait( detected_object_set );
+  auto p_info = peek_at_port_using_trait( detected_object_set );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( detected_object_set );
     mark_process_as_complete();

--- a/sprokit/processes/core/compute_track_descriptors_process.cxx
+++ b/sprokit/processes/core/compute_track_descriptors_process.cxx
@@ -149,9 +149,9 @@ compute_track_descriptors_process
 ::_step()
 {
   // Peek at next input to see if we're at end of video
-  auto port_info = peek_at_port_using_trait( image );
+  auto p_info = peek_at_port_using_trait( image );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( image );
     mark_process_as_complete();

--- a/sprokit/processes/core/downsample_process.cxx
+++ b/sprokit/processes/core/downsample_process.cxx
@@ -33,6 +33,7 @@
 #include <kwiver_type_traits.h>
 
 #include <vital/types/timestamp.h>
+#include <vital/vital_config.h>
 
 namespace kwiver
 {
@@ -50,7 +51,7 @@ public:
   explicit priv( downsample_process* p );
   ~priv();
 
-  bool skip_frame( vital::timestamp const& ts, double frame_rate );
+  bool skip_frame( VITAL_UNUSED vital::timestamp const& ts, double frame_rate );
 
   downsample_process* parent;
 
@@ -210,7 +211,8 @@ int downsample_process::priv
 
 
 bool downsample_process::priv
-::skip_frame( vital::timestamp const& ts, double frame_rate )
+::skip_frame( VITAL_UNUSED vital::timestamp const& ts,
+              double frame_rate )
 {
   ds_frame_time_ = ts.has_valid_time() ?
     ts.get_time_seconds() : ds_frame_time_ + 1 / frame_rate;

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -190,7 +190,7 @@ void image_file_reader_process
   if ( ! kwiversys::SystemTools::FileExists( file ) )
   {
     // Resolve against specified path
-    std::string resolved_file = kwiversys::SystemTools::FindFile( file, d->m_config_path, true );
+    resolved_file = kwiversys::SystemTools::FindFile( file, d->m_config_path, true );
     if ( resolved_file.empty() )
     {
       switch (d->m_config_error_mode)

--- a/sprokit/processes/core/keyframe_selection_process.cxx
+++ b/sprokit/processes/core/keyframe_selection_process.cxx
@@ -279,7 +279,7 @@ vital::feature_track_set_sptr
 keyframe_selection_process::priv
 ::remove_non_keyframes_between_keyframes(
   vital::feature_track_set_sptr input_tracks,
-  vital::frame_id_t current_frame_number)
+  VITAL_UNUSED vital::frame_id_t current_frame_number)
 {
   bool passed_a_keyframe = false;
   auto afd = input_tracks->all_frame_data();
@@ -344,7 +344,7 @@ vital::feature_track_set_sptr
 keyframe_selection_process::priv
 ::merge_next_tracks_into_loop_back_track(
   vital::feature_track_set_sptr next_tracks,
-  vital::frame_id_t next_tracks_frame_num,
+  VITAL_UNUSED vital::frame_id_t next_tracks_frame_num,
   vital::feature_track_set_sptr loop_back_tracks)
 {
   vital::feature_track_set_sptr curr_tracks = loop_back_tracks;

--- a/sprokit/processes/core/perform_query_process.cxx
+++ b/sprokit/processes/core/perform_query_process.cxx
@@ -214,9 +214,9 @@ perform_query_process
 ::_step()
 {
   // Check for termination since we are in manual mode
-  auto port_info = peek_at_port_using_trait( database_query );
+  auto p_info = peek_at_port_using_trait( database_query );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( database_query );
     grab_edge_datum_using_trait( iqr_feedback );

--- a/sprokit/processes/core/serializer_base.cxx
+++ b/sprokit/processes/core/serializer_base.cxx
@@ -113,11 +113,11 @@ serializer_base
       elem_spec.m_serializer = std::dynamic_pointer_cast< vital::algo::data_serializer > ( base_nested_algo );
       if ( ! elem_spec.m_serializer )
       {
-        std::stringstream str;
-        str << "Unable to create serializer for type \""
+        std::stringstream sstr;
+        sstr << "Unable to create serializer for type \""
             << elem_spec.m_algo_name << "\" for " << m_serialization_type;
 
-        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
+        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), sstr.str() );
       }
 
       if ( ! vital::algorithm::check_nested_algo_configuration( ser_algo_type,

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -137,8 +137,8 @@ void write_object_track_process
 void write_object_track_process
 ::_step()
 {
-  auto const& port_info = peek_at_port_using_trait( object_track_set );
-  if( port_info.datum->type() == sprokit::datum::complete )
+  auto const& p_info = peek_at_port_using_trait( object_track_set );
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( object_track_set );
     d->m_writer->close();

--- a/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
+++ b/sprokit/processes/examples/process_template/template_algo_wrapper.cxx
@@ -41,6 +41,7 @@
 #include <sprokit/processes/kwiver_type_traits.h>
 #include <sprokit/pipeline/process_exception.h>
 #include <vital/types/timestamp.h>
+#include <vital/vital_config.h>
 #include <arrows/ocv/image_container.h>
 
 //++ include definition of abstract base algorithm.
@@ -239,7 +240,7 @@ template_algo_wrapper
 //++ to get the new config values from the supplied config
 void
 template_algo_wrapper
-::_reconfigure(kwiver::vital::config_block_sptr const& conf)
+::_reconfigure( VITAL_UNUSED kwiver::vital::config_block_sptr const& conf)
 {
   scoped_reconfigure_instrumentation();
 

--- a/sprokit/processes/examples/process_template/template_process.cxx
+++ b/sprokit/processes/examples/process_template/template_process.cxx
@@ -40,6 +40,7 @@
 
 #include <sprokit/processes/kwiver_type_traits.h>
 #include <vital/types/timestamp.h>
+#include <vital/vital_config.h>
 #include <arrows/ocv/image_container.h>
 
 #include <opencv2/core/core.hpp>
@@ -236,7 +237,7 @@ template_process
 //++ to get the new config values from the supplied config
 void
 template_process
-::_reconfigure(kwiver::vital::config_block_sptr const& conf)
+::_reconfigure( VITAL_UNUSED kwiver::vital::config_block_sptr const& conf)
 {
   scoped_reconfigure_instrumentation();
 

--- a/sprokit/processes/flow/mux_process.cxx
+++ b/sprokit/processes/flow/mux_process.cxx
@@ -362,9 +362,10 @@ mux_process
           break;
         }
 
-        default:
-          VITAL_THROW( invalid_configuration_exception, name(),
-                       "Invalid option specified for termination_policy." );
+      default:
+      case priv::term_policy_t::skip:
+        VITAL_THROW( invalid_configuration_exception, name(),
+                     "Invalid option specified for termination_policy." );
       } // end switch
 
       continue;

--- a/sprokit/processes/ocv/image_viewer_process.cxx
+++ b/sprokit/processes/ocv/image_viewer_process.cxx
@@ -148,15 +148,15 @@ public:
     // header
     if ( ! m_header.empty() )
     {
-      cv::Size tbox = cv::getTextSize( m_header,
+      cv::Size t_box = cv::getTextSize( m_header,
                                        font_face,
                                        font_scale,
                                        font_thickness,
                                        &baseline );
 
       // Calculate point for lower left of text block
-      cv::Point header_org( ( image.cols - tbox.width ) / 2,
-                            tbox.height + 3 );
+      cv::Point header_org( ( image.cols - t_box.width ) / 2,
+                            t_box.height + 3 );
 
       cv::putText( image,
                    m_header,
@@ -170,14 +170,14 @@ public:
     // footer
     if ( ! m_footer.empty() )
     {
-      cv::Size tbox = cv::getTextSize( m_footer,
+      cv::Size t_box = cv::getTextSize( m_footer,
                                        font_face,
                                        font_scale,
                                        font_thickness,
                                        &baseline );
 
       // Calculate point for lower left of text block
-      cv::Point footer_org( ( image.cols - tbox.width ) / 2,
+      cv::Point footer_org( ( image.cols - t_box.width ) / 2,
                             ( image.rows - 3 ) );
 
       cv::putText( image,

--- a/sprokit/processes/trait_utils.h
+++ b/sprokit/processes/trait_utils.h
@@ -256,7 +256,7 @@ sprokit::process::type_t const PN ## _port_trait::type_name = sprokit::process::
 sprokit::process::port_t const PN ## _port_trait::port_name = sprokit::process::port_t( # PN ); \
 sprokit::process::port_description_t const PN ## _port_trait::description = sprokit::process::port_description_t( DESCRIP ); }
 
-#if VITAL_VARIADAC_MACRO
+#ifdef VITAL_VARIADAC_MACRO
 
 //
 // Substantial macro magic

--- a/sprokit/src/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/src/sprokit/pipeline/CMakeLists.txt
@@ -130,5 +130,3 @@ kwiver_install_headers(
   SUBDIR sprokit/pipeline
   NOPATH
   )
-
-sprokit_configure_pkgconfig(sprokit-pipeline)

--- a/sprokit/src/sprokit/pipeline/process.cxx
+++ b/sprokit/src/sprokit/pipeline/process.cxx
@@ -37,6 +37,7 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/string.h>
 #include <vital/optional.h>
+#include <vital/vital_config.h>
 
 #include <boost/assign/ptr_map_inserter.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
@@ -832,7 +833,7 @@ process
 // ------------------------------------------------------------------
 void
 process
-::input_port_undefined( port_t const& port )
+::input_port_undefined( VITAL_UNUSED port_t const& port )
 {
 }
 
@@ -866,7 +867,7 @@ process
 // ------------------------------------------------------------------
 void
 process
-::output_port_undefined( port_t const& port )
+::output_port_undefined( VITAL_UNUSED port_t const& port )
 {
 }
 

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -237,8 +237,8 @@ public:
   };
 
   process_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& mod_name_ )
+    : plugin_registrar( vpl, mod_name_ )
   {
   }
 

--- a/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
+++ b/sprokit/src/sprokit/pipeline/process_instrumentation.cxx
@@ -35,6 +35,7 @@
 
 #include "process_instrumentation.h"
 
+#include <vital/vital_config.h>
 #include <sprokit/pipeline/process.h>
 
 namespace sprokit {
@@ -55,7 +56,7 @@ set_process( sprokit::process const& proc )
 
 void
 process_instrumentation::
-configure( kwiver::vital::config_block_sptr const config )
+configure( VITAL_UNUSED kwiver::vital::config_block_sptr const config )
 { }
 
 

--- a/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
+++ b/sprokit/src/sprokit/pipeline_util/bakery_base.cxx
@@ -37,10 +37,11 @@
 
 #include "pipe_bakery_exception.h"
 
-#include <vital/util/string.h>
-#include <vital/util/token_type_sysenv.h>
-#include <vital/util/token_type_env.h>
 #include <vital/config/token_type_config.h>
+#include <vital/util/string.h>
+#include <vital/util/token_type_env.h>
+#include <vital/util/token_type_sysenv.h>
+#include <vital/vital_config.h>
 
 #include <kwiversys/SystemTools.hxx>
 
@@ -70,7 +71,8 @@ protected:
   }
 
 
-  virtual bool handle_missing_provider( const std::string& provider, const std::string& entry )
+  virtual bool handle_missing_provider( const std::string& provider,
+                                        VITAL_UNUSED const std::string& entry )
   {
     std::stringstream str;
     str << "Provider \"" << provider << "\" is not available";

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -414,10 +414,10 @@ lex_processor
       // look for "::"
       if ( c == ':' && n == ':' )
       {
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
-        t->set_location( current_location() );
+        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
+        tt->set_location( current_location() );
 
-        return t;
+        return tt;
       }
 
       if ( c == ':' && n == '=' )
@@ -425,11 +425,11 @@ lex_processor
         // Collect rest of line as text
         std::string text( m_priv->m_cur_char + 1, m_priv->m_input_line.end() );
         kwiver::vital::string_trim( text );
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
-        t->set_location( current_location() );
+        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
+        tt->set_location( current_location() );
 
         m_priv->flush_line();
-        return t;
+        return tt;
       }
 
       // Reset pointer to restore our second character

--- a/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_scheduler_registry.cxx
@@ -32,6 +32,7 @@
 
 #include <vital/config/config_block.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/vital_config.h>
 
 #include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/scheduler.h>
@@ -181,7 +182,8 @@ IMPLEMENT_TEST(unknown_types)
 
 // ------------------------------------------------------------------
 sprokit::scheduler_t
-null_scheduler(sprokit::pipeline_t const& /*pipeline*/, kwiver::vital::config_block_sptr const& /*config*/)
+null_scheduler_ptr( VITAL_UNUSED sprokit::pipeline_t const& pipeline,
+                    VITAL_UNUSED kwiver::vital::config_block_sptr const& config )
 {
   return sprokit::scheduler_t();
 }

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -157,8 +157,8 @@ class algorithm_registrar
 {
 public:
   algorithm_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& module_name )
+    : plugin_registrar( vpl, module_name )
   {
   }
 
@@ -214,9 +214,9 @@ public:
    * serializer method. Typical entries could be "protobuf" or "json".
    */
   serializer_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name,
+                       const std::string& mod,
                        const std::string& ser_method)
-    : plugin_registrar( vpl, mod_name ),
+    : plugin_registrar( vpl, mod ),
       m_serialize_method( "serialize-" + ser_method )
   { }
 

--- a/vital/algo/bundle_adjust.cxx
+++ b/vital/algo/bundle_adjust.cxx
@@ -37,6 +37,7 @@
 #include <vital/algo/bundle_adjust.h>
 #include <vital/algo/algorithm.txx>
 #include <vital/logger/logger.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -62,8 +63,8 @@ bundle_adjust
   kwiver::vital::simple_camera_perspective_map &cameras,
   kwiver::vital::landmark_map::map_landmark_t &landmarks,
   vital::feature_track_set_sptr tracks,
-  const std::set<vital::frame_id_t>& fixed_cameras,
-  const std::set<vital::landmark_id_t>& fixed_landmarks,
+  VITAL_UNUSED const std::set<vital::frame_id_t>& fixed_cameras,
+  VITAL_UNUSED const std::set<vital::landmark_id_t>& fixed_landmarks,
   kwiver::vital::sfm_constraints_sptr constraints) const
 {
   auto cam_map = std::static_pointer_cast<vital::camera_map>(

--- a/vital/algo/image_io.cxx
+++ b/vital/algo/image_io.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/algo/algorithm.txx>
 #include <vital/exceptions/io.h>
+#include <vital/vital_config.h>
 #include <vital/vital_types.h>
 
 #include <kwiversys/SystemTools.hxx>
@@ -135,7 +136,7 @@ image_io
 
 metadata_sptr
 image_io
-::load_metadata_(std::string const& filename) const
+::load_metadata_(VITAL_UNUSED std::string const& filename) const
 {
   // No metadata-only loading by default.
   return nullptr;

--- a/vital/algo/train_detector.cxx
+++ b/vital/algo/train_detector.cxx
@@ -36,6 +36,7 @@
 #include "train_detector.h"
 
 #include <vital/algo/algorithm.txx>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -50,11 +51,11 @@ train_detector
 void
 train_detector
 ::train_from_disk(
-  vital::category_hierarchy_sptr object_labels,
-  std::vector< std::string > train_image_names,
-  std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
-  std::vector< std::string > test_image_names,
-  std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
+  VITAL_UNUSED vital::category_hierarchy_sptr object_labels,
+  VITAL_UNUSED std::vector< std::string > train_image_names,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
+  VITAL_UNUSED std::vector< std::string > test_image_names,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
 {
   throw std::runtime_error( "Method not implemented" );
 }
@@ -63,11 +64,11 @@ train_detector
 void
 train_detector
 ::train_from_memory(
-  vital::category_hierarchy_sptr object_labels,
-  std::vector< kwiver::vital::image_container_sptr > train_images,
-  std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
-  std::vector< kwiver::vital::image_container_sptr > test_images,
-  std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
+  VITAL_UNUSED vital::category_hierarchy_sptr object_labels,
+  VITAL_UNUSED std::vector< kwiver::vital::image_container_sptr > train_images,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > train_groundtruth,
+  VITAL_UNUSED std::vector< kwiver::vital::image_container_sptr > test_images,
+  VITAL_UNUSED std::vector< kwiver::vital::detected_object_set_sptr > test_groundtruth)
 {
   throw std::runtime_error( "Method not implemented" );
 }

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -703,8 +703,8 @@ config_block
   // iterate over all strings and convert to target type
   for (std::string str : sv )
   {
-    T val = config_block_get_value_cast<T>( str );
-    val_vector.push_back( val );
+    T l_val = config_block_get_value_cast<T>( str );
+    val_vector.push_back( l_val );
   }
 
   return val_vector;

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -37,6 +37,7 @@
 
 #include <vital/math_constants.h>
 #include <vital/types/metadata_traits.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -301,7 +302,7 @@ bool
 update_camera_from_metadata(metadata const& md,
                             local_geo_cs const& lgcs,
                             simple_camera_perspective& cam,
-                            rotation_d const& rot_offset)
+               VITAL_UNUSED rotation_d const& rot_offset)
 {
   bool rotation_set = false;
   bool translation_set = false;

--- a/vital/io/mesh_io.cxx
+++ b/vital/io/mesh_io.cxx
@@ -325,7 +325,7 @@ read_obj(std::istream& is)
     {
       case 'v': // read a vertex
       {
-        char c2 = (char)is.peek();
+        char c2 = static_cast<char>(is.peek());
         switch (c2)
         {
           case 'n': // read a normal

--- a/vital/klv/convert_0104_metadata.cxx
+++ b/vital/klv/convert_0104_metadata.cxx
@@ -39,8 +39,8 @@
 #include <vital/klv/klv_data.h>
 
 #include <vital/exceptions/metadata.h>
-
 #include <vital/types/geodesy.h>
+#include <vital/vital_config.h>
 
 namespace kwiver {
 namespace vital {
@@ -105,7 +105,7 @@ is_valid_lon_lat( vector_3d const& vec )
  */
 kwiver::vital::any
 convert_metadata
-::normalize_0104_tag_data( klv_0104::tag tag,
+::normalize_0104_tag_data( VITAL_UNUSED klv_0104::tag tag,
                            kwiver::vital::vital_metadata_tag vital_tag,
                            kwiver::vital::any const& data )
 {

--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -399,6 +399,11 @@ convert_metadata
       raw_target_location[0] = klv_0601_value_double( KLV_0601_TARGET_LOCATION_LONG, data );
       break;
 
+      // And all the others
+    case KLV_0601_UNKNOWN:
+    case KLV_0601_CHECKSUM:
+    case KLV_0601_ENUM_END:
+    case KLV_0601_GENERIC_FLAG_DATA_01:
     default:
       LOG_DEBUG( logger, "KLV 0601 key: " << int(itr->first) << " is not supported." );
       break;

--- a/vital/klv/klv_0104.h
+++ b/vital/klv/klv_0104.h
@@ -39,6 +39,7 @@
 #include <vital/klv/vital_klv_export.h>
 #include <vital/klv/klv_key.h>
 #include <vital/any.h>
+#include <vital/vital_config.h>
 
 #include <vector>
 #include <string>
@@ -138,7 +139,7 @@ public:
       : m_name( name )
     { }
 
-    traits_base( std::string const& name, bool set )
+    traits_base( std::string const& name, VITAL_UNUSED bool set )
       : m_name( name )
     { }
 

--- a/vital/klv/klv_data.cxx
+++ b/vital/klv/klv_data.cxx
@@ -54,11 +54,11 @@ namespace vital {
 klv_data
 ::klv_data(container_t const& raw_packet,
          std::size_t key_offset, std::size_t key_len,
-         std::size_t m_value_offset, std::size_t value_len)
+         std::size_t value_offset, std::size_t value_len)
   : m_raw_data( raw_packet ),
     m_key_offset( key_offset ),
     key_len_( key_len ),
-    m_value_offset( m_value_offset ),
+    m_value_offset( value_offset ),
     m_value_len ( value_len )
 { }
 

--- a/vital/logger/log4cplus_factory.cxx
+++ b/vital/logger/log4cplus_factory.cxx
@@ -107,6 +107,7 @@ virtual void set_level( log_level_t level )
     break;
 
   default:
+  case LEVEL_NONE:
     // log or throw
     break;
   } // end switch
@@ -281,22 +282,29 @@ virtual void log_message ( log_level_t level, std::string const& msg)
   case LEVEL_TRACE:
     log_trace(msg);
     break;
+
   case LEVEL_DEBUG:
     log_debug(msg);
     break;
+
   case LEVEL_INFO:
     log_info(msg);
     break;
+
   case LEVEL_WARN:
     log_warn(msg);
     break;
+
   case LEVEL_ERROR:
     log_error(msg);
     break;
+
   case LEVEL_FATAL:
     log_fatal(msg);
     break;
+
   default:
+  case LEVEL_NONE:
     break;
   } // end switch
 }
@@ -333,6 +341,7 @@ virtual void log_message ( log_level_t level, std::string const& msg,
     break;
 
   default:
+  case LEVEL_NONE:
     break;
   } // end switch
 }

--- a/vital/plugin_loader/plugin_loader_filter.h
+++ b/vital/plugin_loader/plugin_loader_filter.h
@@ -82,8 +82,8 @@ public:
    *
    * @return \b true if the plugin should be loaded, \b false if plugin should not be loaded
    */
-  virtual bool load_plugin( path_t const& path,
-                            DL::LibraryHandle lib_handle ) const
+  virtual bool load_plugin( path_t const& /* path */,
+                            DL::LibraryHandle /* lib_handle */ ) const
     { return true; }
 
   /**
@@ -107,7 +107,7 @@ public:
    *
    * @return \b true if the plugin should be registered, \b false otherwise.
    */
-  virtual bool add_factory( plugin_factory_handle_t fact ) const
+  virtual bool add_factory( plugin_factory_handle_t /* fact */ ) const
     { return true; }
 
 

--- a/vital/tests/test_estimate_similarity_transform.cxx
+++ b/vital/tests/test_estimate_similarity_transform.cxx
@@ -68,14 +68,14 @@ public:
     : expected_size(0)
   {}
 
-  dummy_est(size_t expected_size)
-    : expected_size(expected_size)
+  dummy_est(size_t expected_size_)
+    : expected_size(expected_size_)
   {}
 
   virtual ~dummy_est() = default;
 
-  void set_configuration(kwiver::vital::config_block_sptr config) {}
-  bool check_configuration(kwiver::vital::config_block_sptr config) const {return true;}
+  void set_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config) {}
+  bool check_configuration( VITAL_UNUSED kwiver::vital::config_block_sptr config) const {return true;}
 
   using kwiver::vital::algo::estimate_similarity_transform::estimate_transform;
 

--- a/vital/tests/test_image.cxx
+++ b/vital/tests/test_image.cxx
@@ -38,6 +38,7 @@
 #include <vital/types/image.h>
 #include <vital/types/image_container.h>
 #include <vital/util/transform_image.h>
+#include <vital/vital_config.h>
 
 #include <gtest/gtest.h>
 
@@ -78,7 +79,7 @@ struct val_zero_op
 // ----------------------------------------------------------------------------
 struct val_incr_op
 {
-  byte operator()( byte const &b )
+  byte operator()( VITAL_UNUSED byte const &b )
   {
     return val_incr_op_i++;
   }

--- a/vital/types/descriptor.h
+++ b/vital/types/descriptor.h
@@ -127,7 +127,7 @@ public:
    * to store the node_id.  Derived classes that do store the node_id
    * should return true if it successfully stored.
   */
-  virtual bool set_node_id(unsigned int node_id) { return false; }
+  virtual bool set_node_id( unsigned int /* node_id */ ) { return false; }
 
 };
 

--- a/vital/types/feature_track_set.h
+++ b/vital/types/feature_track_set.h
@@ -65,24 +65,24 @@ class VITAL_EXPORT feature_track_state : public track_state
 public:
   //@{
   /// Constructor
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr const& feature = nullptr,
-                                descriptor_sptr const& descriptor = nullptr,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ feature }
-    , descriptor{ descriptor }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr const& p_feature = nullptr,
+                                descriptor_sptr const& p_descriptor = nullptr,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ p_feature }
+    , descriptor{ p_descriptor }
+    , inlier{ p_inlier }
   {}
 
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr&& feature,
-                                descriptor_sptr&& descriptor,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ std::move( feature ) }
-    , descriptor{ std::move( descriptor ) }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr&& p_feature,
+                                descriptor_sptr&& p_descriptor,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ std::move( p_feature ) }
+    , descriptor{ std::move( p_descriptor ) }
+    , inlier{ p_inlier }
   {}
   //@}
 

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -129,8 +129,8 @@ config_block_get_value_cast( config_block_value_t const& value )
   }
 
   // Set up helper lambda to check for errors
-  auto try_or_die = [&value]( std::istream& s ) {
-    if ( s.fail() ) {
+  auto try_or_die = [&value]( std::istream& s_ ) {
+    if ( s_.fail() ) {
       VITAL_THROW( bad_config_block_cast,
                    "failed to convert from string representation \"" + value + "\"" );
     }

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -68,23 +68,23 @@ namespace vital {
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any const& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ data },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any const& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ p_data },
+      m_tag{ p_tag }
 {
 }
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any&& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ std::move( data ) },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any&& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ std::move( p_data ) },
+      m_tag{ p_tag }
 {
 }
 
@@ -291,15 +291,15 @@ metadata
 
   for (size_t i = 0; i < len; i++)
   {
-    char const byte = val[i];
-    if ( ! isprint( byte ) )
+    char const l_byte = val[i];
+    if ( ! isprint( l_byte ) )
     {
       ascii.append( 1, '.' );
       unprintable_found = true;
     }
     else
     {
-      ascii.append( 1, byte );
+      ascii.append( 1, l_byte );
     }
 
     // format as hex
@@ -308,8 +308,8 @@ metadata
       hex += " ";
     }
 
-    hex += hex_chars[ ( byte & 0xF0 ) >> 4 ];
-    hex += hex_chars[ ( byte & 0x0F ) >> 0 ];
+    hex += hex_chars[ ( l_byte & 0xF0 ) >> 4 ];
+    hex += hex_chars[ ( l_byte & 0x0F ) >> 0 ];
 
   } // end for
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -253,24 +253,24 @@ class typed_metadata
   : public metadata_item
 {
 public:
-  typed_metadata( std::string const& name, TYPE const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, TYPE const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
   }
 
-  typed_metadata( std::string const& name, TYPE&& data )
-    : metadata_item( name, std::move( data ), TAG )
+  typed_metadata( std::string const& p_name, TYPE&& p_data )
+    : metadata_item( p_name, std::move( p_data ), TAG )
   {
   }
 
-  typed_metadata( std::string const& name, kwiver::vital::any const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, kwiver::vital::any const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
-    if ( data.type() != typeid(TYPE) )
+    if ( p_data.type() != typeid(TYPE) )
     {
       std::stringstream msg;
       msg << "Creating typed_metadata object with data type ("
-          << demangle( data.type().name() )
+          << demangle( p_data.type().name() )
           << ") different from type object was created with ("
           << demangle( typeid(TYPE).name() ) << ")";
       VITAL_THROW( metadata_exception, msg.str() );

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -135,7 +135,8 @@ metadata_traits
     KWIVER_VITAL_METADATA_TAGS( TAG_CASE )
 
   default:
-    return "-- unknown tag code --";
+  case VITAL_META_LAST_TAG:
+      return "-- unknown tag code --";
     break;
   } // end switch
 

--- a/vital/types/point.cxx
+++ b/vital/types/point.cxx
@@ -64,6 +64,9 @@ out(std::ostream& str, point< N, T >const& p)
   case 4:
     str << "[ " << v[0] << ", " << v[1] << ", " << v[2] << ", " << v[3] << " ]\n";
     break;
+  default:
+    str << "Unexpected dimension for point.\n";
+    break;
   }
 
   str << " - covariance : ";
@@ -84,6 +87,9 @@ out(std::ostream& str, point< N, T >const& p)
                 << c(1, 0) << ", " << c(1, 1) << ", " << c(1, 2) << ", " << c(1, 3) << "\n                  "
                 << c(2, 0) << ", " << c(2, 1) << ", " << c(2, 2) << ", " << c(2, 3) << "\n                  "
                 << c(3, 0) << ", " << c(3, 1) << ", " << c(3, 2) << ", " << c(3, 3) << " ]\n";
+    break;
+  default:
+    str << "Unexpected dimension for point.\n";
     break;
   }
 

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -144,7 +144,7 @@ rotation_< T >
 ::angle() const
 {
   static const T _pi = static_cast< T > ( pi );
-  static const T two_pi = static_cast< T > ( 2.0 * pi );
+  static const T _two_pi = static_cast< T > ( 2.0 * pi );
 
   const double i = Eigen::Matrix< T, 3, 1 > ( q_.x(), q_.y(), q_.z() ).norm();
   const double r = q_.w();
@@ -154,11 +154,11 @@ rotation_< T >
   // i.e. -pi/2 < a < pi/2
   if ( a >= _pi )
   {
-    a -= two_pi;
+    a -= _two_pi;
   }
   if ( a <= -_pi )
   {
-    a += two_pi;
+    a += _two_pi;
   }
   return a;
 }

--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -60,8 +60,8 @@ class VITAL_EXPORT track_ref : public std::weak_ptr< track >
 {
 public:
   track_ref() = default;
-  track_ref( track_ref const& other ) {}
-  track_ref( track_ref&& other ) {}
+  track_ref( VITAL_UNUSED track_ref const& other ) {}
+  track_ref( VITAL_UNUSED track_ref&& other ) {}
 
   track_ref& operator= ( track_ref const& rhs ) = delete;
   track_ref& operator= ( track_ref&& rhs ) = delete;

--- a/vital/types/track_set.cxx
+++ b/vital/types/track_set.cxx
@@ -119,7 +119,7 @@ track_set_implementation
 /// Notify the container that a new state has been added to an existing track
 void
 track_set_implementation
-::notify_new_state( track_state_sptr ts )
+::notify_new_state( VITAL_UNUSED track_state_sptr ts )
 {
   // by default, notification does nothing
 }
@@ -127,7 +127,7 @@ track_set_implementation
 /// Notify the container that a state has been removed from an existing track
 void
 track_set_implementation
-::notify_removed_state(track_state_sptr ts)
+::notify_removed_state( VITAL_UNUSED track_state_sptr ts)
 {
   //by default, notification does nothing
 }

--- a/vital/util/string.cxx
+++ b/vital/util/string.cxx
@@ -45,7 +45,8 @@ namespace vital {
 std::string
 string_format( const std::string fmt_str, ... )
 {
-  int final_n, n = ( (int)fmt_str.size() ) * 2; /* Reserve two times as much as the length of the fmt_str */
+  int final_n;
+  int n = static_cast<int>(fmt_str.size() ) * 2; /* Reserve two times as much as the length of the fmt_str */
   std::string str;
   std::unique_ptr< char[] > formatted;
   va_list ap;

--- a/vital/util/token_expander.cxx
+++ b/vital/util/token_expander.cxx
@@ -158,7 +158,8 @@ expand_token( std::string const& initial_string )
 // ------------------------------------------------------------------
 bool
 token_expander::
-handle_missing_entry( const std::string& provider, const std::string& entry )
+handle_missing_entry( VITAL_UNUSED std::string const& provider,
+                      VITAL_UNUSED std::string const& entry )
 {
   // default is to insert unresolved text
   return true;
@@ -168,7 +169,8 @@ handle_missing_entry( const std::string& provider, const std::string& entry )
 // ------------------------------------------------------------------
 bool
 token_expander::
-handle_missing_provider( const std::string& provider, const std::string& entry )
+handle_missing_provider( VITAL_UNUSED std::string const& provider,
+                         VITAL_UNUSED std::string const& entry )
 {
   // default is to insert unresolved text
   return true;

--- a/vital/util/whereami.c
+++ b/vital/util/whereami.c
@@ -306,13 +306,12 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 
             if (dirname_length)
             {
-              int i;
-
-              for (i = length - 1; i >= 0; --i)
+              int ii;
+              for (ii = length - 1; ii >= 0; --ii)
               {
-                if (out[i] == '/')
+                if (out[ii] == '/')
                 {
-                  *dirname_length = i;
+                  *dirname_length = ii;
                   break;
                 }
               }


### PR DESCRIPTION
Remediate some warnings when using KWIVER_CPP_EXTRA option.
    
    Specifically:
    - addressing unused parameters
    - shadowed variables
    - old style casts
    - adding default case to switch statements