### PR TITLE
Fix partial loading of plugins

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -72,6 +72,7 @@ set( vital_public_headers
   algorithm_capabilities.h
   any.h
   attribute_set.h
+  bitflags.h
   context.h
   exceptions.h
   iterator.h

--- a/vital/bitflags.h
+++ b/vital/bitflags.h
@@ -1,0 +1,107 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef KWIVER_VITAL_BITFLAGS_H
+#define KWIVER_VITAL_BITFLAGS_H
+
+#include <type_traits>
+
+#define KWIVER_DECLARE_BITFLAGS( _flags, _enum ) \
+  using _flags = ::kwiver::vital::bitflags< _enum >
+
+#define KWIVER_DECLARE_OPERATORS_FOR_BITFLAGS( _flags ) \
+  inline _flags operator|( _flags::enum_t f1, _flags::enum_t f2 ) \
+    { return _flags{ f1 } | f2; } \
+  inline _flags operator|( _flags::enum_t f1, _flags f2 ) \
+    { return f2 | f1; } \
+  inline ::kwiver::vital::incompatible_flag operator|( \
+    _flags::enum_t f1, int f2 ) \
+    { return {}; }
+
+namespace kwiver {
+namespace vital {
+
+//-----------------------------------------------------------------------------
+class incompatible_flag
+{
+};
+
+//-----------------------------------------------------------------------------
+template < typename Enum >
+class bitflags
+{
+public:
+  using enum_t = Enum;
+  using int_t = typename std::underlying_type< Enum >::type;
+  using uint_t = typename std::make_unsigned< int_t >::type;
+
+  inline bitflags() : m_i{ 0 } {}
+  inline bitflags( enum_t flag ) : m_i{ static_cast< int_t >( flag ) } {}
+  inline bitflags( bitflags const& other) = default;
+
+  inline bitflags& operator=( bitflags const& other ) = default;
+
+  // Bitwise and
+  inline bitflags& operator&=( int_t mask )
+  { this->m_i &= mask; return *this; }
+
+  inline bitflags& operator&=( uint_t mask )
+  { this->m_i &= mask; return *this; }
+
+  inline bitflags operator&( enum_t f ) const
+  { bitflags g; g.m_i = this->m_i & static_cast< int_t >( f ); return g; }
+
+  inline bitflags operator&( int_t mask ) const
+  { bitflags g; g.m_i = this->m_i & mask; return g; }
+
+  inline bitflags operator&( uint_t mask ) const
+  { bitflags g; g.m_i = this->m_i & static_cast< int_t >( mask ); return g; }
+
+  // Bitwise or
+  inline bitflags& operator|=( bitflags f )
+  { this->m_i |= f.m_i; return *this; }
+
+  inline bitflags& operator|=( enum_t f )
+  { this->m_i |= static_cast< int_t >( f ); return *this; }
+
+  inline bitflags operator|( bitflags f ) const
+  { bitflags g; g.m_i = this->m_i | f.m_i; return g; }
+
+  inline bitflags operator|( enum_t f ) const
+  { bitflags g; g.m_i = this->m_i | static_cast< int_t >( f ); return g; }
+
+  // Bitwise xor
+  inline bitflags& operator^=( bitflags f )
+  { this->m_i ^= f.m_i; return *this; }
+
+  inline bitflags& operator^=( enum_t f )
+  { this->m_i ^= static_cast< int_t >( f ); return *this; }
+
+  inline bitflags operator^( bitflags f ) const
+  { bitflags g; g.m_i = this->m_i ^ f.m_i; return g; }
+
+  inline bitflags operator^( enum_t f ) const
+  { bitflags g; g.m_i = this->m_i ^ static_cast< int_t >( f ); return g; }
+
+  // Implicit conversion to plain type
+  inline operator int_t() const { return this->m_i; }
+
+  // Bitwise invert
+  inline int_t operator~() const { return ~this->m_i; }
+
+  // Test if no bits are set
+  inline bool operator!() const { return !m_i; }
+
+  // Test if specific bit(s) are set
+  inline bool test( enum_t f ) const
+  { return ( m_i & f ) == f && ( f != 0 || m_i == 0 ); }
+
+protected:
+  int_t m_i;
+};
+
+} // namespace vital
+} // namespace kwiver
+
+#endif

--- a/vital/plugin_loader/plugin_manager.h
+++ b/vital/plugin_loader/plugin_manager.h
@@ -17,6 +17,7 @@
 #include <vital/exceptions/plugin.h>
 #include <vital/logger/logger.h>
 #include <vital/util/demangle.h>
+#include <vital/bitflags.h>
 #include <vital/noncopyable.h>
 
 #include <memory>
@@ -50,6 +51,7 @@ public:
     DEFAULT    = 0x00f7,
     ALL        = 0xffff
   };
+  KWIVER_DECLARE_BITFLAGS( plugin_types, plugin_type );
 
   static plugin_manager& instance();  // singleton interface
 
@@ -69,7 +71,7 @@ public:
    *
    * @throws plugin_already_exists - if a duplicate plugin is detected
    */
-  void load_all_plugins( plugin_type type = plugin_type::DEFAULT );
+  void load_all_plugins( plugin_types types = plugin_type::DEFAULT );
 
   /**
    * @brief Load plugins from list of directories.
@@ -413,6 +415,8 @@ public:
     : implementation_factory<T>( kwiver::vital::plugin_factory::PLUGIN_NAME )
   { }
 };
+
+KWIVER_DECLARE_OPERATORS_FOR_BITFLAGS( plugin_manager::plugin_types )
 
 } } // end namespace
 


### PR DESCRIPTION
Add flags type to vital. Use this to specify types of plugins to load; essentially this gives us nice operators for enumerators meant to be used as bitmasks, which greatly improves user convenience. Tweak loading to keep track of which plugins are loaded, so that multiple requests to load different types of plugins works as expected.