### PR TITLE
Work around MOC bug

### DIFF
--- a/vital/klv/convert_0601_metadata.cxx
+++ b/vital/klv/convert_0601_metadata.cxx
@@ -268,9 +268,9 @@ convert_metadata
 
       // Source specific metadata tags
 
-      // These are prefixed with the spec. number because the data format is specification specific.
-      CASE2( WEAPON_LOAD, 0601_WEAPON_LOAD );
-      CASE2( WEAPON_FIRED, 0601_WEAPON_FIRED );
+      // These are suffixed with the spec. number because the data format is specification specific.
+      CASE2( WEAPON_LOAD, WEAPON_LOAD_0601 );
+      CASE2( WEAPON_FIRED, WEAPON_FIRED_0601 );
 
 #undef CASE
 #undef CASE2

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016-2017, 2019 by Kitware, Inc.
+ * Copyright 2016-2017, 2019-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -361,11 +361,11 @@
         "Security Local Metadata Set",                                  \
         std::string,                                                    \
         "Refer to std 0102 lds" )                                       \
-  CALL( 0601_WEAPON_LOAD,                                               \
+  CALL( WEAPON_LOAD_0601,                                               \
         "Weapon Load",                                                  \
         uint64_t,                                                       \
         "Current weapons stored on aircraft" )                          \
-  CALL( 0601_WEAPON_FIRED,                                              \
+  CALL( WEAPON_FIRED_0601,                                              \
         "Weapon Fired",                                                 \
         uint64_t,                                                       \
         "Indication when a particular weapon is released. "             \


### PR DESCRIPTION
Rename some metadata items to work around a bug in Qt's MOC where it chokes on macro arguments that start with numbers.

Even though this code doesn't use Qt itself, the issue makes it impossible for Qt users to include this header, which can prevent Qt applications from using KWIVER.

See also https://bugreports.qt.io/browse/QTBUG-87219.