### PR TITLE
Refactor applet config validation

### DIFF
--- a/arrows/mvg/applets/init_cameras_landmarks.cxx
+++ b/arrows/mvg/applets/init_cameras_landmarks.cxx
@@ -35,6 +35,7 @@
 
 #include <vital/algo/initialize_cameras_landmarks.h>
 #include <vital/algo/video_input.h>
+#include <vital/applets/config_validation.h>
 #include <vital/config/config_block_io.h>
 #include <vital/config/config_block.h>
 #include <vital/config/config_parser.h>
@@ -106,78 +107,37 @@ kwiver::vital::config_block_sptr default_config()
 // ------------------------------------------------------------------
 bool check_config(kwiver::vital::config_block_sptr config)
 {
+  using namespace kwiver::tools;
   bool config_valid = true;
 
 #define KWIVER_CONFIG_FAIL(msg) \
   LOG_ERROR(main_logger, "Config Check Fail: " << msg); \
   config_valid = false
 
-  if(config->has_value("video_source") &&
-    config->get_value<std::string>("video_source") != "")
+  config_valid =
+    validate_required_input_file("input_tracks_file", *config, main_logger)
+    && config_valid;
+
+  config_valid =
+    validate_optional_input_file("video_source", *config, main_logger)
+    && config_valid;
+
+  config_valid =
+    validate_required_output_dir("output_cameras_directory", *config, main_logger)
+    && config_valid;
+
+  config_valid =
+    validate_required_output_file("output_landmarks_filename", *config, main_logger)
+    && config_valid;
+
+  if (!video_input::check_nested_algo_configuration("video_reader", config))
   {
-    std::string path = config->get_value<std::string>("video_source");
-    if ( ! ST::FileExists( kwiver::vital::path_t(path), true ) )
-    {
-      KWIVER_CONFIG_FAIL("video_source path, " << path
-                         << ", does not exist or is not a regular file");
-    }
-    if ( !video_input::check_nested_algo_configuration("video_reader", config) )
-    {
-      KWIVER_CONFIG_FAIL("video_reader configuration check failed");
-    }
+    KWIVER_CONFIG_FAIL("video_reader configuration check failed");
   }
 
-  if ( ! config->has_value("input_tracks_file") ||
-    config->get_value<std::string>("input_tracks_file") == "")
+  if (!initialize_cameras_landmarks::check_nested_algo_configuration("initializer", config))
   {
-    KWIVER_CONFIG_FAIL("Config needs value input_tracks_file");
-  }
-  else
-  {
-    std::string path = config->get_value<std::string>("input_tracks_file");
-    if ( ! ST::FileExists( kwiver::vital::path_t(path), true ) )
-    {
-      KWIVER_CONFIG_FAIL("input_tracks_file path, " << path
-                         << ", does not exist or is not a regular file");
-    }
-  }
-
-  if (!config->has_value("output_cameras_directory") ||
-    config->get_value<std::string>("output_cameras_directory") == "" )
-  {
-    KWIVER_CONFIG_FAIL("Config needs value output_cameras_directory");
-  }
-  else if ( ! ST::FileIsDirectory(
-    config->get_value<kwiver::vital::path_t>("output_cameras_directory") ) )
-  {
-    KWIVER_CONFIG_FAIL("output_cameras_director is not a valid directory");
-  }
-
-  if (!config->has_value("output_landmarks_filename") ||
-    config->get_value<std::string>("output_landmarks_filename") == "" )
-  {
-    KWIVER_CONFIG_FAIL("Config needs value output_landmarks_filename");
-  }
-  else if ( ! ST::FileIsDirectory( ST::CollapseFullPath( ST::GetFilenamePath(
-    config->get_value<kwiver::vital::path_t>("output_landmarks_filename") ))))
-  {
-    KWIVER_CONFIG_FAIL("output_landmarks_filename is not in a valid directory");
-  }
-
-  {
-    kwiver::vital::path_t out_landmarks_path =
-      config->get_value<kwiver::vital::path_t>("output_landmarks_filename");
-
-    // verify that we can open the output file for writing
-    // so that we don't find a problem only after spending
-    // hours of computation time.
-    std::ofstream ofs(out_landmarks_path.c_str());
-    if (!ofs)
-    {
-      KWIVER_CONFIG_FAIL("Could not open landmark file for writing: \""
-                         + out_landmarks_path + "\"");
-    }
-    ofs.close();
+    KWIVER_CONFIG_FAIL("initializer configuration check failed");
   }
 
 #undef KWIVER_CONFIG_FAIL

--- a/arrows/mvg/applets/track_features.cxx
+++ b/arrows/mvg/applets/track_features.cxx
@@ -33,6 +33,7 @@
 #include <vital/algo/track_features.h>
 #include <vital/algo/compute_ref_homography.h>
 #include <vital/algo/video_input.h>
+#include <vital/applets/config_validation.h>
 #include <vital/io/track_set_io.h>
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/config/config_block_io.h>
@@ -73,63 +74,28 @@ kv::logger_handle_t main_logger( kv::get_logger( "track_features_applet" ) );
 // ------------------------------------------------------------------
 bool check_config(kv::config_block_sptr config)
 {
+  using namespace kwiver::tools;
   bool config_valid = true;
 
 #define KWIVER_CONFIG_FAIL(msg) \
   LOG_ERROR(main_logger, "Config Check Fail: " << msg); \
   config_valid = false
 
-  // A given homography file is invalid if it names a directory, or if its
-  // parent path either doesn't exist or names a regular file.
-  if ( config->has_value("output_homography_file")
-    && config->get_value<std::string>("output_homography_file") != "" )
-  {
-    kv::config_path_t fp = config->get_value<kv::config_path_t>("output_homography_file");
-    if ( kwiversys::SystemTools::FileIsDirectory( fp ) )
-    {
-      KWIVER_CONFIG_FAIL("Given output homography file is a directory! "
-                        << "(Given: " << fp << ")");
-    }
-    else if ( ST::GetFilenamePath( fp ) != std::string("") &&
-              ! ST::FileIsDirectory( ST::GetFilenamePath( fp ) ))
-    {
-      KWIVER_CONFIG_FAIL("Given output homography file does not have a valid "
-                        << "parent path! (Given: " << fp << ")");
-    }
+  config_valid =
+    validate_required_input_file("video_source", *config, main_logger)
+    && config_valid;
 
-    // Check that compute_ref_homography algo is correctly configured
-    if( !kv::algo::compute_ref_homography
-             ::check_nested_algo_configuration("output_homography_generator",
-                                               config) )
-    {
-      KWIVER_CONFIG_FAIL("output_homography_generator configuration check failed");
-    }
-  }
+  config_valid =
+    validate_optional_input_file("mask_source", *config, main_logger)
+    && config_valid;
 
-  if ( ! config->has_value("video_source") ||
-      config->get_value<std::string>("video_source") == "")
-  {
-    KWIVER_CONFIG_FAIL("Config needs value video_source");
-  }
-  else
-  {
-    std::string path = config->get_value<std::string>("video_source");
-    if ( ! ST::FileExists( kv::path_t(path), true ) )
-    {
-      KWIVER_CONFIG_FAIL("video_source path, " << path << ", does not exist or is not a regular file");
-    }
-  }
+  config_valid =
+    validate_required_output_file("output_tracks_file", *config, main_logger)
+    && config_valid;
 
-  if (!config->has_value("output_tracks_file") ||
-      config->get_value<std::string>("output_tracks_file") == "" )
-  {
-    KWIVER_CONFIG_FAIL("Config needs value output_tracks_file");
-  }
-  else if ( ! ST::FileIsDirectory( ST::CollapseFullPath( ST::GetFilenamePath(
-              config->get_value<kv::path_t>("output_tracks_file") ) ) ) )
-  {
-    KWIVER_CONFIG_FAIL("output_tracks_file is not in a valid directory");
-  }
+  config_valid =
+    validate_optional_output_file("output_homography_file", *config, main_logger)
+    && config_valid;
 
   if (!kv::algo::video_input::check_nested_algo_configuration("video_reader", config))
   {

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -13,6 +13,11 @@ Vital Algo
 
  * Extended the API for compute_depth to also return an uncertainty image.
 
+Vital Applets
+
+ * Added utility functions to help validate config file entries for input
+   and output files and directories.
+
 Vital Types
 
  * Add new method to metadata class to add a metadata item being

--- a/vital/applets/CMakeLists.txt
+++ b/vital/applets/CMakeLists.txt
@@ -21,6 +21,8 @@ include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 ###
 # tools applet support library
 kwiver_add_library( kwiver_tools_applet
+               config_validation.h
+               config_validation.cxx
                kwiver_applet.h
                kwiver_applet.cxx
 )
@@ -29,6 +31,8 @@ target_link_libraries( kwiver_tools_applet
   PUBLIC      ${VITAL_BOOST_REGEX}
               vital_util
               vital_config
+              vital_logger
+              kwiversys
                 )
 
 
@@ -49,6 +53,7 @@ kwiver_add_plugin( vital_applets
 ###
 # Install header files
 kwiver_install_headers(
+  config_validation.h
   kwiver_applet.h
   cxxopts.hpp
   SUBDIR      vital/applets

--- a/vital/applets/config_validation.cxx
+++ b/vital/applets/config_validation.cxx
@@ -1,0 +1,192 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config_validation.h"
+
+#include <kwiversys/SystemTools.hxx>
+
+#include <fstream>
+
+
+namespace kwiver {
+namespace tools {
+
+namespace kv = ::kwiver::vital;
+typedef kwiversys::SystemTools ST;
+
+//=============================================================================
+bool
+validate_required_input_file(std::string const& name,
+                             kv::config_block const& config,
+                             kv::logger_handle_t logger)
+{
+  if (!config.has_value(name) ||
+      config.get_value<std::string>(name) != "")
+  {
+    LOG_ERROR(logger, "Configuration value for " << name
+                     << " is missing but required");
+    return false;
+  }
+
+  return validate_optional_input_file(name, config, logger);
+}
+
+//=============================================================================
+bool
+validate_optional_input_file(std::string const& name,
+                             kv::config_block const& config,
+                             kv::logger_handle_t logger)
+{
+  if (config.has_value(name) &&
+      config.get_value<std::string>(name) != "")
+  {
+    std::string path = config.get_value<std::string>(name);
+    if (!ST::FileExists(path, true))
+    {
+      LOG_ERROR(logger, name << " path, " << path
+        << ", does not exist or is not a regular file");
+      return false;
+    }
+  }
+  return true;
+}
+
+//=============================================================================
+bool
+validate_required_output_file(std::string const& name,
+                              kv::config_block const& config,
+                              kv::logger_handle_t logger,
+                              bool make_directory,
+                              bool test_write)
+{
+  if (!config.has_value(name) ||
+      config.get_value<std::string>(name) != "")
+  {
+    LOG_ERROR(logger, "Configuration value for " << name
+                     << " is missing but required");
+    return false;
+  }
+
+  return validate_optional_output_file(name, config, logger,
+                                       make_directory, test_write);
+}
+
+//=============================================================================
+bool
+validate_optional_output_file(std::string const& name,
+                              kv::config_block const& config,
+                              kv::logger_handle_t logger,
+                              bool make_directory,
+                              bool test_write)
+{
+  if (config.has_value(name) &&
+      config.get_value<std::string>(name) != "")
+  {
+    auto path = config.get_value<std::string>(name);
+    auto parent_dir = ST::GetFilenamePath(ST::CollapseFullPath(path));
+    if (!ST::FileIsDirectory(parent_dir))
+    {
+      if (make_directory && !ST::MakeDirectory(parent_dir))
+      {
+        LOG_ERROR(logger, "unable to create directory " << parent_dir
+                          << " for configuration option " << name);
+        return false;
+      }
+      LOG_ERROR(logger, "directory " << parent_dir << " does not exist"
+                        << " for configuration option " << name);
+      return false;
+    }
+
+    if (test_write)
+    {
+      std::ofstream ofs(path.c_str());
+      if (!ofs)
+      {
+        LOG_ERROR(logger, "Could not open file " << path << " for writing "
+                          << "as required by configuration option " << name);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+//=============================================================================
+bool
+validate_required_output_dir(std::string const& name,
+                             kv::config_block const& config,
+                             kv::logger_handle_t logger,
+                             bool make_directory)
+{
+  if (!config.has_value(name) ||
+      config.get_value<std::string>(name) != "")
+  {
+    LOG_ERROR(logger, "Configuration value for " << name
+                     << " is missing but required");
+    return false;
+  }
+  return validate_optional_output_dir(name, config, logger, make_directory);
+}
+
+//=============================================================================
+bool
+validate_optional_output_dir(std::string const& name,
+                             kv::config_block const& config,
+                             kv::logger_handle_t logger,
+                             bool make_directory)
+{
+  if (config.has_value(name) &&
+      config.get_value<std::string>(name) != "")
+  {
+    std::string path = config.get_value<std::string>(name);
+    if (!ST::FileIsDirectory(path))
+    {
+      if (ST::FileExists(path))
+      {
+        LOG_ERROR(logger, name << " is set to " << path
+                          << " and is a file, not a valid directory");
+        return false;
+      }
+      if (make_directory && !ST::MakeDirectory(path))
+      {
+        LOG_ERROR(logger, "unable to create directory " << path
+                          << " for configuration option " << name);
+        return false;
+      }
+    }
+    LOG_ERROR(logger, path << " is not a valid directory for "
+                      << "configuration option " << name);
+    return false;
+  }
+  return true;
+}
+
+} // end namespace tools
+} // end namespace kwiver

--- a/vital/applets/config_validation.h
+++ b/vital/applets/config_validation.h
@@ -1,0 +1,88 @@
+/*ckwg +29
+ * Copyright 2020 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KWIVER_TOOLS_CONFIG_VALIDATION_H
+#define KWIVER_TOOLS_CONFIG_VALIDATION_H
+
+#include <vital/applets/kwiver_tools_applet_export.h>
+
+#include <vital/config/config_block.h>
+#include <vital/logger/logger.h>
+
+#include <string>
+
+namespace kwiver {
+namespace tools {
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_required_input_file(std::string const& name,
+                             kwiver::vital::config_block const& config,
+                             kwiver::vital::logger_handle_t logger);
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_optional_input_file(std::string const& name,
+                             kwiver::vital::config_block const& config,
+                             kwiver::vital::logger_handle_t logger);
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_required_output_file(std::string const& name,
+                              kwiver::vital::config_block const& config,
+                              kwiver::vital::logger_handle_t logger,
+                              bool make_directory = true,
+                              bool test_write = true);
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_optional_output_file(std::string const& name,
+                              kwiver::vital::config_block const& config,
+                              kwiver::vital::logger_handle_t logger,
+                              bool make_directory = true,
+                              bool test_write = true);
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_required_output_dir(std::string const& name,
+                             kwiver::vital::config_block const& config,
+                             kwiver::vital::logger_handle_t logger,
+                             bool make_directory = true);
+
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_optional_output_dir(std::string const& name,
+                             kwiver::vital::config_block const& config,
+                             kwiver::vital::logger_handle_t logger,
+                             bool make_directory = true);
+
+}
+}
+#endif

--- a/vital/applets/config_validation.h
+++ b/vital/applets/config_validation.h
@@ -41,18 +41,56 @@
 namespace kwiver {
 namespace tools {
 
+/// Validate a required input file for a key name in the given config block
+/**
+ * Verify that the config block contains the key \a name, that the value is
+ * not the empty string, and that it refers to a valid file on disk
+ *
+ * \param name   The key name to look for in the configuration block
+ * \param config The configuration block to check for the key
+ * \param logger The logger handle to log error messages to
+ *
+ * \returns true if sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_required_input_file(std::string const& name,
                              kwiver::vital::config_block const& config,
                              kwiver::vital::logger_handle_t logger);
 
+/// Validate an optional input file for a key name in the given config block
+/**
+ * If the config block contains the key \a name and the value is not empty
+ * then verify that it refers to a valid file on disk
+ *
+ * \param name   The key name to look for in the configuration block
+ * \param config The configuration block to check for the key
+ * \param logger The logger handle to log error messages
+ *
+ * \returns true if file not set or if set and sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_optional_input_file(std::string const& name,
                              kwiver::vital::config_block const& config,
                              kwiver::vital::logger_handle_t logger);
 
+/// Validate a required output file for a key name in the given config block
+/**
+ * Verify that the config block contains the key \a name, that the value is
+ * not the empty string, and that it refers to a valid path for writing an
+ * output file.  If \a make_directory is true then construct directories
+ * as needed to make a valid path.  If \a test_write is true then try to
+ * open the file for writing to confirm write permissions.
+ *
+ * \param name           The key name to look for in the configuration block
+ * \param config         The configuration block to check for the key
+ * \param logger         The logger handle to log error messages
+ * \param make_directory If true, create any missing directory structure
+ * \param test_write     If true, test create the file to verify write
+ *                       permission
+ * \returns true if sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_required_output_file(std::string const& name,
@@ -61,6 +99,22 @@ validate_required_output_file(std::string const& name,
                               bool make_directory = true,
                               bool test_write = true);
 
+/// Validate an optional output file for a key name in the given config block
+/**
+ * If the config block contains the key \a name and the value is not empty
+ * then verify that it refers to a valid path for writing an output file.
+ * If \a make_directory is true then construct directories as needed to make
+ * a valid path.  If \a test_write is true then try to open the file for
+ * writing to confirm write permissions.
+ *
+ * \param name           The key name to look for in the configuration block
+ * \param config         The configuration block to check for the key
+ * \param logger         The logger handle to log error messages
+ * \param make_directory If true, create any missing directory structure
+ * \param test_write     If true, test create the file to verify write
+ *                       permission
+ * \returns true if file not set or if set and sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_optional_output_file(std::string const& name,
@@ -69,6 +123,20 @@ validate_optional_output_file(std::string const& name,
                               bool make_directory = true,
                               bool test_write = true);
 
+/// Validate a required output directory for a key name in the given config block
+/**
+ * Verify that the config block contains the key \a name, that the value is
+ * not the empty string, and that it refers to a valid directory for writing
+ * output files.  If \a make_directory is true then construct directories
+ * as needed to make a valid path.
+ *
+ * \param name           The key name to look for in the configuration block
+ * \param config         The configuration block to check for the key
+ * \param logger         The logger handle to log error messages
+ * \param make_directory If true, create any missing directory structure
+ *
+ * \returns true if sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_required_output_dir(std::string const& name,
@@ -76,6 +144,20 @@ validate_required_output_dir(std::string const& name,
                              kwiver::vital::logger_handle_t logger,
                              bool make_directory = true);
 
+/// Validate an optional output directory for a key name in the given config block
+/**
+ * If the config block contains the key \a name and the value is not empty
+ * then verify that it refers to a valid directory for writing output files.
+ * If \a make_directory is true then construct directories as needed to make
+ * a valid path.
+ *
+ * \param name           The key name to look for in the configuration block
+ * \param config         The configuration block to check for the key
+ * \param logger         The logger handle to log error messages
+ * \param make_directory If true, create any missing directory structure
+ *
+ * \returns true if directory not set or if set and sucessfully validated
+ */
 KWIVER_TOOLS_APPLET_EXPORT
 bool
 validate_optional_output_dir(std::string const& name,


### PR DESCRIPTION
Applets reuse the same pattern repeatedly of checking configuration for input or output files and directories.  Depending on whether the input or output is required or optional the logic is slightly different, but generally we want to see if the parameter is set and if it points to a valid file or directory on disk.  For outputs, we may even want to create missing directories and test that we have permission to write to output files.

This PR refactors current applets to move this logic into a set of reusable utility functions that any applet can reuse. 