### PR TITLE
Reduce warnings from shadowing symbols

### DIFF
--- a/CMake/kwiver-flags-gnu.cmake
+++ b/CMake/kwiver-flags-gnu.cmake
@@ -17,6 +17,7 @@ kwiver_check_compiler_flag( -Werror=overloaded-virtual )
 kwiver_check_compiler_flag( -Werror=cast-qual )
 kwiver_check_compiler_flag( -Werror=vla )
 kwiver_check_compiler_flag( -Wunused-parameter )
+kwiver_check_compiler_flag( -Wshadow=local )
 
 # to slience this warning
 kwiver_check_compiler_flag( -Wno-unknown-pragmas )
@@ -55,8 +56,6 @@ if (KWIVER_CPP_EXTRA)
 
   # TODO: Python triggers warnings with this
   kwiver_check_compiler_flag(-Wold-style-cast)
-  # Variable naming warnings
-  kwiver_check_compiler_flag(-Wshadow)
   # Exception warnings
   kwiver_check_compiler_flag(-Wnoexcept)
   # Miscellaneous warnings
@@ -66,6 +65,7 @@ if (KWIVER_CPP_EXTRA)
   kwiver_check_compiler_flag(-Wdocumentation)
   kwiver_check_compiler_flag(-Wundef)
   kwiver_check_compiler_flag(-Wunused-macros)
+  kwiver_check_compiler_flag( -Wshadow )
 endif()
 
 OPTION(KWIVER_CPP_NITPICK "Generate warnings about nitpicky things" OFF)

--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -678,17 +678,17 @@ camera_options
     const double scale = constraints.size() / sum_dist;
     auto scaled_loss = new ::ceres::ScaledLoss(NULL, weight,
                            ::ceres::Ownership::TAKE_OWNERSHIP);
-    for (auto curr_cam : constraints)
+    for (auto curr_cam_constr : constraints)
     {
-      auto prev_cam = curr_cam - 1;
-      double inv_dist = 1.0 / static_cast<double>(curr_cam->first -
-                                                  prev_cam->first);
+      auto p_cam = curr_cam_constr - 1;
+      double inv_dist = 1.0 / static_cast<double>(curr_cam_constr->first -
+                                                  p_cam->first);
       ::ceres::CostFunction* fwd_mo_cost =
         camera_limit_forward_motion::create(scale * inv_dist);
       problem.AddResidualBlock(fwd_mo_cost,
                                scaled_loss,
-                               prev_cam->second,
-                               curr_cam->second);
+                               p_cam->second,
+                               curr_cam_constr->second);
     }
   }
 }

--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -678,17 +678,17 @@ camera_options
     const double scale = constraints.size() / sum_dist;
     auto scaled_loss = new ::ceres::ScaledLoss(NULL, weight,
                            ::ceres::Ownership::TAKE_OWNERSHIP);
-    for (auto curr_cam_constr : constraints)
+    for (auto curr_constraint : constraints)
     {
-      auto p_cam = curr_cam_constr - 1;
-      double inv_dist = 1.0 / static_cast<double>(curr_cam_constr->first -
-                                                  p_cam->first);
+      auto prev_constraint = curr_constraint - 1;
+      double inv_dist = 1.0 / static_cast<double>(curr_constraint->first -
+                                                  prev_constraint->first);
       ::ceres::CostFunction* fwd_mo_cost =
         camera_limit_forward_motion::create(scale * inv_dist);
       problem.AddResidualBlock(fwd_mo_cost,
                                scaled_loss,
-                               p_cam->second,
-                               curr_cam_constr->second);
+                               prev_constraint->second,
+                               curr_constraint->second);
     }
   }
 }

--- a/arrows/core/close_loops_keyframe.cxx
+++ b/arrows/core/close_loops_keyframe.cxx
@@ -272,14 +272,14 @@ close_loops_keyframe
     all_matches[*f] = pool.enqueue(match_func, *f);
   }
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    all_matches[*kitr] = pool.enqueue(match_func, *kitr);
+    all_matches[*k_itr] = pool.enqueue(match_func, *k_itr);
   }
 
 
@@ -331,20 +331,20 @@ close_loops_keyframe
     static_cast<unsigned int>(last_frame_itr - frames.rbegin() - 2);
 
   // stitch with all previous keyframes
-  for(auto kitr = keyframes.rbegin(); kitr != keyframes.rend(); ++kitr)
+  for(auto k_itr = keyframes.rbegin(); k_itr != keyframes.rend(); ++k_itr)
   {
     // if this frame was already matched above then skip it
-    if(last_frame_itr == frames.rend() || *kitr >= *last_frame_itr)
+    if(last_frame_itr == frames.rend() || *k_itr >= *last_frame_itr)
     {
       continue;
     }
-    if (!all_matches[*kitr].valid())
+    if (!all_matches[*k_itr].valid())
     {
       LOG_WARN(logger(), "keyframe match from "<< frame_number << " to "
-                         << *kitr << " not available");
+                         << *k_itr << " not available");
       continue;
     }
-    auto const& matches = all_matches[*kitr].get();
+    auto const& matches = all_matches[*k_itr].get();
     int num_matched = static_cast<int>(matches.size());
     int num_linked = 0;
     if( num_matched >= d_->match_req )
@@ -357,7 +357,7 @@ close_loops_keyframe
         }
       }
     }
-    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *kitr
+    LOG_INFO(logger(), "Matching frame " << frame_number << " to keyframe "<< *k_itr
                        << " has "<< num_matched << " matches and "
                        << num_linked << " joined tracks");
     if( num_matched > max_keyframe_matched )
@@ -373,7 +373,7 @@ close_loops_keyframe
     {
       break;
     }
-  }
+  } // end for
 
 
   // keep track of frames that matched no keyframes

--- a/arrows/core/depth_utils.cxx
+++ b/arrows/core/depth_utils.cxx
@@ -159,8 +159,8 @@ project_3d_bounds(kwiver::vital::vector_3d const& minpt,
 
   for (vector_3d const& p : points)
   {
-    vector_2d pp = cam.project(p);
-    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(pp[1]);
+    const vector_2d p_p = cam.project(p);
+    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(p_p[1]);
     i0 = std::min(i0, ui);
     j0 = std::min(j0, vi);
     i1 = std::max(i1, ui);

--- a/arrows/core/depth_utils.cxx
+++ b/arrows/core/depth_utils.cxx
@@ -153,14 +153,16 @@ project_3d_bounds(kwiver::vital::vector_3d const& minpt,
   std::vector<vector_3d> points = points_of_box(minpt, maxpt);
 
   int i0, j0, i1, j1;
-  vector_2d pp = cam.project(points[0]);
-  i0 = i1 = static_cast<int>(pp[0]);
-  j0 = j1 = static_cast<int>(pp[1]);
+  {
+    vector_2d pp = cam.project(points[0]);
+    i0 = i1 = static_cast<int>(pp[0]);
+    j0 = j1 = static_cast<int>(pp[1]);
+  }
 
   for (vector_3d const& p : points)
   {
-    const vector_2d p_p = cam.project(p);
-    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(p_p[1]);
+    const vector_2d pp = cam.project(p);
+    int ui = static_cast<int>(pp[0]), vi = static_cast<int>(pp[1]);
     i0 = std::min(i0, ui);
     j0 = std::min(j0, vi);
     i1 = std::max(i1, ui);

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -235,9 +235,9 @@ write_set( const kwiver::vital::detected_object_set_sptr set,
     double ily = ( bbox.min_y() + bbox.max_y() ) / 2.0;
 
     static std::atomic<unsigned> id_counter( 0 );
-    const unsigned id = id_counter++;
+    const unsigned l_id = id_counter++;
 
-    stream() << id                  // 1: track id
+    stream() << l_id                  // 1: track id
              << " 1 "               // 2: track length
              << d->m_frame_number-1 // 3: frame number / set number
              << " 0 "               // 4: tracking plane x
@@ -272,6 +272,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set,
           f1 = std::max( f1, clf->score( id ) );
         }
       }
+
       for( const std::string id : d->m_parsed_tot_ids2 )
       {
         if( clf->has_class_name( id ) )
@@ -282,7 +283,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set,
 
       f3 = 1.0 - f2 - f1;
 
-      (*d->m_tot_writer) << id << " " << f1 << " " << f2 << " " << f3 << std::endl;
+      (*d->m_tot_writer) << l_id << " " << f1 << " " << f2 << " " << f3 << std::endl;
 
     } // end write_tot
   } // end foreach

--- a/arrows/core/feature_descriptor_io.cxx
+++ b/arrows/core/feature_descriptor_io.cxx
@@ -216,7 +216,7 @@ read_descriptors(Archive & ar, size_t num_desc)
 
   std::vector<descriptor_sptr> descriptors;
   descriptors.reserve(num_desc);
-  for( size_t i=0; i<num_desc; ++i )
+  for( size_t i = 0; i < num_desc; ++i )
   {
     std::shared_ptr<descriptor_array_of<T> > d;
     // allocate fixed vectors for common dimensions
@@ -232,7 +232,7 @@ read_descriptors(Archive & ar, size_t num_desc)
         d = std::make_shared<descriptor_dynamic<T> >(dim);
     }
     T* data = d->raw_data();
-    for(unsigned i=0; i<dim; ++i, ++data)
+    for(unsigned x = 0; x < dim; ++x, ++data)
     {
       ar( *data );
     }

--- a/arrows/core/filter_features_nonmax.cxx
+++ b/arrows/core/filter_features_nonmax.cxx
@@ -208,10 +208,10 @@ public:
     Eigen::AlignedBox<double, 1> scale_box;
     for (unsigned int i = 0; i < feat_vec.size(); i++)
     {
-      auto const& feat = feat_vec[i];
-      indices.push_back(std::make_pair(i, feat->magnitude()));
-      bbox.extend(feat->loc());
-      scale_box.extend(Eigen::Matrix<double,1,1>(feat->scale()));
+      auto const& l_feat = feat_vec[i];
+      indices.push_back(std::make_pair(i, l_feat->magnitude()));
+      bbox.extend(l_feat->loc());
+      scale_box.extend(Eigen::Matrix<double,1,1>(l_feat->scale()));
     }
 
     const double scale_min = std::log2(scale_box.min()[0]);
@@ -269,12 +269,12 @@ public:
       for (auto const& p : indices)
       {
         unsigned int index = p.first;
-        auto const& feat = feat_vec[index];
-        if (suppressor.cover(*feat))
+        auto const& f = feat_vec[index];
+        if (suppressor.cover(*f))
         {
           // add this feature to the accepted list
           ind.push_back(index);
-          filtered.push_back(feat);
+          filtered.push_back(f);
         }
       }
       // if not using a target number of features, keep this result

--- a/arrows/core/filter_features_nonmax.cxx
+++ b/arrows/core/filter_features_nonmax.cxx
@@ -191,13 +191,13 @@ public:
 
   // --------------------------------------------------------------------------
   feature_set_sptr
-  filter(feature_set_sptr feat, std::vector<unsigned int> &ind) const
+  filter(feature_set_sptr feat_set, std::vector<unsigned int> &ind) const
   {
-    const std::vector<feature_sptr> &feat_vec = feat->features();
+    const std::vector<feature_sptr> &feat_vec = feat_set->features();
 
     if (feat_vec.size() <= num_features_target)
     {
-      return feat;
+      return feat_set;
     }
 
     //  Create a new vector with the index and magnitude for faster sorting
@@ -208,10 +208,10 @@ public:
     Eigen::AlignedBox<double, 1> scale_box;
     for (unsigned int i = 0; i < feat_vec.size(); i++)
     {
-      auto const& l_feat = feat_vec[i];
-      indices.push_back(std::make_pair(i, l_feat->magnitude()));
-      bbox.extend(l_feat->loc());
-      scale_box.extend(Eigen::Matrix<double,1,1>(l_feat->scale()));
+      auto const& feat = feat_vec[i];
+      indices.push_back(std::make_pair(i, feat->magnitude()));
+      bbox.extend(feat->loc());
+      scale_box.extend(Eigen::Matrix<double,1,1>(feat->scale()));
     }
 
     const double scale_min = std::log2(scale_box.min()[0]);

--- a/arrows/core/match_features_fundamental_matrix.cxx
+++ b/arrows/core/match_features_fundamental_matrix.cxx
@@ -251,9 +251,9 @@ match_features_fundamental_matrix
   auto f2 = feat2->features();
   std::vector<double> dists;
   dists.reserve(inlier_m.size());
-  for (auto const& m : inlier_m)
+  for (auto const& i_m : inlier_m)
   {
-    vector_2d dist = f1[m.first]->loc() - f2[m.second]->loc();
+    vector_2d dist = f1[i_m.first]->loc() - f2[i_m.second]->loc();
     dists.push_back(dist.norm());
   }
   double max_dist = 2.0 * percentile(dists, d_->motion_filter_percentile);

--- a/arrows/core/tests/test_feature_descriptor_io.cxx
+++ b/arrows/core/tests/test_feature_descriptor_io.cxx
@@ -126,11 +126,11 @@ make_n_descriptors(size_t num_desc, size_t dim)
                     ? static_cast<double>(std::numeric_limits<T>::max()) : 1.0;
   const double scale = (tmax - tmin) / rmax;
 
-  for(unsigned i=0; i<num_desc; ++i)
+  for(unsigned i = 0; i < num_desc; ++i)
   {
     auto d = std::make_shared<descriptor_dynamic<T> >(dim);
     T* data = d->raw_data();
-    for(unsigned i=0; i<dim; ++i, ++data)
+    for(unsigned j = 0; j < dim; ++j, ++data)
     {
       *data = static_cast<T>(rand() * scale + tmin );
     }

--- a/arrows/core/transform_detected_object_set.cxx
+++ b/arrows/core/transform_detected_object_set.cxx
@@ -221,14 +221,14 @@ box_around_box3d( kwiver::vital::camera_perspective_sptr const camera,
 // ---------------------------------------------------------------------------
 vital::bounding_box<double>
 transform_detected_object_set::
-view_to_view( kwiver::vital::camera_perspective_sptr const src_camera,
-              kwiver::vital::camera_perspective_sptr const dest_camera,
+view_to_view( kwiver::vital::camera_perspective_sptr const src_camera_,
+              kwiver::vital::camera_perspective_sptr const dest_camera_,
               vital::bounding_box<double> const& bbox ) const
 {
   Eigen::Matrix<double, 8, 3> box3d =
-    this->backproject_bbox( src_camera, bbox );
+    this->backproject_bbox( src_camera_, bbox );
 
-  return this->box_around_box3d( dest_camera, box3d );
+  return this->box_around_box3d( dest_camera_, box3d );
 }
 
 // ---------------------------------------------------------------------------

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -461,9 +461,9 @@ parse_activity( const YAML::Node& n, KPF::packet_buffer_t& local_packet_buffer )
       }
       else if (h.style == KPF::packet_style::EVAL)
       {
-        KPF::packet_t p(h);
-        if ( ! parse_packet( i, p )) return false;
-        act.evals.push_back ( {p.eval, p.header.domain} );
+        KPF::packet_t pp(h);
+        if ( ! parse_packet( i, pp )) return false;
+        act.evals.push_back ( {p.eval, pp.header.domain} );
       }
       else if (h.style == KPF::packet_style::ACT)
       {

--- a/arrows/kpf/yaml/kpf_yaml_parser.cxx
+++ b/arrows/kpf/yaml/kpf_yaml_parser.cxx
@@ -461,9 +461,9 @@ parse_activity( const YAML::Node& n, KPF::packet_buffer_t& local_packet_buffer )
       }
       else if (h.style == KPF::packet_style::EVAL)
       {
-        KPF::packet_t pp(h);
-        if ( ! parse_packet( i, pp )) return false;
-        act.evals.push_back ( {p.eval, pp.header.domain} );
+        KPF::packet_t packet(h);
+        if ( ! parse_packet( i, packet )) return false;
+        act.evals.push_back ( {p.eval, packet.header.domain} );
       }
       else if (h.style == KPF::packet_style::ACT)
       {

--- a/arrows/mvg/algo/initialize_cameras_landmarks.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks.cxx
@@ -1,4 +1,4 @@
-/*cOAkwg +29
+/*ckwg +29
  * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
@@ -2126,9 +2126,9 @@ initialize_cameras_landmarks::priv
     return false;
   }
 
-  int l_num_constraints_used;
+  int constraints_used;
   if (fit_reconstruction_to_constraints(cams, lms, tracks,
-                                        constraints, l_num_constraints_used))
+                                        constraints, constraints_used))
   {
     std::set<frame_id_t> fixed_cams_empty;
     std::set<landmark_id_t> fixed_lms_empty;
@@ -2253,7 +2253,7 @@ initialize_cameras_landmarks::priv
                          << after_new_cam_rmse);
 
     }
-    int constraints_used;
+
     ba_constraints = nullptr;
     m_solution_was_fit_to_constraints = false;
     if (fit_reconstruction_to_constraints(cams, lms, tracks,

--- a/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
@@ -1028,8 +1028,8 @@ initialize_cameras_landmarks_basic
 
     // find existing landmarks for tracks also having features on the other frame
     map_landmark_t flms;
-    std::vector<track_sptr> trks = ftracks->active_tracks(static_cast<int>(other_frame));
-    for(const track_sptr& t : trks)
+    std::vector<track_sptr> ftrks = ftracks->active_tracks(static_cast<int>(other_frame));
+    for(const track_sptr& t : ftrks)
     {
       map_landmark_t::const_iterator li = lms.find(t->id());
       if( li != lms.end() )
@@ -1087,9 +1087,9 @@ initialize_cameras_landmarks_basic
       camera_map::map_camera_t opt_cam_map;
       opt_cam_map[f] = cams[f];
       camera_map_sptr opt_cams = std::make_shared<simple_camera_map>(opt_cam_map);
-      landmark_map_sptr landmarks = std::make_shared<simple_landmark_map>(flms);
-      auto tracks = std::make_shared<feature_track_set>(trks);
-      d_->camera_optimizer->optimize(opt_cams, tracks, landmarks, constraints);
+      landmark_map_sptr landmarks_map = std::make_shared<simple_landmark_map>(flms);
+      auto f_tracks = std::make_shared<feature_track_set>(trks);
+      d_->camera_optimizer->optimize(opt_cams, f_tracks, landmarks_map, constraints);
       cams[f] = opt_cams->cameras()[f];
     }
 

--- a/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks_basic.cxx
@@ -1028,8 +1028,8 @@ initialize_cameras_landmarks_basic
 
     // find existing landmarks for tracks also having features on the other frame
     map_landmark_t flms;
-    std::vector<track_sptr> ftrks = ftracks->active_tracks(static_cast<int>(other_frame));
-    for(const track_sptr& t : ftrks)
+    std::vector<track_sptr> aftracks = ftracks->active_tracks(static_cast<int>(other_frame));
+    for(const track_sptr& t : aftracks)
     {
       map_landmark_t::const_iterator li = lms.find(t->id());
       if( li != lms.end() )

--- a/arrows/mvg/transform.cxx
+++ b/arrows/mvg/transform.cxx
@@ -92,13 +92,13 @@ void transform_inplace(vital::landmark_map::map_landmark_t& landmarks,
 {
   for (vital::landmark_map::map_landmark_t::value_type& p : landmarks)
   {
-    if (vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(p.second.get()))
+    if (vital::landmark_d* vlm_d = dynamic_cast<vital::landmark_d*>(p.second.get()))
     {
-      transform_inplace(*vlm, xform);
+      transform_inplace(*vlm_d, xform);
     }
-    else if (vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(p.second.get()))
+    else if (vital::landmark_f* vlm_f = dynamic_cast<vital::landmark_f*>(p.second.get()))
     {
-      transform_inplace(*vlm, vital::similarity_f(xform));
+      transform_inplace(*vlm_f, vital::similarity_f(xform));
     }
   }
 }
@@ -184,13 +184,13 @@ vital::landmark_sptr transform(vital::landmark_sptr lm,
     return vital::landmark_sptr();
   }
   lm = lm->clone();
-  if( vital::landmark_d* vlm = dynamic_cast<vital::landmark_d*>(lm.get()) )
+  if( vital::landmark_d* vlm_d = dynamic_cast<vital::landmark_d*>(lm.get()) )
   {
-    transform_inplace(*vlm, xform);
+    transform_inplace(*vlm_d, xform);
   }
-  else if( vital::landmark_f* vlm = dynamic_cast<vital::landmark_f*>(lm.get()) )
+  else if( vital::landmark_f* vlm_f = dynamic_cast<vital::landmark_f*>(lm.get()) )
   {
-    transform_inplace(*vlm, vital::similarity_f(xform));
+    transform_inplace(*vlm_f, vital::similarity_f(xform));
   }
   else
   {

--- a/arrows/ocv/extract_descriptors_DAISY.cxx
+++ b/arrows/ocv/extract_descriptors_DAISY.cxx
@@ -131,10 +131,10 @@ public:
   {
     bool valid = true;
 
-    int norm = config->get_value<int>( "norm" );
-    if( ! check_norm_type( norm ) )
+    int n = config->get_value<int>( "norm" );
+    if( ! check_norm_type( n ) )
     {
-      LOG_ERROR( log, "Invalid norm option '" << norm << "'. Valid choices "
+      LOG_ERROR( log, "Invalid norm option '" << n << "'. Valid choices "
                       "are: " << list_norm_options() );
       valid = false;
     }

--- a/arrows/ocv/extract_descriptors_LATCH.cxx
+++ b/arrows/ocv/extract_descriptors_LATCH.cxx
@@ -81,17 +81,17 @@ public:
     bool valid = true;
 
     // Bytes can only be one of the following values
-    int bytes = config->get_value<int>( "bytes" );
-    if( ! ( bytes == 1 ||
-            bytes == 2 ||
-            bytes == 4 ||
-            bytes == 8 ||
-            bytes == 16 ||
-            bytes == 32 ||
-            bytes == 64 ) )
+    int bytes_ = config->get_value<int>( "bytes" );
+    if( ! ( bytes_ == 1 ||
+            bytes_ == 2 ||
+            bytes_ == 4 ||
+            bytes_ == 8 ||
+            bytes_ == 16 ||
+            bytes_ == 32 ||
+            bytes_ == 64 ) )
     {
       LOG_ERROR( log, "bytes value must be one of [1, 2, 4, 8, 16, 32, 64]. "
-                      "Given: " << bytes );
+                      "Given: " << bytes_ );
       valid = false;
     }
 

--- a/arrows/ocv/feature_detect_extract_ORB.cxx
+++ b/arrows/ocv/feature_detect_extract_ORB.cxx
@@ -165,9 +165,9 @@ public:
     bool valid = true;
 
     // Must be one of the enumeration values
-    int score_type = config->get_value<int>( "score_type" );
-    if( ! ( score_type == cv::ORB::HARRIS_SCORE ||
-            score_type == cv::ORB::FAST_SCORE ) )
+    int temp = config->get_value<int>( "score_type" );
+    if( ! ( temp == cv::ORB::HARRIS_SCORE ||
+            temp == cv::ORB::FAST_SCORE ) )
     {
       LOG_ERROR( logger, "Score type not a valid enumeration value. Must be "
         "either " << cv::ORB::HARRIS_SCORE << " for cv::ORB::HARRIS_SCORE or "

--- a/arrows/ocv/match_features_bruteforce.cxx
+++ b/arrows/ocv/match_features_bruteforce.cxx
@@ -43,10 +43,10 @@ namespace ocv {
 class match_features_bruteforce::priv
 {
 public:
-  priv(int norm_type=cv::NORM_L2, bool cross_check=false)
-      : norm_type( norm_type ),
-        cross_check( cross_check ),
-        matcher( new cv::BFMatcher(norm_type, cross_check) )
+  priv(int n_type = cv::NORM_L2, bool c_check = false)
+      : norm_type( n_type ),
+        cross_check( c_check ),
+        matcher( new cv::BFMatcher(n_type, cross_check) )
   {
   }
 

--- a/arrows/ocv/match_features_bruteforce.cxx
+++ b/arrows/ocv/match_features_bruteforce.cxx
@@ -43,10 +43,10 @@ namespace ocv {
 class match_features_bruteforce::priv
 {
 public:
-  priv(int n_type = cv::NORM_L2, bool c_check = false)
-      : norm_type( n_type ),
-        cross_check( c_check ),
-        matcher( new cv::BFMatcher(n_type, cross_check) )
+  priv(int p_norm_type = cv::NORM_L2, bool p_cross_check = false)
+      : norm_type( p_norm_type ),
+        cross_check( p_cross_check ),
+        matcher( new cv::BFMatcher( norm_type, cross_check ) )
   {
   }
 

--- a/arrows/serialize/json/activity.cxx
+++ b/arrows/serialize/json/activity.cxx
@@ -59,14 +59,14 @@ std::shared_ptr< std::string >
 activity::
 serialize( const kwiver::vital::any& element )
 {
-  kwiver::vital::activity activity =
+  kwiver::vital::activity l_activity =
     kwiver::vital::any_cast< kwiver::vital::activity > ( element );
 
   std::stringstream msg;
   msg << "activity ";
   {
     cereal::JSONOutputArchive ar( msg );
-    save( ar, activity );
+    save( ar, l_activity );
   }
 
   return std::make_shared< std::string > ( msg.str() );
@@ -77,7 +77,7 @@ kwiver::vital::any activity::
 deserialize( const std::string& message )
 {
   std::stringstream msg(message);
-  kwiver::vital::activity activity;
+  kwiver::vital::activity l_activity;
   std::string tag;
   msg >> tag;
 
@@ -89,10 +89,10 @@ deserialize( const std::string& message )
   else
   {
     cereal::JSONInputArchive ar( msg );
-    load( ar, activity );
+    load( ar, l_activity );
   }
 
-  return kwiver::vital::any( activity );
+  return kwiver::vital::any( l_activity );
 }
 
 } } } }

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -792,7 +792,7 @@ TEST( load_save, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/json/tests/test_serialize.cxx
+++ b/arrows/serialize/json/tests/test_serialize.cxx
@@ -692,7 +692,7 @@ TEST(serialize , track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -848,7 +848,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t ii = 0; ii < ser_dot_sptr->size(); ++ii )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -395,7 +395,7 @@ TEST( convert_protobuf, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -745,7 +745,7 @@ TEST( convert_protobuf, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -895,7 +895,7 @@ TEST( convert_protobuf, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/tests/test_convert_protobuf.cxx
@@ -395,7 +395,7 @@ TEST( convert_protobuf, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+      for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -745,7 +745,7 @@ TEST( convert_protobuf, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+      for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -758,7 +758,7 @@ TEST( convert_protobuf, track )
   trk = kwiver::vital::track::create();
   trk_dser = kwiver::vital::track::create();
   trk->set_id( 2 );
-  for ( int i=0; i<10; i++ )
+  for ( int i = 0; i < 10; i++ )
   {
     auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( i );
     bool insert_success = trk->insert( trk_state_sptr );
@@ -895,7 +895,7 @@ TEST( convert_protobuf, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+        for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -424,7 +424,7 @@ TEST( serialize, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto deser_it = deser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( deser_it->second, deser_it->second );
@@ -676,7 +676,7 @@ TEST( serialize, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
       {
         EXPECT_EQ( *( ser_it->first ), *( ser_it->first ) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -689,9 +689,9 @@ TEST( serialize, track )
   // test track with track state
   auto trk = kwiver::vital::track::create();
   trk->set_id( 2 );
-  for ( int i=0; i<10; i++ )
+  for ( int ii = 0; ii < 10; ii++ )
   {
-    auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( i );
+    auto trk_state_sptr = std::make_shared< kwiver::vital::track_state>( ii );
     bool insert_success = trk->insert( trk_state_sptr );
     if ( !insert_success )
     {
@@ -840,7 +840,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t i = 0; i < ser_dot_sptr->size(); ++i )
+        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/serialize/protobuf/tests/test_serialize.cxx
+++ b/arrows/serialize/protobuf/tests/test_serialize.cxx
@@ -424,7 +424,7 @@ TEST( serialize, detected_object_set )
       auto ser_it = ser_dot_sptr->begin();
       auto deser_it = deser_dot_sptr->begin();
 
-      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+      for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
       {
         EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
         EXPECT_EQ( deser_it->second, deser_it->second );
@@ -676,7 +676,7 @@ TEST( serialize, track )
       auto ser_it = ser_dot_sptr->begin();
       auto dser_it = dser_dot_sptr->begin();
 
-      for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+      for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
       {
         EXPECT_EQ( *( ser_it->first ), *( ser_it->first ) );
         EXPECT_EQ( dser_it->second, dser_it->second );
@@ -840,7 +840,7 @@ TEST( serialize, object_track_set )
         auto ser_it = ser_dot_sptr->begin();
         auto dser_it = dser_dot_sptr->begin();
 
-        for ( size_t idx = 0; idx < ser_dot_sptr->size(); ++idx )
+        for ( size_t j = 0; j < ser_dot_sptr->size(); ++j )
         {
           EXPECT_EQ( *(ser_it->first), *(ser_it->first) );
           EXPECT_EQ( dser_it->second, dser_it->second );

--- a/arrows/super3d/compute_depth.cxx
+++ b/arrows/super3d/compute_depth.cxx
@@ -46,12 +46,6 @@
 #include <vital/types/bounding_box.h>
 #include <vital/vital_config.h>
 
-//#include <vital/types/landmark.h>
-//#include <vital/vital_config.h>
-//#include <vnl/vnl_double_3.h>
-//#include <vpgl/vpgl_perspective_camera.h>
-
-
 #include <sstream>
 #include <memory>
 #include <functional>

--- a/arrows/super3d/compute_depth.cxx
+++ b/arrows/super3d/compute_depth.cxx
@@ -34,20 +34,23 @@
 */
 
 #include <arrows/super3d/compute_depth.h>
-#include <arrows/vxl/image_container.h>
-#include <vital/types/landmark.h>
-#include <vital/util/transform_image.h>
+
 #include <arrows/vxl/camera.h>
-#include <vnl/vnl_double_3.h>
+#include <arrows/vxl/image_container.h>
 #include <vil/algo/vil_threshold.h>
-#include <vil/vil_image_view.h>
-#include <vil/vil_math.h>
 #include <vil/vil_convert.h>
 #include <vil/vil_crop.h>
+#include <vil/vil_image_view.h>
+#include <vil/vil_math.h>
 #include <vil/vil_plane.h>
-#include <vpgl/vpgl_perspective_camera.h>
 #include <vital/types/bounding_box.h>
 #include <vital/vital_config.h>
+
+//#include <vital/types/landmark.h>
+//#include <vital/vital_config.h>
+//#include <vnl/vnl_double_3.h>
+//#include <vpgl/vpgl_perspective_camera.h>
+
 
 #include <sstream>
 #include <memory>
@@ -89,7 +92,7 @@ public:
 
   std::unique_ptr<world_space> compute_world_space_roi(vpgl_perspective_camera<double> &cam,
                                                        vil_image_view<double> &frame,
-                                                       double depth_min, double depth_max,
+                                                       double d_min, double d_max,
                                                        vital::bounding_box<int> const& roi);
 
   double theta0;
@@ -208,14 +211,14 @@ std::unique_ptr<world_space>
 compute_depth::priv
 ::compute_world_space_roi(vpgl_perspective_camera<double> &cam,
                           vil_image_view<double> &frame,
-                          double depth_min, double depth_max,
+                          double d_min, double d_max,
                           vital::bounding_box<int> const& roi)
 {
   frame = vil_crop(frame, roi.min_x(), roi.width(), roi.min_y(), roi.height());
   cam = crop_camera(cam, roi.min_x(), roi.min_y());
 
   return std::unique_ptr<world_space>(new world_angled_frustum(cam, world_plane_normal,
-                                                                depth_min, depth_max, roi.width(), roi.height()));
+                                                                d_min, d_max, roi.width(), roi.height()));
 }
 
 //*****************************************************************************

--- a/arrows/super3d/tv_refine_search.cxx
+++ b/arrows/super3d/tv_refine_search.cxx
@@ -265,8 +265,8 @@ min_search_bound(vil_image_view<double> &a,
         {
           continue;
         }
-        const double diff = dij - k;
-        const double e = coeff*diff*diff + (*cost);
+        const double dd = dij - k;
+        const double e = coeff * dd * dd + (*cost);
         if (e < best_e)
         {
           best_e = e;

--- a/arrows/vxl/bundle_adjust.cxx
+++ b/arrows/vxl/bundle_adjust.cxx
@@ -256,15 +256,15 @@ bundle_adjust
       }
       super_map_inner_t frame_lm2feature_map;
 
-      for(const track_sptr& tt : ftracks)
+      for(const track_sptr& ft : ftracks)
       {
-        const track_id_t id = tt->id();
+        const track_id_t id = ft->id();
         // make sure the track id has an associated landmark
 
         if( lms.find(id) != lms.end() )
         {
           auto fts = std::dynamic_pointer_cast<feature_track_state>(
-                          *tt->find(frame) );
+                          *ft->find(frame) );
           if( fts && fts->feature )
           {
             frame_lm2feature_map[id] = fts->feature;

--- a/arrows/vxl/bundle_adjust.cxx
+++ b/arrows/vxl/bundle_adjust.cxx
@@ -256,15 +256,15 @@ bundle_adjust
       }
       super_map_inner_t frame_lm2feature_map;
 
-      for(const track_sptr& t : ftracks)
+      for(const track_sptr& tt : ftracks)
       {
-        const track_id_t id = t->id();
+        const track_id_t id = tt->id();
         // make sure the track id has an associated landmark
 
         if( lms.find(id) != lms.end() )
         {
           auto fts = std::dynamic_pointer_cast<feature_track_state>(
-                          *t->find(frame) );
+                          *tt->find(frame) );
           if( fts && fts->feature )
           {
             frame_lm2feature_map[id] = fts->feature;

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -7,6 +7,8 @@ over the previous v1.5.0 release.
 Updates since v1.5.0
 --------------------
 
+ * Renamed symbols or other approaches to reduce "shadowing" warnings.
+
 Vital
 
 Vital Algo

--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -157,9 +157,9 @@ class embedded_pipeline_extension_registrar
   : public plugin_registrar
 {
 public:
-  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl,
-                    const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl_,
+                    const std::string& mod_name_ )
+    : plugin_registrar( vpl_, mod_name_ )
   {
   }
 

--- a/sprokit/processes/adapters/embedded_pipeline_extension.h
+++ b/sprokit/processes/adapters/embedded_pipeline_extension.h
@@ -157,9 +157,9 @@ class embedded_pipeline_extension_registrar
   : public plugin_registrar
 {
 public:
-  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& vpl_,
-                    const std::string& mod_name_ )
-    : plugin_registrar( vpl_, mod_name_ )
+  embedded_pipeline_extension_registrar( kwiver::vital::plugin_loader& p_vpl,
+                    const std::string& p_module_name )
+    : plugin_registrar( p_vpl, p_module_name )
   {
   }
 

--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -77,16 +77,16 @@ kwiver::adapter::ports_info_t
 input_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t port_info;
+  kwiver::adapter::ports_info_t l_port_info;
 
   // formulate list of current input ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    port_info[port] = this->input_port_info( port );
+    l_port_info[port] = this->input_port_info( port );
   }
 
-  return port_info;
+  return l_port_info;
 }
 
 

--- a/sprokit/processes/adapters/input_adapter_process.cxx
+++ b/sprokit/processes/adapters/input_adapter_process.cxx
@@ -77,16 +77,16 @@ kwiver::adapter::ports_info_t
 input_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t l_port_info;
+  kwiver::adapter::ports_info_t p_info;
 
   // formulate list of current input ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    l_port_info[port] = this->input_port_info( port );
+    p_info[port] = this->input_port_info( port );
   }
 
-  return l_port_info;
+  return p_info;
 }
 
 

--- a/sprokit/processes/adapters/output_adapter_process.cxx
+++ b/sprokit/processes/adapters/output_adapter_process.cxx
@@ -101,16 +101,16 @@ kwiver::adapter::ports_info_t
 output_adapter_process
 ::get_ports()
 {
-  kwiver::adapter::ports_info_t port_info;
+  kwiver::adapter::ports_info_t p_info;
 
   // formulate list of current output ports
   auto ports = this->output_ports();
   for( auto port : ports )
   {
-    port_info[port] = this->output_port_info( port );
+    p_info[port] = this->output_port_info( port );
   }
 
-  return port_info;
+  return p_info;
 }
 
 

--- a/sprokit/processes/adapters/tests/test_non_blocking.cxx
+++ b/sprokit/processes/adapters/tests/test_non_blocking.cxx
@@ -120,7 +120,7 @@ main(int argc, char* argv[])
 }
 
 // ==================================================================
-IMPLEMENT_TEST(non_blocking)
+IMPLEMENT_TEST(nonblocking)
 {
   std::stringstream pipeline_desc;
   pipeline_desc

--- a/sprokit/processes/core/compute_association_matrix_process.cxx
+++ b/sprokit/processes/core/compute_association_matrix_process.cxx
@@ -124,9 +124,9 @@ compute_association_matrix_process
 ::_step()
 {
   // Check for end of video since we're in manual management mode
-  auto port_info = peek_at_port_using_trait( detected_object_set );
+  auto p_info = peek_at_port_using_trait( detected_object_set );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( detected_object_set );
     mark_process_as_complete();

--- a/sprokit/processes/core/compute_track_descriptors_process.cxx
+++ b/sprokit/processes/core/compute_track_descriptors_process.cxx
@@ -149,9 +149,9 @@ compute_track_descriptors_process
 ::_step()
 {
   // Peek at next input to see if we're at end of video
-  auto port_info = peek_at_port_using_trait( image );
+  auto p_info = peek_at_port_using_trait( image );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( image );
     mark_process_as_complete();

--- a/sprokit/processes/core/image_file_reader_process.cxx
+++ b/sprokit/processes/core/image_file_reader_process.cxx
@@ -190,7 +190,7 @@ void image_file_reader_process
   if ( ! kwiversys::SystemTools::FileExists( file ) )
   {
     // Resolve against specified path
-    std::string resolved_file = kwiversys::SystemTools::FindFile( file, d->m_config_path, true );
+    resolved_file = kwiversys::SystemTools::FindFile( file, d->m_config_path, true );
     if ( resolved_file.empty() )
     {
       switch (d->m_config_error_mode)

--- a/sprokit/processes/core/perform_query_process.cxx
+++ b/sprokit/processes/core/perform_query_process.cxx
@@ -214,9 +214,9 @@ perform_query_process
 ::_step()
 {
   // Check for termination since we are in manual mode
-  auto port_info = peek_at_port_using_trait( database_query );
+  auto p_info = peek_at_port_using_trait( database_query );
 
-  if( port_info.datum->type() == sprokit::datum::complete )
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( database_query );
     grab_edge_datum_using_trait( iqr_feedback );

--- a/sprokit/processes/core/serializer_base.cxx
+++ b/sprokit/processes/core/serializer_base.cxx
@@ -113,11 +113,11 @@ serializer_base
       elem_spec.m_serializer = std::dynamic_pointer_cast< vital::algo::data_serializer > ( base_nested_algo );
       if ( ! elem_spec.m_serializer )
       {
-        std::stringstream str;
-        str << "Unable to create serializer for type \""
+        std::stringstream sstr;
+        sstr << "Unable to create serializer for type \""
             << elem_spec.m_algo_name << "\" for " << m_serialization_type;
 
-        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), str.str() );
+        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), sstr.str() );
       }
 
       if ( ! vital::algorithm::check_nested_algo_configuration( ser_algo_type,

--- a/sprokit/processes/core/serializer_base.cxx
+++ b/sprokit/processes/core/serializer_base.cxx
@@ -97,10 +97,12 @@ serializer_base
 
       algo_config->set_value( ser_type, elem_spec.m_algo_name );
 
-      std::stringstream str;
-      vital::config_block_formatter fmt( algo_config );
-      fmt.print( str );
-      LOG_TRACE( m_logger, "Creating algorithm for (config block):\n" << str.str() << std::endl );
+      {
+        std::stringstream ss;
+        vital::config_block_formatter fmt( algo_config );
+        fmt.print( ss );
+        LOG_TRACE( m_logger, "Creating algorithm for (config block):\n" << ss.str() << std::endl );
+      }
 
       vital::algorithm_sptr base_nested_algo;
 
@@ -113,11 +115,11 @@ serializer_base
       elem_spec.m_serializer = std::dynamic_pointer_cast< vital::algo::data_serializer > ( base_nested_algo );
       if ( ! elem_spec.m_serializer )
       {
-        std::stringstream sstr;
-        sstr << "Unable to create serializer for type \""
+        std::stringstream ss;
+        ss << "Unable to create serializer for type \""
             << elem_spec.m_algo_name << "\" for " << m_serialization_type;
 
-        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), sstr.str() );
+        VITAL_THROW( sprokit::invalid_configuration_exception, m_proc.name(), ss.str() );
       }
 
       if ( ! vital::algorithm::check_nested_algo_configuration( ser_algo_type,

--- a/sprokit/processes/core/write_object_track_process.cxx
+++ b/sprokit/processes/core/write_object_track_process.cxx
@@ -137,8 +137,8 @@ void write_object_track_process
 void write_object_track_process
 ::_step()
 {
-  auto const& port_info = peek_at_port_using_trait( object_track_set );
-  if( port_info.datum->type() == sprokit::datum::complete )
+  auto const& p_info = peek_at_port_using_trait( object_track_set );
+  if( p_info.datum->type() == sprokit::datum::complete )
   {
     grab_edge_datum_using_trait( object_track_set );
     d->m_writer->close();

--- a/sprokit/processes/ocv/image_viewer_process.cxx
+++ b/sprokit/processes/ocv/image_viewer_process.cxx
@@ -148,15 +148,15 @@ public:
     // header
     if ( ! m_header.empty() )
     {
-      cv::Size tbox = cv::getTextSize( m_header,
+      cv::Size t_box = cv::getTextSize( m_header,
                                        font_face,
                                        font_scale,
                                        font_thickness,
                                        &baseline );
 
       // Calculate point for lower left of text block
-      cv::Point header_org( ( image.cols - tbox.width ) / 2,
-                            tbox.height + 3 );
+      cv::Point header_org( ( image.cols - t_box.width ) / 2,
+                            t_box.height + 3 );
 
       cv::putText( image,
                    m_header,
@@ -170,14 +170,14 @@ public:
     // footer
     if ( ! m_footer.empty() )
     {
-      cv::Size tbox = cv::getTextSize( m_footer,
+      cv::Size t_box = cv::getTextSize( m_footer,
                                        font_face,
                                        font_scale,
                                        font_thickness,
                                        &baseline );
 
       // Calculate point for lower left of text block
-      cv::Point footer_org( ( image.cols - tbox.width ) / 2,
+      cv::Point footer_org( ( image.cols - t_box.width ) / 2,
                             ( image.rows - 3 ) );
 
       cv::putText( image,

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -237,8 +237,8 @@ public:
   };
 
   process_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& mod_name_ )
+    : plugin_registrar( vpl, mod_name_ )
   {
   }
 

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -414,10 +414,10 @@ lex_processor
       // look for "::"
       if ( c == ':' && n == ':' )
       {
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
-        t->set_location( current_location() );
+        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
+        tt->set_location( current_location() );
 
-        return t;
+        return tt;
       }
 
       if ( c == ':' && n == '=' )
@@ -425,11 +425,11 @@ lex_processor
         // Collect rest of line as text
         std::string text( m_priv->m_cur_char + 1, m_priv->m_input_line.end() );
         kwiver::vital::string_trim( text );
-        token_sptr t = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
-        t->set_location( current_location() );
+        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
+        tt->set_location( current_location() );
 
         m_priv->flush_line();
-        return t;
+        return tt;
       }
 
       // Reset pointer to restore our second character

--- a/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
+++ b/sprokit/src/sprokit/pipeline_util/lex_processor.cxx
@@ -414,10 +414,10 @@ lex_processor
       // look for "::"
       if ( c == ':' && n == ':' )
       {
-        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
-        tt->set_location( current_location() );
+        token_sptr tok = std::make_shared< token > ( m_priv->find_res_word( "::" ), "::" );
+        tok->set_location( current_location() );
 
-        return tt;
+        return tok;
       }
 
       if ( c == ':' && n == '=' )
@@ -425,11 +425,11 @@ lex_processor
         // Collect rest of line as text
         std::string text( m_priv->m_cur_char + 1, m_priv->m_input_line.end() );
         kwiver::vital::string_trim( text );
-        token_sptr tt = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
-        tt->set_location( current_location() );
+        token_sptr tok = std::make_shared< token > ( m_priv->find_res_word( ":=" ), text );
+        tok->set_location( current_location() );
 
         m_priv->flush_line();
-        return tt;
+        return tok;
       }
 
       // Reset pointer to restore our second character

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2018 by Kitware, Inc.
+ * Copyright 2018-2020 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -157,8 +157,8 @@ class algorithm_registrar
 {
 public:
   algorithm_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name )
-    : plugin_registrar( vpl, mod_name )
+                       const std::string& module_name )
+    : plugin_registrar( vpl, module_name )
   {
   }
 
@@ -214,9 +214,9 @@ public:
    * serializer method. Typical entries could be "protobuf" or "json".
    */
   serializer_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod_name,
+                       const std::string& mod,
                        const std::string& ser_method)
-    : plugin_registrar( vpl, mod_name ),
+    : plugin_registrar( vpl, mod ),
       m_serialize_method( "serialize-" + ser_method )
   { }
 

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -208,15 +208,15 @@ public:
    * \brief Constructor for serializer registrar
    *
    * \param vpl Plugin loader reference.
-   * \param mod_name  name of module to register.
+   * \param module_name  name of module to register.
    * \param ser_method short serialization method. This specifies the
    * string that is used in the pipe config file to select the
    * serializer method. Typical entries could be "protobuf" or "json".
    */
   serializer_registrar( kwiver::vital::plugin_loader& vpl,
-                       const std::string& mod,
+                       const std::string& module_name,
                        const std::string& ser_method)
-    : plugin_registrar( vpl, mod ),
+    : plugin_registrar( vpl, module_name ),
       m_serialize_method( "serialize-" + ser_method )
   { }
 

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -703,8 +703,8 @@ config_block
   // iterate over all strings and convert to target type
   for (std::string str : sv )
   {
-    T val = config_block_get_value_cast<T>( str );
-    val_vector.push_back( val );
+    T l_val = config_block_get_value_cast<T>( str );
+    val_vector.push_back( l_val );
   }
 
   return val_vector;

--- a/vital/config/config_block.h
+++ b/vital/config/config_block.h
@@ -693,18 +693,20 @@ std::vector< T >
 config_block
 ::get_value_as_vector( config_block_key_t const& key, const std::string& delim ) const
 {
-  config_block_value_t val = get_value< std::string >( key );
-
   std::vector< std::string> sv;
-  // Split string by delimeter into vector of strings
-  tokenize( val, sv, delim, kwiver::vital::TokenizeTrimEmpty );
-
   std::vector< T > val_vector;
+
+  {
+    config_block_value_t val = get_value< std::string >( key );
+    // Split string by delimeter into vector of strings
+    tokenize( val, sv, delim, kwiver::vital::TokenizeTrimEmpty );
+  }
+
   // iterate over all strings and convert to target type
   for (std::string str : sv )
   {
-    T l_val = config_block_get_value_cast<T>( str );
-    val_vector.push_back( l_val );
+    T val = config_block_get_value_cast<T>( str );
+    val_vector.push_back( val );
   }
 
   return val_vector;

--- a/vital/klv/klv_data.cxx
+++ b/vital/klv/klv_data.cxx
@@ -54,11 +54,11 @@ namespace vital {
 klv_data
 ::klv_data(container_t const& raw_packet,
          std::size_t key_offset, std::size_t key_len,
-         std::size_t m_value_offset, std::size_t value_len)
+         std::size_t value_offset, std::size_t value_len)
   : m_raw_data( raw_packet ),
     m_key_offset( key_offset ),
     key_len_( key_len ),
-    m_value_offset( m_value_offset ),
+    m_value_offset( value_offset ),
     m_value_len ( value_len )
 { }
 

--- a/vital/tests/test_estimate_similarity_transform.cxx
+++ b/vital/tests/test_estimate_similarity_transform.cxx
@@ -68,8 +68,8 @@ public:
     : expected_size(0)
   {}
 
-  dummy_est(size_t expected_size)
-    : expected_size(expected_size)
+  dummy_est(size_t expected_size_)
+    : expected_size(expected_size_)
   {}
 
   virtual ~dummy_est() = default;

--- a/vital/types/feature_track_set.h
+++ b/vital/types/feature_track_set.h
@@ -65,24 +65,24 @@ class VITAL_EXPORT feature_track_state : public track_state
 public:
   //@{
   /// Constructor
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr const& feature = nullptr,
-                                descriptor_sptr const& descriptor = nullptr,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ feature }
-    , descriptor{ descriptor }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr const& p_feature = nullptr,
+                                descriptor_sptr const& p_descriptor = nullptr,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ p_feature }
+    , descriptor{ p_descriptor }
+    , inlier{ p_inlier }
   {}
 
-  explicit feature_track_state( frame_id_t frame,
-                                feature_sptr&& feature,
-                                descriptor_sptr&& descriptor,
-                                bool inlier = false )
-    : track_state{ frame }
-    , feature{ std::move( feature ) }
-    , descriptor{ std::move( descriptor ) }
-    , inlier{ inlier }
+  explicit feature_track_state( frame_id_t p_frame,
+                                feature_sptr&& p_feature,
+                                descriptor_sptr&& p_descriptor,
+                                bool p_inlier = false )
+    : track_state{ p_frame }
+    , feature{ std::move( p_feature ) }
+    , descriptor{ std::move( p_descriptor ) }
+    , inlier{ p_inlier }
   {}
   //@}
 

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -129,8 +129,8 @@ config_block_get_value_cast( config_block_value_t const& value )
   }
 
   // Set up helper lambda to check for errors
-  auto try_or_die = [&value]( std::istream& s ) {
-    if ( s.fail() ) {
+  auto try_or_die = [&value]( std::istream& s_ ) {
+    if ( s_.fail() ) {
       VITAL_THROW( bad_config_block_cast,
                    "failed to convert from string representation \"" + value + "\"" );
     }

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -129,8 +129,8 @@ config_block_get_value_cast( config_block_value_t const& value )
   }
 
   // Set up helper lambda to check for errors
-  auto try_or_die = [&value]( std::istream& s_ ) {
-    if ( s_.fail() ) {
+  auto try_or_die = [&value]( std::istream& in ) {
+    if ( in.fail() ) {
       VITAL_THROW( bad_config_block_cast,
                    "failed to convert from string representation \"" + value + "\"" );
     }

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -68,23 +68,23 @@ namespace vital {
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any const& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ data },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any const& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ p_data },
+      m_tag{ p_tag }
 {
 }
 
 // ----------------------------------------------------------------------------
 metadata_item
-::metadata_item( std::string const& name,
-                 kwiver::vital::any&& data,
-                 vital_metadata_tag tag )
-    : m_name{ name },
-      m_data{ std::move( data ) },
-      m_tag{ tag }
+::metadata_item( std::string const& p_name,
+                 kwiver::vital::any&& p_data,
+                 vital_metadata_tag p_tag )
+    : m_name{ p_name },
+      m_data{ std::move( p_data ) },
+      m_tag{ p_tag }
 {
 }
 
@@ -291,15 +291,15 @@ metadata
 
   for (size_t i = 0; i < len; i++)
   {
-    char const byte = val[i];
-    if ( ! isprint( byte ) )
+    char const l_byte = val[i];
+    if ( ! isprint( l_byte ) )
     {
       ascii.append( 1, '.' );
       unprintable_found = true;
     }
     else
     {
-      ascii.append( 1, byte );
+      ascii.append( 1, l_byte );
     }
 
     // format as hex
@@ -308,8 +308,8 @@ metadata
       hex += " ";
     }
 
-    hex += hex_chars[ ( byte & 0xF0 ) >> 4 ];
-    hex += hex_chars[ ( byte & 0x0F ) >> 0 ];
+    hex += hex_chars[ ( l_byte & 0xF0 ) >> 4 ];
+    hex += hex_chars[ ( l_byte & 0x0F ) >> 0 ];
 
   } // end for
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -253,24 +253,24 @@ class typed_metadata
   : public metadata_item
 {
 public:
-  typed_metadata( std::string const& name, TYPE const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, TYPE const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
   }
 
-  typed_metadata( std::string const& name, TYPE&& data )
-    : metadata_item( name, std::move( data ), TAG )
+  typed_metadata( std::string const& p_name, TYPE&& p_data )
+    : metadata_item( p_name, std::move( p_data ), TAG )
   {
   }
 
-  typed_metadata( std::string const& name, kwiver::vital::any const& data )
-    : metadata_item( name, data, TAG )
+  typed_metadata( std::string const& p_name, kwiver::vital::any const& p_data )
+    : metadata_item( p_name, p_data, TAG )
   {
-    if ( data.type() != typeid(TYPE) )
+    if ( p_data.type() != typeid(TYPE) )
     {
       std::stringstream msg;
       msg << "Creating typed_metadata object with data type ("
-          << demangle( data.type().name() )
+          << demangle( p_data.type().name() )
           << ") different from type object was created with ("
           << demangle( typeid(TYPE).name() ) << ")";
       VITAL_THROW( metadata_exception, msg.str() );

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -144,7 +144,7 @@ rotation_< T >
 ::angle() const
 {
   static const T _pi = static_cast< T > ( pi );
-  static const T two_pi = static_cast< T > ( 2.0 * pi );
+  static const T _two_pi = static_cast< T > ( 2.0 * pi );
 
   const double i = Eigen::Matrix< T, 3, 1 > ( q_.x(), q_.y(), q_.z() ).norm();
   const double r = q_.w();
@@ -154,11 +154,11 @@ rotation_< T >
   // i.e. -pi/2 < a < pi/2
   if ( a >= _pi )
   {
-    a -= two_pi;
+    a -= _two_pi;
   }
   if ( a <= -_pi )
   {
-    a += two_pi;
+    a += _two_pi;
   }
   return a;
 }

--- a/vital/util/whereami.c
+++ b/vital/util/whereami.c
@@ -306,13 +306,12 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 
             if (dirname_length)
             {
-              int i;
-
-              for (i = length - 1; i >= 0; --i)
+              int ii;
+              for (ii = length - 1; ii >= 0; --ii)
               {
-                if (out[i] == '/')
+                if (out[ii] == '/')
                 {
-                  *dirname_length = i;
+                  *dirname_length = ii;
                   break;
                 }
               }


### PR DESCRIPTION
Generally shadowing symbols is benign, but there are cases where it has masked a legitimate bug. It is not that difficult to use an alternate name to avoid shadowing.