### PR TITLE
Add missing utilities for config validation for input directories

### DIFF
--- a/vital/applets/config_validation.cxx
+++ b/vital/applets/config_validation.cxx
@@ -150,15 +150,9 @@ validate_required_input_dir(std::string const& name,
                             kv::config_block const& config,
                             kv::logger_handle_t logger)
 {
-  if (!config.has_value(name) ||
-      config.get_value<std::string>(name) == "")
-  {
-    LOG_ERROR(logger, "Configuration value for " << name
-                      << " is missing but required");
-    return false;
-  }
-
-  return validate_optional_input_dir(name, config, logger);
+  // validation for input directories is the same as output directories except
+  // that we never create missing directories for inputs
+  return validate_required_output_dir(name, config, logger, false);
 }
 
 //=============================================================================
@@ -167,24 +161,9 @@ validate_optional_input_dir(std::string const& name,
                             kv::config_block const& config,
                             kv::logger_handle_t logger)
 {
-  if (config.has_value(name) &&
-      config.get_value<std::string>(name) != "")
-  {
-    std::string path = config.get_value<std::string>(name);
-    if (!ST::FileIsDirectory(path))
-    {
-      if (ST::FileExists(path))
-      {
-        LOG_ERROR(logger, name << " is set to " << path
-                          << " and is a file, not a valid directory");
-        return false;
-      }
-      LOG_ERROR(logger, name << " path, " << path
-                        << ", does not exist");
-      return false;
-    }
-  }
-  return true;
+  // validation for input directories is the same as output directories except
+  // that we never create missing directories for inputs
+  return validate_optional_output_dir(name, config, logger, false);
 }
 
 //=============================================================================

--- a/vital/applets/config_validation.cxx
+++ b/vital/applets/config_validation.cxx
@@ -146,6 +146,49 @@ validate_optional_output_file(std::string const& name,
 
 //=============================================================================
 bool
+validate_required_input_dir(std::string const& name,
+                            kv::config_block const& config,
+                            kv::logger_handle_t logger)
+{
+  if (!config.has_value(name) ||
+      config.get_value<std::string>(name) == "")
+  {
+    LOG_ERROR(logger, "Configuration value for " << name
+                      << " is missing but required");
+    return false;
+  }
+
+  return validate_optional_input_dir(name, config, logger);
+}
+
+//=============================================================================
+bool
+validate_optional_input_dir(std::string const& name,
+                            kv::config_block const& config,
+                            kv::logger_handle_t logger)
+{
+  if (config.has_value(name) &&
+      config.get_value<std::string>(name) != "")
+  {
+    std::string path = config.get_value<std::string>(name);
+    if (!ST::FileIsDirectory(path))
+    {
+      if (ST::FileExists(path))
+      {
+        LOG_ERROR(logger, name << " is set to " << path
+                          << " and is a file, not a valid directory");
+        return false;
+      }
+      LOG_ERROR(logger, name << " path, " << path
+                        << ", does not exist");
+      return false;
+    }
+  }
+  return true;
+}
+
+//=============================================================================
+bool
 validate_required_output_dir(std::string const& name,
                              kv::config_block const& config,
                              kv::logger_handle_t logger,

--- a/vital/applets/config_validation.h
+++ b/vital/applets/config_validation.h
@@ -123,6 +123,40 @@ validate_optional_output_file(std::string const& name,
                               bool make_directory = true,
                               bool test_write = true);
 
+/// Validate a required input directory for a key name in the given config block
+/**
+ * Verify that the config block contains the key \a name, that the value is
+ * not the empty string, and that it refers to a valid directory on disk
+ *
+ * \param name   The key name to look for in the configuration block
+ * \param config The configuration block to check for the key
+ * \param logger The logger handle to log error messages to
+ *
+ * \returns true if sucessfully validated
+ */
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_required_input_dir(std::string const& name,
+                            kwiver::vital::config_block const& config,
+                            kwiver::vital::logger_handle_t logger);
+
+/// Validate an optional input directory for a key name in the given config block
+/**
+ * If the config block contains the key \a name and the value is not empty
+ * then verify that it refers to a valid directory on disk
+ *
+ * \param name   The key name to look for in the configuration block
+ * \param config The configuration block to check for the key
+ * \param logger The logger handle to log error messages
+ *
+ * \returns true if directory not set or if set and sucessfully validated
+ */
+KWIVER_TOOLS_APPLET_EXPORT
+bool
+validate_optional_input_dir(std::string const& name,
+                            kwiver::vital::config_block const& config,
+                            kwiver::vital::logger_handle_t logger);
+
 /// Validate a required output directory for a key name in the given config block
 /**
  * Verify that the config block contains the key \a name, that the value is


### PR DESCRIPTION
Previously we provided functions for input files, output files, and output directories.  This PR completes the set by adding input directories.