### PR TITLE
Fix OpenCV 4.x support

### DIFF
--- a/arrows/ocv/extract_descriptors_DAISY.cxx
+++ b/arrows/ocv/extract_descriptors_DAISY.cxx
@@ -79,7 +79,7 @@ public:
                        "amount of angular range division quantity" );
     config->set_value( "q_hist", q_hist,
                        "amount of gradient orientations range division quantity" );
-    config->set_value( "norm", norm,
+    config->set_value( "norm", static_cast< int >( norm ),
                        "descriptor normalization type. valid choices:\n"
                        + list_norm_options() );
     config->set_value( "interpolation", interpolation,
@@ -94,7 +94,7 @@ public:
     q_radius = config->get_value<int>( "q_radius" );
     q_theta = config->get_value<int>( "q_theta" );
     q_hist = config->get_value<int>( "q_hist" );
-    norm = config->get_value<int>( "norm" );
+    norm = static_cast< decltype( norm ) >( config->get_value<int>( "norm" ) );
     interpolation = config->get_value<bool>( "interpolation" );
     use_orientation = config->get_value<bool>( "use_orientation" );
   }
@@ -119,7 +119,11 @@ public:
   int q_radius;
   int q_theta;
   int q_hist;
+#if KWIVER_OPENCV_VERSION_MAJOR >= 4
+  cv::xfeatures2d::DAISY::NormalizationType norm;
+#else
   int norm;
+#endif
   bool interpolation;
   bool use_orientation;
 };

--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -13,16 +13,22 @@
 
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
+#include <opencv2/core/version.hpp>
+
 // Include the correct file and unify different namespace locations of SIFT type
 // across versions
-#if KWIVER_OPENCV_VERSION_MAJOR < 3
+#if CV_VERSION_MAJOR < 3
 // 2.4.x header location
 #include <opencv2/nonfree/features2d.hpp>
 typedef cv::SIFT cv_SIFT_t;
-#else
-// 3.x header location
+#elif CV_VERSION_MAJOR < 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR < 3)
+// 3.x - 4.2 header location
 #include <opencv2/xfeatures2d/nonfree.hpp>
 typedef cv::xfeatures2d::SIFT cv_SIFT_t;
+#else
+// 4.4+ header location
+#include <opencv2/features2d.hpp>
+typedef cv::SIFT cv_SIFT_t;
 #endif
 
 using namespace kwiver::vital;


### PR DESCRIPTION
Apply another fix for OpenCV 4.x. This was missed from the prior changes because this code is not built on my machine.

This is a (hopefully less broken) alternative to #1166. However, I have not built it, as my OpenCV does not include xfeatures2d.