### PR TITLE
Improve Ceres logging

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -73,6 +73,10 @@ Arrows: Core
 
 Arrows: Ceres
 
+ * Improve logging in bundle_adjust to allow logging per-iteration summaries
+   and independently control logging fully summaries after optimization
+   completes.
+
 Arrows: CUDA
 
 Arrows: FFmpeg


### PR DESCRIPTION
To achieve these logging improvements required a slight change to how callbacks are used.  We now always register a callback to the underlying Ceres code so that it can handle logging of per iteration summaries, at a minimum.  The callback is only propagated further if a callback was registered to this class.  The callback class now needs to be a member of the PImpl class so that it has access to the `verbose` state and `logger()` handle.