### PR TITLE
WIP: Disable VTK when a bad version is found

### DIFF
--- a/CMake/kwiver-depends-VTK.cmake
+++ b/CMake/kwiver-depends-VTK.cmake
@@ -6,16 +6,16 @@ option( KWIVER_ENABLE_VTK
   )
 
 if( KWIVER_ENABLE_VTK )
-    find_package(VTK REQUIRED
+    find_package(VTK 8.2
         COMPONENTS
         vtkCommonCore
         vtkCommonDataModel
         )
     if(VTK_VERSION VERSION_LESS 8.2)
-        message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "
-            "(Found ${VTK_VERSION})")
-    endif()
-
-  include(${VTK_USE_FILE})
-
+        message(WARNING  "${PROJECT_NAME} supports VTK >= v8.2 "
+          "(Found ${VTK_VERSION}). Disabling VTK support")
+        set( KWIVER_ENABLE_VTK OFF CACHE BOOL "" FORCE)
+      else()
+        include(${VTK_USE_FILE})
+      endif()
 endif( KWIVER_ENABLE_VTK )


### PR DESCRIPTION
When we find VTK but the version isn't usable, disable VTK rather than failing.

I realize that this PR is a bit of a break in the current kwiver patter for third party library support but I wanted to pose it as a possible alternative since we have a growing number of packages that need newer versions that some of the supported fletch versions.

This PR isn't critical since I can easily change the dashboard scripts that build VIVIA, for example but again, wanted to see if there were objections to changing the pattern for supported packages in kwiver.