### PR TITLE
Add support for OpenCV 4.x

### DIFF
--- a/CMake/kwiver-depends-OpenCV.cmake
+++ b/CMake/kwiver-depends-OpenCV.cmake
@@ -12,9 +12,14 @@ if( KWIVER_ENABLE_OPENCV )
 
   if( OpenCV_VERSION VERSION_GREATER "2.4.6" )
     set( USE_OPENCV True )
-    if( OpenCV_VERSION VERSION_GREATER "3.0" OR
+    if( OpenCV_VERSION VERSION_GREATER "4.0" OR
+        OpenCV_VERSION VERSION_EQUAL "4.0")
+      message(STATUS "Found OPENCV 4.x")
+      set (KWIVER_HAS_OPENCV_VER_3 True)
+      set (KWIVER_HAS_OPENCV_VER_4 True)
+    elseif( OpenCV_VERSION VERSION_GREATER "3.0" OR
         OpenCV_VERSION VERSION_EQUAL "3.0")
-      message(STATUS "Found OPENCV 3.0")
+      message(STATUS "Found OPENCV 3.x")
       set (KWIVER_HAS_OPENCV_VER_3 True)
     endif()
 

--- a/CMake/kwiver-depends-OpenCV.cmake
+++ b/CMake/kwiver-depends-OpenCV.cmake
@@ -15,12 +15,14 @@ if( KWIVER_ENABLE_OPENCV )
     if( OpenCV_VERSION VERSION_GREATER "4.0" OR
         OpenCV_VERSION VERSION_EQUAL "4.0")
       message(STATUS "Found OPENCV 4.x")
-      set (KWIVER_HAS_OPENCV_VER_3 True)
-      set (KWIVER_HAS_OPENCV_VER_4 True)
+      set (KWIVER_OPENCV_VERSION_MAJOR 4)
     elseif( OpenCV_VERSION VERSION_GREATER "3.0" OR
-        OpenCV_VERSION VERSION_EQUAL "3.0")
+            OpenCV_VERSION VERSION_EQUAL "3.0")
       message(STATUS "Found OPENCV 3.x")
-      set (KWIVER_HAS_OPENCV_VER_3 True)
+      set (KWIVER_OPENCV_VERSION_MAJOR 3)
+    else()
+      message(STATUS "Found OPENCV 2.x")
+      set (KWIVER_OPENCV_VERSION_MAJOR 2)
     endif()
 
   else()

--- a/arrows/dbow2/CMakeLists.txt
+++ b/arrows/dbow2/CMakeLists.txt
@@ -39,10 +39,6 @@ set( dbow2_sources
   Timestamp.cxx
   )
 
-if( KWIVER_HAS_OPENCV_VER_3 )
-  add_definitions(-DKWIVER_HAS_OPENCV_VER_3)
-endif()
-
 kwiver_add_library( kwiver_algo_dbow2
   ${dbow2_headers_public}
   ${dbow2_headers_private}

--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -99,16 +99,12 @@ set( ocv_sources
   track_features_klt.cxx
   )
 
-if( KWIVER_HAS_OPENCV_VER_4 )
-  add_definitions(-DKWIVER_HAS_OPENCV_VER_4)
-endif()
-if( KWIVER_HAS_OPENCV_VER_3 )
-  add_definitions(-DKWIVER_HAS_OPENCV_VER_3)
-endif()
-
 kwiver_add_library( kwiver_algo_ocv
   ${ocv_headers_public}
   ${ocv_sources}
+  )
+target_compile_definitions( kwiver_algo_ocv
+  PUBLIC KWIVER_OPENCV_VERSION_MAJOR=${KWIVER_OPENCV_VERSION_MAJOR}
   )
 target_link_libraries( kwiver_algo_ocv
   PUBLIC               kwiver_algo_core

--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -99,6 +99,9 @@ set( ocv_sources
   track_features_klt.cxx
   )
 
+if( KWIVER_HAS_OPENCV_VER_4 )
+  add_definitions(-DKWIVER_HAS_OPENCV_VER_4)
+endif()
 if( KWIVER_HAS_OPENCV_VER_3 )
   add_definitions(-DKWIVER_HAS_OPENCV_VER_3)
 endif()

--- a/arrows/ocv/bounding_box.h
+++ b/arrows/ocv/bounding_box.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,12 +39,7 @@
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
 
 #include <vital/types/bounding_box.h>
-#ifndef KWIVER_HAS_OPENCV_VER_3
-#include <opencv2/core/types_c.h>      // OCV rect
-#else
-#include <opencv2/core.hpp>            // OCV rect
-#endif
-
+#include <opencv2/core.hpp>
 
 namespace kwiver {
 namespace arrows {
@@ -60,7 +55,7 @@ namespace ocv {
  * @return Equivalent bounding box.
  */
 template <typename T>
-kwiver::vital::bounding_box<T> convert( const CvRect& vbox )
+kwiver::vital::bounding_box<T> convert( const cv::Rect& vbox )
 {
   typename kwiver::vital::bounding_box<T>::vector_type bb_tl( vbox.x, vbox.y );
   return kwiver::vital::bounding_box<T>( bb_tl, vbox.width, vbox.height );
@@ -76,14 +71,14 @@ kwiver::vital::bounding_box<T> convert( const CvRect& vbox )
  * @return Equivalent CvRect
  */
 template <typename T>
-CvRect convert(const kwiver::vital::bounding_box<T>& bbox )
+cv::Rect convert(const kwiver::vital::bounding_box<T>& bbox )
 {
   // Note that CvRect has integer values. If T is a floating type. the
   // fractions are turncated.
-  return cvRect( static_cast<int>(bbox.min_x()),
-                 static_cast<int>(bbox.min_y()),
-                 static_cast<int>(bbox.width()),
-                 static_cast<int>(bbox.height()));
+  return { static_cast< int >( bbox.min_x() ),
+           static_cast< int >( bbox.min_y() ),
+           static_cast< int >( bbox.width() ),
+           static_cast< int >( bbox.height() ) };
 }
 
 

--- a/arrows/ocv/detect_features_AGAST.cxx
+++ b/arrows/ocv/detect_features_AGAST.cxx
@@ -36,7 +36,7 @@
 #include "detect_features_AGAST.h"
 
 // Only available in OpenCV 3.x
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
 
 using namespace kwiver::vital;
 
@@ -150,7 +150,7 @@ public:
   // Parameters
   int threshold;
   bool nonmax_suppression;
-#ifdef KWIVER_HAS_OPENCV_VER_4
+#if KWIVER_OPENCV_VERSION_MAJOR >= 4
   cv::AgastFeatureDetector::DetectorType type;
 #else
   int type;
@@ -208,4 +208,4 @@ detect_features_AGAST
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif //KWIVER_HAS_OPENCV_VER_3
+#endif //KWIVER_OPENCV_VERSION_MAJOR >= 3

--- a/arrows/ocv/detect_features_AGAST.cxx
+++ b/arrows/ocv/detect_features_AGAST.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -116,7 +116,7 @@ public:
     config->set_value( "nonmax_suppression", nonmax_suppression,
                        "if true, non-maximum suppression is applied to "
                        "detected corners (keypoints)" );
-    config->set_value( "type", type,
+    config->set_value( "type", static_cast< int >( type ),
                        "Neighborhood pattern type. Should be one of the "
                        "following enumeration type values:\n"
                        + list_agast_types() + " (default)" );
@@ -127,7 +127,7 @@ public:
   {
     threshold = config->get_value<int>( "threshold" );
     nonmax_suppression = config->get_value<bool>( "nonmax_suppression" );
-    type = config->get_value<int>( "type" );
+    type = static_cast< decltype( type ) >( config->get_value<int>( "type" ) );
   }
 
   /// Check config parameter values
@@ -150,7 +150,11 @@ public:
   // Parameters
   int threshold;
   bool nonmax_suppression;
+#ifdef KWIVER_HAS_OPENCV_VER_4
+  cv::AgastFeatureDetector::DetectorType type;
+#else
   int type;
+#endif
 };
 
 

--- a/arrows/ocv/detect_features_AGAST.h
+++ b/arrows/ocv/detect_features_AGAST.h
@@ -37,7 +37,7 @@
 #define KWIVER_ARROWS_DETECT_FEATURES_AGAST_H_
 
 // Only available in OpenCV 3.x
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
 
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/kwiver_algo_ocv_export.h>
@@ -83,6 +83,6 @@ private:
 } // end namespace kwiver
 
 
-#endif //KWIVER_HAS_OPENCV_VER_3
+#endif //KWIVER_OPENCV_VERSION_MAJOR >= 3
 
 #endif //KWIVER_ARROWS_DETECT_FEATURES_AGAST_H_

--- a/arrows/ocv/detect_features_FAST.cxx
+++ b/arrows/ocv/detect_features_FAST.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -102,7 +102,8 @@ public:
       "TYPE_5_8=" << cv::FastFeatureDetector::TYPE_5_8 << ", "
       "TYPE_7_12=" << cv::FastFeatureDetector::TYPE_7_12 << ", "
       "TYPE_9_16=" << cv::FastFeatureDetector::TYPE_9_16 << ".";
-    config->set_value( "neighborhood_type", neighborhood_type , ss.str());
+    config->set_value( "neighborhood_type",
+                       static_cast< int >( neighborhood_type ), ss.str());
 #endif
 
     config->set_value("target_num_features_detected", targetNumDetections,
@@ -118,7 +119,9 @@ public:
     nonmaxSuppression = config->get_value<bool>( "nonmaxSuppression" );
 
 #ifdef KWIVER_HAS_OPENCV_VER_3
-    neighborhood_type = config->get_value<int>( "neighborhood_type" );
+    neighborhood_type =
+      static_cast< decltype( neighborhood_type ) >(
+        config->get_value<int>( "neighborhood_type" ) );
 #endif
     targetNumDetections = config->get_value<int>("target_num_features_detected");
   }
@@ -150,7 +153,11 @@ public:
   mutable int threshold;
   bool nonmaxSuppression;
 #ifdef KWIVER_HAS_OPENCV_VER_3
+#ifdef KWIVER_HAS_OPENCV_VER_4
+  cv::FastFeatureDetector::DetectorType neighborhood_type;
+#else
   int neighborhood_type;
+#endif
 #endif
   int targetNumDetections;
 };

--- a/arrows/ocv/detect_features_FAST.cxx
+++ b/arrows/ocv/detect_features_FAST.cxx
@@ -51,7 +51,7 @@ public:
       nonmaxSuppression(true),
       targetNumDetections(2500)
   {
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     neighborhood_type = cv::FastFeatureDetector::TYPE_9_16;
 #endif
   }
@@ -59,7 +59,7 @@ public:
   /// Create a new FAST detector instance with the current parameter values
   cv::Ptr<cv::FastFeatureDetector> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     // 2.4.x version constructor
     return cv::Ptr<cv::FastFeatureDetector>(
         new cv::FastFeatureDetector(threshold, nonmaxSuppression)
@@ -74,7 +74,7 @@ public:
   /// Update the parameters of the given detector with the currently set values
   void update(cv::Ptr<cv::FeatureDetector> detector) const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     detector->set("threshold", threshold);
     detector->set("nonmaxSuppression", nonmaxSuppression);
 #else
@@ -96,7 +96,7 @@ public:
                        "if true, non-maximum suppression is applied to "
                        "detected corners (keypoints)" );
 
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     std::stringstream ss;
     ss << "one of the three neighborhoods as defined in the paper: "
       "TYPE_5_8=" << cv::FastFeatureDetector::TYPE_5_8 << ", "
@@ -118,7 +118,7 @@ public:
     threshold = config->get_value<int>( "threshold" );
     nonmaxSuppression = config->get_value<bool>( "nonmaxSuppression" );
 
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     neighborhood_type =
       static_cast< decltype( neighborhood_type ) >(
         config->get_value<int>( "neighborhood_type" ) );
@@ -132,7 +132,7 @@ public:
   {
     bool valid = true;
 
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     // Check that the input integer is one of the valid enum values
     int nt = config->get_value<int>( "neighborhood_type" );
     if( ! ( nt == cv::FastFeatureDetector::TYPE_5_8 ||
@@ -152,8 +152,8 @@ public:
 
   mutable int threshold;
   bool nonmaxSuppression;
-#ifdef KWIVER_HAS_OPENCV_VER_3
-#ifdef KWIVER_HAS_OPENCV_VER_4
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 4
   cv::FastFeatureDetector::DetectorType neighborhood_type;
 #else
   int neighborhood_type;

--- a/arrows/ocv/detect_features_GFTT.cxx
+++ b/arrows/ocv/detect_features_GFTT.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,7 +59,7 @@ public:
   /// Create a new GFTT detector instance with the current parameter values
   cv::Ptr<cv::GFTTDetector> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv::GFTTDetector>(
       new cv::GFTTDetector( max_corners, quality_level, min_distance,
                             block_size, use_harris_detector, k )
@@ -70,7 +70,7 @@ public:
 #endif
   }
 
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
   /// Update the parameters of the given detector with the currently set values
   /**
    * Returns false if the algo could not be updating, requiring recreation.
@@ -151,7 +151,7 @@ detect_features_GFTT
   config_block_sptr c = get_configuration();
   c->merge_config( config );
   p_->set_config( c );
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   // since 2.4.x does not have params set for everything that's given to the
   // constructor, lets just remake the algo instance.
   detector = p_->create();

--- a/arrows/ocv/detect_features_MSER.cxx
+++ b/arrows/ocv/detect_features_MSER.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,13 +56,13 @@ public:
       min_margin( 0.003 ),
       edge_blur_size( 5 )
   {
-    #ifdef KWIVER_HAS_OPENCV_VER_3
+    #if KWIVER_OPENCV_VERSION_MAJOR >= 3
     pass2only = false;
     #endif
   }
 
   cv::Ptr<cv::MSER> create() const {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     // 2.4.x version constructor
     return cv::Ptr<cv::MSER>(
         new cv::MSER( delta, min_area, max_area, max_variation,
@@ -106,7 +106,7 @@ public:
                        "For color images, ignore too-small regions." );
     config->set_value( "edge_blur_size", edge_blur_size,
                        "For color images, the aperture size for edge blur" );
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     config->set_value( "pass2only", pass2only, "Undocumented" );
 #endif
   }
@@ -123,7 +123,7 @@ public:
     area_threshold = c->get_value<double>("area_threshold");
     min_margin = c->get_value<double>("min_margin");
     edge_blur_size = c->get_value<int>("edge_blur_size");
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     pass2only = c->get_value<bool>("pass2only");
 #endif
   }
@@ -156,7 +156,7 @@ public:
   double area_threshold;
   double min_margin;
   int edge_blur_size;
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
   bool pass2only;
 #endif
 };

--- a/arrows/ocv/detect_features_STAR.cxx
+++ b/arrows/ocv/detect_features_STAR.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,9 @@
 
 #include "detect_features_STAR.h"
 
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
 typedef cv::StarDetector cv_STAR_t;
 #else
 #include <opencv2/xfeatures2d.hpp>
@@ -65,7 +65,7 @@ public:
 
   cv::Ptr<cv_STAR_t> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv_STAR_t>(
       new cv_STAR_t( max_size, response_threshold, line_threshold_projected,
                      line_threshold_binarized, suppress_nonmax_size )
@@ -77,7 +77,7 @@ public:
 #endif
   }
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   void update( cv::Ptr<cv_STAR_t> a ) const
   {
     a->set( "maxSize", max_size );
@@ -147,7 +147,7 @@ detect_features_STAR
   config_block_sptr c = get_configuration();
   c->merge_config( config );
   p_->set_config( c );
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( detector );
 #else
   detector = p_->create();

--- a/arrows/ocv/detect_features_STAR.h
+++ b/arrows/ocv/detect_features_STAR.h
@@ -37,7 +37,7 @@
 #define KWIVER_ARROWS_DETECT_FEATURES_STAR_H_
 
 #include <opencv2/opencv_modules.hpp>
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
 #include <memory>
 #include <string>

--- a/arrows/ocv/detect_features_simple_blob.cxx
+++ b/arrows/ocv/detect_features_simple_blob.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ public:
   /// Create new algorithm based on current parameter values
   cv::Ptr<cv::SimpleBlobDetector> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv::SimpleBlobDetector>(
       new cv::SimpleBlobDetector( p )
     );

--- a/arrows/ocv/detect_heat_map.cxx
+++ b/arrows/ocv/detect_heat_map.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017-2019 by Kitware, Inc.
+ * Copyright 2017-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -621,7 +621,7 @@ public:
     mask.col(0) = 0;
     mask.row(mask.rows-1) = 0;
     mask.col(mask.cols-1) = 0;
-    cv::findContours(mask, contours, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE,
+    cv::findContours(mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE,
                      cv::Point(0, 0) );
 
     auto dot = std::make_shared< detected_object_type >();

--- a/arrows/ocv/detect_motion_3frame_differencing.cxx
+++ b/arrows/ocv/detect_motion_3frame_differencing.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -71,7 +71,7 @@ rms_over_channels( const cv::Mat &src, cv::Mat &dst)
 {
   cv::Mat *src_split = new cv::Mat[src.channels()];
   cv::split(src, src_split);
-  cv::Mat accum = cv::Mat(src.rows, src.cols, CV_32F, cvScalar(0));
+  cv::Mat accum = cv::Mat(src.rows, src.cols, CV_32F, cv::Scalar(0));
   for( int i=0; i<src.channels(); ++i)
   {
     cv::Mat temp;
@@ -178,7 +178,7 @@ public:
     {
       LOG_TRACE( m_logger, "Haven't collected enough frames yet, so setting "
                            "foreground mask to all zeros.");
-      fgmask = cv::Mat(cv_src.rows, cv_src.cols, CV_8UC1, cvScalar(0));
+      fgmask = cv::Mat(cv_src.rows, cv_src.cols, CV_8UC1, cv::Scalar(0));
       return;
     }
 

--- a/arrows/ocv/detect_motion_mog2.cxx
+++ b/arrows/ocv/detect_motion_mog2.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2017 by Kitware, Inc.
+ * Copyright 2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,7 +88,7 @@ public:
   void reset()
   {
     m_frame_count = 0;
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     bg_model = cv::createBackgroundSubtractorMOG2( m_history, m_var_threshold, false );
     bg_model->setNMixtures( m_nmixtures );
 #else
@@ -226,7 +226,7 @@ detect_motion_mog2
   }
 
   cv::Mat fgmask;
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
   d_->bg_model->apply( cv_src, fgmask, d_->m_learning_rate );
 #else
   d_->bg_model->operator()(cv_src, fgmask, d_->m_learning_rate);

--- a/arrows/ocv/draw_detected_object_set.cxx
+++ b/arrows/ocv/draw_detected_object_set.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -194,7 +194,7 @@ public:
 
       cv::Size text = cv::getTextSize( txt, fontface, scale, thickness, &baseline );
       cv::rectangle( overlay, pt + cv::Point( 0, baseline ), pt +
-                     cv::Point( text.width, -text.height ), cv::Scalar( 0, 0, 0 ), CV_FILLED );
+                     cv::Point( text.width, -text.height ), cv::Scalar( 0, 0, 0 ), cv::FILLED );
 
       cv::putText( overlay, txt, pt, fontface, scale, cv::Scalar( 255, 255, 255 ), thickness, 8 );
     }

--- a/arrows/ocv/draw_tracks.cxx
+++ b/arrows/ocv/draw_tracks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014-2018 by Kitware, Inc.
+ * Copyright 2014-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -370,7 +370,7 @@ draw_tracks
     // Convert to 3 channel image if not one already
     if( img.channels() == 1 )
     {
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
       cv::cvtColor( img, img, cv::COLOR_GRAY2BGR );
 #else
       cv::cvtColor( img, img, CV_GRAY2BGR );

--- a/arrows/ocv/estimate_fundamental_matrix.cxx
+++ b/arrows/ocv/estimate_fundamental_matrix.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -149,7 +149,7 @@ estimate_fundamental_matrix
 
   cv::Mat inliers_mat;
   cv::Mat F = cv::findFundamentalMat( cv::Mat(points1), cv::Mat(points2),
-                                      CV_FM_RANSAC,
+                                      cv::FM_RANSAC,
                                       inlier_scale,
                                       d_->confidence_threshold,
                                       inliers_mat );

--- a/arrows/ocv/estimate_homography.cxx
+++ b/arrows/ocv/estimate_homography.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016 by Kitware, Inc.
+ * Copyright 2013-2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/core/eigen.hpp>
 
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
 #define OPENCV_METHOD_RANSAC cv::RANSAC
 #else
 #define OPENCV_METHOD_RANSAC CV_RANSAC

--- a/arrows/ocv/extract_descriptors_BRIEF.cxx
+++ b/arrows/ocv/extract_descriptors_BRIEF.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,11 +35,11 @@
 
 #include "extract_descriptors_BRIEF.h"
 
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
 #include <sstream>
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
 typedef cv::BriefDescriptorExtractor cv_BRIEF_t;
 #else
 #include <opencv2/xfeatures2d.hpp>
@@ -59,7 +59,7 @@ public:
   /// Constructor
   priv()
     : bytes( 32 )
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     , use_orientation( false )
 #endif
   {
@@ -68,14 +68,14 @@ public:
   /// Create new algorithm instance using current parameter values
   cv::Ptr<cv_BRIEF_t> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv_BRIEF_t>( new cv_BRIEF_t(bytes) );
 #else
     return cv_BRIEF_t::create( bytes, use_orientation );
 #endif
   }
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   /// Update given algorithm using current parameter values
   void update(cv::Ptr<cv_BRIEF_t> descriptor) const
   {
@@ -88,7 +88,7 @@ public:
     config->set_value( "bytes", bytes,
                        "Length of descriptor in bytes. It can be equal 16, 32 "
                        "or 64 bytes." );
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     config->set_value( "use_orientation", use_orientation,
                        "sample patterns using keypoints orientation, disabled "
                        "by default." );
@@ -98,7 +98,7 @@ public:
   void set_config( config_block_sptr config )
   {
     bytes = config->get_value<int>( "bytes" );
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     use_orientation = config->get_value<bool>( "use_orientation" );
 #endif
   }
@@ -121,7 +121,7 @@ public:
 
   // Parameters
   int bytes;
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
   bool use_orientation;
 #endif
 };
@@ -163,7 +163,7 @@ extract_descriptors_BRIEF
   c->merge_config( config );
   p_->set_config( c );
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( extractor );
 #else
   extractor = p_->create();

--- a/arrows/ocv/extract_descriptors_BRIEF.h
+++ b/arrows/ocv/extract_descriptors_BRIEF.h
@@ -37,7 +37,7 @@
 #define KWIVER_ARROWS_EXTRACT_DESCRIPTORS_BRIEF_H_
 
 #include <opencv2/opencv_modules.hpp>
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
 #include <vital/algo/extract_descriptors.h>
 

--- a/arrows/ocv/extract_descriptors_FREAK.cxx
+++ b/arrows/ocv/extract_descriptors_FREAK.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,10 +35,10 @@
 
 #include "extract_descriptors_FREAK.h"
 
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
 // typedef FREAK into a common symbol
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
 typedef cv::FREAK cv_FREAK_t;
 #else
 #include <opencv2/xfeatures2d.hpp>
@@ -65,7 +65,7 @@ public:
   /// Create new cv::Ptr algo instance
   cv::Ptr<cv_FREAK_t> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv_FREAK_t>(
         new cv_FREAK_t( orientation_normalized, scale_normalized, pattern_scale,
                         n_octaves )
@@ -76,7 +76,7 @@ public:
 #endif
   }
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   /// Update algorithm instance with current parameter values
   void update( cv::Ptr<cv_FREAK_t> freak ) const
   {
@@ -151,7 +151,7 @@ extract_descriptors_FREAK
   vital::config_block_sptr c = get_configuration();
   c->merge_config( config );
   p_->set_config( c );
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( extractor );
 #else
   extractor = p_->create();
@@ -171,4 +171,4 @@ extract_descriptors_FREAK
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif //! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#endif //KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)

--- a/arrows/ocv/extract_descriptors_FREAK.h
+++ b/arrows/ocv/extract_descriptors_FREAK.h
@@ -37,7 +37,7 @@
 #define KWIVER_ARROWS_EXTRACT_DESCRIPTORS_FREAK_H_
 
 #include <opencv2/opencv_modules.hpp>
-#if ! defined(KWIVER_HAS_OPENCV_VER_3) || defined(HAVE_OPENCV_XFEATURES2D)
+#if KWIVER_OPENCV_VERSION_MAJOR < 3 || defined(HAVE_OPENCV_XFEATURES2D)
 
 #include <memory>
 #include <string>

--- a/arrows/ocv/feature_detect_extract_BRISK.cxx
+++ b/arrows/ocv/feature_detect_extract_BRISK.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public:
   /// Create new impl instance based on current parameters
   cv::Ptr<cv::BRISK> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv::BRISK>(
       new cv::BRISK( threshold, octaves, pattern_scale )
     );

--- a/arrows/ocv/feature_detect_extract_ORB.cxx
+++ b/arrows/ocv/feature_detect_extract_ORB.cxx
@@ -58,7 +58,7 @@ public:
      , wta_k( 2 )
      , score_type( cv::ORB::HARRIS_SCORE )
      , patch_size( 31 )
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
      , fast_threshold( 20 )
 #endif
   {
@@ -67,7 +67,7 @@ public:
   /// Create new impl instance based on current parameters
   cv::Ptr<cv::ORB> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv::ORB>(
        new cv::ORB( n_features, scale_factor, n_levels, edge_threshold,
                             first_level, wta_k, score_type, patch_size )
@@ -136,7 +136,7 @@ public:
                            "descriptor. Of course, on smaller pyramid layers "
                            "the perceived image area covered by a feature will "
                            "be larger." );
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     config->set_value( "fast_threshold", fast_threshold, "Undocumented" );
 #endif
   }
@@ -154,7 +154,7 @@ public:
       static_cast< decltype( score_type ) >(
         config->get_value<int>("score_type") );
     patch_size = config->get_value<int>("patch_size");
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
     fast_threshold = config->get_value<int>("fast_threshold");
 #endif
   }
@@ -181,7 +181,7 @@ public:
   /// Update algo with current parameter values
   void update_algo(cv::Ptr<cv::ORB> orb) const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     orb->set( "nFeatures", n_features );
     orb->set( "scaleFactor", scale_factor );
     orb->set( "nLevels", n_levels );
@@ -210,13 +210,13 @@ public:
   int edge_threshold;
   int first_level;
   int wta_k;
-#ifdef KWIVER_HAS_OPENCV_VER_4
+#if KWIVER_OPENCV_VERSION_MAJOR >= 4
   cv::ORB::ScoreType score_type;
 #else
   int score_type;
 #endif
   int patch_size;
-#ifdef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR >= 3
   int fast_threshold;
 #endif
 };
@@ -268,7 +268,7 @@ detect_features_ORB
   config_block_sptr c = get_configuration();
   c->merge_config(config);
   p_->set_configuration(c);
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update_algo( detector );
 #else
   p_->update_algo( detector.dynamicCast<cv::ORB>() );
@@ -318,7 +318,7 @@ extract_descriptors_ORB
   config_block_sptr c = get_configuration();
   c->merge_config(config);
   p_->set_configuration(c);
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update_algo( extractor );
 #else
   p_->update_algo( extractor.dynamicCast<cv::ORB>() );

--- a/arrows/ocv/feature_detect_extract_ORB.cxx
+++ b/arrows/ocv/feature_detect_extract_ORB.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,7 +129,8 @@ public:
        << "features); FAST_SCORE (value=" << cv::ORB::FAST_SCORE << ") is "
        << "alternative value of the parameter that produces slightly less "
        << "stable key-points, but it is a little faster to compute.";
-    config->set_value( "score_type", score_type, ss.str() );
+    config->set_value( "score_type", static_cast< int >( score_type ),
+                       ss.str() );
     config->set_value( "patch_size", patch_size,
                        "Size of the patch used by the oriented BRIEF "
                            "descriptor. Of course, on smaller pyramid layers "
@@ -149,7 +150,9 @@ public:
     edge_threshold = config->get_value<int>("edge_threshold");
     first_level = config->get_value<int>("first_level");
     wta_k = config->get_value<int>("wta_k");
-    score_type = config->get_value<int>("score_type");
+    score_type =
+      static_cast< decltype( score_type ) >(
+        config->get_value<int>("score_type") );
     patch_size = config->get_value<int>("patch_size");
 #ifdef KWIVER_HAS_OPENCV_VER_3
     fast_threshold = config->get_value<int>("fast_threshold");
@@ -207,7 +210,11 @@ public:
   int edge_threshold;
   int first_level;
   int wta_k;
+#ifdef KWIVER_HAS_OPENCV_VER_4
+  cv::ORB::ScoreType score_type;
+#else
   int score_type;
+#endif
   int patch_size;
 #ifdef KWIVER_HAS_OPENCV_VER_3
   int fast_threshold;

--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@
 
 // Include the correct file and unify different namespace locations of SIFT type
 // across versions
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
 // 2.4.x header location
 #include <opencv2/nonfree/features2d.hpp>
 typedef cv::SIFT cv_SIFT_t;
@@ -77,7 +77,7 @@ public:
   // Create new algorithm instance from current parameters
   cv::Ptr<cv_SIFT_t> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv_SIFT_t>(
       new cv_SIFT_t( n_features, n_octave_layers, contrast_threshold,
                      edge_threshold, sigma )
@@ -88,7 +88,7 @@ public:
 #endif
   }
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   // Update algorithm with current parameter, 2.4.x only
   void update( cv::Ptr<cv_SIFT_t> a ) const
   {
@@ -195,7 +195,7 @@ detect_features_SIFT
   c->merge_config( config );
   p_->set_config( c );
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( detector );
 #else
   // version 3.x doesn't have parameter update methods
@@ -244,7 +244,7 @@ extract_descriptors_SIFT
   config_block_sptr c = get_configuration();
   c->merge_config(config);
   p_->set_config(c);
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( extractor );
 #else
   extractor = p_->create();

--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2018 by Kitware, Inc.
+ * Copyright 2016-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@
 
 // Include the correct file and unify different namespace locations of SURF type
 // across versions
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
 // 2.4.x header location
 #include <opencv2/nonfree/features2d.hpp>
 typedef cv::SURF cv_SURF_t;
@@ -77,7 +77,7 @@ public:
   // Create new algorithm instance from current parameters
   cv::Ptr<cv_SURF_t> create() const
   {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
     return cv::Ptr<cv_SURF_t>(
       new cv_SURF_t( hessian_threshold, n_octaves, n_octave_layers,
                      extended, upright  )
@@ -88,7 +88,7 @@ public:
 #endif
   }
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   // Update algorithm with current parameter
   void update( cv::Ptr<cv_SURF_t> a ) const
   {
@@ -186,7 +186,7 @@ detect_features_SURF
   c->merge_config( config );
   p_->set_config( c );
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( detector );
 #else
   // Create a new detector rather than update on version 3.
@@ -237,7 +237,7 @@ extract_descriptors_SURF
   c->merge_config( config );
   p_->set_config( c );
 
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   p_->update( extractor );
 #else
   // Create a new detector rather than update on version 3.

--- a/arrows/ocv/hough_circle_detector.cxx
+++ b/arrows/ocv/hough_circle_detector.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016, 2019 by Kitware, Inc.
+ * Copyright 2016, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -177,7 +177,7 @@ detect( vital::image_container_sptr image_data) const
   cv::Mat src_gray;
 
   // Convert it to gray
-  cvtColor( src, src_gray, CV_BGR2GRAY );
+  cvtColor( src, src_gray, cv::COLOR_BGR2GRAY );
 
   // Reduce the noise so we avoid false circle detection
   cv::GaussianBlur( src_gray, src_gray, cv::Size( 9, 9 ), 2, 2 );
@@ -187,7 +187,7 @@ detect( vital::image_container_sptr image_data) const
   // Apply the Hough Transform to find the circles
   cv::HoughCircles( src_gray, // i: source image
                     circles, // o: detected circles
-                    CV_HOUGH_GRADIENT, // i: method
+                    cv::HOUGH_GRADIENT, // i: method
                     d->m_dp, // i: dp
                     d->m_min_dist, //+ src_gray.rows / 8, // i: minDist
                     d->m_param1, // i: param1 for canny edge detector

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -116,7 +116,7 @@ image_container
   // counted reference too it.  If it doesn't own its memory, then the
   // vital image won't take ownership either
   image_memory_sptr memory;
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   if ( img.refcount )
 #else
   if ( img.u )
@@ -192,7 +192,7 @@ image_container
           dynamic_cast<mat_image_memory*>(memory.get()) )
     {
       // extract the existing reference counter from the VITAL wrapper
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
       out.refcount = mat_memory->get_ref_counter();
 #else
       out.u = mat_memory->get_umatdata();

--- a/arrows/ocv/image_container.cxx
+++ b/arrows/ocv/image_container.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2018 by Kitware, Inc.
+ * Copyright 2013-2018, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ image_container
         cv::Mat new_color;
         new_color.create( d.rows, d.cols, d.type() );
 
-        cv::cvtColor(data_, new_color, (data_.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        cv::cvtColor(data_, new_color, (data_.channels() == 3)?cv::COLOR_BGR2RGB:cv::COLOR_BGRA2RGBA);
         data_ = new_color;
         break;
       }
@@ -215,7 +215,7 @@ image_container
         case CV_32F:
         {
           cv::Mat bgr;
-          cv::cvtColor(out, bgr, (out.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+          cv::cvtColor(out, bgr, (out.channels() == 3)?cv::COLOR_BGR2RGB:cv::COLOR_BGRA2RGBA);
           return bgr;
         }
         case CV_8S:
@@ -251,7 +251,7 @@ image_container
       case CV_32F:
       {
         cv::Mat bgr;
-        cv::cvtColor(out, bgr, (out.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        cv::cvtColor(out, bgr, (out.channels() == 3)?cv::COLOR_BGR2RGB:cv::COLOR_BGRA2RGBA);
         return bgr;
       }
       case CV_8S:
@@ -332,7 +332,7 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
   if(const ocv::image_container* c =
           dynamic_cast<const ocv::image_container*>(&img))
   {
-    if(cm != image_container::BGR_COLOR || 
+    if(cm != image_container::BGR_COLOR ||
       result.channels() < 3 || result.channels() > 4)
     {
       //Want something other than a BGR(A) image
@@ -352,7 +352,7 @@ image_container_to_ocv_matrix(const vital::image_container& img, image_container
       case CV_8U:
       case CV_16U:
       case CV_32F:
-        cv::cvtColor(result, result, (result.channels() == 3)?CV_BGR2RGB:CV_BGRA2RGBA);
+        cv::cvtColor(result, result, (result.channels() == 3)?cv::COLOR_BGR2RGB:cv::COLOR_BGRA2RGBA);
         break;
       case CV_8S:
       case CV_16S:

--- a/arrows/ocv/mat_image_memory.cxx
+++ b/arrows/ocv/mat_image_memory.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2015 by Kitware, Inc.
+ * Copyright 2013-2015, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,13 +53,13 @@ namespace ocv
 mat_image_memory
 ::mat_image_memory(const cv::Mat& m)
 : mat_data_( const_cast<unsigned char*>(m.datastart) ),
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   mat_refcount_(m.refcount)
 #else
   u_( m.u )
 #endif
 {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   if ( this->mat_refcount_ )
   {
     CV_XADD(this->mat_refcount_, 1);
@@ -78,7 +78,7 @@ mat_image_memory
 mat_image_memory
 ::~mat_image_memory()
 {
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   if( this->mat_refcount_ && CV_XADD(this->mat_refcount_, -1) == 1 )
 #else
   if( u_ && CV_XADD( &u_->refcount, -1 ) == 1 )

--- a/arrows/ocv/mat_image_memory.h
+++ b/arrows/ocv/mat_image_memory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2016, 2019 by Kitware, Inc.
+ * Copyright 2013-2016, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ public:
   virtual void* data() { return this->mat_data_; }
 
   /// Return the OpenCV reference counter
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   int* get_ref_counter() const { return this->mat_refcount_; }
 #else
   cv::UMatData* get_umatdata() const { return this->u_; }
@@ -74,7 +74,7 @@ protected:
   unsigned char* mat_data_;
 
   /// The ref count shared with cv::Mat
-#ifndef KWIVER_HAS_OPENCV_VER_3
+#if KWIVER_OPENCV_VERSION_MAJOR < 3
   int* mat_refcount_;
 #else
   cv::UMatData *u_;

--- a/arrows/ocv/tests/test_bounding_box.cxx
+++ b/arrows/ocv/tests/test_bounding_box.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
+ * Copyright 2016-2017, 2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,7 +59,7 @@ TEST(bounding_box, convert_bb2ocv)
 // ----------------------------------------------------------------------------
 TEST(bounding_box, convert_ocv2bb)
 {
-  CvRect vbox= cvRect( 1, 3, 10, 34 );
+  auto vbox= cv::Rect( 1, 3, 10, 34 );
   auto const& bbox = kwiver::arrows::ocv::convert<double>( vbox );
 
   EXPECT_EQ( vbox.x, bbox.min_x() );


### PR DESCRIPTION
Update OpenCV arrow to be able to compile against OpenCV 4.x. A shocking lot of the changes are simply "don't rely on the C API", which we shouldn't be (ab)using in C++ code anyway. In fact, just stop including any C API headers, which seems to be much more portable across different versions of OpenCV anyway.