### PR TITLE
Removed API from header that was not implemented

### DIFF
--- a/arrows/vtk/applets/estimate_depth.h
+++ b/arrows/vtk/applets/estimate_depth.h
@@ -26,9 +26,6 @@ public:
                "Depth estimation utility");
 
   int run() override;
-  int run_frame(int frame, const kwiver::vital::camera_map::map_camera_t &cm,
-                kwiver::vital::landmark_map_sptr lm, std::string mask_path,
-                double angle_span, int num_support, bool hasMask);
   void add_command_options() override;
 
 private:


### PR DESCRIPTION
I intended to address the comment about the naming of `hasMask`, but then I realized this function is not implemented in the cxx, so I'm just removing it entirely.