### PR TITLE
Peg FFmpeg version to 3.3.3. Fletch version 2.6.2 doesn't build anymore.

### DIFF
--- a/CMake/kwiver-depends-ffmpeg.cmake
+++ b/CMake/kwiver-depends-ffmpeg.cmake
@@ -6,5 +6,5 @@ option( KWIVER_ENABLE_FFMPEG
   )
 
 if( KWIVER_ENABLE_FFMPEG )
-  find_package( FFMPEG REQUIRED )
+  find_package( FFMPEG 3.0  REQUIRED )
 endif( KWIVER_ENABLE_FFMPEG )


### PR DESCRIPTION
Recent FFmpeg changes are preventing the arrow from building against the older Fletch version, 2.6.2. I've pushed this PR to peg the find_package version to the newer one from Fletch, 3.3.3. Considering these changes, I'm not sure if there is a need to keep 2.6.2 in Fletch anymore. If not, I will remove that and push a PR there.

Alternatively, if the older version is still desired, I can regenerate the build errors and post them here so they can get fixed.