### PR TITLE
Write externally-readable JSON metadata maps

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -55,3 +55,9 @@ Arrows: OpenCV
    A workaround was previously added that forced a deep copy, but this created
    another bug resulting in images with invalid first_pixel() values.
    Both of these issues have been addressed.
+
+Arrows: Serialize
+
+ * Fixed a bug in JSON serialization of metadata maps which caused name
+   collisions for multiple metadata packets associated the same frame. This
+   made the output unusable by applications other than KWIVER.


### PR DESCRIPTION
Previously, JSON serialization of metadata maps for a video would
have the same key for each packet of metadata associated with one
frame. While this could be handled internally by relying on aditional
serialized data, external applications would only be able to access
one packet.