### PR TITLE
Update descriptions for geo_point-type metadata

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -16,6 +16,9 @@ Vital
  * Added a missing include file in track.cxx required to build on MSVC 2019.
  * Changed incorrect metadata tag in convert_0601_metadata.cxx from
    KLV_0601_TARGET_LOCATION_LAT to KLV_0601_TARGET_LOCATION_ELEV.
+ * Fixed a typo in the TARGET_LOCATION metadata field name.
+ * Updated metadata field names for kv::geo_point types to be more
+   descriptive. Made the distinction between elevation and altitude.
 
 Arrows: Core
 

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -127,7 +127,7 @@
         bool,                                                           \
         "" )                                                            \
   CALL( SENSOR_LOCATION,                                                \
-        "Sensor Geodetic Location (lon/lat/meters)",                    \
+        "Sensor Geodetic Location (lon/lat/alt)",                       \
         geo_point,                                                      \
         "Contains the 3D coordinate of the sensor. "                    \
         "The location is ordered lon, lat. "                            \
@@ -183,11 +183,11 @@
         double,                                                         \
         "Target Width within sensor field of view." )                   \
   CALL( FRAME_CENTER,                                                   \
-        "Geodetic Frame Center, (lon/lat/meters)",                      \
+        "Geodetic Frame Center, (lon/lat/elev)",                        \
         geo_point,                                                      \
         "Contains the 3D coordinate of the frame center. "              \
-        "The location is ordered lon, lat, and altitude in meters. "    \
-        "Altitude is not always set." )                                 \
+        "The location is ordered lon, lat, and elevation in meters. "   \
+        "Elevation is not always set." )                                \
   CALL( CORNER_POINTS,                                                  \
         "Corner points (lon/lat)",                                      \
         geo_polygon,                                                    \
@@ -222,11 +222,11 @@
         double,                                                         \
         "Temperature outside aircraft." )                               \
   CALL( TARGET_LOCATION,                                                \
-        "Target Geodetic Locationq (lon/lat/meters)",                   \
+        "Target Geodetic Location (lon/lat/elev)",                      \
         geo_point,                                                      \
         "Contains the 3D coordinate of the target. "                    \
         "The location is ordered lon, lat. "                            \
-        "The altitude is optional and is in meters." )                  \
+        "The elevation is optional and is in meters." )                 \
   CALL( TARGET_TRK_GATE_WIDTH,                                          \
         "Target Track Gate Width (pixels)",                             \
         double,                                                         \


### PR DESCRIPTION
Fix typo `Target Geodetic Locationq` -> `Target Geodetic Location`

Update third item of metdata short tag from `meters` to `alt` or `elev` based on MISB 0601.