### PR TITLE
Support VTK 9

### DIFF
--- a/CMake/kwiver-depends-VTK.cmake
+++ b/CMake/kwiver-depends-VTK.cmake
@@ -6,6 +6,8 @@ option( KWIVER_ENABLE_VTK
   )
 
 if( KWIVER_ENABLE_VTK )
+  find_package(VTK)
+  if(VTK_VERSION VERSION_LESS 9.0)
     find_package(VTK REQUIRED
         COMPONENTS
         vtkCommonCore
@@ -21,6 +23,18 @@ if( KWIVER_ENABLE_VTK )
             "(Found ${VTK_VERSION})")
     endif()
 
-  include(${VTK_USE_FILE})
+    include(${VTK_USE_FILE})
+  else()
+    find_package(VTK REQUIRED
+        COMPONENTS
+        CommonCore
+        CommonDataModel
+        IOXML
+        IOPLY
+        IOGeometry
+        RenderingCore
+        RenderingOpenGL2
+        )
+  endif()
 
 endif( KWIVER_ENABLE_VTK )

--- a/arrows/vtk/CMakeLists.txt
+++ b/arrows/vtk/CMakeLists.txt
@@ -27,15 +27,31 @@ kwiver_add_library( kwiver_algo_vtk
   ${plugin_vtk_sources}
   )
 
+if(VTK_VERSION VERSION_LESS 9.0)
+  set(VTK_public_targets
+      vtkRenderingCore
+      vtkRenderingOpenGL2)
+  set(VTK_private_targets
+      vtkCommonCore
+      vtkCommonDataModel
+      vtkIOImage
+      vtkIOXML)
+else()
+  set(VTK_public_targets
+      VTK::RenderingCore
+      VTK::RenderingOpenGL2)
+  set(VTK_private_targets
+      VTK::CommonCore
+      VTK::CommonDataModel
+      VTK::IOImage
+      VTK::IOXML)
+endif()
+
 target_link_libraries( kwiver_algo_vtk
   PUBLIC               vital
-                       vtkRenderingCore
-                       vtkRenderingOpenGL2
+                       ${VTK_public_targets}
   PRIVATE              vital_algo
-                       vtkCommonCore
-                       vtkCommonDataModel
-                       vtkIOImage
-                       vtkIOXML
+                       ${VTK_private_targets}
   )
 
 #algorithms_create_plugin( kwiver_algo_vtk

--- a/arrows/vtk/applets/CMakeLists.txt
+++ b/arrows/vtk/applets/CMakeLists.txt
@@ -20,6 +20,18 @@ if(NOT KWIVER_ENABLE_MVG)
   message(FATAL_ERROR "-- The MVG arrow must be enabled (KWIVER_ENABLE_MVG)")
 endif()
 
+if(VTK_VERSION VERSION_LESS 9.0)
+  set(VTK_targets vtkFiltersCore
+                  vtkIOGeometry
+                  vtkIOPLY
+                  vtkIOXML)
+else()
+  set(VTK_targets VTK::FiltersCore
+                  VTK::IOGeometry
+                  VTK::IOPLY
+                  VTK::IOXML)
+endif()
+
 # Add applet plugin
 kwiver_add_plugin( kwiver_algo_vtk_applets
   SUBDIR       ${kwiver_plugin_applets_subdir}
@@ -29,8 +41,5 @@ kwiver_add_plugin( kwiver_algo_vtk_applets
                kwiver_algo_vtk
                kwiver_tools_applet
                kwiversys
-               vtkFiltersCore
-               vtkIOGeometry
-               vtkIOPLY
-               vtkIOXML
+               ${VTK_targets}
   )

--- a/arrows/vtk/mesh_coloration.cxx
+++ b/arrows/vtk/mesh_coloration.cxx
@@ -24,6 +24,7 @@
 #include "vtkRenderWindow.h"
 #include "vtkSequencePass.h"
 #include "vtkSmartPointer.h"
+#include "vtkUnsignedCharArray.h"
 #include "vtkWindowToImageFilter.h"
 #include "vtkXMLImageDataWriter.h"
 #include "vtkXMLPolyDataWriter.h"


### PR DESCRIPTION
VTK 9.0 changes how components are found and used in CMake.  This branch lets KWIVER use VTK 8.2 or VTK 9.