### PR TITLE
fix the crash on new project feature/descriptor extraction

### DIFF
--- a/arrows/core/track_features_core.cxx
+++ b/arrows/core/track_features_core.cxx
@@ -365,19 +365,18 @@ track_features_core
                          << " to " << kwfd_file );
   }
 
-  std::vector<feature_sptr> vf = curr_feat->features();
+  auto vf = curr_feat->features();
+  auto vd = curr_desc->descriptors();
 
   track_id_t next_track_id = 0;
 
   // special case for the first frame
   if( !prev_tracks )
   {
-    typedef std::vector<feature_sptr>::const_iterator feat_itr;
-    typedef descriptor_set::const_iterator desc_itr;
-    feat_itr fit = vf.begin();
-    desc_itr dit = curr_desc->begin();
+    auto fit = vf.begin();
+    auto dit = vd.begin();
     std::vector<vital::track_sptr> new_tracks;
-    for(; fit != vf.end() && dit != curr_desc->end(); ++fit, ++dit)
+    for(; fit != vf.end() && dit != vd.end(); ++fit, ++dit)
     {
       auto fts = std::make_shared<feature_track_state>(frame_number);
       fts->feature = *fit;


### PR DESCRIPTION
Address core dump crash on new project, compute track features under ubuntu 20.04. Fix attained by getting a set of descriptors in a std:vector (as opposed to vital::set based) container and iterating over them for the first frame case. The vital set container for the descriptors apparently needs a closer look in case of descriptors that are stored in a cv::Mat, as current implementation attempts to simulate iteration over matrix rows, but does it in an unreliable manner, causing this crash at the attempt to [clone](https://github.com/Kitware/kwiver/blob/888502a3e30fdb74c1882b9c936ed6e2ed264f1e/vital/types/feature_track_set.h#L77) track's descriptors.