### PR TITLE
Fix bug in color commonality filter

### DIFF
--- a/arrows/vxl/color_commonality_filter.cxx
+++ b/arrows/vxl/color_commonality_filter.cxx
@@ -248,7 +248,8 @@ color_commonality_filter::priv
   }
 
   // Populate histogram steps for each channel of the hist
-  std::vector< std::ptrdiff_t > hist_steps{ input.nplanes() };
+  std::vector< std::ptrdiff_t > hist_steps;
+  hist_steps.resize( input.nplanes() );
   hist_steps[ 0 ] = 1;
 
   for( unsigned p = 1; p < input.nplanes(); ++p )

--- a/arrows/vxl/tests/test_color_commonality_filter.cxx
+++ b/arrows/vxl/tests/test_color_commonality_filter.cxx
@@ -46,14 +46,14 @@ TEST_F(color_commonality_filter, color)
   ka::vxl::image_io io;
 
   std::string filename = data_dir + "/" + test_color_image_name;
-  auto const& image_ptr = io.load( filename );
+  auto const image_ptr = io.load( filename );
 
   ka::vxl::color_commonality_filter filter;
 
   auto const filtered_image_ptr = filter.filter( image_ptr );
 
   kv::path_t expected = data_dir + "/" + expected_commonality_default_color;
-  auto const& expected_image_ptr = io.load( expected );
+  auto const expected_image_ptr = io.load( expected );
   EXPECT_TRUE( equal_content( filtered_image_ptr->get_image(),
                               expected_image_ptr->get_image() ) );
 }
@@ -64,14 +64,14 @@ TEST_F(color_commonality_filter, gray)
   ka::vxl::image_io io;
 
   std::string filename = data_dir + "/" + test_image_name;
-  auto const& image_ptr = io.load( filename );
+  auto const image_ptr = io.load( filename );
 
   ka::vxl::color_commonality_filter filter;
 
   auto const filtered_image_ptr = filter.filter( image_ptr );
 
   kv::path_t expected = data_dir + "/" + expected_commonality_default_gray;
-  auto const& expected_image_ptr = io.load( expected );
+  auto const expected_image_ptr = io.load( expected );
   EXPECT_TRUE( equal_content( filtered_image_ptr->get_image(),
                               expected_image_ptr->get_image() ) );
 }


### PR DESCRIPTION
Suggested by @mwoehlke-kitware to eliminate the chance of calling the wrong constructor. This fixes Valgrind errors, but has not been tested on any of the failing platforms. 