### PR TITLE
Dev/applet command tree

### DIFF
--- a/arrows/core/applets/render_mesh.h
+++ b/arrows/core/applets/render_mesh.h
@@ -23,7 +23,7 @@ public:
   render_mesh(){}
   virtual ~render_mesh() = default;
 
-  PLUGIN_INFO( "render-mesh",
+  PLUGIN_INFO( "mesh:render",
                "Render a depth or height map from a mesh.\n\n"
                "This tool reads in a mesh file and a camera and renders "
                "various images such as depth map or height map.");

--- a/arrows/qt/applets/pipeline_viewer/pipeline_viewer.h
+++ b/arrows/qt/applets/pipeline_viewer/pipeline_viewer.h
@@ -16,7 +16,7 @@ namespace tools {
 class pipeline_viewer : public kwiver_applet
 {
 public:
-  PLUGIN_INFO( "pipe-gui",
+  PLUGIN_INFO( "pipe:gui",
                "Run pipelines in a simple GUI.\n\n"
                "This program provides a simple Qt-based front-end "
                "for executing pipelines and viewing images produced by the same." );

--- a/arrows/vtk/applets/color_mesh.h
+++ b/arrows/vtk/applets/color_mesh.h
@@ -19,7 +19,7 @@ public:
   color_mesh();
   virtual ~color_mesh();
 
-  PLUGIN_INFO( "color-mesh",
+  PLUGIN_INFO( "mesh:color",
                "Color a mesh from a video and cameras");
 
   int run() override;

--- a/arrows/vtk/applets/estimate_depth.h
+++ b/arrows/vtk/applets/estimate_depth.h
@@ -22,7 +22,7 @@ public:
   estimate_depth();
   virtual ~estimate_depth();
 
-  PLUGIN_INFO( "estimate-depth",
+  PLUGIN_INFO( "depth:estimate",
                "Depth estimation utility");
 
   int run() override;

--- a/arrows/vtk/applets/fuse_depth.h
+++ b/arrows/vtk/applets/fuse_depth.h
@@ -19,7 +19,7 @@ public:
   fuse_depth();
   virtual ~fuse_depth();
 
-  PLUGIN_INFO( "fuse-depth",
+  PLUGIN_INFO( "depth:fuse",
                "Fuse depth maps from multiple cameras into a single surface");
 
   int run() override;

--- a/sprokit/src/applets/pipe_config.h
+++ b/sprokit/src/applets/pipe_config.h
@@ -22,7 +22,7 @@ public:
   int run() override;
   void add_command_options() override;
 
-  PLUGIN_INFO( "pipe-config",
+  PLUGIN_INFO( "pipe:config",
     "Configures a pipeline\n\n"
     "This tool reads a pipeline configuration file, applies the program options "
     "and generates a \"compiled\" config file. "

--- a/sprokit/src/applets/pipe_to_dot.h
+++ b/sprokit/src/applets/pipe_to_dot.h
@@ -22,8 +22,9 @@ public:
   int run() override;
   void add_command_options() override;
 
-  PLUGIN_INFO( "pipe-to-dot",
-               "Create DOT output of pipe topology")
+  PLUGIN_INFO( "pipe:convert-to-dot;pipe:convert:to:dot",
+               "Create DOT output of pipe topology in Graphviz DOT "
+               "graph description language.")
 
 }; // end of class
 

--- a/sprokit/src/applets/pipeline_runner.h
+++ b/sprokit/src/applets/pipeline_runner.h
@@ -19,7 +19,7 @@ class pipeline_runner
 public:
   pipeline_runner();
 
-  PLUGIN_INFO( "runner",
+  PLUGIN_INFO( "pipe:run",
                "Runs a pipeline");
 
   int run() override;

--- a/tools/kwiver_tool_runner.cxx
+++ b/tools/kwiver_tool_runner.cxx
@@ -8,10 +8,9 @@
 #include <vital/applets/applet_registrar.h>
 #include <vital/exceptions/base.h>
 #include <vital/plugin_loader/plugin_factory.h>
-#include <vital/plugin_loader/plugin_filter_category.h>
-#include <vital/plugin_loader/plugin_filter_default.h>
 #include <vital/plugin_loader/plugin_manager_internal.h>
 #include <vital/util/get_paths.h>
+#include <vital/util/tokenize.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -22,8 +21,93 @@
 #include <memory>
 #include <utility>
 
-using applet_factory = kwiver::vital::implementation_factory_by_name< kwiver::tools::kwiver_applet >;
 using applet_context_t = std::shared_ptr< kwiver::tools::applet_context >;
+namespace kv = kwiver::vital;
+
+class command_node;
+using command_node_sptr = std::shared_ptr<command_node>;
+bool compare_node( command_node_sptr const& n1, command_node_sptr const& n2 );
+
+// -------------------------------------------------------------------
+class command_node
+{
+public:
+  command_node(std::string const& name)
+    : m_name( name ),
+      m_is_command( false )
+  { }
+
+  virtual ~command_node() = default;
+
+  void
+  add_factory( kv::plugin_factory_handle_t fact )
+  {
+    m_factory = fact;
+    m_is_command = true;
+  }
+
+  bool
+  is_command() const { return m_is_command; }
+
+  command_node_sptr
+  find( std::string const& name )
+  {
+    for ( auto& n : m_nodes )
+    {
+      if ( name == n->m_name )
+      {
+        return n;
+      }
+    } // end for
+    return nullptr;
+  }
+
+  void
+  add( command_node_sptr n )
+  {
+    m_nodes.push_back(n);
+
+    // sort vector
+    std::sort( m_nodes.begin(), m_nodes.end(), compare_node );
+    return;
+  }
+
+  void
+  print_subtree_help( std::string const& pfx = "")
+  {
+    for ( auto const& n : m_nodes )
+    {
+      n->print_subtree_help( pfx + " " + this->m_name );
+    }
+
+    if( this->is_command() )
+    {
+      std::cout << pfx << " " << this->m_name << " " << std::endl;
+      return;
+    }
+  }
+
+  void
+  dump_tree(std::string const& pfx = "") const
+  {
+    std::cout << pfx << "Name: " << m_name << "   is_command: " << is_command() << "\n";
+    for ( auto const& n : m_nodes )
+    {
+      n->dump_tree( pfx + "    " );
+    }
+  }
+
+  std::string m_name;
+  bool m_is_command { false };
+  std::vector<command_node_sptr> m_nodes;
+  kv::plugin_factory_handle_t m_factory;
+};
+
+// --------------------------------------------------------------------
+bool compare_node( command_node_sptr const& n1, command_node_sptr const& n2 )
+{
+  return (n1->m_name < n2->m_name);
+}
 
 // ============================================================================
 /**
@@ -40,7 +124,7 @@ public:
 
     // Parse the command line
     // Command line format:
-    // arg0 [runner-flags] <applet> [applet-args]
+    // arg0 [runner-flags] <applet path> [applet-args]
 
     // The first applet args is the program name.
     m_applet_args.push_back( "kwiver" );
@@ -57,15 +141,29 @@ public:
         }
         else
         {
-          // found applet name
-          m_applet_name = std::string( (*p_argv)[i] );
-          state = 1; // advance state
+          // found applet name component
+          //+ Should just change state and re-evaluate token
+          m_applet_name.push_back( std::string( (*p_argv)[i] ));
+          state = 1;
         }
       }
       else if (state == 1)
       {
-        // Collecting applet parameters
-        m_applet_args.push_back( (*p_argv)[i] );
+       if ( (*p_argv)[i][0] == '-' )
+        {
+          // Collecting applet parameters
+          m_applet_args.push_back( (*p_argv)[i] );
+          state = 2;
+        }
+       else
+       {
+          m_applet_name.push_back( std::string( (*p_argv)[i] ));
+       }
+      }
+      else if (state == 2)
+      {
+          // Collecting applet parameters
+          m_applet_args.push_back( (*p_argv)[i] );
       }
     } // end for
 
@@ -77,8 +175,81 @@ public:
 
   std::vector<std::string> m_runner_args;
   std::vector<std::string> m_applet_args;
-  std::string m_applet_name;
+
+  // Applet name may contain args but we can't tell before running
+  // these words against the command tree.
+  std::vector<std::string> m_applet_name;
 };
+
+// --------------------------------------------------------------------
+// This function parses all applets and builds the command
+// tree, which is returned
+command_node_sptr
+build_command_tree( kwiver::vital::plugin_manager& vpm )
+{
+  command_node_sptr root = std::make_shared<command_node>( "Root" );
+
+  // Get list of factories for implementations of the applet
+  const auto fact_list = vpm.get_factories( typeid( kwiver::tools::kwiver_applet ).name() );
+
+  for( auto fact : fact_list )
+  {
+    std::string buf = "-- Not Set --";
+    fact->get_attribute( kv::plugin_factory::PLUGIN_NAME, buf );
+
+    // split string on ';' for multiple paths
+    std::vector<std::string> paths;
+    tokenize( buf, paths, ";", kv::TokenizeTrimEmpty );
+
+    for ( auto const& w : paths )
+    {
+      auto current_node = root;
+      // split each path string on ':'
+      std::vector<std::string> words;
+      tokenize( w, words, ":", kv::TokenizeTrimEmpty );
+
+      for ( auto const& c : words )
+      {
+        command_node_sptr n = current_node->find( c );
+        if ( !n )
+        {
+          // node doesn't exist, need to add it
+          n =  std::make_shared< command_node >( c );
+          current_node->add( n );
+        }
+        else if ( n && n->is_command() )
+        {
+          // error found a terminal node
+          std::cerr << "Could not register applet. Command \"";
+          for ( auto const& ew : words )
+          {
+            std::cerr << ew;
+            if ( ew == c )
+            {
+              break;
+            }
+            std::cerr << " ";
+
+          }
+          std::cerr << "\" already exists. Defined by ";
+          auto nn = current_node->find(c);
+          auto f = nn->m_factory;
+          std::string plugin_file;
+          f->get_attribute( kv::plugin_factory::PLUGIN_FILE_NAME, plugin_file );
+          std::cerr << plugin_file << std::endl;
+          exit( -1 );
+        }
+
+        current_node = n;
+      } // end for
+
+      // Add factory to the last node.
+      current_node->add_factory( fact );
+    }
+  } // end for
+
+  return root;
+}
 
 // ----------------------------------------------------------------------------
 /**
@@ -88,8 +259,8 @@ void tool_runner_usage( VITAL_UNUSED applet_context_t ctxt,
                         kwiver::vital::plugin_manager& vpm )
 {
   // display help message
-  std::cout << "Usage: kwiver  <applet>  [args]" << std::endl
-            << "<applet> can be one of the following:" << std::endl
+  std::cout << "Usage: kwiver <tool>  [args]" << std::endl
+            << "<tool> can be one of the following:" << std::endl
             << "help - prints this message." << std::endl
             << "Available tools are listed below:" << std::endl;
 
@@ -105,6 +276,9 @@ void tool_runner_usage( VITAL_UNUSED applet_context_t ctxt,
   {
     std::string buf = "-- Not Set --";
     fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, buf );
+    // need to format the name since the command words are separated by ':'
+    std::vector<std::string> paths;
+    tokenize( buf, paths, ";", kv::TokenizeTrimEmpty );
 
     std::string descr = "-- Not Set --";
     fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, descr );
@@ -117,8 +291,13 @@ void tool_runner_usage( VITAL_UNUSED applet_context_t ctxt,
       descr = descr.substr( 0, pos );
     }
 
-    help_text.push_back( help_pair({ buf, descr }) );
-    tab_stop = std::max( tab_stop, buf.size() );
+    // make help entry for all name variants
+    for ( auto name : paths )
+    {
+      std::replace( name.begin(), name.end(), ':', ' ');
+      help_text.push_back( help_pair({ name, descr }) );
+      tab_stop = std::max( tab_stop, name.size() );
+    }
   } // end for
 
   // add some space after the longest applet name
@@ -134,43 +313,11 @@ void tool_runner_usage( VITAL_UNUSED applet_context_t ctxt,
   }
 }
 
-// ----------------------------------------------------------------------------
-/**
- * This function handles the "help" operation. If there is an arg
- * after the help, then that arg is taken to be the applet name and
- * help is displayed for it.
- *
- * If the only arg is "help", then call the function to generate short
- * help for all known applets.
- */
-void help_applet( const command_line_parser& options,
-                  applet_context_t tool_context,
-                  kwiver::vital::plugin_manager& vpm )
-{
-  if ( options.m_applet_args.size() < 2 )
-  {
-    tool_runner_usage( tool_context, vpm );
-    return;
-  }
-
-  // Create applet based on the name provided
-  applet_factory app_fact;
-  std::string buf = "-- Not Set --";
-  auto fact = app_fact.find_factory( options.m_applet_args[1] );
-  fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, buf );
-
-  kwiver::tools::kwiver_applet_sptr applet( app_fact.create( options.m_applet_args[1] ) );
-  tool_context->m_applet_name = options.m_applet_args[1];
-  applet->initialize( tool_context.get() );
-  applet->add_command_options();
-
-  // display help text
-  std::cout << applet->m_cmd_options->help();
-}
-
 // ============================================================================
 int main(int argc, char *argv[])
 {
+command_node_sptr cmd_root;
+
   //
   // Global shared context
   // Allocated on the stack so it will automatically clean up
@@ -186,12 +333,13 @@ int main(int argc, char *argv[])
 
   // initialize the global context
   tool_context->m_wtb.set_indent_string( "      " );
-
+  cmd_root = build_command_tree( vpm );
   command_line_parser options( argc, &argv );
 
-  if ( (options.m_applet_name == "help") || (argc == 1) )
+  // If there is only a 'help' as an argument
+  if ( (argc == 1) || (options.m_applet_name[0] == "help") )
   {
-    help_applet( options, tool_context, vpm );
+    tool_runner_usage( tool_context, vpm );
     return 0;
   } // end help code
 
@@ -199,8 +347,45 @@ int main(int argc, char *argv[])
   try
   {
     // Create applet based on the name provided
-    applet_factory app_fact;
-    kwiver::tools::kwiver_applet_sptr applet( app_fact.create( options.m_applet_name ) );
+    auto cn = cmd_root;
+    size_t ci;
+    for ( ci = 0; ci < options.m_applet_name.size(); ci++)
+    {
+      auto n = cn->find( options.m_applet_name[ci] );
+      if ( ! n )
+      {
+        break;
+      }
+      cn = n;
+    } // end for
+
+    // If there are no matches or we run out of command words
+    // before we reach a terminal command node.
+    if ( ci == 0 && !cn->is_command() )
+    {
+      // error - no command match at all. Give full help
+      std::cerr << "Command not found.\n\n";
+      tool_runner_usage( tool_context, vpm );
+      exit(-1);
+    }
+    else if ( ci > 0 && !cn->is_command() )
+    {
+      // Partial command match - just subtree help
+      std::cerr << "Command not found. Related commands are as follows:\n";
+      cn->print_subtree_help();
+      exit(-1);
+    }
+
+    // Insert name words[ci+1] [size-1] at start of options.m_applet_args
+    for( size_t ai = ci; ai < options.m_applet_name.size(); ai++)
+    {
+      options.m_applet_args.insert(
+        options.m_applet_args.begin()+1, // skip first "kwiver" element
+        options.m_applet_name[ai] );
+    } // end for
+
+    kwiver::tools::kwiver_applet_sptr applet(
+      cn->m_factory->create_object<kwiver::tools::kwiver_applet>() );
 
     tool_context->m_applet_name = options.m_applet_name;
     tool_context->m_argv = options.m_applet_args; // save a copy of the args
@@ -225,7 +410,7 @@ int main(int argc, char *argv[])
     {
       // Convert args list back to argv style. :-(
       // This is needed for the command options support package.
-      argv_vect.resize( options.m_applet_args.size() +1, nullptr );
+      argv_vect.resize( options.m_applet_args.size()+1, nullptr );
       for (std::size_t i = 0; i != options.m_applet_args.size(); ++i)
       {
         argv_vect[i] = &options.m_applet_args[i][0];
@@ -241,7 +426,7 @@ int main(int argc, char *argv[])
     local_argv = &argv_vect[0];
 
     // The parse result has to be created locally due to class design.
-    // No default CTOR, copy CTOR or operation.
+    // No default CTOR, copy CTOR or copy operation so we just have to use the local copy.
     cxxopts::ParseResult local_result = applet->m_cmd_options->parse( local_argc, local_argv );
 
     // Make results available in the context,
@@ -262,7 +447,7 @@ int main(int argc, char *argv[])
 
     exit(-1);
   }
-  catch ( kwiver::vital::vital_exception& e )
+  catch ( kv::vital_exception& e )
   {
     std::cerr << "Caught unhandled kwiver::vital::vital_exception: " << e.what() << std::endl;
     exit( -1 );

--- a/vital/applets/applet_context.h
+++ b/vital/applets/applet_context.h
@@ -28,8 +28,8 @@ public:
   // Used to wrap large text blocks
   kwiver::vital::wrap_text_block m_wtb;
 
-  // name of the applet. as in kwiver <applet> <args..>
-  std::string m_applet_name;
+  // name of the applet. as in kwiver <ap pl et> <args..>
+  std::vector<std::string> m_applet_name;
 
     /**
    * Results from parsing the command options. Note that you do not

--- a/vital/applets/applet_context.h
+++ b/vital/applets/applet_context.h
@@ -28,7 +28,7 @@ public:
   // Used to wrap large text blocks
   kwiver::vital::wrap_text_block m_wtb;
 
-  // name of the applet. as in kwiver <ap pl et> <args..>
+  // array of names forming fully qualified name of applet
   std::vector<std::string> m_applet_name;
 
     /**

--- a/vital/applets/kwiver_applet.cxx
+++ b/vital/applets/kwiver_applet.cxx
@@ -8,6 +8,7 @@
 
 #include <vital/config/config_block_io.h>
 #include <vital/util/get_paths.h>
+#include <vital/util/string.h>
 
 namespace kwiver {
 namespace tools {
@@ -80,7 +81,7 @@ initialize( kwiver::tools::applet_context* ctxt)
 // ----------------------------------------------------------------------------
 std::string
 kwiver_applet::
-wrap_text( const std::string& text )
+wrap_text( std::string const& text )
 {
   if ( m_context )
   {
@@ -91,7 +92,7 @@ wrap_text( const std::string& text )
 }
 
 // ----------------------------------------------------------------------------
-const std::vector<std::string>&
+std::vector<std::string> const&
 kwiver_applet::
 applet_args() const
 {
@@ -104,13 +105,13 @@ applet_args() const
 }
 
 // ----------------------------------------------------------------------------
-const std::string&
+std::string
 kwiver_applet::
 applet_name() const
 {
   if ( m_context )
   {
-    return m_context->m_applet_name;
+    return ::kwiver::vital::join( m_context->m_applet_name, " " );
   }
 
   throw std::runtime_error( "Invalid context pointer" );

--- a/vital/applets/kwiver_applet.h
+++ b/vital/applets/kwiver_applet.h
@@ -118,7 +118,7 @@ protected:
    *
    * @return Applet name
    */
-  const std::string& applet_name() const;
+  std::string applet_name() const;
 
   /**
    * @brief Wrap text block.
@@ -130,7 +130,7 @@ protected:
    *
    * @return Text string wrapped into a block.
    */
-  std::string wrap_text( const std::string& text );
+  std::string wrap_text( std::string const& text );
 
   /**
    * @brief Return original arguments
@@ -139,7 +139,7 @@ protected:
    *
    * @return Read only vector of args
    */
-  const std::vector<std::string>& applet_args() const;
+  std::vector<std::string> const& applet_args() const;
 
 private:
   /**

--- a/vital/util/string.cxx
+++ b/vital/util/string.cxx
@@ -46,8 +46,8 @@ string_format( const std::string fmt_str, ... )
 
 // ------------------------------------------------------------------
 std::string
-join( const std::vector< std::string >& elements,
-      const std::string&                str_separator )
+join( std::vector< std::string > const& elements,
+      std::string const&                str_separator )
 {
   const char* const separator = str_separator.c_str();
 
@@ -72,8 +72,8 @@ join( const std::vector< std::string >& elements,
 
 // ------------------------------------------------------------------
 std::string
-join( const std::set< std::string >&  elements,
-      const std::string&              str_separator )
+join( std::set< std::string > const&  elements,
+      std::string const&              str_separator )
 {
   std::vector< std::string > vec_elem( elements.size() );
   std::copy( elements.begin(), elements.end(), vec_elem.begin() );

--- a/vital/util/string.h
+++ b/vital/util/string.h
@@ -40,7 +40,7 @@ string_format( const std::string fmt_str, ... );
  * @return \b true if string starts with pattern
  */
 inline bool
-starts_with( const std::string& input, const std::string& pattern)
+starts_with( std::string const& input, std::string const& pattern)
 {
   return (0 == input.compare( 0, pattern.size(), pattern ) );
 }
@@ -59,10 +59,10 @@ starts_with( const std::string& input, const std::string& pattern)
  * @return Single string with all elements joined with separator.
  */
 VITAL_UTIL_EXPORT std::string
-join( const std::vector<std::string>& elements, const std::string& str_separator);
+join( std::vector<std::string> const& elements, std::string const& str_separator);
 
 VITAL_UTIL_EXPORT std::string
-join( const std::set<std::string>& elements, const std::string& str_separator);
+join( std::set<std::string> const& elements, std::string const& str_separator);
 //@}
 
 /**


### PR DESCRIPTION
This branch adds hierarchical commands to the kwiver applet runner. The command name is still taken from the applet plugin name, but the string is then processed to extract the command levels. The command levels are separated by a colon (':'). The "kwiver run pipe" command would be encoded as "run:pipe". It is also possible to have the same applet appear at multiple points in the command tree. The alternate command locations are separated by a semi-colon (';'). 