### PR TITLE
Update `average_frames` variance return type

### DIFF
--- a/arrows/vxl/average_frames.cxx
+++ b/arrows/vxl/average_frames.cxx
@@ -545,10 +545,13 @@ public:
     }
     else
     {
-      vil_image_view< PixType > tmp;
-      vil_image_view< double > output;
-      averager->process_frame( input, tmp, output );
-      return std::make_shared< vxl::image_container >( output );
+      // This is initially an unused argument and then the cast value we return
+      vil_image_view< PixType > placeholder;
+      vil_image_view< double > variance;
+      averager->process_frame( input, placeholder, variance );
+      // Convert the pixel format from to PixType
+      vil_convert_cast( variance, placeholder );
+      return std::make_shared< vxl::image_container >( placeholder );
     }
   }
 };
@@ -590,8 +593,7 @@ average_frames
     "Should we spend a little extra time rounding when possible?" );
   config->set_value(
     "output_variance", d->output_variance,
-    "If set, will compute an estimated variance for each pixel which "
-    "will be outputted as either a double-precision or byte image." );
+    "If set, will compute an estimated variance for each pixel." );
 
   return config;
 }


### PR DESCRIPTION
The current implementation returned the estimated variance as a `vxl_image_view< double >`. Since all other processes in the burnout filtering stack return the same type as the input, which in practice is a `vxl_byte`, this broke the concatenation stage. I'm open to having the concatenation stage do type checking in addition or instead of this update, but if we choose to go this route, I think we should re-evaluate the types of the images returned by many of these filters. If we choose to allow these filters to return a different type than the input, I would advocate for making the returned average value from this filter also `double`, both for higher precision results and consistency with the variance.