### PR TITLE
Convert type in `pixel_feature_extractor` arrow

### DIFF
--- a/arrows/vxl/tests/CMakeLists.txt
+++ b/arrows/vxl/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ kwiver_discover_gtests(vxl high_pass_filter               LIBRARIES ${test_libra
 kwiver_discover_gtests(vxl image                          LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl image_io                       LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vxl morphology                     LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(vxl pixel_feature_extractor        LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vxl polygon                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vxl vidl_ffmpeg_video_input        LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 


### PR DESCRIPTION
Previously, this filter assumed that all input types were the same. This adds support for differently-typed inputs.

Additionally, the unit test CMake code got lost at some point. This reintroduces it. 