### PR TITLE
WIP: Support VTK v9

### DIFF
--- a/CMake/kwiver-depends-VTK.cmake
+++ b/CMake/kwiver-depends-VTK.cmake
@@ -6,16 +6,18 @@ option( KWIVER_ENABLE_VTK
   )
 
 if( KWIVER_ENABLE_VTK )
-    find_package(VTK REQUIRED
-        COMPONENTS
-        vtkCommonCore
-        vtkCommonDataModel
-        )
-    if(VTK_VERSION VERSION_LESS 8.2)
-        message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "
-            "(Found ${VTK_VERSION})")
-    endif()
-
-  include(${VTK_USE_FILE})
-
+  find_package(VTK REQUIRED
+    COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    )
+  if(VTK_VERSION VERSION_LESS 8.2)
+    message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "
+      "(Found ${VTK_VERSION})")
+  elseif(NOT VTK_VERSION VERSION_LESS 8.90 )
+    get_target_property(VTK_INCLUDE_DIR VTK::CommonCore INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(SYSTEM "${VTK_INCLUDE_DIR}")
+  else()
+    include(${VTK_USE_FILE})
+  endif()
 endif( KWIVER_ENABLE_VTK )

--- a/CMake/kwiver-depends-VTK.cmake
+++ b/CMake/kwiver-depends-VTK.cmake
@@ -10,6 +10,7 @@ if( KWIVER_ENABLE_VTK )
     COMPONENTS
     vtkCommonCore
     vtkCommonDataModel
+    vtkRenderingCore
     )
   if(VTK_VERSION VERSION_LESS 8.2)
     message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "

--- a/arrows/vtk/CMakeLists.txt
+++ b/arrows/vtk/CMakeLists.txt
@@ -18,6 +18,20 @@ set( plugin_vtk_sources
   depth_utils.cxx
   )
 
+if (NOT VTK_VERSION VERSION_LESS 8.90)
+  set (VTK_ARROW_LIBS
+    VTK::CommonCore
+    VTK::CommonDataModel
+    VTK::RenderingCore
+    )
+else()
+  set (VTK_ARROW_LIBS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkRenderingCore
+    )
+endif()
+
 kwiver_add_library( kwiver_algo_vtk
   ${plugin_vtk_headers}
   ${plugin_vtk_sources}
@@ -25,7 +39,7 @@ kwiver_add_library( kwiver_algo_vtk
 
 target_link_libraries( kwiver_algo_vtk
   PUBLIC               vital
-                       ${VTK_LIBRARIES}
+                       ${VTK_ARROW_LIBS}
   )
 
 #algorithms_create_plugin( kwiver_algo_vtk

--- a/arrows/vtk/CMakeLists.txt
+++ b/arrows/vtk/CMakeLists.txt
@@ -25,8 +25,7 @@ kwiver_add_library( kwiver_algo_vtk
 
 target_link_libraries( kwiver_algo_vtk
   PUBLIC               vital
-                       vtkCommonCore
-                       vtkCommonDataModel
+                       ${VTK_LIBRARIES}
   )
 
 #algorithms_create_plugin( kwiver_algo_vtk


### PR DESCRIPTION
VTK interfaces have changed since v8.

- We need to get_property for INTERFACE_INCLUDE_DIRECTORIES so we can find the headers.
- We have to use VTK_LIBRARIES for library links because of the shift from vtkCommonCore to VTK::CommonCore, etc.
- VTK_USE_FILE is no longer provided.

The latest PR adds a new module that's pending in #1128. It's probably worth landing that PR first to avoid conflicts.
