### PR TITLE
Reduce plugin_loader includes

### DIFF
--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -11,10 +11,11 @@
 #include <vital/util/demangle.h>
 #include <vital/util/string.h>
 
-#include <sstream>
-
-#include <kwiversys/SystemTools.hxx>
 #include <kwiversys/Directory.hxx>
+#include <kwiversys/DynamicLoader.hxx>
+#include <kwiversys/SystemTools.hxx>
+
+#include <sstream>
 
 namespace kwiver {
 namespace vital {

--- a/vital/plugin_loader/plugin_loader.h
+++ b/vital/plugin_loader/plugin_loader.h
@@ -10,8 +10,6 @@
 #include <vital/vital_types.h>
 #include <vital/logger/logger.h>
 
-#include <kwiversys/DynamicLoader.hxx>
-
 #include <vector>
 #include <string>
 #include <map>
@@ -43,8 +41,6 @@ class plugin_loader_impl;
 class VITAL_VPM_EXPORT plugin_loader
 {
 public:
-  typedef kwiversys::DynamicLoader   DL;
-
   /**
    * @brief Constructor
    *


### PR DESCRIPTION
Don't include `DynamicLoader.hxx` in `plugin_loader.h`; there is absolutely no need for it, and on Windows, it drags in `windows.h` which, besides being enormous, can have nasty side effects, such as defining the illegal-per-the-standard macro `max`, which breaks incautious use of `std::max`.