### PR TITLE
Make end of pipeline detectable

### DIFF
--- a/arrows/qt/EmbeddedPipelineWorker.cxx
+++ b/arrows/qt/EmbeddedPipelineWorker.cxx
@@ -154,6 +154,13 @@ EmbeddedPipelineWorkerPrivate
   kwiver::adapter::adapter_data_set_t const& output )
 {
   KQ_Q();
+
+  if( output->is_end_of_data() )
+  {
+    emit q->finished();
+    return;
+  }
+
   q->processOutput( output );
 }
 
@@ -166,14 +173,7 @@ Endcap
 
   for( int currentFrame = 0;; ++currentFrame )
   {
-    const auto& ods = q->pipeline.receive();
-
-    if( ods->is_end_of_data() )
-    {
-      return;
-    }
-
-    q->processOutput( ods );
+    q->processOutput( q->pipeline.receive() );
   }
 }
 

--- a/arrows/qt/EmbeddedPipelineWorker.h
+++ b/arrows/qt/EmbeddedPipelineWorker.h
@@ -74,6 +74,13 @@ public:
   ///         otherwise \c false.
   virtual bool initialize( QString const& pipelineFile );
 
+signals:
+  /// Signal when the pipeline is finished.
+  ///
+  /// This signal is emitted when the pipeline is finished; that is, when the
+  /// output endcap has received an end-of-input notification.
+  void finished();
+
 public slots:
   /// Execute the pipeline.
   ///
@@ -133,6 +140,10 @@ protected:
   /// pipeline endcap, so that users may act on the output produced by the
   /// pipeline. As the default implementation does nothing, most users will
   /// want to override this method.
+  ///
+  /// Note that this does \em not receive the end-of-input notification. Users
+  /// that need to handle termination of output processing should connect to
+  /// finished().
   ///
   /// This method executes on the pipeline worker thread.
   virtual void processOutput(


### PR DESCRIPTION
Add `EmbeddedPipelineWorker::finished` signal to notify users when the output endcap has received an end-of-input notification. This allows better handling of pipeline completion for users that aren't tracking completion based on number of frames processed. (This is also beneficial to detect when the pipeline has halted if input is terminated prematurely, as when aborting pipeline execution.)