### PR TITLE
Update copyright banner in vital/bindings

### DIFF
--- a/vital/bindings/c/algo_def/bundle_adjust.cxx
+++ b/vital/bindings/c/algo_def/bundle_adjust.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -42,12 +16,9 @@
 #include <vital/bindings/c/helpers/landmark_map.h>
 #include <vital/bindings/c/helpers/track_set.h>
 
-
 DEFINE_COMMON_ALGO_API( bundle_adjust )
 
-
 using namespace kwiver;
-
 
 /// Optimize the camera and landmark parameters given a set of tracks
 void

--- a/vital/bindings/c/algo_def/bundle_adjust.h
+++ b/vital/bindings/c/algo_def/bundle_adjust.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -49,10 +23,8 @@ extern "C"
 #include <vital/bindings/c/types/landmark_map.h>
 #include <vital/bindings/c/types/track_set.h>
 
-
 /// Common algorithm functions
 DECLARE_COMMON_ALGO_API( bundle_adjust )
-
 
 /// Optimize the camera and landmark parameters given a set of tracks
 /**
@@ -69,7 +41,6 @@ vital_algorithm_bundle_adjust_optimize( vital_algorithm_t *algo,
                                         vital_landmark_map_t **lmap,
                                         vital_trackset_t *tset,
                                         vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/convert_image.cxx
+++ b/vital/bindings/c/algo_def/convert_image.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,9 +14,7 @@
 
 #include <vital/algo/convert_image.h>
 
-
 DEFINE_COMMON_ALGO_API( convert_image );
-
 
 /// Convert image base type
 vital_image_container_t*

--- a/vital/bindings/c/algo_def/convert_image.h
+++ b/vital/bindings/c/algo_def/convert_image.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,10 +19,8 @@ extern "C"
 #include <vital/bindings/c/vital_c_export.h>
 #include <vital/bindings/c/types/image_container.h>
 
-
 /// Declare common type-specific functions
 DECLARE_COMMON_ALGO_API( convert_image );
-
 
 /// Convert image base type
 /**
@@ -65,7 +37,6 @@ vital_image_container_t*
 vital_algorithm_convert_image_convert( vital_algorithm_t *algo,
                                        vital_image_container_t *ic,
                                        vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/estimate_canonical_transform.cxx
+++ b/vital/bindings/c/algo_def/estimate_canonical_transform.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,12 +15,9 @@
 #include <vital/bindings/c/helpers/camera_map.h>
 #include <vital/bindings/c/helpers/landmark_map.h>
 
-
 DEFINE_COMMON_ALGO_API( estimate_canonical_transform )
 
-
 using namespace kwiver;
-
 
 /// Estimate a canonical similarity transform for cameras and points
 vital_similarity_d_t*

--- a/vital/bindings/c/algo_def/estimate_canonical_transform.h
+++ b/vital/bindings/c/algo_def/estimate_canonical_transform.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,9 +22,7 @@ extern "C"
 #include <vital/bindings/c/types/similarity.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 DECLARE_COMMON_ALGO_API( estimate_canonical_transform )
-
 
 /// Estimate a canonical similarity transform for cameras and points
 /**
@@ -73,8 +45,6 @@ vital_algorithm_estimate_canonical_transform_estimate( vital_algorithm_t *algo,
                                                        vital_camera_map_t const *cam_map,
                                                        vital_landmark_map_t const *lm_map,
                                                        vital_error_handle_t *eh );
-
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/estimate_similarity_transform.cxx
+++ b/vital/bindings/c/algo_def/estimate_similarity_transform.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,12 +19,9 @@
 
 #include <vital/exceptions/algorithm.h>
 
-
 DEFINE_COMMON_ALGO_API( estimate_similarity_transform )
 
-
 using namespace kwiver;
-
 
 /// Estimate the similarity transform between two corresponding point sets
 vital_similarity_d_t*
@@ -97,7 +68,6 @@ vital_algorithm_estimate_similarity_transform_estimate_transform_points(
   return NULL;
 }
 
-
 /// Estimate the similarity transform between two corresponding camera maps
 vital_similarity_d_t*
 vital_algorithm_estimate_similarity_transform_estimate_camera_map(
@@ -133,7 +103,6 @@ vital_algorithm_estimate_similarity_transform_estimate_camera_map(
   );
   return NULL;
 }
-
 
 /// Estimate the similarity transform between two corresponding landmark maps
 vital_similarity_d_t*

--- a/vital/bindings/c/algo_def/estimate_similarity_transform.h
+++ b/vital/bindings/c/algo_def/estimate_similarity_transform.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,9 +22,7 @@ extern "C"
 #include <vital/bindings/c/types/similarity.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 DECLARE_COMMON_ALGO_API( estimate_similarity_transform )
-
 
 /// Estimate the similarity transform between two corresponding point sets
 /**
@@ -75,7 +47,6 @@ vital_algorithm_estimate_similarity_transform_estimate_transform_points(
   vital_eigen_matrix3x1d_t const **to,
   vital_error_handle_t *eh
 );
-
 
 /// Estimate the similarity transform between two corresponding camera maps
 /**
@@ -105,7 +76,6 @@ vital_algorithm_estimate_similarity_transform_estimate_camera_map(
   vital_error_handle_t *eh
 );
 
-
 /// Estimate the similarity transform between two corresponding landmark maps
 /**
  * Landmarks with corresponding frame IDs in the two maps are paired for
@@ -133,7 +103,6 @@ vital_algorithm_estimate_similarity_transform_estimate_landmark_map(
   vital_landmark_map_t const *from, vital_landmark_map_t const *to,
   vital_error_handle_t *eh
 );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/image_io.cxx
+++ b/vital/bindings/c/algo_def/image_io.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,9 +13,7 @@
 #include <vital/bindings/c/helpers/algorithm.h>
 #include <vital/bindings/c/helpers/image_container.h>
 
-
 DEFINE_COMMON_ALGO_API( image_io );
-
 
 /// Load image from file
 vital_image_container_t* vital_algorithm_image_io_load( vital_algorithm_t *algo,
@@ -56,7 +28,6 @@ vital_image_container_t* vital_algorithm_image_io_load( vital_algorithm_t *algo,
   );
   return 0;
 }
-
 
 /// Save an image to file
 void vital_algorithm_image_io_save( vital_algorithm_t *algo,

--- a/vital/bindings/c/algo_def/image_io.h
+++ b/vital/bindings/c/algo_def/image_io.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,10 +19,8 @@ extern "C"
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/types/image_container.h>
 
-
 /// Declare common type-specific functions
 DECLARE_COMMON_ALGO_API( image_io );
-
 
 /// Load image from file
 /**
@@ -64,7 +36,6 @@ vital_image_container_t* vital_algorithm_image_io_load( vital_algorithm_t *algo,
                                                         char const *filename,
                                                         vital_error_handle_t *eh);
 
-
 /// Save an image to file
 /**
  * \param algo Opaque pointer to algorithm instance.
@@ -77,7 +48,6 @@ void vital_algorithm_image_io_save( vital_algorithm_t *algo,
                                     char const *filename,
                                     vital_image_container_t *ic,
                                     vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/initialize_cameras_landmarks.cxx
+++ b/vital/bindings/c/algo_def/initialize_cameras_landmarks.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,12 +15,9 @@
 #include <vital/bindings/c/helpers/landmark_map.h>
 #include <vital/bindings/c/helpers/track_set.h>
 
-
 DEFINE_COMMON_ALGO_API( initialize_cameras_landmarks )
 
-
 using namespace kwiver;
-
 
 /// Initialize the camera and landmark parameters given a set of tracks
 void

--- a/vital/bindings/c/algo_def/initialize_cameras_landmarks.h
+++ b/vital/bindings/c/algo_def/initialize_cameras_landmarks.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,9 +22,7 @@ extern "C"
 #include <vital/bindings/c/types/track_set.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 DECLARE_COMMON_ALGO_API( initialize_cameras_landmarks )
-
 
 /// Initialize the camera and landmark parameters given a set of tracks
 /**
@@ -67,7 +39,6 @@ vital_algorithm_initialize_cameras_landmarks_initialize( vital_algorithm_t *algo
                                                          vital_landmark_map_t **landmarks,
                                                          vital_trackset_t *tracks,
                                                          vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/track_features.cxx
+++ b/vital/bindings/c/algo_def/track_features.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,10 +15,8 @@
 #include <vital/bindings/c/helpers/image_container.h>
 #include <vital/bindings/c/helpers/track_set.h>
 
-
 /// Common API implementation
 DEFINE_COMMON_ALGO_API( track_features );
-
 
 /// Extend a previous set of tracks using the current frame
 vital_trackset_t*
@@ -68,7 +40,6 @@ vital_algorithm_track_features_track( vital_algorithm_t *algo,
   );
   return 0;
 }
-
 
 /// Extend a previous set of tracks using the current frame, masked version
 vital_trackset_t*

--- a/vital/bindings/c/algo_def/track_features.h
+++ b/vital/bindings/c/algo_def/track_features.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -47,10 +21,8 @@ extern "C"
 #include <vital/bindings/c/types/image_container.h>
 #include <vital/bindings/c/types/track_set.h>
 
-
 /// Common algorithm definition API
 DECLARE_COMMON_ALGO_API( track_features );
-
 
 /// New track set of extended tracks using the current frame
 VITAL_C_EXPORT
@@ -61,7 +33,6 @@ vital_algorithm_track_features_track( vital_algorithm_t *algo,
                                       vital_image_container_t *ic,
                                       vital_error_handle_t *eh );
 
-
 /// New track set of extended tracks using the current frame, masked version
 VITAL_C_EXPORT
 vital_trackset_t*
@@ -71,7 +42,6 @@ vital_algorithm_track_features_track_with_mask( vital_algorithm_t *algo,
                                                 vital_image_container_t *ic,
                                                 vital_image_container_t *mask,
                                                 vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algo_def/triangulate_landmarks.cxx
+++ b/vital/bindings/c/algo_def/triangulate_landmarks.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -42,12 +16,9 @@
 #include <vital/bindings/c/helpers/landmark_map.h>
 #include <vital/bindings/c/helpers/track_set.h>
 
-
 DEFINE_COMMON_ALGO_API( triangulate_landmarks )
 
-
 using namespace kwiver;
-
 
 /// Triangulate the landmark locations given sets of cameras and tracks
 void

--- a/vital/bindings/c/algo_def/triangulate_landmarks.h
+++ b/vital/bindings/c/algo_def/triangulate_landmarks.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,9 +22,7 @@ extern "C"
 #include <vital/bindings/c/types/track_set.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 DECLARE_COMMON_ALGO_API( triangulate_landmarks )
-
 
 /// Triangulate the landmark locations given sets of cameras and tracks
 /**
@@ -70,7 +42,6 @@ vital_algorithm_triangulate_landmarks_triangulate( vital_algorithm_t *algo,
                                                    vital_trackset_t *tracks,
                                                    vital_landmark_map_t **landmarks,
                                                    vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/algorithm.cxx
+++ b/vital/bindings/c/algorithm.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,7 +13,6 @@
 
 #include <vital/bindings/c/helpers/algorithm.h>
 #include <vital/bindings/c/helpers/c_utils.h>
-
 
 // ===========================================================================
 // Helper stuff
@@ -54,7 +27,6 @@ SharedPointerCache< kwiver::vital::algorithm,
 
 } // end namespace vital_c
 } // end namespace kwiver
-
 
 // ===========================================================================
 // Functions on general algorithm pointer
@@ -72,7 +44,6 @@ vital_algorithm_type_name( vital_algorithm_t *algo,
   return 0;
 }
 
-
 char const*
 vital_algorithm_impl_name( vital_algorithm_t const *algo,
                            vital_error_handle_t *eh )
@@ -84,7 +55,6 @@ vital_algorithm_impl_name( vital_algorithm_t const *algo,
   );
   return "";
 }
-
 
 /// Get an algorithm implementation's configuration block
 vital_config_block_t*
@@ -101,7 +71,6 @@ vital_algorithm_get_impl_configuration( vital_algorithm_t *algo,
   return 0;
 }
 
-
 /// Set this algorithm implementation's properties via a config block
 void
 vital_algorithm_set_impl_configuration( vital_algorithm_t *algo,
@@ -115,7 +84,6 @@ vital_algorithm_set_impl_configuration( vital_algorithm_t *algo,
     );
   );
 }
-
 
 /// Check that the algorithm implementation's configuration is valid
 bool

--- a/vital/bindings/c/algorithm.h
+++ b/vital/bindings/c/algorithm.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -49,10 +23,8 @@ extern "C"
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/types/image_container.h>
 
-
 /// Opaque pointer to a VITAL Algorithm instance
 typedef struct vital_algorithm_s vital_algorithm_t;
-
 
 // ===========================================================================
 // Functions on general algorithm pointer
@@ -67,7 +39,6 @@ VITAL_C_EXPORT
 char const* vital_algorithm_type_name( vital_algorithm_t *algo,
                                        vital_error_handle_t *eh );
 
-
 // Return the name of this implementation
 /**
  * \param algo Opaque pointer to algorithm instance.
@@ -78,13 +49,11 @@ char const*
 vital_algorithm_impl_name( vital_algorithm_t const *algo,
                            vital_error_handle_t *eh );
 
-
 /// Get an algorithm implementation's configuration block
 VITAL_C_EXPORT
 vital_config_block_t*
 vital_algorithm_get_impl_configuration( vital_algorithm_t *algo,
                                         vital_error_handle_t *eh );
-
 
 /// Set this algorithm implementation's properties via a config block
 VITAL_C_EXPORT
@@ -93,14 +62,12 @@ vital_algorithm_set_impl_configuration( vital_algorithm_t *algo,
                                         vital_config_block_t *cb,
                                         vital_error_handle_t *eh );
 
-
 /// Check that the algorithm implementation's configuration is valid
 VITAL_C_EXPORT
 bool
 vital_algorithm_check_impl_configuration( vital_algorithm_t *algo,
                                           vital_config_block_t *cb,
                                           vital_error_handle_t *eh );
-
 
 /// Common methods for classes that descend from algorithm_def
 /**
@@ -172,7 +139,6 @@ vital_algorithm_check_impl_configuration( vital_algorithm_t *algo,
   vital_algorithm_##type##_check_type_config( char const *name,                 \
                                               vital_config_block_t const *cb,   \
                                               vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/common.cxx
+++ b/vital/bindings/c/common.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -37,7 +11,6 @@
 
 #include <cstdlib>
 #include <cstring>
-
 
 /// Allocate a new vital string structure
 vital_string_t* vital_string_new(size_t length, char const* s)
@@ -57,14 +30,12 @@ vital_string_t* vital_string_new(size_t length, char const* s)
   return n;
 }
 
-
 /// Free an alocated string structure
 void vital_string_free( vital_string_t *s )
 {
   free(s->str);
   free(s);
 }
-
 
 /// Common function for freeing string lists
 void vital_common_free_string_list( size_t length,
@@ -77,7 +48,6 @@ void vital_common_free_string_list( size_t length,
   free(keys);
 }
 
-
 void vital_free_pointer( void *thing )
 {
   if( thing )
@@ -85,7 +55,6 @@ void vital_free_pointer( void *thing )
     free(thing);
   }
 }
-
 
 void vital_free_double_pointer( size_t length, void **things )
 {

--- a/vital/bindings/c/common.h
+++ b/vital/bindings/c/common.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,7 +19,6 @@ extern "C"
 
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// Simple string structure
 typedef struct {
   size_t length;
@@ -60,16 +33,13 @@ vital_string_t* vital_string_new(size_t length, char const* s);
 VITAL_C_EXPORT
 void vital_string_free( vital_string_t *s );
 
-
 /// Common function for freeing string lists
 VITAL_C_EXPORT
 void vital_common_free_string_list( size_t length, char **keys );
 
-
 /// Other free functions
 VITAL_C_EXPORT void vital_free_pointer( void *thing );
 VITAL_C_EXPORT void vital_free_double_pointer( size_t length, void **things );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/config_block.cxx
+++ b/vital/bindings/c/config_block.cxx
@@ -1,38 +1,11 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
  * \brief C Interface to \p config_block object implementation
  */
-
 
 #include "config_block.h"
 
@@ -60,7 +33,6 @@ CONFIG_BLOCK_SPTR_CACHE( "config_block" );
 
 } }
 
-
 // Static Constant getters
 
 /// Separator between blocks within the config
@@ -80,7 +52,6 @@ vital_config_block_block_sep()
   return static_bs;
 }
 
-
 /// The magic group for global parameters
 char const*
 vital_config_block_global_value()
@@ -98,7 +69,6 @@ vital_config_block_global_value()
   return static_gv;
 }
 
-
 /// Create a new, empty \p config_block object
 vital_config_block_t*
 vital_config_block_new()
@@ -111,7 +81,6 @@ vital_config_block_new()
   );
   return 0;
 }
-
 
 /// Create a new, empty \p config_block object with a name
 vital_config_block_t*
@@ -126,7 +95,6 @@ vital_config_block_new_named( char const* name )
   return 0;
 }
 
-
 /// Destroy a config block object
 void
 vital_config_block_destroy( vital_config_block_t* cb,
@@ -137,7 +105,6 @@ vital_config_block_destroy( vital_config_block_t* cb,
     kwiver::vital_c::CONFIG_BLOCK_SPTR_CACHE.erase( cb );
   );
 }
-
 
 /// Get the name of the \p config_block instance
 char const*
@@ -152,7 +119,6 @@ vital_config_block_get_name( vital_config_block_t* cb,
   );
   return 0;
 }
-
 
 /// Get a copy of a sub-block of the configuration
 vital_config_block_t*
@@ -170,7 +136,6 @@ vital_config_block_subblock( vital_config_block_t* cb,
   return 0;
 }
 
-
 /// Get a mutable view of a sub-block within a configuration
 vital_config_block_t*
 vital_config_block_subblock_view( vital_config_block_t* cb,
@@ -186,7 +151,6 @@ vital_config_block_subblock_view( vital_config_block_t* cb,
   );
   return 0;
 }
-
 
 /// Get the string value for a key
 char const*
@@ -212,7 +176,6 @@ vital_config_block_get_value( vital_config_block_t* cb,
   return 0;
 }
 
-
 /// Get the boolean value for a key
 bool
 vital_config_block_get_value_bool( vital_config_block_t*  cb,
@@ -234,7 +197,6 @@ vital_config_block_get_value_bool( vital_config_block_t*  cb,
   return false;
 }
 
-
 /// Get the string value for a key if it exists, else the default
 char const*
 vital_config_block_get_value_default( vital_config_block_t* cb,
@@ -253,7 +215,6 @@ vital_config_block_get_value_default( vital_config_block_t* cb,
   return 0;
 }
 
-
 /// Get the boolean value for a key if it exists, else the default
 bool
 vital_config_block_get_value_default_bool( vital_config_block_t*  cb,
@@ -268,7 +229,6 @@ vital_config_block_get_value_default_bool( vital_config_block_t*  cb,
   );
   return false;
 }
-
 
 /// Get the description string for a given key
 char const*
@@ -294,7 +254,6 @@ vital_config_block_get_description( vital_config_block_t* cb,
   return 0;
 }
 
-
 /// Set the string value for a key
 void
 vital_config_block_set_value( vital_config_block_t* cb,
@@ -315,7 +274,6 @@ vital_config_block_set_value( vital_config_block_t* cb,
     }
   );
 }
-
 
 /// Set a string value with an associated description
 void
@@ -338,7 +296,6 @@ vital_config_block_set_value_descr( vital_config_block_t* cb,
     }
   );
 }
-
 
 /// Remove a key/value pair from the configuration.
 void
@@ -363,7 +320,6 @@ vital_config_block_unset_value( vital_config_block_t* cb,
   );
 }
 
-
 /// Query if a value is read-only
 bool
 vital_config_block_is_read_only( vital_config_block_t* cb,
@@ -377,7 +333,6 @@ vital_config_block_is_read_only( vital_config_block_t* cb,
   return false;
 }
 
-
 /// Mark the given key as read-only
 void
 vital_config_block_mark_read_only( vital_config_block_t* cb,
@@ -389,7 +344,6 @@ vital_config_block_mark_read_only( vital_config_block_t* cb,
     kwiver::vital_c::CONFIG_BLOCK_SPTR_CACHE.get( cb )->mark_read_only( key );
   );
 }
-
 
 /// Merge another \p config_block's entries into this \p config_block
 void
@@ -412,7 +366,6 @@ vital_config_block_merge_config( vital_config_block_t*  cb,
   );
 }
 
-
 /// Check if a value exists for the given key
 bool
 vital_config_block_has_value( vital_config_block_t* cb,
@@ -425,7 +378,6 @@ vital_config_block_has_value( vital_config_block_t* cb,
   );
   return false;
 }
-
 
 /// Return the values available in the configuration.
 void
@@ -447,7 +399,6 @@ vital_config_block_available_values( vital_config_block_t*  cb,
     kwiver::vital_c::make_string_list( cb_keys, *length, *keys );
   );
 }
-
 
 namespace {
 
@@ -480,7 +431,6 @@ read_config_file_helper( vital_error_handle_t* eh, Args... args )
 
 }
 
-
 /// Read in a configuration file, producing a config_block object
 vital_config_block_t*
 vital_config_block_file_read( char const*           filepath,
@@ -496,7 +446,6 @@ vital_config_block_file_read( char const*           filepath,
   );
   return 0;
 }
-
 
 /// Read in a configuration file, producing a named config_block object
 vital_config_block_t*
@@ -519,7 +468,6 @@ vital_config_block_file_read_from_standard_location(
   );
   return 0;
 }
-
 
 /// Output to file the given \c config_block object to the specified file path
 void

--- a/vital/bindings/c/config_block.h
+++ b/vital/bindings/c/config_block.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -35,7 +9,6 @@
 
 #ifndef VITAL_C_CONFIG_BLOCK_H_
 #define VITAL_C_CONFIG_BLOCK_H_
-
 
 #ifdef __cplusplus
 extern "C"
@@ -48,10 +21,8 @@ extern "C"
 
 #include <stdbool.h>
 
-
 /// Structure for opaque pointers to \p config_block objects
 typedef struct vital_config_block_s vital_config_block_t;
-
 
 // Config block constant getters
 
@@ -70,7 +41,6 @@ vital_config_block_block_sep();
 VITAL_C_EXPORT
 char const*
 vital_config_block_global_value();
-
 
 /// Create a new, empty \p config_block object
 /**
@@ -374,7 +344,6 @@ vital_config_block_available_values( vital_config_block_t *cb,
                                      char ***keys,
                                      vital_error_handle_t *eh );
 
-
 /// Read in a configuration file, producing a config_block object
 /**
  * This may fail if the given filepath is not found, could not be read, or some
@@ -395,7 +364,6 @@ VITAL_C_EXPORT
 vital_config_block_t*
 vital_config_block_file_read( char const *filepath,
                               vital_error_handle_t *eh );
-
 
 /// Read in a configuration file from standard locations, producing a config_block object
 /**
@@ -440,7 +408,6 @@ vital_config_block_file_read_from_standard_location(
   bool                  merge,
   vital_error_handle_t* eh );
 
-
 /// Output to file the given \c config_block object to the specified file path
 /**
  * If a file exists at the target location, it will be overwritten. If the
@@ -462,10 +429,8 @@ vital_config_block_file_write( vital_config_block_t *cb,
                                char const *filepath,
                                vital_error_handle_t *eh );
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // VITAL_C_CONFIG_BLOCK_H_

--- a/vital/bindings/c/error_handle.cxx
+++ b/vital/bindings/c/error_handle.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -36,7 +10,6 @@
 #include "error_handle.h"
 
 #include <cstdlib>
-
 
 /// Return a new, empty error handle object.
 vital_error_handle_t* vital_eh_new()
@@ -50,7 +23,6 @@ vital_error_handle_t* vital_eh_new()
   }
   return eh;
 }
-
 
 /// Destroy the given non-null error handle structure pointer
 void vital_eh_destroy( vital_error_handle_t *eh )

--- a/vital/bindings/c/error_handle.h
+++ b/vital/bindings/c/error_handle.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -42,7 +16,6 @@ extern "C"
 #endif
 
 #include <vital/bindings/c/vital_c_export.h>
-
 
 /// Common error handle structure
 /**
@@ -61,14 +34,12 @@ typedef struct vital_error_handle_s {
   char *message;
 } vital_error_handle_t;
 
-
 /// Return a new, empty error handle object.
 /**
  * \returns New error handle whose error code is set to 0 and message to NULL.
  */
 VITAL_C_EXPORT
 vital_error_handle_t* vital_eh_new();
-
 
 /// Destroy the given error handle structure pointer
 /**
@@ -78,7 +49,6 @@ vital_error_handle_t* vital_eh_new();
  */
 VITAL_C_EXPORT
 void vital_eh_destroy( vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/helpers/activity_type.h
+++ b/vital/bindings/c/helpers/activity_type.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,6 +25,5 @@ extern SharedPointerCache< kwiver::vital::activity_type,
                            vital_activity_type_t > AT_SPTR_CACHE;
 
 } }
-
 
 #endif //VITAL_C_HELPERS_ACTIVTY_TYPE_H_

--- a/vital/bindings/c/helpers/algorithm.h
+++ b/vital/bindings/c/helpers/algorithm.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -49,7 +23,6 @@
 #include <vital/bindings/c/algorithm.h>
 #include <vital/bindings/c/helpers/config_block.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -57,7 +30,6 @@ namespace vital_c {
 extern
 SharedPointerCache< kwiver::vital::algorithm, vital_algorithm_t >
   ALGORITHM_SPTR_CACHE;
-
 
 class invalid_algorithm_pointer
   : public vital::vital_exception
@@ -71,7 +43,6 @@ public:
 
 } // end namespace vital_c
 } // end namespace kwiver
-
 
 /// Macro companion to DECLARE_COMMON_ALGO_API, providing type implementations
 #define DEFINE_COMMON_ALGO_API( type )                                  \

--- a/vital/bindings/c/helpers/c_utils.cxx
+++ b/vital/bindings/c/helpers/c_utils.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -37,7 +11,6 @@
 
 namespace kwiver {
 namespace vital_c {
-
 
 void make_string_list( std::vector<std::string> const &list,
                        unsigned int &length, char ** &strings )
@@ -51,6 +24,5 @@ void make_string_list( std::vector<std::string> const &list,
     std::strcpy( strings[i], list[i].c_str() );
   }
 }
-
 
 } } // end vital_c namespace

--- a/vital/bindings/c/helpers/c_utils.h
+++ b/vital/bindings/c/helpers/c_utils.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2018 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -83,7 +57,6 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
     }                                                                               \
   } while(0)
 
-
 /// Standardized try/catch for general use.
 /**
  * If the provided code block contains a return, make sure to provide a
@@ -120,7 +93,6 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
       }                                                         \
     } while( 0 )
 
-
 /// Wrap an optional string parameter.
 /**
  * This converts a potentially null character array pointer ("string") to an
@@ -130,7 +102,6 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
  * pointer.
  */
 #define MAYBE_EMPTY_STRING(s) (s?s:"")
-
 
 /// Convenience macro for reinterpret cast pointer to a different type
 /**
@@ -154,7 +125,6 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
     }                                                   \
   } while(0)
 
-
 /**
  * Convenience macro for dynamic casting a pointer to a different type with
  * error checking. This macro expects a {} block after its invocations that is
@@ -172,7 +142,6 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
 
 namespace kwiver {
 namespace vital_c {
-
 
 /// Common shared pointer cache object
 template < typename vital_t,  // VITAL type
@@ -326,7 +295,6 @@ private:
     return ss.str();
   }
 };
-
 
 /// Helper function to create a char** list of strings given a vector of strings
 void make_string_list( std::vector<std::string> const &list,

--- a/vital/bindings/c/helpers/camera.h
+++ b/vital/bindings/c/helpers/camera.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/helpers/camera_intrinsics.h
+++ b/vital/bindings/c/helpers/camera_intrinsics.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 #ifndef VITAL_C_HELPERS_CAMERA_INTRINSICS_H_
 #define VITAL_C_HELPERS_CAMERA_INTRINSICS_H_

--- a/vital/bindings/c/helpers/camera_map.h
+++ b/vital/bindings/c/helpers/camera_map.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -49,6 +23,5 @@ extern SharedPointerCache< vital::camera_map,
                            vital_camera_map_t > CAM_MAP_SPTR_CACHE;
 
 } }
-
 
 #endif // VITAL_C_HELPERS_CAMERA_MAP_H_

--- a/vital/bindings/c/helpers/config_block.h
+++ b/vital/bindings/c/helpers/config_block.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -50,6 +24,5 @@ namespace vital_c {
                            vital_config_block_t > CONFIG_BLOCK_SPTR_CACHE;
 
 } }
-
 
 #endif //VITAL_C_HELPERS_CONFIG_BLOCK_H_

--- a/vital/bindings/c/helpers/descriptor.h
+++ b/vital/bindings/c/helpers/descriptor.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/descriptor.h>
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -49,6 +22,5 @@ extern SharedPointerCache< kwiver::vital::descriptor, vital_descriptor_t >
 
 }
 }
-
 
 #endif //VITAL_C_HELPERS_DESCRIPTOR_H_

--- a/vital/bindings/c/helpers/descriptor_set.h
+++ b/vital/bindings/c/helpers/descriptor_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/descriptor_set.h>
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -49,6 +22,5 @@ extern SharedPointerCache< kwiver::vital::descriptor_set, vital_descriptor_set_t
 
 }
 }
-
 
 #endif //VITAL_C_HELPERS_DESCRIPTOR_SET_H_

--- a/vital/bindings/c/helpers/detected_object.h
+++ b/vital/bindings/c/helpers/detected_object.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,6 +25,5 @@ extern SharedPointerCache< kwiver::vital::detected_object,
                            vital_detected_object_t > DOBJ_SPTR_CACHE;
 
 } }
-
 
 #endif //VITAL_C_HELPERS_DETECTED_OBJECT_H_

--- a/vital/bindings/c/helpers/detected_object_set.h
+++ b/vital/bindings/c/helpers/detected_object_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,6 +25,5 @@ extern SharedPointerCache< kwiver::vital::detected_object_set,
                            vital_detected_object_set_t > DOBJ_SET_SPTR_CACHE;
 
 } }
-
 
 #endif // VITAL_C_HELPERS_DETECTED_OBJECT_SET_H_

--- a/vital/bindings/c/helpers/detected_object_type.h
+++ b/vital/bindings/c/helpers/detected_object_type.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/helpers/feature.h
+++ b/vital/bindings/c/helpers/feature.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/feature.h>
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -49,6 +22,5 @@ extern SharedPointerCache< vital::feature, vital_feature_t >
 
 }
 }
-
 
 #endif //VITAL_C_HELPERS_FEATURE_H_

--- a/vital/bindings/c/helpers/homography.h
+++ b/vital/bindings/c/helpers/homography.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/homography.h>
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -49,6 +22,5 @@ extern SharedPointerCache< vital::homography, vital_homography_t >
 
 } // end namespace vital_c
 } // end namespace kwiver
-
 
 #endif //VITAL_C_HELPERS_HOMOGRAPHY_H_

--- a/vital/bindings/c/helpers/image_container.h
+++ b/vital/bindings/c/helpers/image_container.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,6 +25,5 @@ extern SharedPointerCache< kwiver::vital::image_container,
                            vital_image_container_t > IMGC_SPTR_CACHE;
 
 } }
-
 
 #endif //VITAL_C_HELPERS_IMAGE_CONTAINER_H_

--- a/vital/bindings/c/helpers/landmark.h
+++ b/vital/bindings/c/helpers/landmark.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/helpers/landmark_map.h
+++ b/vital/bindings/c/helpers/landmark_map.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,7 +13,6 @@
 #include <vital/types/landmark_map.h>
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/bindings/c/types/landmark_map.h>
-
 
 namespace kwiver {
 namespace vital_c {

--- a/vital/bindings/c/helpers/track.h
+++ b/vital/bindings/c/helpers/track.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/helpers/track_set.h
+++ b/vital/bindings/c/helpers/track_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/types/activity_type.cxx
+++ b/vital/bindings/c/types/activity_type.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -50,7 +24,6 @@ AT_SPTR_CACHE( "activity_type" );
 
 } }
 
-
 // ------------------------------------------------------------------
 vital_activity_type_t* vital_activity_type_new()
 {
@@ -64,7 +37,6 @@ vital_activity_type_t* vital_activity_type_new()
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_activity_type_destroy(vital_activity_type_t* obj)
 {
@@ -74,7 +46,6 @@ void vital_activity_type_destroy(vital_activity_type_t* obj)
 
     );
 }
-
 
 // ------------------------------------------------------------------
 vital_activity_type_t*
@@ -99,7 +70,6 @@ vital_activity_type_new_from_list( VITAL_UNUSED vital_activity_type_t* obj,
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 bool
 vital_activity_type_has_class_name( vital_activity_type_t* obj, char* class_name )
@@ -111,7 +81,6 @@ vital_activity_type_has_class_name( vital_activity_type_t* obj, char* class_name
   return false;
 }
 
-
 // ------------------------------------------------------------------
 double vital_activity_type_score( vital_activity_type_t* obj, char* class_name )
 {
@@ -121,7 +90,6 @@ double vital_activity_type_score( vital_activity_type_t* obj, char* class_name )
     );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 char* vital_activity_type_get_most_likely_class( vital_activity_type_t* obj )
@@ -138,7 +106,6 @@ char* vital_activity_type_get_most_likely_class( vital_activity_type_t* obj )
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 double vital_activity_type_get_most_likely_score( vital_activity_type_t* obj )
 {
@@ -154,7 +121,6 @@ double vital_activity_type_get_most_likely_score( vital_activity_type_t* obj )
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_activity_type_set_score( vital_activity_type_t* obj,
                                     char* class_name,
@@ -166,7 +132,6 @@ void vital_activity_type_set_score( vital_activity_type_t* obj,
     );
 }
 
-
 // ------------------------------------------------------------------
 void vital_activity_type_delete_score( vital_activity_type_t* obj,
                                        char* class_name)
@@ -176,7 +141,6 @@ void vital_activity_type_delete_score( vital_activity_type_t* obj,
     kwiver::vital_c::AT_SPTR_CACHE.get( obj )->delete_score( std::string( class_name ) );
     );
 }
-
 
 // ------------------------------------------------------------------
 char** vital_activity_type_class_names( vital_activity_type_t* obj,
@@ -197,7 +161,6 @@ char** vital_activity_type_class_names( vital_activity_type_t* obj,
     );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 char** vital_activity_type_all_class_names( VITAL_UNUSED vital_activity_type_t* obj )

--- a/vital/bindings/c/types/activity_type.h
+++ b/vital/bindings/c/types/activity_type.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -47,7 +21,6 @@ extern "C"
 
 /// VITAL Image opaque structure
 typedef struct vital_activity_type_s vital_activity_type_t;
-
 
 VITAL_C_EXPORT
 vital_activity_type_t* vital_activity_type_new();
@@ -84,7 +57,6 @@ char** vital_activity_type_class_names( vital_activity_type_t* obj, double thres
 
 VITAL_C_EXPORT
 char** vital_activity_type_all_class_names(vital_activity_type_t* obj);
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/bounding_box.cxx
+++ b/vital/bindings/c/types/bounding_box.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -56,7 +30,6 @@ vital_bounding_box_t* vital_bounding_box_new_from_vectors( double* ul, double* l
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 vital_bounding_box_t* vital_bounding_box_new_from_point_width_height( double* ul,
                                                                       double  width,
@@ -70,7 +43,6 @@ vital_bounding_box_t* vital_bounding_box_new_from_point_width_height( double* ul
   );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 vital_bounding_box_t* vital_bounding_box_new_from_coordinates( double xmin,
@@ -86,7 +58,6 @@ vital_bounding_box_t* vital_bounding_box_new_from_coordinates( double xmin,
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 vital_bounding_box_t* vital_bounding_box_copy( vital_bounding_box_t* bbox )
 {
@@ -100,7 +71,6 @@ vital_bounding_box_t* vital_bounding_box_copy( vital_bounding_box_t* bbox )
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_bounding_box_destroy( vital_bounding_box_t* bbox )
 {
@@ -110,7 +80,6 @@ void vital_bounding_box_destroy( vital_bounding_box_t* bbox )
     delete b_ptr;
   );
 };
-
 
 // ------------------------------------------------------------------
 //
@@ -126,7 +95,6 @@ TYPE vital_bounding_box_ ## NAME( vital_bounding_box_t *bbox )          \
   return 0;                                                             \
 }
 
-
 double* vital_bounding_box_center( vital_bounding_box_t* bbox)
 {
   STANDARD_CATCH(
@@ -139,7 +107,6 @@ double* vital_bounding_box_center( vital_bounding_box_t* bbox)
   );
   return 0;
 }
-
 
 double* vital_bounding_box_upper_left( vital_bounding_box_t* bbox)
 {
@@ -154,7 +121,6 @@ double* vital_bounding_box_upper_left( vital_bounding_box_t* bbox)
   return 0;
 }
 
-
 double* vital_bounding_box_lower_right( vital_bounding_box_t* bbox)
 {
   STANDARD_CATCH(
@@ -167,7 +133,6 @@ double* vital_bounding_box_lower_right( vital_bounding_box_t* bbox)
   );
   return 0;
 }
-
 
 ACCESSOR( double, min_x )
 ACCESSOR( double, max_x )

--- a/vital/bindings/c/types/bounding_box.h
+++ b/vital/bindings/c/types/bounding_box.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/types/camera.cxx
+++ b/vital/bindings/c/types/camera.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -42,7 +16,6 @@
 #include <vital/bindings/c/helpers/camera.h>
 #include <vital/bindings/c/helpers/camera_intrinsics.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -52,9 +25,7 @@ namespace vital_c {
 }
 }
 
-
 using namespace kwiver;
-
 
 /// Destroy a vital_camera_t instance
 void vital_camera_destroy( vital_camera_t *cam,
@@ -65,7 +36,6 @@ void vital_camera_destroy( vital_camera_t *cam,
     kwiver::vital_c::CAMERA_SPTR_CACHE.erase( cam );
   );
 }
-
 
 /// Create a new simple camera
 vital_camera_t*
@@ -89,7 +59,6 @@ vital_camera_new( vital_eigen_matrix3x1d_t const *center,
   return 0;
 }
 
-
 /// Create a new simple camera instance with default parameters
 vital_camera_t*
 vital_camera_new_default( vital_error_handle_t *eh )
@@ -102,7 +71,6 @@ vital_camera_new_default( vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Create a new simple camera from a string
 vital_camera_t*
@@ -123,7 +91,6 @@ vital_camera_new_from_string( char const *s, vital_error_handle_t *eh )
 
 }
 
-
 /// Clone the given camera instance, returning a new camera instance
 vital_camera_t*
 vital_camera_clone( vital_camera_t const *cam, vital_error_handle_t *eh )
@@ -139,7 +106,6 @@ vital_camera_clone( vital_camera_t const *cam, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the 3D center point of the camera as a new 3x1 matrix (column-vector)
 vital_eigen_matrix3x1d_t*
 vital_camera_center( vital_camera_t const *cam, vital_error_handle_t *eh )
@@ -153,7 +119,6 @@ vital_camera_center( vital_camera_t const *cam, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get the 3D translation vector of the camera as a new 3x1 matrix (column-vector)
 vital_eigen_matrix3x1d_t*
@@ -169,7 +134,6 @@ vital_camera_translation( vital_camera_t const *cam, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the covariance of the camera center as a new vital covariance instance
 vital_covariance_3d_t*
 vital_camera_center_covar( vital_camera_t const *cam, vital_error_handle_t *eh )
@@ -183,7 +147,6 @@ vital_camera_center_covar( vital_camera_t const *cam, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get rotation of the camera as a new vital rotation instance
 vital_rotation_d_t*
@@ -199,7 +162,6 @@ vital_camera_rotation( vital_camera_t const *cam, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get new reference to the intrinsics of the camera
 vital_camera_intrinsics_t*
 vital_camera_intrinsics( vital_camera_t const *cam, vital_error_handle_t *eh )
@@ -213,7 +175,6 @@ vital_camera_intrinsics( vital_camera_t const *cam, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Create a clone of this camera that is rotated to look at the given point
 vital_camera_t*
@@ -235,7 +196,6 @@ vital_camera_clone_look_at( vital_camera_t const *cam,
   return NULL;
 }
 
-
 /// Convert camera to a 3x4 homogeneous projection matrix
 vital_eigen_matrix3x4d_t*
 vital_camera_as_matrix( vital_camera_t const *cam, vital_error_handle_t *eh )
@@ -249,7 +209,6 @@ vital_camera_as_matrix( vital_camera_t const *cam, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Project a 3D point into a (new) 2D image point via the given camera
 vital_eigen_matrix2x1d_t*
@@ -268,7 +227,6 @@ vital_camera_project( vital_camera_t const *cam,
   return 0;
 }
 
-
 /// Compute the distance of the 3D point to the image plane
 double
 vital_camera_depth( vital_camera_t const *cam,
@@ -283,7 +241,6 @@ vital_camera_depth( vital_camera_t const *cam,
   );
   return 0;
 }
-
 
 /// Convert the camera into a string representation
 char*
@@ -303,7 +260,6 @@ vital_camera_to_string( vital_camera_t const *cam, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Read in a KRTD file, producing a new vital::camera object
 vital_camera_t* vital_camera_read_krtd_file( char const *filepath,
                                              vital_error_handle_t *eh )
@@ -316,7 +272,6 @@ vital_camera_t* vital_camera_read_krtd_file( char const *filepath,
   );
   return 0;
 }
-
 
 /// Output the given vital_camera_t object to the specified file path
 void vital_camera_write_krtd_file( vital_camera_t const *cam,

--- a/vital/bindings/c/types/camera.h
+++ b/vital/bindings/c/types/camera.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -35,8 +9,6 @@
 
 #ifndef VITAL_C_CAMERA_H_
 #define VITAL_C_CAMERA_H_
-
-
 
 #ifdef __cplusplus
 extern "C"
@@ -51,10 +23,8 @@ extern "C"
 #include <vital/bindings/c/types/rotation.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// Opaque structure to a vital::camera class
 typedef struct vital_camera_s vital_camera_t;
-
 
 /// Destroy a vital_camera_t instance
 /**
@@ -67,7 +37,6 @@ typedef struct vital_camera_s vital_camera_t;
 VITAL_C_EXPORT
 void vital_camera_destroy( vital_camera_t *cam,
                            vital_error_handle_t *eh );
-
 
 /// Create a new simple camera
 /**
@@ -86,7 +55,6 @@ vital_camera_new( vital_eigen_matrix3x1d_t const *center,
                   vital_camera_intrinsics_t const *intrinsics,
                   vital_error_handle_t *eh );
 
-
 /// Create a new simple camera instance with default parameters
 /**
  * \param eh Vital error handle instance.
@@ -95,7 +63,6 @@ vital_camera_new( vital_eigen_matrix3x1d_t const *center,
 VITAL_C_EXPORT
 vital_camera_t*
 vital_camera_new_default( vital_error_handle_t *eh );
-
 
 /// Create a new simple camera from a string
 /**
@@ -110,7 +77,6 @@ VITAL_C_EXPORT
 vital_camera_t*
 vital_camera_new_from_string( char const *s, vital_error_handle_t *eh );
 
-
 /// Clone the given camera instance, returning a new camera instance
 /**
  * \param cam Camera instance to clone.
@@ -120,7 +86,6 @@ vital_camera_new_from_string( char const *s, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_camera_t*
 vital_camera_clone( vital_camera_t const *cam, vital_error_handle_t *eh );
-
 
 /// Get the 3D center point of the camera as a new 3x1 matrix (column-vector)
 /**
@@ -132,7 +97,6 @@ VITAL_C_EXPORT
 vital_eigen_matrix3x1d_t*
 vital_camera_center( vital_camera_t const *cam, vital_error_handle_t *eh );
 
-
 /// Get the 3D translation vector of the camera as a new 3x1 matrix (column-vector)
 /**
  * \param cam Camera instance to use
@@ -142,7 +106,6 @@ vital_camera_center( vital_camera_t const *cam, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_eigen_matrix3x1d_t*
 vital_camera_translation( vital_camera_t const *cam, vital_error_handle_t *eh );
-
 
 /// Get the covariance of the camera center as a new vital covariance instance
 /**
@@ -154,7 +117,6 @@ VITAL_C_EXPORT
 vital_covariance_3d_t*
 vital_camera_center_covar( vital_camera_t const *cam, vital_error_handle_t *eh );
 
-
 /// Get rotation of the camera as a new vital rotation instance
 /**
  * \param cam Camera instance to use
@@ -164,7 +126,6 @@ vital_camera_center_covar( vital_camera_t const *cam, vital_error_handle_t *eh )
 VITAL_C_EXPORT
 vital_rotation_d_t*
 vital_camera_rotation( vital_camera_t const *cam, vital_error_handle_t *eh );
-
 
 /// Get new reference to the shared intrinsics instance of the camera
 /**
@@ -178,7 +139,6 @@ vital_camera_rotation( vital_camera_t const *cam, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_camera_intrinsics_t*
 vital_camera_intrinsics( vital_camera_t const *cam, vital_error_handle_t *eh );
-
 
 /// Create a clone of this camera that is rotated to look at the given point
 /**
@@ -197,7 +157,6 @@ vital_camera_clone_look_at( vital_camera_t const *cam,
                             vital_eigen_matrix3x1d_t const *up_direction,
                             vital_error_handle_t *eh );
 
-
 /// Convert camera to a 3x4 homogeneous projection matrix instance
 /**
  * \note This matrix representation does not account for lens distortion
@@ -211,7 +170,6 @@ VITAL_C_EXPORT
 vital_eigen_matrix3x4d_t*
 vital_camera_as_matrix( vital_camera_t const *cam, vital_error_handle_t *eh );
 
-
 /// Project a 3D point into a (new) 2D image point via the given camera
 /**
  * \param cam Camera instance to use
@@ -224,7 +182,6 @@ vital_eigen_matrix2x1d_t*
 vital_camera_project( vital_camera_t const *cam,
                       vital_eigen_matrix3x1d_t const *pt,
                       vital_error_handle_t *eh );
-
 
 /// Compute the distance of the 3D point to the image plane
 /**
@@ -241,7 +198,6 @@ vital_camera_depth( vital_camera_t const *cam,
                     vital_eigen_matrix3x1d_t const *pt,
                     vital_error_handle_t *eh );
 
-
 /// Convert the camera into a new string representation
 /**
  * \param cam Camera instance to use
@@ -251,7 +207,6 @@ vital_camera_depth( vital_camera_t const *cam,
 VITAL_C_EXPORT
 char*
 vital_camera_to_string( vital_camera_t const *cam, vital_error_handle_t *eh );
-
 
 /// Read in a KRTD file, producing a new vital::camera object
 /**
@@ -264,7 +219,6 @@ vital_camera_t*
 vital_camera_read_krtd_file( char const *filepath,
                              vital_error_handle_t *eh );
 
-
 /// Output the given vital_camera_t object to the specified file path
 /**
  * \param cam Camera instance to use
@@ -276,7 +230,6 @@ void
 vital_camera_write_krtd_file( vital_camera_t const *cam,
                               char const *filepath,
                               vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/camera_intrinsics.cxx
+++ b/vital/bindings/c/types/camera_intrinsics.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/helpers/camera_intrinsics.h>
 #include <vital/types/camera_intrinsics.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -49,7 +22,6 @@ SharedPointerCache< vital::camera_intrinsics, vital_camera_intrinsics_t >
 
 } // end namespace vital_c
 } // end namespace kwiver
-
 
 /// Create new simple camera intrinsics object with default parameters
 vital_camera_intrinsics_t*
@@ -65,7 +37,6 @@ vital_camera_intrinsics_new_default( vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /**
  * Create a new simple camera intrinsics object with specified focal length and
@@ -90,7 +61,6 @@ vital_camera_intrinsics_new_partial( double focal_length,
   );
   return 0;
 }
-
 
 /// Create a new simple camera intrinsics object
 vital_camera_intrinsics_t*
@@ -120,7 +90,6 @@ vital_camera_intrinsics_new( double focal_length,
   return 0;
 }
 
-
 /// Destroy a given non-null camera intrinsics object
 void
 vital_camera_intrinsics_destroy( vital_camera_intrinsics_t *ci,
@@ -131,7 +100,6 @@ vital_camera_intrinsics_destroy( vital_camera_intrinsics_t *ci,
     kwiver::vital_c::CAMERA_INTRINSICS_SPTR_CACHE.erase( ci );
   );
 }
-
 
 /// Get the focal length
 double
@@ -144,7 +112,6 @@ vital_camera_intrinsics_get_focal_length( vital_camera_intrinsics_t *ci,
   );
   return 0;
 }
-
 
 /// Get a new copy of the principle point
 vital_eigen_matrix2x1d_t*
@@ -161,7 +128,6 @@ vital_camera_intrinsics_get_principle_point( vital_camera_intrinsics_t *ci,
   return 0;
 }
 
-
 /// Get the aspect ratio
 double
 vital_camera_intrinsics_get_aspect_ratio( vital_camera_intrinsics_t *ci,
@@ -174,7 +140,6 @@ vital_camera_intrinsics_get_aspect_ratio( vital_camera_intrinsics_t *ci,
   return 0;
 }
 
-
 /// Get the skew value
 double
 vital_camera_intrinsics_get_skew( vital_camera_intrinsics_t *ci,
@@ -186,7 +151,6 @@ vital_camera_intrinsics_get_skew( vital_camera_intrinsics_t *ci,
   );
   return 0;
 }
-
 
 /// Get the distance coefficients
 vital_eigen_matrixXx1d_t*
@@ -205,7 +169,6 @@ vital_camera_intrinsics_get_dist_coeffs( vital_camera_intrinsics_t *ci,
   return 0;
 }
 
-
 /// Access the intrinsics as an upper triangular matrix
 vital_eigen_matrix3x3d_t*
 vital_camera_intrinsics_as_matrix( vital_camera_intrinsics_t *ci,
@@ -220,7 +183,6 @@ vital_camera_intrinsics_as_matrix( vital_camera_intrinsics_t *ci,
   );
   return 0;
 }
-
 
 /// Map normalized image coordinates into actual image coordinates
 vital_eigen_matrix2x1d_t*
@@ -239,7 +201,6 @@ vital_camera_intrinsics_map_2d( vital_camera_intrinsics_t *ci,
   return 0;
 }
 
-
 /// Map a 3D point in camera coordinates into actual image coordinates
 vital_eigen_matrix2x1d_t*
 vital_camera_intrinsics_map_3d( vital_camera_intrinsics_t *ci,
@@ -256,7 +217,6 @@ vital_camera_intrinsics_map_3d( vital_camera_intrinsics_t *ci,
   );
   return 0;
 }
-
 
 /// Unmap actual image coordinates back into normalized image coordinates
 vital_eigen_matrix2x1d_t*
@@ -275,7 +235,6 @@ vital_camera_intrinsics_unmap_2d( vital_camera_intrinsics_t *ci,
   return 0;
 }
 
-
 /// Map normalized image coordinates into distorted coordinates
 vital_eigen_matrix2x1d_t*
 vital_camera_intrinsics_distort_2d( vital_camera_intrinsics_t *ci,
@@ -292,7 +251,6 @@ vital_camera_intrinsics_distort_2d( vital_camera_intrinsics_t *ci,
   );
   return 0;
 }
-
 
 /// Unmap distorted normalized coordinates into normalized coordinates
 vital_eigen_matrix2x1d_t*

--- a/vital/bindings/c/types/camera_intrinsics.h
+++ b/vital/bindings/c/types/camera_intrinsics.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,10 +19,8 @@ extern "C"
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// Opaque pointer to camera intrinsics objects
 typedef struct vital_camera_intrinsics_s vital_camera_intrinsics_t;
-
 
 /// Create new simple camera intrinsics object with default parameters
 /**
@@ -58,7 +30,6 @@ typedef struct vital_camera_intrinsics_s vital_camera_intrinsics_t;
 VITAL_C_EXPORT
 vital_camera_intrinsics_t*
 vital_camera_intrinsics_new_default( vital_error_handle_t *eh );
-
 
 /**
  * Create a new simple camera intrinsics object with specified focal length and
@@ -74,7 +45,6 @@ vital_camera_intrinsics_t*
 vital_camera_intrinsics_new_partial( double focal_length,
                                      vital_eigen_matrix2x1d_t *principle_point,
                                      vital_error_handle_t *eh );
-
 
 /// Create a new simple camera intrinsics object
 /**
@@ -100,13 +70,11 @@ vital_camera_intrinsics_new( double focal_length,
                              vital_eigen_matrixXx1d_t *dist_coeffs,
                              vital_error_handle_t *eh );
 
-
 /// Destroy a given non-null camera intrinsics object
 VITAL_C_EXPORT
 void
 vital_camera_intrinsics_destroy( vital_camera_intrinsics_t *ci,
                                  vital_error_handle_t *eh );
-
 
 /// Get the focal length
 /**
@@ -119,7 +87,6 @@ double
 vital_camera_intrinsics_get_focal_length( vital_camera_intrinsics_t *ci,
                                           vital_error_handle_t *eh );
 
-
 /// Get a new copy of the principle point
 /**
  * \param ci Camera intrinsics object opaque pointer
@@ -130,7 +97,6 @@ VITAL_C_EXPORT
 vital_eigen_matrix2x1d_t*
 vital_camera_intrinsics_get_principle_point( vital_camera_intrinsics_t *ci,
                                              vital_error_handle_t *eh );
-
 
 /// Get the aspect ratio
 /**
@@ -143,7 +109,6 @@ double
 vital_camera_intrinsics_get_aspect_ratio( vital_camera_intrinsics_t *ci,
                                           vital_error_handle_t *eh );
 
-
 /// Get the skew value
 /**
  * \param ci Camera intrinsics object opaque pointer
@@ -155,7 +120,6 @@ double
 vital_camera_intrinsics_get_skew( vital_camera_intrinsics_t *ci,
                                   vital_error_handle_t *eh );
 
-
 /// Get the distortion coefficients
 /**
  * \param ci Camera intrinsics object opaque pointer
@@ -166,7 +130,6 @@ VITAL_C_EXPORT
 vital_eigen_matrixXx1d_t*
 vital_camera_intrinsics_get_dist_coeffs( vital_camera_intrinsics_t *ci,
                                          vital_error_handle_t *eh );
-
 
 /// Access the intrinsics as an upper triangular matrix
 /**
@@ -181,7 +144,6 @@ VITAL_C_EXPORT
 vital_eigen_matrix3x3d_t*
 vital_camera_intrinsics_as_matrix( vital_camera_intrinsics_t *ci,
                                    vital_error_handle_t *eh );
-
 
 /// Map normalized image coordinates into actual image coordinates
 /**
@@ -198,7 +160,6 @@ vital_camera_intrinsics_map_2d( vital_camera_intrinsics_t *ci,
                                 vital_eigen_matrix2x1d_t *p,
                                 vital_error_handle_t *eh );
 
-
 /// Map a 3D point in camera coordinates into actual image coordinates
 /**
  * \param p Point to transform
@@ -210,7 +171,6 @@ vital_eigen_matrix2x1d_t*
 vital_camera_intrinsics_map_3d( vital_camera_intrinsics_t *ci,
                                 vital_eigen_matrix3x1d_t *p,
                                 vital_error_handle_t *eh );
-
 
 /// Unmap actual image coordinates back into normalized image coordinates
 /**
@@ -224,7 +184,6 @@ vital_camera_intrinsics_unmap_2d( vital_camera_intrinsics_t *ci,
                                   vital_eigen_matrix2x1d_t *p,
                                   vital_error_handle_t *eh );
 
-
 /// Map normalized image coordinates into distorted coordinates
 /**
  * \param p Point to transform
@@ -237,7 +196,6 @@ vital_camera_intrinsics_distort_2d( vital_camera_intrinsics_t *ci,
                                     vital_eigen_matrix2x1d_t *p,
                                     vital_error_handle_t *eh );
 
-
 /// Unmap distorted normalized coordinates into normalized coordinates
 /**
  * \param p Point to transform
@@ -249,7 +207,6 @@ vital_eigen_matrix2x1d_t*
 vital_camera_intrinsics_undistort_2d( vital_camera_intrinsics_t *ci,
                                       vital_eigen_matrix2x1d_t *p,
                                       vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/camera_map.cxx
+++ b/vital/bindings/c/types/camera_map.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,9 +25,7 @@ SharedPointerCache<vital::camera_map,
 }
 }
 
-
 using namespace kwiver;
-
 
 /// New, simple camera map
 vital_camera_map_t* vital_camera_map_new( size_t length,
@@ -84,7 +56,6 @@ vital_camera_map_t* vital_camera_map_new( size_t length,
   return 0;
 }
 
-
 /// Destroy the given camera_map
 void vital_camera_map_destroy( vital_camera_map_t *cam_map,
                                vital_error_handle_t *eh )
@@ -94,7 +65,6 @@ void vital_camera_map_destroy( vital_camera_map_t *cam_map,
     vital_c::CAM_MAP_SPTR_CACHE.erase( cam_map );
   );
 }
-
 
 /// Return the number of cameras in the map
 size_t vital_camera_map_size( vital_camera_map_t *cam_map,
@@ -106,7 +76,6 @@ size_t vital_camera_map_size( vital_camera_map_t *cam_map,
   );
   return 0;
 }
-
 
 /// Set pointers to parallel arrays of frame numers and camera instances
 void vital_camera_map_get_map( vital_camera_map_t *cam_map,

--- a/vital/bindings/c/types/camera_map.h
+++ b/vital/bindings/c/types/camera_map.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -47,10 +21,8 @@ extern "C"
 #include <vital/bindings/c/types/camera.h>
 #include <vital/bindings/c/error_handle.h>
 
-
 /// Opaque structure for vital::camera_map class
 typedef struct vital_camera_map_s vital_camera_map_t;
-
 
 /// New, simple camera map
 /**
@@ -77,18 +49,15 @@ vital_camera_map_t* vital_camera_map_new( size_t length,
                                           vital_camera_t **cameras,
                                           vital_error_handle_t *eh );
 
-
 /// Destroy the given camera_map
 VITAL_C_EXPORT
 void vital_camera_map_destroy( vital_camera_map_t *cam_map,
                                vital_error_handle_t *eh );
 
-
 /// Return the number of cameras in the map
 VITAL_C_EXPORT
 size_t vital_camera_map_size( vital_camera_map_t *cam_map,
                               vital_error_handle_t *eh );
-
 
 /// Set pointers to parallel arrays of frame numbers and camera instances
 VITAL_C_EXPORT
@@ -97,7 +66,6 @@ void vital_camera_map_get_map( vital_camera_map_t *cam_map,
                                int64_t **frame_numbers,
                                vital_camera_t ***cameras,
                                vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/color.cxx
+++ b/vital/bindings/c/types/color.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,9 +13,7 @@
 
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 using namespace kwiver;
-
 
 /// Create a new rgb_color instance
 vital_rgb_color_t*
@@ -57,7 +29,6 @@ vital_rgb_color_new( unsigned char cr, unsigned char cg, unsigned char cb,
   return 0;
 }
 
-
 /// Create a new default (white) rgb_color instance
 vital_rgb_color_t*
 vital_rgb_color_new_default( vital_error_handle_t *eh )
@@ -71,7 +42,6 @@ vital_rgb_color_new_default( vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Destroy an rgb_color instance
 void
 vital_rgb_color_destroy( vital_rgb_color_t *c, vital_error_handle_t *eh )
@@ -82,7 +52,6 @@ vital_rgb_color_destroy( vital_rgb_color_t *c, vital_error_handle_t *eh )
     delete c_ptr;
   );
 }
-
 
 /// Get the red value
 unsigned char
@@ -96,7 +65,6 @@ vital_rgb_color_r( vital_rgb_color_t *c, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the green value
 unsigned char
 vital_rgb_color_g( vital_rgb_color_t *c, vital_error_handle_t *eh )
@@ -109,7 +77,6 @@ vital_rgb_color_g( vital_rgb_color_t *c, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the blue value
 unsigned char
 vital_rgb_color_b( vital_rgb_color_t *c, vital_error_handle_t *eh )
@@ -121,7 +88,6 @@ vital_rgb_color_b( vital_rgb_color_t *c, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Test equality between two rgb_color instances
 bool

--- a/vital/bindings/c/types/color.h
+++ b/vital/bindings/c/types/color.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -44,10 +18,8 @@ extern "C"
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// Opaque structure type
 typedef struct vital_rgb_color_s vital_rgb_color_t;
-
 
 /// Create a new rgb_color instance
 /**
@@ -62,7 +34,6 @@ vital_rgb_color_t*
 vital_rgb_color_new( unsigned char cr, unsigned char cg, unsigned char cb,
                      vital_error_handle_t *eh );
 
-
 /// Create a new default (white) rgb_color instance
 /**
  * \returns New rgb_color instance with default color values (white)
@@ -72,7 +43,6 @@ VITAL_C_EXPORT
 vital_rgb_color_t*
 vital_rgb_color_new_default( vital_error_handle_t *eh );
 
-
 /// Destroy an rgb_color instance
 /**
  * \param c the instance to destroy
@@ -81,7 +51,6 @@ vital_rgb_color_new_default( vital_error_handle_t *eh );
 VITAL_C_EXPORT
 void
 vital_rgb_color_destroy( vital_rgb_color_t *c, vital_error_handle_t *eh );
-
 
 /// Get the red value
 /**
@@ -93,7 +62,6 @@ VITAL_C_EXPORT
 unsigned char
 vital_rgb_color_r( vital_rgb_color_t *c, vital_error_handle_t *eh );
 
-
 /// Get the green value
 /**
  * \param c rgb color instance
@@ -103,7 +71,6 @@ vital_rgb_color_r( vital_rgb_color_t *c, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 unsigned char
 vital_rgb_color_g( vital_rgb_color_t *c, vital_error_handle_t *eh );
-
 
 /// Get the blue value
 /**
@@ -115,7 +82,6 @@ VITAL_C_EXPORT
 unsigned char
 vital_rgb_color_b( vital_rgb_color_t *c, vital_error_handle_t *eh );
 
-
 /// Test equality between two rgb_color instances
 /**
  * \param a First color to compare
@@ -126,7 +92,6 @@ VITAL_C_EXPORT
 bool
 vital_rgb_color_is_equal( vital_rgb_color_t *a, vital_rgb_color_t *b,
                           vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/covariance.cxx
+++ b/vital/bindings/c/types/covariance.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,7 +13,6 @@
 
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/types/covariance.h>
-
 
 /// Define Vital Covariance type functions (templates class)
 /**
@@ -185,12 +158,10 @@ vital_covariance_##N##S##_set( vital_covariance_##N##S##_t *cov,                
   );                                                                                 \
 }
 
-
 // Define functions for sizes and types
 DEFINE_VITAL_COVARIANCE_FUNCTIONS( 2, double, d )
 DEFINE_VITAL_COVARIANCE_FUNCTIONS( 2, float,  f )
 DEFINE_VITAL_COVARIANCE_FUNCTIONS( 3, double, d )
 DEFINE_VITAL_COVARIANCE_FUNCTIONS( 3, float,  f )
-
 
 #undef DEFINE_VITAL_COVARIANCE_FUNCTIONS

--- a/vital/bindings/c/types/covariance.h
+++ b/vital/bindings/c/types/covariance.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -38,7 +12,6 @@
 
 #include "eigen.h"
 
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -46,7 +19,6 @@ extern "C"
 
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
-
 
 /// Declare Vital Covariance type functions (templates class)
 /**
@@ -135,16 +107,13 @@ vital_covariance_##N##S##_set( vital_covariance_##N##S##_t *cov,               \
                                unsigned int i, unsigned int j, T value,        \
                                vital_error_handle_t *eh );
 
-
 // Declare functions for sizes and types
 DECLARE_VITAL_COVARIANCE_FUNCTIONS( 2, double, d )
 DECLARE_VITAL_COVARIANCE_FUNCTIONS( 2, float,  f )
 DECLARE_VITAL_COVARIANCE_FUNCTIONS( 3, double, d )
 DECLARE_VITAL_COVARIANCE_FUNCTIONS( 3, float,  f )
 
-
 #undef DECLARE_VITAL_COVARIANCE_FUNCTIONS
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/descriptor.cxx
+++ b/vital/bindings/c/types/descriptor.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,7 +13,6 @@
 
 #include <vital/bindings/c/helpers/descriptor.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -51,9 +24,6 @@ SharedPointerCache< kwiver::vital::descriptor, vital_descriptor_t >
 
 using namespace kwiver;
 
-
-
-
 /// Destroy a descriptor instance
 void
 vital_descriptor_destroy( vital_descriptor_t const *d,
@@ -64,7 +34,6 @@ vital_descriptor_destroy( vital_descriptor_t const *d,
     vital_c::DESCRIPTOR_SPTR_CACHE.erase( d );
   );
 }
-
 
 /// Get the number of elements in the descriptor
 size_t
@@ -79,7 +48,6 @@ vital_descriptor_size( vital_descriptor_t const *d,
   return 0;
 }
 
-
 /// Get the number of bytes used to represent the descriptor's data
 size_t
 vital_descriptor_num_bytes( vital_descriptor_t const *d,
@@ -92,7 +60,6 @@ vital_descriptor_num_bytes( vital_descriptor_t const *d,
   );
   return 0;
 }
-
 
 /// Convert the descriptor into a new array of bytes
 unsigned char*
@@ -113,7 +80,6 @@ vital_descriptor_as_bytes( vital_descriptor_t const *d,
   return 0;
 }
 
-
 /// Convert the descriptor into a new array of doubles
 double*
 vital_descriptor_as_doubles( vital_descriptor_t const *d,
@@ -133,7 +99,6 @@ vital_descriptor_as_doubles( vital_descriptor_t const *d,
   return 0;
 }
 
-
 /// Get the name of the descriptor instance's data type
 char const*
 vital_descriptor_type_name( vital_descriptor_t const *d,
@@ -146,7 +111,6 @@ vital_descriptor_type_name( vital_descriptor_t const *d,
   );
   return 0;
 }
-
 
 #define DEFINE_TYPED_OPERATIONS( T, S ) \
 \
@@ -183,7 +147,6 @@ vital_descriptor_get_##S##_raw_data( vital_descriptor_t *d, \
   ); \
   return 0; \
 }
-
 
 DEFINE_TYPED_OPERATIONS( double, d )
 DEFINE_TYPED_OPERATIONS( float,  f )

--- a/vital/bindings/c/types/descriptor.h
+++ b/vital/bindings/c/types/descriptor.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -52,7 +26,6 @@ extern "C"
 /// Base opaque descriptor instance type
 typedef struct vital_descriptor_s {} vital_descriptor_t;
 
-
 /// Destroy a descriptor instance
 /**
  * \param d descriptor instance to destroy
@@ -62,7 +35,6 @@ VITAL_C_EXPORT
 void
 vital_descriptor_destroy( vital_descriptor_t const *d,
                           vital_error_handle_t *eh );
-
 
 /// Get the number of elements in the descriptor
 /**
@@ -75,7 +47,6 @@ size_t
 vital_descriptor_size( vital_descriptor_t const *d,
                        vital_error_handle_t *eh );
 
-
 /// Get the number of bytes used to represent the descriptor's data
 /**
  * \param d descriptor instance to destroy
@@ -86,7 +57,6 @@ VITAL_C_EXPORT
 size_t
 vital_descriptor_num_bytes( vital_descriptor_t const *d,
                             vital_error_handle_t *eh );
-
 
 /// Convert the descriptor into a new array of bytes
 /**
@@ -101,7 +71,6 @@ unsigned char*
 vital_descriptor_as_bytes( vital_descriptor_t const *d,
                            vital_error_handle_t *eh );
 
-
 /// Convert the descriptor into a new array of doubles
 /**
  * Length of the returned array is the same as ``vital_descriptor_size``.
@@ -115,7 +84,6 @@ double*
 vital_descriptor_as_doubles( vital_descriptor_t const *d,
                              vital_error_handle_t *eh );
 
-
 /// Get the name of the descriptor instance's data type
 /**
  * \param d Descriptor instance
@@ -126,7 +94,6 @@ VITAL_C_EXPORT
 char const*
 vital_descriptor_type_name( vital_descriptor_t const *d,
                             vital_error_handle_t *eh );
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Type-specific functions (and constructors)
@@ -158,12 +125,10 @@ T* \
 vital_descriptor_get_##S##_raw_data( vital_descriptor_t *d, \
                                      vital_error_handle_t *eh );
 
-
 DECLARE_TYPED_OPERATIONS( double, d )
 DECLARE_TYPED_OPERATIONS( float,  f )
 
 #undef DECLARE_TYPED_OPERATIONS
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/descriptor_set.cxx
+++ b/vital/bindings/c/types/descriptor_set.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017-2018 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,7 +15,6 @@
 #include <vital/bindings/c/helpers/descriptor.h>
 #include <vital/bindings/c/helpers/descriptor_set.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -52,7 +25,6 @@ SharedPointerCache< kwiver::vital::descriptor_set, vital_descriptor_set_t >
 }
 
 using namespace kwiver;
-
 
 /// Create a new descriptor set from the array of descriptors.
 vital_descriptor_set_t*
@@ -82,7 +54,6 @@ vital_descriptor_set_new( vital_descriptor_t const **d_array,
   return NULL;
 }
 
-
 /// Create a vital_descriptor_set_t around an existing shared pointer.
 vital_descriptor_set_t*
 vital_descriptor_set_new_from_sptr( kwiver::vital::descriptor_set_sptr ds_sptr,
@@ -97,7 +68,6 @@ vital_descriptor_set_new_from_sptr( kwiver::vital::descriptor_set_sptr ds_sptr,
   return NULL;
 }
 
-
 /// Destroy a descriptor set
 void
 vital_descriptor_set_destroy( vital_descriptor_set_t const *ds,
@@ -108,7 +78,6 @@ vital_descriptor_set_destroy( vital_descriptor_set_t const *ds,
     vital_c::DESCRIPTOR_SET_SPTR_CACHE.erase( ds );
   );
 }
-
 
 /// Get the size of a descriptor set
 size_t
@@ -121,7 +90,6 @@ vital_descriptor_set_size( vital_descriptor_set_t const *ds,
   );
   return 0;
 }
-
 
 /// Get the descriptors stored in this set.
 void
@@ -152,7 +120,6 @@ vital_descriptor_set_get_descriptors( vital_descriptor_set_t const *ds,
     *out_d_array_length = ds_sptr->size();
   );
 }
-
 
 /// Get the vital::descriptor_set shared pointer for a handle.
 kwiver::vital::descriptor_set_sptr

--- a/vital/bindings/c/types/descriptor_set.h
+++ b/vital/bindings/c/types/descriptor_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -50,7 +24,6 @@ extern "C"
 /// Base opaque descriptor instance type
 typedef struct vital_descriptor_set_s vital_descriptor_set_t;
 
-
 /// Create a new descriptor set from the array of descriptors.
 /**
  * \param eh Vital error handle instance.
@@ -60,7 +33,6 @@ vital_descriptor_set_t*
 vital_descriptor_set_new( vital_descriptor_t const **d_array,
                           size_t d_array_length,
                           vital_error_handle_t *eh );
-
 
 /// Destroy a descriptor set
 /**
@@ -72,7 +44,6 @@ void
 vital_descriptor_set_destroy( vital_descriptor_set_t const *ds,
                               vital_error_handle_t *eh );
 
-
 /// Get the size of a descriptor set
 /**
  * \param ds The handle of the descriptor set instance.
@@ -82,7 +53,6 @@ VITAL_C_EXPORT
 size_t
 vital_descriptor_set_size( vital_descriptor_set_t const *ds,
                            vital_error_handle_t *eh );
-
 
 /// Get the descritpors stored in this set.
 /**
@@ -99,7 +69,6 @@ vital_descriptor_set_get_descriptors( vital_descriptor_set_t const *ds,
                                       vital_descriptor_t ***out_d_array,
                                       size_t *out_d_array_length,
                                       vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/descriptor_set.hxx
+++ b/vital/bindings/c/types/descriptor_set.hxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,12 +14,10 @@
 #include <vital/bindings/c/types/descriptor_set.h>
 #include <vital/types/descriptor_set.h>
 
-
 // -----------------------------------------------------------------------------
 // These two functions are a bridge between C++ and the internal C smart pointer
 // management.
 // -----------------------------------------------------------------------------
-
 
 /// Create a vital_descriptor_set_t around an existing shared pointer.
 /**
@@ -59,7 +31,6 @@ vital_descriptor_set_t*
 vital_descriptor_set_new_from_sptr( kwiver::vital::descriptor_set_sptr ds_sptr,
                                     vital_error_handle_t* eh );
 
-
 /// Get the vital::descriptor_set shared pointer for a handle.
 /**
  * If an error occurs, an empty shared pointer is returned.
@@ -72,6 +43,5 @@ VITAL_C_EXPORT
 kwiver::vital::descriptor_set_sptr
 vital_descriptor_set_to_sptr( vital_descriptor_set_t* ds,
                               vital_error_handle_t* eh );
-
 
 #endif // VITAL_C_DESCRIPTOR_SET_HXX_

--- a/vital/bindings/c/types/detected_object.cxx
+++ b/vital/bindings/c/types/detected_object.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -53,7 +27,6 @@ SharedPointerCache< kwiver::vital::detected_object, vital_detected_object_t >
 
 } }
 
-
 vital_detected_object_t* vital_detected_object_new_with_bbox( vital_bounding_box_t* bbox,
                                                               double confidence,
                                                               vital_detected_object_type_t* dot)
@@ -79,7 +52,6 @@ vital_detected_object_t* vital_detected_object_new_with_bbox( vital_bounding_box
   return 0;
 }
 
-
 vital_detected_object_t* vital_detected_object_copy(vital_detected_object_t * obj)
 {
   STANDARD_CATCH(
@@ -93,7 +65,6 @@ vital_detected_object_t* vital_detected_object_copy(vital_detected_object_t * ob
   return 0;
 }
 
-
 void vital_detected_object_destroy( vital_detected_object_t * obj )
 {
   STANDARD_CATCH(
@@ -101,7 +72,6 @@ void vital_detected_object_destroy( vital_detected_object_t * obj )
     kwiver::vital_c::DOBJ_SPTR_CACHE.erase( obj );
   );
 }
-
 
 vital_bounding_box_t* vital_detected_object_bounding_box( vital_detected_object_t * obj )
 {
@@ -114,14 +84,12 @@ vital_bounding_box_t* vital_detected_object_bounding_box( vital_detected_object_
   return 0;
 }
 
-
 void vital_detected_object_set_bounding_box( vital_detected_object_t * obj,
                                              vital_bounding_box_t* bbox )
 {
   kwiver::vital_c::DOBJ_SPTR_CACHE.get( obj )->set_bounding_box(
     *reinterpret_cast<kwiver::vital::bounding_box_d*>( bbox ) );
 }
-
 
 double vital_detected_object_confidence( vital_detected_object_t * obj )
 {
@@ -132,7 +100,6 @@ double vital_detected_object_confidence( vital_detected_object_t * obj )
   return 0;
 }
 
-
 void vital_detected_object_set_confidence( vital_detected_object_t * obj,
                                            double conf )
 {
@@ -141,7 +108,6 @@ void vital_detected_object_set_confidence( vital_detected_object_t * obj,
     kwiver::vital_c::DOBJ_SPTR_CACHE.get( obj )->set_confidence( conf );
   );
 }
-
 
 vital_detected_object_type_t* vital_detected_object_get_type( vital_detected_object_t * obj )
 {
@@ -152,7 +118,6 @@ vital_detected_object_type_t* vital_detected_object_get_type( vital_detected_obj
   );
   return 0;
 }
-
 
 void vital_detected_object_set_type( vital_detected_object_t *      obj,
                                      vital_detected_object_type_t * dot )
@@ -166,7 +131,6 @@ void vital_detected_object_set_type( vital_detected_object_t *      obj,
   );
 }
 
-
 int64_t vital_detected_object_index( vital_detected_object_t * obj )
 {
   STANDARD_CATCH(
@@ -176,13 +140,11 @@ int64_t vital_detected_object_index( vital_detected_object_t * obj )
   return 0;
 }
 
-
 void vital_detected_object_set_index(vital_detected_object_t * obj,
                                      int64_t idx)
 {
   kwiver::vital_c::DOBJ_SPTR_CACHE.get( obj )->set_index(idx);
 }
-
 
 char* vital_detected_object_detector_name(vital_detected_object_t * obj)
 {
@@ -191,7 +153,6 @@ char* vital_detected_object_detector_name(vital_detected_object_t * obj)
   return 0;
 }
 
-
 void vital_detected_object_detector_set_name(vital_detected_object_t * obj,
                                             char* name )
 {
@@ -199,13 +160,11 @@ void vital_detected_object_detector_set_name(vital_detected_object_t * obj,
   kwiver::vital_c::DOBJ_SPTR_CACHE.get( obj )->set_detector_name( sname );
 }
 
-
 vital_image_t* vital_detected_object_mask(vital_detected_object_t * obj)
 {
   //+ TBD need to look up image_sptr in cache
   return 0;
 }
-
 
 void vital_detected_object_set_mask(vital_detected_object_t * obj,
                                     vital_image_t* mask)

--- a/vital/bindings/c/types/detected_object.h
+++ b/vital/bindings/c/types/detected_object.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/types/detected_object_set.cxx
+++ b/vital/bindings/c/types/detected_object_set.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -54,7 +28,6 @@ SharedPointerCache< kwiver::vital::detected_object_set, vital_detected_object_se
 
 typedef std::vector< kwiver::vital::detected_object_sptr > vector_t;
 
-
 // ==================================================================
 // These two functions support C++ access to the SPTR_CACHE.
 
@@ -80,7 +53,6 @@ vital_detected_object_set_t* vital_detected_object_set_from_sptr( kwiver::vital:
   return 0;
 }
 
-
 vital_detected_object_set_t* vital_detected_object_set_from_c_pointer( kwiver::vital::detected_object_set* ptr )
 {
   STANDARD_CATCH(
@@ -92,7 +64,6 @@ vital_detected_object_set_t* vital_detected_object_set_from_c_pointer( kwiver::v
   return 0;
 }
 
-
 kwiver::vital::detected_object_set_sptr vital_detected_object_set_to_sptr( vital_detected_object_set_t* handle )
 {
   STANDARD_CATCH(
@@ -102,7 +73,6 @@ kwiver::vital::detected_object_set_sptr vital_detected_object_set_to_sptr( vital
     );
   return kwiver::vital::detected_object_set_sptr();
 }
-
 
 // ------------------------------------------------------------------
 vital_detected_object_set_t* vital_detected_object_set_new()
@@ -118,7 +88,6 @@ vital_detected_object_set_t* vital_detected_object_set_new()
   return 0;
 
 }
-
 
 // ------------------------------------------------------------------
 vital_detected_object_set_t*
@@ -142,7 +111,6 @@ vital_detected_object_set_new_from_list( vital_detected_object_t**  dobj,
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_detected_object_set_destroy( vital_detected_object_set_t* obj)
 {
@@ -153,7 +121,6 @@ void vital_detected_object_set_destroy( vital_detected_object_set_t* obj)
   );
 
 }
-
 
 // ------------------------------------------------------------------
 void vital_detected_object_set_add( vital_detected_object_set_t* set,
@@ -166,7 +133,6 @@ void vital_detected_object_set_add( vital_detected_object_set_t* set,
     );
 }
 
-
 // ------------------------------------------------------------------
 size_t vital_detected_object_set_size( vital_detected_object_set_t* obj)
 {
@@ -177,7 +143,6 @@ size_t vital_detected_object_set_size( vital_detected_object_set_t* obj)
     );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 void vital_detected_object_set_select_threshold( vital_detected_object_set_t* obj,
@@ -203,7 +168,6 @@ void vital_detected_object_set_select_threshold( vital_detected_object_set_t* ob
     }
     );
 }
-
 
 // ------------------------------------------------------------------
 void vital_detected_object_set_select_class_threshold( vital_detected_object_set_t* obj,

--- a/vital/bindings/c/types/detected_object_set.h
+++ b/vital/bindings/c/types/detected_object_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file

--- a/vital/bindings/c/types/detected_object_set.hxx
+++ b/vital/bindings/c/types/detected_object_set.hxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/detected_object_set.h>
 #include <vital/types/detected_object_set.h>
 
-
 // ------------------------------------------------------------------
 // These two functions are a bridge between c++ and the internal smart pointer management
 // ------------------------------------------------------------------
@@ -52,6 +25,5 @@ vital_detected_object_set_t* vital_detected_object_set_from_sptr( kwiver::vital:
 // Return sptr from handle
 VITAL_C_EXPORT
 kwiver::vital::detected_object_set_sptr vital_detected_object_set_to_sptr( vital_detected_object_set_t* handle );
-
 
 #endif // VITAL_C_DETECTED_OBJECT_SET_HXX_

--- a/vital/bindings/c/types/detected_object_type.cxx
+++ b/vital/bindings/c/types/detected_object_type.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -39,7 +13,6 @@
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/bindings/c/helpers/detected_object_type.h>
 
-
 #include <cstring>
 
 namespace kwiver {
@@ -51,7 +24,6 @@ SharedPointerCache< kwiver::vital::detected_object_type,
 DOT_SPTR_CACHE( "detected_object_type" );
 
 } }
-
 
 // ------------------------------------------------------------------
 vital_detected_object_type_t* vital_detected_object_type_new()
@@ -66,7 +38,6 @@ vital_detected_object_type_t* vital_detected_object_type_new()
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_detected_object_type_destroy(vital_detected_object_type_t* obj)
 {
@@ -76,7 +47,6 @@ void vital_detected_object_type_destroy(vital_detected_object_type_t* obj)
 
   );
 }
-
 
 // ------------------------------------------------------------------
 vital_detected_object_type_t*
@@ -101,7 +71,6 @@ vital_detected_object_type_new_from_list( VITAL_UNUSED vital_detected_object_typ
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 bool
 vital_detected_object_type_has_class_name( vital_detected_object_type_t* obj, char* class_name )
@@ -113,7 +82,6 @@ vital_detected_object_type_has_class_name( vital_detected_object_type_t* obj, ch
   return false;
 }
 
-
 // ------------------------------------------------------------------
 double vital_detected_object_type_score( vital_detected_object_type_t* obj, char* class_name )
 {
@@ -123,7 +91,6 @@ double vital_detected_object_type_score( vital_detected_object_type_t* obj, char
     );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 char* vital_detected_object_type_get_most_likely_class( vital_detected_object_type_t* obj )
@@ -140,7 +107,6 @@ char* vital_detected_object_type_get_most_likely_class( vital_detected_object_ty
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 double vital_detected_object_type_get_most_likely_score( vital_detected_object_type_t* obj )
 {
@@ -156,7 +122,6 @@ double vital_detected_object_type_get_most_likely_score( vital_detected_object_t
   return 0;
 }
 
-
 // ------------------------------------------------------------------
 void vital_detected_object_type_set_score( vital_detected_object_type_t* obj,
                                            char* class_name,
@@ -168,7 +133,6 @@ void vital_detected_object_type_set_score( vital_detected_object_type_t* obj,
     );
 }
 
-
 // ------------------------------------------------------------------
 void vital_detected_object_type_delete_score( vital_detected_object_type_t* obj,
                                               char* class_name)
@@ -178,7 +142,6 @@ void vital_detected_object_type_delete_score( vital_detected_object_type_t* obj,
     kwiver::vital_c::DOT_SPTR_CACHE.get( obj )->delete_score( std::string( class_name ) );
     );
 }
-
 
 // ------------------------------------------------------------------
 char** vital_detected_object_type_class_names( vital_detected_object_type_t* obj,
@@ -198,7 +161,6 @@ char** vital_detected_object_type_class_names( vital_detected_object_type_t* obj
     );
   return 0;
 }
-
 
 // ------------------------------------------------------------------
 char** vital_detected_object_type_all_class_names(

--- a/vital/bindings/c/types/detected_object_type.h
+++ b/vital/bindings/c/types/detected_object_type.h
@@ -1,33 +1,6 @@
-/*ckwg +29
- * Copyright 2016-2017 by Kitware, Inc.
- * Copyright 2016-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -82,7 +55,6 @@ char** vital_detected_object_type_class_names( vital_detected_object_type_t* obj
 
 VITAL_C_EXPORT
 char** vital_detected_object_type_all_class_names(vital_detected_object_type_t* obj);
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/eigen.cxx
+++ b/vital/bindings/c/types/eigen.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 
 #include <Eigen/Core>
 #include <vital/bindings/c/helpers/c_utils.h>
-
 
 /// Define Eigen matrix interface functions for use with Vital
 /**
@@ -193,7 +166,6 @@ vital_eigen_matrix##R##x##C##S##_data( vital_eigen_matrix##R##x##C##S##_t *m, \
   return 0; \
 }
 
-
 /// Define operations for both combinations of X and Y
 #define DEFINE_EIGEN_RECTANGLES( T, S, X, Y )\
 DEFINE_EIGEN_OPERATIONS( T, S, X, Y ) \
@@ -220,16 +192,13 @@ DEFINE_EIGEN_RECTANGLES( T, S, 3, 2 )   \
 DEFINE_EIGEN_RECTANGLES( T, S, 4, 2 )   \
 DEFINE_EIGEN_RECTANGLES( T, S, 4, 3 )
 
-
 // Set a constant X for convenience in struct/function naming
 namespace {
 int const X = Eigen::Dynamic;
 }
 
-
 DEFINE_EIGEN_ALL_SHAPES( double, d )
 DEFINE_EIGEN_ALL_SHAPES( float,  f )
-
 
 #undef DEFINE_EIGEN_OPERATIONS
 #undef DEFINE_EIGEN_RECTANGLES

--- a/vital/bindings/c/types/eigen.h
+++ b/vital/bindings/c/types/eigen.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,7 +19,6 @@ extern "C"
 
 #include <vital/bindings/c/vital_c_export.h>
 #include <vital/bindings/c/error_handle.h>
-
 
 /// Declare Eigen matrix interface functions for use with Vital
 /**
@@ -155,7 +128,6 @@ T* \
 vital_eigen_matrix##R##x##C##S##_data( vital_eigen_matrix##R##x##C##S##_t *m, \
                                        vital_error_handle_t *eh );
 
-
 /// Declare operations for both combinations of X and Y
 #define DECLARE_EIGEN_RECTANGLES( T, S, X, Y ) \
 DECLARE_EIGEN_OPERATIONS( T, S, X, Y ) \
@@ -188,15 +160,12 @@ DECLARE_EIGEN_RECTANGLES( T, S, 3, 2 )   \
 DECLARE_EIGEN_RECTANGLES( T, S, 4, 2 )   \
 DECLARE_EIGEN_RECTANGLES( T, S, 4, 3 )
 
-
 DECLARE_EIGEN_ALL_SHAPES( double, d )
 DECLARE_EIGEN_ALL_SHAPES( float,  f )
-
 
 #undef DECLARE_EIGEN_OPERATIONS
 #undef DECLARE_EIGEN_RECTANGLES
 #undef DECLARE_EIGEN_ALL_SHAPES
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/feature.cxx
+++ b/vital/bindings/c/types/feature.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 
 #include <vital/types/color.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -50,9 +23,7 @@ SharedPointerCache< vital::feature, vital_feature_t >
 }
 }
 
-
 using namespace kwiver;
-
 
 /// Destroy a feature instance
 void
@@ -63,7 +34,6 @@ vital_feature_destroy( vital_feature_t *f, vital_error_handle_t *eh )
     vital_c::FEATURE_SPTR_CACHE.erase( f );
   );
 }
-
 
 /// Get 2D image location
 vital_eigen_matrix2x1d_t*
@@ -79,7 +49,6 @@ vital_feature_loc( vital_feature_t *f, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get feature magnitude
 double
 vital_feature_magnitude( vital_feature_t *f, vital_error_handle_t *eh )
@@ -90,7 +59,6 @@ vital_feature_magnitude( vital_feature_t *f, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get feature scale
 double
@@ -103,7 +71,6 @@ vital_feature_scale( vital_feature_t *f, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get feature angle
 double
 vital_feature_angle( vital_feature_t *f, vital_error_handle_t *eh )
@@ -114,7 +81,6 @@ vital_feature_angle( vital_feature_t *f, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get feature 2D covariance
 vital_covariance_2d_t*
@@ -130,7 +96,6 @@ vital_feature_covar( vital_feature_t *f, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get Feature location's pixel color
 vital_rgb_color_t*
 vital_feature_color( vital_feature_t *f, vital_error_handle_t *eh )
@@ -144,7 +109,6 @@ vital_feature_color( vital_feature_t *f, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the name of the instance's data type
 char const*
 vital_feature_type_name( vital_feature_t const *f,
@@ -157,7 +121,6 @@ vital_feature_type_name( vital_feature_t const *f,
   );
   return 0;
 }
-
 
 /// Define type-specific feature functions
 /**
@@ -317,7 +280,6 @@ vital_feature_##S##_set_color( vital_feature_t *f, \
     f_ptr->set_color( *c_ptr ); \
   ); \
 }
-
 
 DEFINE_FEATURE_OPERATIONS( double, d )
 DEFINE_FEATURE_OPERATIONS( float,  f )

--- a/vital/bindings/c/types/feature.h
+++ b/vital/bindings/c/types/feature.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -47,14 +21,11 @@ extern "C"
 #include <vital/bindings/c/types/color.h>
 #include <vital/bindings/c/types/eigen.h>
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Generic functions + accessors
 
-
 /// Base opaque structure for vital::feature
 typedef struct vital_feature_s vital_feature_t;
-
 
 /// Destroy a feature instance
 /**
@@ -64,7 +35,6 @@ typedef struct vital_feature_s vital_feature_t;
 VITAL_C_EXPORT
 void
 vital_feature_destroy( vital_feature_t *f, vital_error_handle_t *eh );
-
 
 /// Get 2D image location
 /**
@@ -76,7 +46,6 @@ VITAL_C_EXPORT
 vital_eigen_matrix2x1d_t*
 vital_feature_loc( vital_feature_t *f, vital_error_handle_t *eh );
 
-
 /// Get feature magnitude
 /**
  * \param f Feature instance
@@ -86,7 +55,6 @@ vital_feature_loc( vital_feature_t *f, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 double
 vital_feature_magnitude( vital_feature_t *f, vital_error_handle_t *eh );
-
 
 /// Get feature scale
 /**
@@ -98,7 +66,6 @@ VITAL_C_EXPORT
 double
 vital_feature_scale( vital_feature_t *f, vital_error_handle_t *eh );
 
-
 /// Get feature angle
 /**
  * \param f Feature instance
@@ -108,7 +75,6 @@ vital_feature_scale( vital_feature_t *f, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 double
 vital_feature_angle( vital_feature_t *f, vital_error_handle_t *eh );
-
 
 /// Get feature 2D covariance
 /**
@@ -120,7 +86,6 @@ VITAL_C_EXPORT
 vital_covariance_2d_t*
 vital_feature_covar( vital_feature_t *f, vital_error_handle_t *eh );
 
-
 /// Get Feature location's pixel color
 /**
  * \param f Feature instance
@@ -130,7 +95,6 @@ vital_feature_covar( vital_feature_t *f, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_rgb_color_t*
 vital_feature_color( vital_feature_t *f, vital_error_handle_t *eh );
-
 
 /// Get the name of the instance's data type
 /**
@@ -142,10 +106,8 @@ VITAL_C_EXPORT
 char const*
 vital_feature_type_name( vital_feature_t const *f, vital_error_handle_t *eh );
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Type specific constructors + functions
-
 
 /// Declare type-specific feature functions
 /**
@@ -276,10 +238,8 @@ vital_feature_##S##_set_color( vital_feature_t *f, \
                                vital_rgb_color_t *c, \
                                vital_error_handle_t *eh ); \
 
-
 DECLARE_FEATURE_OPERATIONS( double, d )
 DECLARE_FEATURE_OPERATIONS( float,  f )
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/feature_track_set.cxx
+++ b/vital/bindings/c/types/feature_track_set.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,7 +15,6 @@
 #include <vital/bindings/c/helpers/descriptor.h>
 #include <vital/bindings/c/helpers/feature.h>
 #include <vital/bindings/c/helpers/track.h>
-
 
 using namespace kwiver;
 
@@ -69,7 +42,6 @@ vital_feature_track_state_new( int64_t frame,
   return 0;
 }
 
-
 /// Get a track state's feature
 vital_feature_t*
 vital_feature_track_state_feature( vital_track_state_t *td,
@@ -87,7 +59,6 @@ vital_feature_track_state_feature( vital_track_state_t *td,
   );
   return 0;
 }
-
 
 /// Get a track state's descriptor
 vital_descriptor_t*

--- a/vital/bindings/c/types/feature_track_set.h
+++ b/vital/bindings/c/types/feature_track_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -64,7 +38,6 @@ vital_feature_track_state_new( int64_t frame,
                                vital_descriptor_t *d,
                                vital_error_handle_t *eh );
 
-
 /// Get a track state's feature
 /**
  * \param td Track state instance
@@ -76,7 +49,6 @@ vital_feature_t*
 vital_feature_track_state_feature( vital_track_state_t *td,
                                    vital_error_handle_t *eh );
 
-
 /// Get a track state's descriptor
 /**
  * \param td Track state instance
@@ -87,7 +59,6 @@ VITAL_C_EXPORT
 vital_descriptor_t*
 vital_feature_track_state_descriptor( vital_track_state_t *td,
                                       vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/homography.cxx
+++ b/vital/bindings/c/types/homography.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016, 2019 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,7 +15,6 @@
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/bindings/c/helpers/homography.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -51,9 +24,7 @@ SharedPointerCache< kwiver::vital::homography, vital_homography_t >
 }
 }
 
-
 using namespace kwiver;
-
 
 /// Destroy a homography instance
 void
@@ -64,7 +35,6 @@ vital_homography_destroy( vital_homography_t *h, vital_error_handle_t *eh )
     vital_c::HOMOGRAPHY_SPTR_CACHE.erase( h );
   );
 }
-
 
 /// Get the name of the descriptor instance's underlying data type
 char const*
@@ -78,7 +48,6 @@ vital_homography_type_name( vital_homography_t const *h,
   );
   return 0;
 }
-
 
 /// Create a clone of a homography instance
 vital_homography_t*
@@ -95,7 +64,6 @@ vital_homography_clone( vital_homography_t const *h, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get a new homography instance that is normalized
 vital_homography_t*
 vital_homography_normalize( vital_homography_t const *h,
@@ -110,7 +78,6 @@ vital_homography_normalize( vital_homography_t const *h,
   return 0;
 }
 
-
 /// Get a new homography instance that has been inverted
 vital_homography_t*
 vital_homography_inverse( vital_homography_t const *h,
@@ -124,7 +91,6 @@ vital_homography_inverse( vital_homography_t const *h,
   );
   return 0;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Type specific functions and constructors
@@ -235,7 +201,6 @@ vital_homography_##S##_multiply( vital_homography_t const *lhs, \
   ); \
   return 0; \
 }
-
 
 DEFINE_TYPED_OPERATIONS( double, d )
 DEFINE_TYPED_OPERATIONS( float,  f )

--- a/vital/bindings/c/types/homography.h
+++ b/vital/bindings/c/types/homography.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,10 +19,8 @@ extern "C"
 #include <vital/bindings/c/types/eigen.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// Opaque type structure
 typedef struct vital_homography_s vital_homography_t;
-
 
 /// Destroy a homography instance
 /**
@@ -58,7 +30,6 @@ typedef struct vital_homography_s vital_homography_t;
 VITAL_C_EXPORT
 void
 vital_homography_destroy( vital_homography_t *h, vital_error_handle_t *eh );
-
 
 /// Get the name of the descriptor instance's underlying data type
 /**
@@ -71,7 +42,6 @@ char const*
 vital_homography_type_name( vital_homography_t const *h,
                             vital_error_handle_t *eh );
 
-
 /// Create a clone of a homography instance
 /**
  * \param h Homography instance to destroy
@@ -81,7 +51,6 @@ vital_homography_type_name( vital_homography_t const *h,
 VITAL_C_EXPORT
 vital_homography_t*
 vital_homography_clone( vital_homography_t const *h, vital_error_handle_t *eh );
-
 
 /// Get a new homography instance that is normalized
 /**
@@ -94,7 +63,6 @@ vital_homography_t*
 vital_homography_normalize( vital_homography_t const *h,
                             vital_error_handle_t *eh );
 
-
 /// Get a new homography instance that has been inverted
 /**
  * \param h Homography instance to destroy
@@ -105,7 +73,6 @@ VITAL_C_EXPORT
 vital_homography_t*
 vital_homography_inverse( vital_homography_t const *h,
                           vital_error_handle_t *eh );
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Type specific functions and constructors
@@ -171,10 +138,8 @@ vital_homography_##S##_multiply( vital_homography_t const *lhs, \
                                  vital_homography_t const *rhs, \
                                  vital_error_handle_t *eh );
 
-
 DECLARE_TYPED_OPERATIONS( double, d )
 DECLARE_TYPED_OPERATIONS( float,  f )
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/image.cxx
+++ b/vital/bindings/c/types/image.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2020 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -51,7 +25,6 @@ vital_image_t* vital_image_new()
   return 0;
 }
 
-
 /// Create a new image with dimensions, allocating memory
 vital_image_t* vital_image_new_with_dim( size_t width, size_t height,
                                          size_t depth, bool interleave,
@@ -69,7 +42,6 @@ vital_image_t* vital_image_new_with_dim( size_t width, size_t height,
   );
   return 0;
 }
-
 
 /// Create a new image wrapping existing data
 vital_image_t* vital_image_new_from_data( void const* first_pixel,
@@ -90,7 +62,6 @@ vital_image_t* vital_image_new_from_data( void const* first_pixel,
   return 0;
 }
 
-
 /// Create a new image from an existing image
 vital_image_t* vital_image_new_from_image( vital_image_t *other_image )
 {
@@ -103,7 +74,6 @@ vital_image_t* vital_image_new_from_image( vital_image_t *other_image )
   return 0;
 }
 
-
 /// Destroy an image instance
 void vital_image_destroy( vital_image_t *image )
 {
@@ -112,7 +82,6 @@ void vital_image_destroy( vital_image_t *image )
     delete reinterpret_cast<kwiver::vital::image*>( image );
   );
 };
-
 
 /// Copy the data from \p image_src into \p image_dest
 void vital_image_copy_from_image(vital_image_t *image_dest,
@@ -125,7 +94,6 @@ void vital_image_copy_from_image(vital_image_t *image_dest,
   );
 }
 
-
 /// Return true if two images have equal content (deep equality)
 VITAL_C_EXPORT
 bool vital_image_equal_content( vital_image_t* image1, vital_image_t* image2 )
@@ -137,7 +105,6 @@ bool vital_image_equal_content( vital_image_t* image1, vital_image_t* image2 )
   );
   return false;
 }
-
 
 //
 // A little shortcut for defining pixel accessors
@@ -174,7 +141,6 @@ GET_PIXEL( int64_t,  int64 )
 GET_PIXEL( float,    float )
 GET_PIXEL( double,   double )
 GET_PIXEL( bool,     bool )
-
 
 //
 // A little shortcut for defining accessors

--- a/vital/bindings/c/types/image.h
+++ b/vital/bindings/c/types/image.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -59,7 +33,6 @@ enum vital_image_pixel_type_t {VITAL_PIXEL_UNKNOWN = 0,
                                VITAL_PIXEL_FLOAT = 3,
                                VITAL_PIXEL_BOOL = 4};
 
-
 /// Create a new, empty image
 VITAL_C_EXPORT
 vital_image_t* vital_image_new();
@@ -80,7 +53,6 @@ vital_image_t* vital_image_new_with_dim( size_t width, size_t height,
                                          size_t depth, bool interleave,
                                          vital_image_pixel_type_t pixel_type,
                                          size_t pixel_num_bytes);
-
 
 /// Create a new image wrapping existing data
 /**
@@ -106,14 +78,12 @@ vital_image_t* vital_image_new_from_data( void const* first_pixel,
                                           vital_image_pixel_type_t pixel_type,
                                           size_t pixel_num_bytes);
 
-
 /// Create a new image from an existing image, sharing the same memory
 /**
  * The new image will share the same memory as the old image
  */
 VITAL_C_EXPORT
 vital_image_t* vital_image_new_from_image( vital_image_t *other_image );
-
 
 /// Destroy an image instance
 VITAL_C_EXPORT
@@ -178,7 +148,6 @@ bool vital_image_is_contiguous( vital_image_t* image );
 /// Return true if two images have equal content (deep equality)
 VITAL_C_EXPORT
 bool vital_image_equal_content( vital_image_t* image1, vital_image_t* image2 );
-
 
 /// Get pixel value at location (i,j) assuming a single channel unsigned 8-bit image
 VITAL_C_EXPORT
@@ -267,7 +236,6 @@ bool vital_image_get_pixel2_bool( vital_image_t *image, unsigned i, unsigned j )
 /// Get pixel value at location (i,j,k) assuming a bool image
 VITAL_C_EXPORT
 bool vital_image_get_pixel3_bool( vital_image_t *image, unsigned i, unsigned j, unsigned k );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/image_container.cxx
+++ b/vital/bindings/c/types/image_container.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -78,7 +52,6 @@ vital_image_container_t* vital_image_container_from_sptr( kwiver::vital::image_c
   return 0;
 }
 
-
 vital_image_container_t* vital_image_container_from_c_pointer( kwiver::vital::image_container* ptr )
 {
   STANDARD_CATCH(
@@ -89,7 +62,6 @@ vital_image_container_t* vital_image_container_from_c_pointer( kwiver::vital::im
     );
   return 0;
 }
-
 
 kwiver::vital::image_container_sptr vital_image_container_to_sptr( vital_image_container_t* handle )
 {
@@ -119,7 +91,6 @@ vital_image_container_t* vital_image_container_new_simple( vital_image_t *img )
   return 0;
 }
 
-
 /// Destroy a vital_image_container_t instance
 void vital_image_container_destroy( vital_image_container_t *img_container,
                                     vital_error_handle_t *eh )
@@ -129,7 +100,6 @@ void vital_image_container_destroy( vital_image_container_t *img_container,
     kwiver::vital_c::IMGC_SPTR_CACHE.erase( img_container );
   );
 }
-
 
 /// Get the size in bytes of an image container
 size_t vital_image_container_size( vital_image_container_t *img_c )
@@ -141,7 +111,6 @@ size_t vital_image_container_size( vital_image_container_t *img_c )
   return 0;
 }
 
-
 /// Get the width of the given image in pixels
 size_t vital_image_container_width( vital_image_container_t *img_c )
 {
@@ -151,7 +120,6 @@ size_t vital_image_container_width( vital_image_container_t *img_c )
   );
   return 0;
 }
-
 
 /// Get the height of the given image in pixels
 size_t vital_image_container_height( vital_image_container_t *img_c )
@@ -163,7 +131,6 @@ size_t vital_image_container_height( vital_image_container_t *img_c )
   return 0;
 }
 
-
 /// Get the depth (number of channels) of the image
 size_t vital_image_container_depth( vital_image_container_t *img_c )
 {
@@ -173,7 +140,6 @@ size_t vital_image_container_depth( vital_image_container_t *img_c )
   );
   return 0;
 }
-
 
 /// Get the in-memory image class to access data
 vital_image_t* vital_image_container_get_image( vital_image_container_t *img_c )

--- a/vital/bindings/c/types/image_container.h
+++ b/vital/bindings/c/types/image_container.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -59,7 +33,6 @@ VITAL_C_EXPORT
 void vital_image_container_destroy( vital_image_container_t *img_container,
                                     vital_error_handle_t *eh );
 
-
 /// Get the size in bytes of an image container
 /**
  * Size includes all allocated image memory, which could be larger than
@@ -68,26 +41,21 @@ void vital_image_container_destroy( vital_image_container_t *img_container,
 VITAL_C_EXPORT
 size_t vital_image_container_size( vital_image_container_t *img_c );
 
-
 /// Get the width of the given image in pixels
 VITAL_C_EXPORT
 size_t vital_image_container_width( vital_image_container_t *img_c );
-
 
 /// Get the height of the given image in pixels
 VITAL_C_EXPORT
 size_t vital_image_container_height( vital_image_container_t *img_c );
 
-
 /// Get the depth (number of channels) of the image
 VITAL_C_EXPORT
 size_t vital_image_container_depth( vital_image_container_t *img_c );
 
-
 /// Get the in-memory image class to access data
 VITAL_C_EXPORT
 vital_image_t* vital_image_container_get_image( vital_image_container_t *img_c );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/image_container.hxx
+++ b/vital/bindings/c/types/image_container.hxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,7 +14,6 @@
 #include <vital/bindings/c/types/image_container.h>
 #include <vital/types/image_container.h>
 
-
 // ------------------------------------------------------------------
 // These two functions are a bridge between c++ and the internal smart pointer management
 // ------------------------------------------------------------------
@@ -52,6 +25,5 @@ vital_image_container_t* vital_image_container_from_sptr( kwiver::vital::image_c
 // Return sptr from handle
 VITAL_C_EXPORT
 kwiver::vital::image_container_sptr vital_image_container_to_sptr( vital_image_container_t* handle );
-
 
 #endif // VITAL_C_IMAGE_CONTAINER_HXX_

--- a/vital/bindings/c/types/landmark.cxx
+++ b/vital/bindings/c/types/landmark.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -36,7 +10,6 @@
 #include "landmark.h"
 
 #include <vital/bindings/c/helpers/landmark.h>
-
 
 namespace kwiver {
 namespace vital_c {
@@ -48,9 +21,7 @@ SharedPointerCache< vital::landmark, vital_landmark_t >
 }
 }
 
-
 using namespace kwiver;
-
 
 // Type independent functions //////////////////////////////////////////////////
 
@@ -63,7 +34,6 @@ vital_landmark_destroy( vital_landmark_t *l, vital_error_handle_t *eh )
     vital_c::LANDMARK_SPTR_CACHE.erase( l );
   );
 }
-
 
 /// Clone the given landmark, returning a new instance.
 vital_landmark_t*
@@ -80,7 +50,6 @@ vital_landmark_clone( vital_landmark_t *l, vital_error_handle_t *eh )
   return NULL;
 }
 
-
 /// Get the name of the stored data type
 char const*
 vital_landmark_type_name( vital_landmark_t const *l, vital_error_handle_t *eh )
@@ -91,7 +60,6 @@ vital_landmark_type_name( vital_landmark_t const *l, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get the world location of a landmark
 vital_eigen_matrix3x1d_t*
@@ -107,7 +75,6 @@ vital_landmark_loc( vital_landmark_t const *l, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the scale or a landmark
 double
 vital_landmark_scale( vital_landmark_t const *l, vital_error_handle_t *eh )
@@ -118,7 +85,6 @@ vital_landmark_scale( vital_landmark_t const *l, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get the normal vector for a landmark
 vital_eigen_matrix3x1d_t*
@@ -134,7 +100,6 @@ vital_landmark_normal( vital_landmark_t const *l, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the covariance of a landmark
 vital_covariance_3d_t*
 vital_landmark_covariance( vital_landmark_t const *l, vital_error_handle_t *eh )
@@ -147,7 +112,6 @@ vital_landmark_covariance( vital_landmark_t const *l, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Get the RGB color of a landmark
 vital_rgb_color_t*
@@ -162,7 +126,6 @@ vital_landmark_color( vital_landmark_t const *l, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Get the observations of a landmark
 unsigned
 vital_landmark_observations( vital_landmark_t const *l, vital_error_handle_t *eh )
@@ -173,7 +136,6 @@ vital_landmark_observations( vital_landmark_t const *l, vital_error_handle_t *eh
   );
   return 0;
 }
-
 
 // Type dependent functions ////////////////////////////////////////////////////
 
@@ -348,7 +310,6 @@ vital_landmark_##S##_set_observations( vital_landmark_t *l, \
     l_ptr->set_observations( observations ); \
   ); \
 }
-
 
 DEFINE_TYPED_OPERATIONS( double, d )
 DEFINE_TYPED_OPERATIONS( float,  f )

--- a/vital/bindings/c/types/landmark.h
+++ b/vital/bindings/c/types/landmark.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -47,10 +21,8 @@ extern "C"
 #include <vital/bindings/c/types/eigen.h>
 #include <vital/bindings/c/types/color.h>
 
-
 /// VITAL Landmark opaque structure
 typedef struct vital_landmark_s vital_landmark_t;
-
 
 // Type independent functions //////////////////////////////////////////////////
 
@@ -63,7 +35,6 @@ VITAL_C_EXPORT
 void
 vital_landmark_destroy( vital_landmark_t *l, vital_error_handle_t *eh );
 
-
 /// Clone the given landmark, returning a new instance.
 /**
  * \param l Landmark instance to clone
@@ -73,7 +44,6 @@ vital_landmark_destroy( vital_landmark_t *l, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_landmark_t*
 vital_landmark_clone( vital_landmark_t *l, vital_error_handle_t *eh );
-
 
 /// Get the name of the stored data type
 /**
@@ -85,7 +55,6 @@ VITAL_C_EXPORT
 char const*
 vital_landmark_type_name( vital_landmark_t const *l, vital_error_handle_t *eh );
 
-
 /// Get the world location of a landmark as a new 3x1 matrix
 /**
  * \param l landmark instance
@@ -95,7 +64,6 @@ vital_landmark_type_name( vital_landmark_t const *l, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_eigen_matrix3x1d_t*
 vital_landmark_loc( vital_landmark_t const *l, vital_error_handle_t *eh );
-
 
 /// Get the scale or a landmark
 /**
@@ -107,7 +75,6 @@ VITAL_C_EXPORT
 double
 vital_landmark_scale( vital_landmark_t const *l, vital_error_handle_t *eh );
 
-
 /// Get the normal vector for a landmark as a new 3x1 matrix
 /**
  * \param l landmark instance
@@ -117,7 +84,6 @@ vital_landmark_scale( vital_landmark_t const *l, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 vital_eigen_matrix3x1d_t*
 vital_landmark_normal( vital_landmark_t const *l, vital_error_handle_t *eh );
-
 
 /// Get the covariance of a landmark
 /**
@@ -129,7 +95,6 @@ VITAL_C_EXPORT
 vital_covariance_3d_t*
 vital_landmark_covariance( vital_landmark_t const *l, vital_error_handle_t *eh );
 
-
 /// Get the RGB color of a landmark
 /**
  * \param l landmark instance
@@ -140,7 +105,6 @@ VITAL_C_EXPORT
 vital_rgb_color_t*
 vital_landmark_color( vital_landmark_t const *l, vital_error_handle_t *eh );
 
-
 /// Get the observations of a landmark
 /**
  * \param l landmark instance
@@ -150,7 +114,6 @@ vital_landmark_color( vital_landmark_t const *l, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 unsigned
 vital_landmark_observations( vital_landmark_t const *l, vital_error_handle_t *eh );
-
 
 // Type-dependent functions ////////////////////////////////////////////////////
 
@@ -290,12 +253,10 @@ vital_landmark_##S##_set_observations( vital_landmark_t *l, \
                                        unsigned observations, \
                                        vital_error_handle_t *eh );
 
-
 DECLARE_TYPED_OPERATIONS( double, d )
 DECLARE_TYPED_OPERATIONS( float,  f )
 
 #undef DECLARE_TYPED_OPERATIONS
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/landmark_map.cxx
+++ b/vital/bindings/c/types/landmark_map.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,7 +15,6 @@
 #include <vital/bindings/c/helpers/landmark.h>
 #include <vital/bindings/c/helpers/landmark_map.h>
 
-
 namespace kwiver {
 namespace vital_c {
 
@@ -51,9 +24,7 @@ SharedPointerCache< vital::landmark_map, vital_landmark_map_t >
 }
 }
 
-
 using namespace kwiver;
-
 
 /// Create a new simple landmark map from an array of landmarks
 vital_landmark_map_t*
@@ -78,7 +49,6 @@ vital_landmark_map_new( vital_landmark_t const **landmarks,
   return NULL;
 }
 
-
 /// Create a new, empty landmark map
 vital_landmark_map_t*
 vital_landmark_map_new_empty( vital_error_handle_t *eh )
@@ -92,7 +62,6 @@ vital_landmark_map_new_empty( vital_error_handle_t *eh )
   return NULL;
 }
 
-
 /// Destroy a landmark map instance
 void
 vital_landmark_map_destroy( vital_landmark_map_t *lm, vital_error_handle_t *eh)
@@ -102,7 +71,6 @@ vital_landmark_map_destroy( vital_landmark_map_t *lm, vital_error_handle_t *eh)
     vital_c::LANDMARK_MAP_SPTR_CACHE.erase( lm );
   );
 }
-
 
 /// Get the size of the landmark map
 size_t
@@ -116,7 +84,6 @@ vital_landmark_map_size( vital_landmark_map_t const *lm,
   );
   return 0;
 }
-
 
 /// Get the landmarks contained in this map
 void

--- a/vital/bindings/c/types/landmark_map.h
+++ b/vital/bindings/c/types/landmark_map.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,10 +22,8 @@ extern "C"
 #include <vital/bindings/c/types/landmark.h>
 #include <vital/bindings/c/vital_c_export.h>
 
-
 /// vital::landmark_map Opaque structure
 typedef struct vital_landmark_map_s vital_landmark_map_t;
-
 
 /// Create a new simple landmark map from an array of landmarks
 /**
@@ -70,7 +42,6 @@ vital_landmark_map_new( vital_landmark_t const **landmarks,
                         size_t length,
                         vital_error_handle_t *eh );
 
-
 /// Create a new, empty landmark map
 /**
  * \param eh Vital error handle instance
@@ -79,7 +50,6 @@ vital_landmark_map_new( vital_landmark_t const **landmarks,
 VITAL_C_EXPORT
 vital_landmark_map_t*
 vital_landmark_map_new_empty( vital_error_handle_t *eh );
-
 
 /// Destroy a landmark map instance
 /**
@@ -90,7 +60,6 @@ VITAL_C_EXPORT
 void
 vital_landmark_map_destroy( vital_landmark_map_t *lm, vital_error_handle_t *eh);
 
-
 /// Get the size of the landmark map
 /**
  * \param lm Landmark map instance
@@ -100,7 +69,6 @@ VITAL_C_EXPORT
 size_t
 vital_landmark_map_size( vital_landmark_map_t const *lm,
                          vital_error_handle_t *eh );
-
 
 /// Get the landmarks contained in this map
 /**
@@ -124,7 +92,6 @@ vital_landmark_map_landmarks( vital_landmark_map_t const *lm,
                               int64_t **lm_ids,
                               vital_landmark_t ***landmarks,
                               vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/object_track_set.cxx
+++ b/vital/bindings/c/types/object_track_set.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017, 2019 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -41,7 +15,6 @@
 #include <vital/bindings/c/helpers/detected_object.h>
 #include <vital/bindings/c/helpers/track.h>
 #include <vital/bindings/c/helpers/track_set.h>
-
 
 using namespace kwiver;
 
@@ -67,7 +40,6 @@ vital_object_track_state_new( int64_t frame,
   return 0;
 }
 
-
 /// Get a track state's object
 vital_detected_object_t*
 vital_object_track_state_detection( vital_track_state_t *td,
@@ -85,7 +57,6 @@ vital_object_track_state_detection( vital_track_state_t *td,
   );
   return 0;
 }
-
 
 /// Create a new track set from an array of track instances
 vital_trackset_t*

--- a/vital/bindings/c/types/object_track_set.h
+++ b/vital/bindings/c/types/object_track_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -46,7 +20,6 @@ extern "C"
 #include <vital/bindings/c/types/detected_object.h>
 #include <vital/bindings/c/types/track_set.h>
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Object Track State
 
@@ -64,7 +37,6 @@ vital_object_track_state_new( int64_t frame,
                               vital_detected_object_t *d,
                               vital_error_handle_t *eh );
 
-
 /// Get a track state's object detection
 /**
  * \param td Track state data instance
@@ -75,7 +47,6 @@ VITAL_C_EXPORT
 vital_detected_object_t*
 vital_object_track_state_detection( vital_track_state_t *td,
                                     vital_error_handle_t *eh );
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Object Track Set

--- a/vital/bindings/c/types/rotation.cxx
+++ b/vital/bindings/c/types/rotation.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -37,7 +11,6 @@
 
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/types/rotation.h>
-
 
 /// Define C rotation functions for a given data type and type character suffix
 /**
@@ -366,9 +339,7 @@ vital_rotation_##S##_interpolated_rotations( vital_rotation_##S##_t *A, \
   return 0;                                                             \
 }
 
-
 DEFINE_FUNCTIONS( double, d )
 DEFINE_FUNCTIONS( float,  f )
-
 
 #undef DEFINE_FUNCTIONS

--- a/vital/bindings/c/types/rotation.h
+++ b/vital/bindings/c/types/rotation.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -38,7 +12,6 @@
 
 #include "eigen.h"
 
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -46,7 +19,6 @@ extern "C"
 
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/vital_c_export.h>
-
 
 /// Declare C rotation function for a given data type and type character suffix
 /**
@@ -304,13 +276,10 @@ vital_rotation_##S##_interpolated_rotations( vital_rotation_##S##_t *A, \
                                              size_t n, \
                                              vital_error_handle_t *eh );
 
-
 DECLARE_FUNCTIONS( double, d )
 DECLARE_FUNCTIONS( float,  f )
 
-
 #undef DECLARE_FUNCTIONS
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/similarity.cxx
+++ b/vital/bindings/c/types/similarity.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -42,9 +16,7 @@
 
 #include <vital/bindings/c/helpers/c_utils.h>
 
-
 using namespace kwiver;
-
 
 #define DEFINE_TYPED_OPERATIONS( T, S ) \
 \
@@ -234,7 +206,6 @@ vital_similarity_##S##_from_matrix4x4( vital_eigen_matrix4x4##S##_t const *m, \
   ); \
   return NULL; \
 }
-
 
 DEFINE_TYPED_OPERATIONS( double, d )
 DEFINE_TYPED_OPERATIONS( float,  f )

--- a/vital/bindings/c/types/similarity.h
+++ b/vital/bindings/c/types/similarity.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2016 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,7 +19,6 @@ extern "C"
 #include <vital/bindings/c/types/eigen.h>
 #include <vital/bindings/c/types/rotation.h>
 #include <vital/bindings/c/vital_c_export.h>
-
 
 #define DECLARE_TYPED_OPERATIONS( T, S ) \
 \
@@ -154,12 +127,10 @@ vital_similarity_##S##_t* \
 vital_similarity_##S##_from_matrix4x4( vital_eigen_matrix4x4##S##_t const *m, \
                                        vital_error_handle_t *eh );
 
-
 DECLARE_TYPED_OPERATIONS( double, d );
 DECLARE_TYPED_OPERATIONS( float,  f );
 
 #undef DECLARE_TYPED_OPERATIONS
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/track.cxx
+++ b/vital/bindings/c/types/track.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -37,7 +11,6 @@
 
 #include <vital/bindings/c/helpers/c_utils.h>
 #include <vital/bindings/c/helpers/track.h>
-
 
 namespace kwiver {
 namespace vital_c {
@@ -50,12 +23,10 @@ SharedPointerCache< vital::track_state, vital_track_state_t >
   TRACK_STATE_SPTR_CACHE( "track_state" );
 } }
 
-
 using namespace kwiver;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Track State
-
 
 /// Create a new track state
 vital_track_state_t*
@@ -70,7 +41,6 @@ vital_track_state_new( int64_t frame, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Destroy a track state instance
 void
 vital_track_state_destroy( vital_track_state_t *ts, vital_error_handle_t *eh )
@@ -80,7 +50,6 @@ vital_track_state_destroy( vital_track_state_t *ts, vital_error_handle_t *eh )
     kwiver::vital_c::TRACK_STATE_SPTR_CACHE.erase( ts );
   );
 }
-
 
 /// Get a track state's frame ID
 int64_t
@@ -93,7 +62,6 @@ vital_track_state_frame_id( vital_track_state_t *ts, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Track
@@ -111,7 +79,6 @@ vital_track_new( vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Destroy a VITAL track pointer
 void
 vital_track_destroy( vital_track_t *track,
@@ -122,7 +89,6 @@ vital_track_destroy( vital_track_t *track,
     kwiver::vital_c::TRACK_SPTR_CACHE.erase( track );
   );
 }
-
 
 /// Get the ID of the track
 int64_t
@@ -135,7 +101,6 @@ vital_track_id( vital_track_t const *t, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Set the track identification number
 void
 vital_track_set_id( vital_track_t *t, int64_t i, vital_error_handle_t *eh )
@@ -145,7 +110,6 @@ vital_track_set_id( vital_track_t *t, int64_t i, vital_error_handle_t *eh )
     vital_c::TRACK_SPTR_CACHE.get( t )->set_id( i );
   );
 }
-
 
 /// Access the first frame number covered by this track
 int64_t
@@ -158,7 +122,6 @@ vital_track_first_frame( vital_track_t const *t, vital_error_handle_t *eh )
   return 0;
 }
 
-
 /// Access the last frame number covered by this track
 int64_t
 vital_track_last_frame( vital_track_t const *t, vital_error_handle_t *eh )
@@ -169,7 +132,6 @@ vital_track_last_frame( vital_track_t const *t, vital_error_handle_t *eh )
   );
   return 0;
 }
-
 
 /// Return the set of all frame IDs covered by this track
 int64_t*
@@ -194,7 +156,6 @@ vital_track_all_frame_ids( vital_track_t const *t, size_t *n,
   return NULL;
 }
 
-
 /// Get the number of states in the track
 size_t
 vital_track_size( vital_track_t const *track,
@@ -206,7 +167,6 @@ vital_track_size( vital_track_t const *track,
   );
   return 0;
 }
-
 
 /// Return whether or not this track has any states
 VITAL_C_EXPORT
@@ -220,7 +180,6 @@ vital_track_empty( vital_track_t const *track,
   );
   return true;
 }
-
 
 /// Append a track state to this track
 bool
@@ -238,7 +197,6 @@ vital_track_append_state( vital_track_t *t, vital_track_state_t *ts,
   );
   return false;
 }
-
 
 /// Find the track state matching the given frame ID
 vital_track_state_t*

--- a/vital/bindings/c/types/track.h
+++ b/vital/bindings/c/types/track.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -48,7 +22,6 @@ extern "C"
 #include <vital/bindings/c/vital_c_export.h>
 #include <vital/bindings/c/error_handle.h>
 
-
 /// Opaque structure for vital::track_state instances
 typedef struct vital_track_state_s vital_track_state_t;
 /// Opaque structure for vital::track instances
@@ -66,7 +39,6 @@ VITAL_C_EXPORT
 vital_track_state_t*
 vital_track_state_new( int64_t frame, vital_error_handle_t *eh );
 
-
 /// Destroy a track state instance
 /**
  * \param ts Track state instance to destroy
@@ -75,7 +47,6 @@ vital_track_state_new( int64_t frame, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 void
 vital_track_state_destroy( vital_track_state_t *ts, vital_error_handle_t *eh );
-
 
 /// Get a track state's frame ID
 /**
@@ -86,7 +57,6 @@ vital_track_state_destroy( vital_track_state_t *ts, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 int64_t
 vital_track_state_frame_id( vital_track_state_t *ts, vital_error_handle_t *eh );
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Track
@@ -100,7 +70,6 @@ VITAL_C_EXPORT
 vital_track_t*
 vital_track_new( vital_error_handle_t *eh );
 
-
 /// Destroy a VITAL track pointer
 /**
  * \param track Track instance
@@ -110,7 +79,6 @@ VITAL_C_EXPORT
 void
 vital_track_destroy( vital_track_t *track,
                      vital_error_handle_t *eh );
-
 
 /// Get the ID of the track
 /**
@@ -122,7 +90,6 @@ VITAL_C_EXPORT
 int64_t
 vital_track_id( vital_track_t const *t, vital_error_handle_t *eh );
 
-
 /// Set the track identification number
 /**
  * \param track Track instance
@@ -132,7 +99,6 @@ vital_track_id( vital_track_t const *t, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 void
 vital_track_set_id( vital_track_t *t, int64_t i, vital_error_handle_t *eh );
-
 
 /// Access the first frame number covered by this track
 /**
@@ -144,7 +110,6 @@ VITAL_C_EXPORT
 int64_t
 vital_track_first_frame( vital_track_t const *t, vital_error_handle_t *eh );
 
-
 /// Access the last frame number covered by this track
 /**
  * \param track Track instance
@@ -154,7 +119,6 @@ vital_track_first_frame( vital_track_t const *t, vital_error_handle_t *eh );
 VITAL_C_EXPORT
 int64_t
 vital_track_last_frame( vital_track_t const *t, vital_error_handle_t *eh );
-
 
 /// Return the set of all frame IDs covered by this track
 /**
@@ -170,7 +134,6 @@ int64_t*
 vital_track_all_frame_ids( vital_track_t const *t, size_t *n,
                            vital_error_handle_t *eh );
 
-
 /// Access the track identification number
 /**
  * \param track Track instance
@@ -181,7 +144,6 @@ size_t
 vital_track_size( vital_track_t const *track,
                   vital_error_handle_t *eh );
 
-
 /// Return whether or not this track has any states
 /**
  * \param track Track instance
@@ -191,7 +153,6 @@ VITAL_C_EXPORT
 bool
 vital_track_empty( vital_track_t const *track,
                    vital_error_handle_t *eh );
-
 
 /// Append a track state to this track
 /**
@@ -208,7 +169,6 @@ bool
 vital_track_append_state( vital_track_t *t, vital_track_state_t *ts,
                           vital_error_handle_t *eh );
 
-
 /// Find the track state matching the given frame ID
 /**
  * \param t the Track instance to search in
@@ -222,7 +182,6 @@ VITAL_C_EXPORT
 vital_track_state_t*
 vital_track_find_state( vital_track_t *t, int64_t frame,
                         vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/track_set.cxx
+++ b/vital/bindings/c/types/track_set.cxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -54,9 +28,7 @@ TRACK_SET_SPTR_CACHE( "track_set" );
 }
 }
 
-
 using namespace kwiver;
-
 
 /// Create a new track set from an array of track instances
 vital_trackset_t*
@@ -79,7 +51,6 @@ vital_trackset_new( size_t length, vital_track_t **tracks,
   return 0;
 }
 
-
 /// Adopt existing track set from sptr
 vital_trackset_t*
 vital_trackset_from_sptr( void* sptr )
@@ -93,7 +64,6 @@ vital_trackset_from_sptr( void* sptr )
   );
   return 0;
 }
-
 
 /// Create a new track set as read from file
 vital_trackset_t*
@@ -109,7 +79,6 @@ vital_trackset_new_from_file( char const *filepath,
   return 0;
 }
 
-
 /// Destroy a track set instance
 void
 vital_trackset_destroy( vital_trackset_t *track_set,
@@ -120,7 +89,6 @@ vital_trackset_destroy( vital_trackset_t *track_set,
     vital_c::TRACK_SET_SPTR_CACHE.erase( track_set );
   );
 }
-
 
 /// Get the size of the track set
 size_t
@@ -133,7 +101,6 @@ vital_trackset_size( vital_trackset_t const *track_set,
   );
   return 0;
 }
-
 
 /// Write track set to the given filepath
 void
@@ -149,7 +116,6 @@ vital_trackset_write_track_file( vital_trackset_t const *ts,
     );
   );
 }
-
 
 /// Get array of contained track references
 vital_track_t**
@@ -171,7 +137,6 @@ vital_trackset_tracks( vital_trackset_t const *track_set,
   );
   return 0;
 }
-
 
 /// Get the set of all frame IDs covered by contained tracks
 int64_t*
@@ -195,7 +160,6 @@ vital_trackset_all_frame_ids( vital_trackset_t const *trackset, size_t *length,
   return 0;
 }
 
-
 /// Get the set of all track IDs in the track set
 int64_t*
 vital_trackset_all_track_ids( vital_trackset_t const *trackset, size_t *length,
@@ -218,7 +182,6 @@ vital_trackset_all_track_ids( vital_trackset_t const *trackset, size_t *length,
   return 0;
 }
 
-
 /// Get the first (smallest) frame number containing tracks
 int64_t
 vital_trackset_first_frame( vital_trackset_t const *trackset,
@@ -231,7 +194,6 @@ vital_trackset_first_frame( vital_trackset_t const *trackset,
   return 0;
 }
 
-
 /// Get the last (largest) frame number containing tracks
 int64_t
 vital_trackset_last_frame( vital_trackset_t const *trackset,
@@ -243,7 +205,6 @@ vital_trackset_last_frame( vital_trackset_t const *trackset,
   );
   return 0;
 }
-
 
 /// Get the track in this set with the specified id
 vital_track_t*
@@ -261,7 +222,6 @@ vital_trackset_get_track( vital_trackset_t const *trackset, int64_t tid,
   return 0;
 }
 
-
 /// Create a vital_track_set_t around an existing shared pointer.
 vital_trackset_t*
 vital_track_set_new_from_sptr( kwiver::vital::track_set_sptr ts_sptr,
@@ -275,7 +235,6 @@ vital_track_set_new_from_sptr( kwiver::vital::track_set_sptr ts_sptr,
   );
   return NULL;
 }
-
 
 /// Get the vital::track_set shared pointer for a handle.
 kwiver::vital::track_set_sptr

--- a/vital/bindings/c/types/track_set.h
+++ b/vital/bindings/c/types/track_set.h
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2015-2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -45,10 +19,8 @@ extern "C"
 #include <vital/bindings/c/error_handle.h>
 #include <vital/bindings/c/types/track.h>
 
-
 /// Opaque structure
 typedef struct vital_trackset_s vital_trackset_t;
-
 
 /// Create a new track set from an array of track instances
 /**
@@ -67,7 +39,6 @@ vital_trackset_t*
 vital_trackset_new( size_t length, vital_track_t **tracks,
                     vital_error_handle_t *eh );
 
-
 /// Adopt existing track set from sptr
 /**
  *
@@ -78,7 +49,6 @@ vital_trackset_new( size_t length, vital_track_t **tracks,
 VITAL_C_EXPORT
 vital_trackset_t*
 vital_trackset_from_sptr( void* sptr );
-
 
 /// Create a new track set as read from file
 /**
@@ -101,7 +71,6 @@ vital_trackset_t*
 vital_trackset_new_from_file( char const *filepath,
                               vital_error_handle_t *eh );
 
-
 /// Destroy a track set instance
 /**
  * This function destroys the referenced track set. The supplied
@@ -117,13 +86,11 @@ void
 vital_trackset_destroy( vital_trackset_t *track_set,
                         vital_error_handle_t *eh );
 
-
 /// Get the size of the track set
 VITAL_C_EXPORT
 size_t
 vital_trackset_size( vital_trackset_t const *track_set,
                      vital_error_handle_t *eh );
-
 
 /// Write track set to the given filepath
 VITAL_C_EXPORT
@@ -131,7 +98,6 @@ void
 vital_trackset_write_track_file( vital_trackset_t const *ts,
                                  char const *filepath,
                                  vital_error_handle_t *eh );
-
 
 /// Get array of contained track references
 /**
@@ -146,7 +112,6 @@ vital_track_t**
 vital_trackset_tracks( vital_trackset_t const *track_set,
                        vital_error_handle_t *eh );
 
-
 /// Get the set of all frame IDs covered by contained tracks
 /**
  * \param trackset the track set instance
@@ -158,7 +123,6 @@ VITAL_C_EXPORT
 int64_t*
 vital_trackset_all_frame_ids( vital_trackset_t const *trackset, size_t *length,
                               vital_error_handle_t *eh );
-
 
 /// Get the set of all track IDs in the track set
 /**
@@ -172,7 +136,6 @@ int64_t*
 vital_trackset_all_track_ids( vital_trackset_t const *trackset, size_t *length,
                               vital_error_handle_t *eh );
 
-
 /// Get the first (smallest) frame number containing tracks
 /**
  * \param trackset the track set instance
@@ -184,7 +147,6 @@ int64_t
 vital_trackset_first_frame( vital_trackset_t const *trackset,
                             vital_error_handle_t *eh );
 
-
 /// Get the last (largest) frame number containing tracks
 /**
  * \param trackset the track set instance
@@ -195,7 +157,6 @@ VITAL_C_EXPORT
 int64_t
 vital_trackset_last_frame( vital_trackset_t const *trackset,
                            vital_error_handle_t *eh );
-
 
 /// Get the track in this set with the specified id
 /**
@@ -211,7 +172,6 @@ VITAL_C_EXPORT
 vital_track_t*
 vital_trackset_get_track( vital_trackset_t const *trackset, int64_t tid,
                           vital_error_handle_t *eh );
-
 
 #ifdef __cplusplus
 }

--- a/vital/bindings/c/types/track_set.hxx
+++ b/vital/bindings/c/types/track_set.hxx
@@ -1,32 +1,6 @@
-/*ckwg +29
- * Copyright 2017 by Kitware, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /**
  * \file
@@ -40,12 +14,10 @@
 #include <vital/bindings/c/types/track_set.h>
 #include <vital/types/track_set.h>
 
-
 // -----------------------------------------------------------------------------
 // These two functions are a bridge between C++ and the internal C smart pointer
 // management.
 // -----------------------------------------------------------------------------
-
 
 /// Create a vital_trackset_t around an existing shared pointer.
 /**
@@ -59,7 +31,6 @@ vital_trackset_t*
 vital_track_set_new_from_sptr( kwiver::vital::track_set_sptr ts_sptr,
                                vital_error_handle_t* eh );
 
-
 /// Get the vital::track_set shared pointer for a handle.
 /**
  * If an error occurs, an empty shared pointer is returned.
@@ -72,6 +43,5 @@ VITAL_C_EXPORT
 kwiver::vital::track_set_sptr
 vital_track_set_to_sptr( vital_trackset_t* ts,
                          vital_error_handle_t* eh );
-
 
 #endif // VITAL_C_TRACK_SET_HXX_


### PR DESCRIPTION
Update copyright banners in `vital/bindings/`.

See also #1142 and other PRs referencing that.