### PR TITLE
Use CMake target folders

### DIFF
--- a/CMake/utils/kwiver-utils-doxygen.cmake
+++ b/CMake/utils/kwiver-utils-doxygen.cmake
@@ -16,6 +16,7 @@ cmake_dependent_option(${CMAKE_PROJECT_NAME}_INSTALL_DOCS
 
 if(${CMAKE_PROJECT_NAME}_ENABLE_DOCS)
   add_custom_target(doxygen ALL)
+  set_target_properties(doxygen PROPERTIES FOLDER "Documentation")
 endif()
 
 include(CMakeParseArguments)
@@ -153,6 +154,7 @@ function(kwiver_create_doxygen name inputdir)
     add_custom_target(doxygen-${name}
       DEPENDS "${doxy_project_output_dir}/index.html"
       )
+    set_target_properties(doxygen-${name} PROPERTIES FOLDER "Documentation")
 
     message(STATUS "[doxy-${name}] Linking to top-level doxygen target")
     add_dependencies(doxygen

--- a/CMake/utils/kwiver-utils-sphinx.cmake
+++ b/CMake/utils/kwiver-utils-sphinx.cmake
@@ -13,5 +13,6 @@ function(kwiver_create_sphinx)
    add_custom_target(sphinx-kwiver
      COMMAND ${SPHINX_EXECUTABLE} -D breathe_projects.kwiver="${CMAKE_BINARY_DIR}/doc/kwiver/xml" ${CMAKE_SOURCE_DIR}/doc/manuals ${CMAKE_BINARY_DIR}/doc/sphinx
   )
+  set_target_properties(sphinx-kwiver PROPERTIES FOLDER "Documentation")
 
 endfunction(kwiver_create_sphinx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
+# Organize target into folders for IDEs that support it
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 ###
 # Look for and use Fletch to find dependencies
 #

--- a/arrows/CMakeLists.txt
+++ b/arrows/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Arrows Algorithms CMake file
 #
 
+set(CMAKE_FOLDER "Arrows")
 set(ARROWS_SOURCE_DIR           "${CMAKE_CURRENT_SOURCE_DIR}")
 set(ARROWS_BINARY_DIR           "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/arrows/burnout/CMakeLists.txt
+++ b/arrows/burnout/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build/install plugin for burnout CNN support
 #
 
+set(CMAKE_FOLDER "Arrows/BurnOut")
+
 set( headers
   burnout_image_enhancer.h
   burnout_pixel_classification.h

--- a/arrows/ceres/CMakeLists.txt
+++ b/arrows/ceres/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing Ceres algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/Ceres")
+
 set( ceres_headers_public
   bundle_adjust.h
   lens_distortion.h

--- a/arrows/ceres/tests/CMakeLists.txt
+++ b/arrows/ceres/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_ceres)
 
+set(CMAKE_FOLDER "Arrows/Ceres/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries    kwiver_algo_ceres kwiver_algo_core)

--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install Plugin containing core algorithm implementations
 
+set(CMAKE_FOLDER "Arrows/Core")
+
 set( plugin_core_headers
   associate_detections_to_tracks_threshold.h
   class_probablity_filter.h

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_core)
 
+set(CMAKE_FOLDER "Arrows/Core/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries    kwiver_algo_core vital vital_vpm )

--- a/arrows/cuda/CMakeLists.txt
+++ b/arrows/cuda/CMakeLists.txt
@@ -1,3 +1,6 @@
+
+set(CMAKE_FOLDER "Arrows/CUDA")
+
 set(header_files
   integrate_depth_maps.h
   )

--- a/arrows/darknet/CMakeLists.txt
+++ b/arrows/darknet/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build/install plugin for darknet CNN support
 #
 
+set(CMAKE_FOLDER "Arrows/Darknet")
+
 set( headers
   darknet_custom_resize.h
   darknet_detector.h

--- a/arrows/dbow2/CMakeLists.txt
+++ b/arrows/dbow2/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing DBoW2 algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/DBoW2")
+
 set( dbow2_headers_public
   match_descriptor_sets.h
   )

--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing ffmpeg algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/FFmpeg")
+
 include_directories(${FFMPEG_INCLUDE_DIR})
 
 if (NOT FFMPEG_FOUND_SEVERAL)

--- a/arrows/ffmpeg/tests/CMakeLists.txt
+++ b/arrows/ffmpeg/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_ffmpeg)
 
+set(CMAKE_FOLDER "Arrows/FFmpeg/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_core)

--- a/arrows/gdal/CMakeLists.txt
+++ b/arrows/gdal/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing GDAL algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/GDAL")
+
 set( gdal_headers_public
   image_container.h
   image_io.h

--- a/arrows/gdal/tests/CMakeLists.txt
+++ b/arrows/gdal/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_gdal)
 
+set(CMAKE_FOLDER "Arrows/GDAL/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries      vital vital_vpm kwiver_algo_gdal )

--- a/arrows/kpf/CMakeLists.txt
+++ b/arrows/kpf/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package( yaml-cpp REQUIRED )
 
+set(CMAKE_FOLDER "Arrows/KPF")
+
 add_subdirectory(yaml)
 
 # Build/install plugin for kpf support for vital objects

--- a/arrows/kpf/yaml/tests/CMakeLists.txt
+++ b/arrows/kpf/yaml/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project( kpf_tests )
 
+set(CMAKE_FOLDER "Arrows/KPF/Tests")
+
 include( kwiver-test-setup )
 
 set( test_libraries kpf_yaml )

--- a/arrows/matlab/CMakeLists.txt
+++ b/arrows/matlab/CMakeLists.txt
@@ -1,6 +1,8 @@
 ###
 # CMake file for matlab bindings
 
+set(CMAKE_FOLDER "Arrows/Matlab")
+
 set( sources
   matlab_util.cxx
   matlab_exception.cxx

--- a/arrows/mvg/CMakeLists.txt
+++ b/arrows/mvg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install Multi-View Geometry arrow
 
+set(CMAKE_FOLDER "Arrows/MVG")
+
 set( plugin_mvg_headers
   algo/hierarchical_bundle_adjust.h
   algo/initialize_cameras_landmarks.h

--- a/arrows/mvg/tests/CMakeLists.txt
+++ b/arrows/mvg/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_mvg)
 
+set(CMAKE_FOLDER "Arrows/MVG/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries    kwiver_algo_mvg vital vital_vpm )

--- a/arrows/ocv/CMakeLists.txt
+++ b/arrows/ocv/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing OpenCV algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/OCV")
+
 set( ocv_headers_public
   analyze_tracks.h
   camera_intrinsics.h

--- a/arrows/ocv/tests/CMakeLists.txt
+++ b/arrows/ocv/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_ocv)
 
+set(CMAKE_FOLDER "Arrows/OCV/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries      vital vital_vpm kwiver_algo_ocv)

--- a/arrows/proj/CMakeLists.txt
+++ b/arrows/proj/CMakeLists.txt
@@ -1,6 +1,8 @@
 ###
 # algorithms/proj
 
+set(CMAKE_FOLDER "Arrows/PROJ")
+
 set(proj_headers_public
   )
 

--- a/arrows/qt/CMakeLists.txt
+++ b/arrows/qt/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install plugin containing Qt support structures
 
+set(CMAKE_FOLDER "Arrows/Qt")
+
 set( CMAKE_AUTOMOC ON )
 set( CMAKE_AUTOUIC ON )
 set( CMAKE_INCLUDE_CURRENT_DIR ON )

--- a/arrows/qt/tests/CMakeLists.txt
+++ b/arrows/qt/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_qt)
 
+set(CMAKE_FOLDER "Arrows/Qt/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries     kwiver_algo_qt)

--- a/arrows/serialize/CMakeLists.txt
+++ b/arrows/serialize/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install plugin for serialization
 
+set(CMAKE_FOLDER "Arrows/Serialize")
+
 
 if( KWIVER_ENABLE_SERIALIZE_PROTOBUF )
   add_subdirectory( protobuf )

--- a/arrows/serialize/json/tests/CMakeLists.txt
+++ b/arrows/serialize/json/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_serialize_json_tests)
 
+set(CMAKE_FOLDER "Arrows/Serialize/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital vital_vpm vital_algo kwiver_serialize_json )

--- a/arrows/super3d/CMakeLists.txt
+++ b/arrows/super3d/CMakeLists.txt
@@ -1,3 +1,6 @@
+
+set(CMAKE_FOLDER "Arrows/Super3D")
+
 set(header_files
   compute_depth.h
   cost_volume.h

--- a/arrows/uuid/CMakeLists.txt
+++ b/arrows/uuid/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install Plugin containing UUID algorithm implementations
 
+set(CMAKE_FOLDER "Arrows/UUID")
+
 set( plugin_headers
   uuid_factory_uuid.h
   )

--- a/arrows/vtk/CMakeLists.txt
+++ b/arrows/vtk/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build / Install VTK arrow
 
+set(CMAKE_FOLDER "Arrows/VTK")
+
 set( plugin_vtk_headers
   depth_utils.h
   mesh_coloration.h

--- a/arrows/vxl/CMakeLists.txt
+++ b/arrows/vxl/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build / Install plugin containing VXL algorithm implementations + support
 # structures
 
+set(CMAKE_FOLDER "Arrows/VXL")
+
 set(vxl_headers_public
   aligned_edge_detection.h
   bounding_box.h

--- a/arrows/vxl/tests/CMakeLists.txt
+++ b/arrows/vxl/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(arrows_test_vxl)
 
+set(CMAKE_FOLDER "Arrows/VXL/Tests")
+
 include(kwiver-test-setup)
 
 set(test_libraries     kwiver_algo_vxl)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "Configuration")
+
 set(config_files
   ceres_bundle_adjuster.conf
   core_feature_descriptor_io.conf

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -167,6 +167,9 @@ Build System
  * Added a new build flag, KWIVER_ENABLE_PYTORCH, to include
    PyTorch-dependent code in the build.
 
+ * Enabled the use of folders for CMake targets to provided better
+   organization in IDEs that support folders, like Visual Studio.
+
 Unit Tests
 
 General Documentation

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_FOLDER "Examples")
 set(EXAMPLE_DIR ${CMAKE_BINARY_DIR}/examples)
 file(MAKE_DIRECTORY "${EXAMPLE_DIR}/pipelines/output")
 

--- a/extras/process_instrumentation/CMakeLists.txt
+++ b/extras/process_instrumentation/CMakeLists.txt
@@ -1,6 +1,9 @@
 ###
 # process instrumentation plugins
 #
+
+set(CMAKE_FOLDER "Extras")
+
 set( sources
   register_plugin.cxx
   logger_process_instrumentation.cxx

--- a/sprokit/CMakeLists.txt
+++ b/sprokit/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(sprokit)
 
+set(CMAKE_FOLDER "Sprokit")
+
 cmake_minimum_required(VERSION 3.0)
 
 set(sprokit_source_dir "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/sprokit/processes/CMakeLists.txt
+++ b/sprokit/processes/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Kwiver processes
 #
 
+set(CMAKE_FOLDER "Sprokit/Processes")
+
 # This policy is new in CMake 3.12. The NEW behavior uses the <PackageName>_ROOT variable in
 # find_package(<PackageName>) calls.
 # See: https://cmake.org/cmake/help/git-stage/policy/CMP0074.html

--- a/sprokit/processes/adapters/tests/CMakeLists.txt
+++ b/sprokit/processes/adapters/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(sprokit_adapters_tests)
 
+set(CMAKE_FOLDER "Sprokit/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries       vital sprokit_pipeline sprokit_pipeline_util kwiver_adapter )

--- a/sprokit/processes/flow/tests/CMakeLists.txt
+++ b/sprokit/processes/flow/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(flow_processes_tests)
 
+set(CMAKE_FOLDER "Sprokit/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries       vital sprokit_pipeline sprokit_pipeline_util kwiver_adapter )

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(sprokit_test_pipeline)
 
+set(CMAKE_FOLDER "Sprokit/Tests")
+
 set(test_libraries
   vital_config vital_vpm
   ${Boost_SYSTEM_LIBRARY}

--- a/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline_util/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(sprokit_test_pipeline_util)
 
+set(CMAKE_FOLDER "Sprokit/Tests")
+
 set(test_libraries
   sprokit_pipeline_util
   sprokit_pipeline

--- a/sprokit/tests/sprokit/test/CMakeLists.txt
+++ b/sprokit/tests/sprokit/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(sprokit_tests_test)
 
+set(CMAKE_FOLDER "Sprokit/Tests")
+
 set(test_libraries      sprokit_pipeline kwiversys )
 
 sprokit_discover_tests(test test_libraries test_test.cxx)

--- a/track_oracle/CMakeLists.txt
+++ b/track_oracle/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "Track Oracle")
+
 OPTION(KWIVER_ENABLE_TRACK_ORACLE_EVENT_ADAPTER  "Enable track_oracle's event_adapter (disable until further notice)" OFF )
 OPTION(KWIVER_ENABLE_TRACK_ORACLE_MGRS  "Enable track_oracle's lat/lon <-> MGRS capabilities (disable until further notice)" OFF )
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Top level build for VITAL
 #
 project( vital )
+set(CMAKE_FOLDER "Vital")
 
 ###
 # KWSys

--- a/vital/config/tests/CMakeLists.txt
+++ b/vital/config/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_config_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital_config vital_exceptions kwiversys Eigen3::Eigen )

--- a/vital/logger/tests/CMakeLists.txt
+++ b/vital/logger/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_logger_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital_logger )

--- a/vital/plugin_loader/tests/CMakeLists.txt
+++ b/vital/plugin_loader/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(plugin_loader_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital vital_vpm )

--- a/vital/range/tests/CMakeLists.txt
+++ b/vital/range/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_util_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries )

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_core_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital vital_vpm vital_algo )

--- a/vital/util/tests/CMakeLists.txt
+++ b/vital/util/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(kwiver_util_tests)
 
+set(CMAKE_FOLDER "Vital/Tests")
+
 include(kwiver-test-setup)
 
 set( test_libraries vital vital_vpm kwiversys )


### PR DESCRIPTION
This change is intended to make it a lot easier to find targets in Visual Studio and other IDEs that support folders.