### PR TITLE
Add "copy" option to vxl_convert_image

### DIFF
--- a/arrows/vxl/convert_image.cxx
+++ b/arrows/vxl/convert_image.cxx
@@ -334,7 +334,7 @@ convert_image::priv
     percentile_scale_image(
       input, output, percentile_norm, 1.0 - percentile_norm, 1e8 );
   }
-  else if( scale_factor == 0.0 )
+  else if( scale_factor == 0.0 || scale_factor == 1.0 )
   {
     vil_convert_cast( input, output );
   }

--- a/arrows/vxl/convert_image.cxx
+++ b/arrows/vxl/convert_image.cxx
@@ -442,41 +442,40 @@ convert_image
     vxl::image_container::vital_to_vxl( image_data->get_image() );
 
   // Perform different actions based on input type
-#define HANDLE_OUTPUT_CASE( S, T )                                             \
-  if( d->format == S )                                                         \
-  {                                                                            \
-    using opix_t = vil_pixel_format_type_of< T >::component_type;              \
-    vil_image_view< opix_t > output = d->scale_and_convert< opix_t >( input ); \
-    return std::make_shared< vxl::image_container >( output );                 \
+#define HANDLE_OUTPUT_CASE( S, T )                                \
+  if( d->format == S )                                            \
+  {                                                               \
+    using opix_t = vil_pixel_format_type_of< T >::component_type; \
+    auto const& output = d->scale_and_convert< opix_t >( input ); \
+    return std::make_shared< vxl::image_container >( output );    \
   }
 
-#define HANDLE_INPUT_CASE( T )                                                \
-  case T:                                                                     \
-  {                                                                           \
-    using ipix_t = vil_pixel_format_type_of< T >::component_type;             \
-    if( d->format == "disable" )                                              \
-    {                                                                         \
-      return image_data;                                                      \
-    }                                                                         \
-    vil_image_view< ipix_t > input = d->apply_transforms< ipix_t >( view );   \
-    if( d->format == "copy" )                                                 \
-    {                                                                         \
-       vil_image_view< ipix_t > output =                                      \
-         d->scale_and_convert< ipix_t >( input );                             \
-       return std::make_shared< vxl::image_container >( output );             \
-    }                                                                         \
-                                                                              \
-    HANDLE_OUTPUT_CASE( "byte", VIL_PIXEL_FORMAT_BYTE );                      \
-    HANDLE_OUTPUT_CASE( "sbyte", VIL_PIXEL_FORMAT_SBYTE );                    \
-    HANDLE_OUTPUT_CASE( "uint16", VIL_PIXEL_FORMAT_UINT_16 );                 \
-    HANDLE_OUTPUT_CASE( "int16", VIL_PIXEL_FORMAT_INT_16 );                   \
-    HANDLE_OUTPUT_CASE( "uint32", VIL_PIXEL_FORMAT_UINT_32 );                 \
-    HANDLE_OUTPUT_CASE( "int32", VIL_PIXEL_FORMAT_INT_32 );                   \
-    HANDLE_OUTPUT_CASE( "uint64", VIL_PIXEL_FORMAT_UINT_64 );                 \
-    HANDLE_OUTPUT_CASE( "int64", VIL_PIXEL_FORMAT_INT_64 );                   \
-    HANDLE_OUTPUT_CASE( "float", VIL_PIXEL_FORMAT_FLOAT );                    \
-    HANDLE_OUTPUT_CASE( "double", VIL_PIXEL_FORMAT_DOUBLE );                  \
-    break;                                                                    \
+#define HANDLE_INPUT_CASE( T )                                      \
+  case T:                                                           \
+  {                                                                 \
+    using ipix_t = vil_pixel_format_type_of< T >::component_type;   \
+    if( d->format == "disable" )                                    \
+    {                                                               \
+      return image_data;                                            \
+    }                                                               \
+    auto const& input = d->apply_transforms< ipix_t >( view );      \
+    if( d->format == "copy" )                                       \
+    {                                                               \
+      auto const& output = d->scale_and_convert< ipix_t >( input ); \
+      return std::make_shared< vxl::image_container >( output );    \
+    }                                                               \
+                                                                    \
+    HANDLE_OUTPUT_CASE( "byte", VIL_PIXEL_FORMAT_BYTE );            \
+    HANDLE_OUTPUT_CASE( "sbyte", VIL_PIXEL_FORMAT_SBYTE );          \
+    HANDLE_OUTPUT_CASE( "uint16", VIL_PIXEL_FORMAT_UINT_16 );       \
+    HANDLE_OUTPUT_CASE( "int16", VIL_PIXEL_FORMAT_INT_16 );         \
+    HANDLE_OUTPUT_CASE( "uint32", VIL_PIXEL_FORMAT_UINT_32 );       \
+    HANDLE_OUTPUT_CASE( "int32", VIL_PIXEL_FORMAT_INT_32 );         \
+    HANDLE_OUTPUT_CASE( "uint64", VIL_PIXEL_FORMAT_UINT_64 );       \
+    HANDLE_OUTPUT_CASE( "int64", VIL_PIXEL_FORMAT_INT_64 );         \
+    HANDLE_OUTPUT_CASE( "float", VIL_PIXEL_FORMAT_FLOAT );          \
+    HANDLE_OUTPUT_CASE( "double", VIL_PIXEL_FORMAT_DOUBLE );        \
+    break;                                                          \
   }
 
   switch( view->pixel_format() )
@@ -501,6 +500,9 @@ convert_image
 #undef HANDLE_INPUT_CASE
 #undef HANDLE_OUTPUT_CASE
 
+  // If we get here, one of the input type handling branches was hit, but did
+  // not produce a result; the output type must have been invalid
+  LOG_ERROR( logger(), "Invalid output format type received" );
   return nullptr;
 }
 

--- a/arrows/vxl/convert_image.cxx
+++ b/arrows/vxl/convert_image.cxx
@@ -46,7 +46,7 @@ scale_image( vil_image_view< InType > const& src,
 
   vil_transform(
     src, dst,
-    [ max_input_value, max_output_value, dp_scale ]( InType pixel ){
+    [ max_input_value, dp_scale ]( InType pixel ){
       if( pixel <= max_input_value )
       {
         return static_cast< OutType >(

--- a/arrows/vxl/convert_image.cxx
+++ b/arrows/vxl/convert_image.cxx
@@ -459,6 +459,12 @@ convert_image
       return image_data;                                                      \
     }                                                                         \
     vil_image_view< ipix_t > input = d->apply_transforms< ipix_t >( view );   \
+    if( d->format == "copy" )                                                 \
+    {                                                                         \
+       vil_image_view< ipix_t > output =                                      \
+         d->scale_and_convert< ipix_t >( input );                             \
+       return std::make_shared< vxl::image_container >( output );             \
+    }                                                                         \
                                                                               \
     HANDLE_OUTPUT_CASE( "byte", VIL_PIXEL_FORMAT_BYTE );                      \
     HANDLE_OUTPUT_CASE( "sbyte", VIL_PIXEL_FORMAT_SBYTE );                    \

--- a/arrows/vxl/convert_image.cxx
+++ b/arrows/vxl/convert_image.cxx
@@ -46,7 +46,7 @@ scale_image( vil_image_view< InType > const& src,
 
   vil_transform(
     src, dst,
-    [ max_input_value, dp_scale ]( InType pixel ){
+    [ = ]( InType pixel ){
       if( pixel <= max_input_value )
       {
         return static_cast< OutType >(


### PR DESCRIPTION
Add an additional value to the format option of `vxl_convert_image` to copy the input format. This differs slightly from the existing `"disable"`, which makes the filter a no-op, in that while no value type conversion is applied, other operations such as scaling or converting to single channel may still be applied.