### PR TITLE
Fix VTK depth loading

### DIFF
--- a/arrows/cuda/integrate_depth_maps.cu
+++ b/arrows/cuda/integrate_depth_maps.cu
@@ -129,11 +129,9 @@ __device__ int computeVoxelIDGrid(int coordinates[3])
 __device__ int computeVoxelIDDepth(int coordinates[3])
 {
   int dimX = c_depthMapDims.x;
-  int dimY = c_depthMapDims.y;
   int x = coordinates[0];
   int y = coordinates[1];
-  // /!\ vtkImageData has its origin at the bottom left, not top left
-  return (dimX*(dimY - 1 - y)) + x;
+  return (dimX * y) + x;
 }
 
 //*****************************************************************************

--- a/arrows/cuda/integrate_depth_maps.cxx
+++ b/arrows/cuda/integrate_depth_maps.cxx
@@ -186,11 +186,11 @@ copy_img_to_gpu(kwiver::vital::image_container_sptr h_img)
 
   //copy to cuda format
   kwiver::vital::image img = h_img->get_image();
-  for (unsigned int i = 0; i < h_img->width(); i++)
+  for (unsigned int j = 0; j < h_img->height(); j++)
   {
-    for (unsigned int j = 0; j < h_img->height(); j++)
+    for (unsigned int i = 0; i < h_img->width(); i++)
     {
-      temp[i*h_img->height() + j] = img.at<double>(i, j);
+      temp[j*h_img->width() + i] = img.at<double>(i, j);
     }
   }
 

--- a/arrows/vtk/depth_utils.cxx
+++ b/arrows/vtk/depth_utils.cxx
@@ -125,9 +125,11 @@ to_kwiver(vtkDataArray const* data, int const dims[3])
   {
     kwiver::vital::image_of<T> output_img(dims[0], dims[1], dims[2]);
     vtkIdType pt_id = 0;
-    for (int x = 0; x < dims[0]; x++)
+    // VTK images are stored with (0,0) at the bottom left instead of top left
+    // so flip vertically when copying memory
+    for (int y = dims[1]-1; y >= 0; y--)
     {
-      for (int y = 0; y < dims[1]; y++)
+      for (int x = 0; x < dims[0]; x++)
       {
         output_img(x, y) = vtk_array->GetValue(pt_id);
         pt_id++;

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -181,6 +181,11 @@ Arrows: Core
 
 Arrows: Ceres
 
+Arrows: CUDA
+
+ * Fixed an issue in which depth imagery was loaded transposed and flipped
+   and then later flipped and transposed back during CUDA processing.
+
 Arrows: Super3D
 
 Sprokit: Processes


### PR DESCRIPTION
The code for loading depth images from a VTK file was storing the data both
flipped horizontally and transposed in the vital image.  The only user of
this data, CUDA depth fusion, was then transposing again during copy to
CUDA memory and flipping during pixel access to compensate.  This worked,
but any other algorithm using the same images would see the same garbled
memory and need would need to do the same operations to make sense of it.

This change removes the flip and transpose in both locations so that the
image passed in between is valid and can be used for other purposes.  This change will not change the outputs current algorithms, but it fixes the intermediate values so that reusing the depth loading code will not cause problems for other future uses. 