### PR TITLE
Removed plugin loader calls from applet.

### DIFF
--- a/arrows/mvg/applets/track_features.h
+++ b/arrows/mvg/applets/track_features.h
@@ -47,8 +47,8 @@ public:
   PLUGIN_INFO( "track_features",
                "Feature tracking utility");
 
-  virtual int run() override;
-  virtual void add_command_options() override;
+  int run() override;
+  void add_command_options() override;
 
 }; // end of class
 

--- a/vital/applets/kwiver_applet.h
+++ b/vital/applets/kwiver_applet.h
@@ -61,6 +61,14 @@ public:
 
   void initialize( kwiver::tools::applet_context* ctxt );
 
+  /**
+   * @brief Main part of the applet.
+   *
+   * This method implements the main functionality of the applet. This
+   * is called for the applet to do its stuff.
+   *
+   * @return Application return code.
+   */
   virtual int run() = 0;
 
   /**


### PR DESCRIPTION
There is no need to load plugins from an applet. An applet is a plugin, so all plugins have to be already loaded before an applet can be instantiated. 

Also minor changes:
-Shorten name spaces
-converted some types to auto const