### PR TITLE
Improve CMake logic and remove some cruft

### DIFF
--- a/CMake/kwiver-configcheck.cmake
+++ b/CMake/kwiver-configcheck.cmake
@@ -50,6 +50,9 @@ macro(vital_check_optional_feature NAME TEST MESSAGE)
   endif()
 endmacro()
 
+# Set default visibility
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
 # C++11 is required
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/CMake/kwiver-flags-clang.cmake
+++ b/CMake/kwiver-flags-clang.cmake
@@ -2,12 +2,10 @@
 # Compiler flags specific to use with clang++
 #
 
-kwiver_check_compiler_flag( -std=c++11 -std=c++0x )
 if(NOT APPLE)
   #MacOS produces warnings with this flag and doesn't seem to need it
   kwiver_check_compiler_flag( -pthread )
 endif()
-kwiver_check_compiler_flag( -fvisibility=hidden )
 kwiver_check_compiler_flag( -Wall )
 kwiver_check_compiler_flag( -Werror=return-type )
 kwiver_check_compiler_flag( -Werror=non-virtual-dtor )

--- a/CMake/kwiver-flags-gnu.cmake
+++ b/CMake/kwiver-flags-gnu.cmake
@@ -4,9 +4,7 @@
 
 include( CMakeDependentOption )
 
-kwiver_check_compiler_flag( -std=c++11 -std=c++0x )
 kwiver_check_compiler_flag( -pthread )
-kwiver_check_compiler_flag( -fvisibility=hidden )
 kwiver_check_compiler_flag( -Wall )
 kwiver_check_compiler_flag( -Werror=return-type )
 kwiver_check_compiler_flag( -Werror=non-virtual-dtor )

--- a/sprokit/CMakeLists.txt
+++ b/sprokit/CMakeLists.txt
@@ -2,8 +2,6 @@ project(sprokit)
 
 set(CMAKE_FOLDER "Sprokit")
 
-cmake_minimum_required(VERSION 3.0)
-
 set(sprokit_source_dir "${CMAKE_CURRENT_SOURCE_DIR}")
 set(sprokit_binary_dir "${CMAKE_CURRENT_BINARY_DIR}")
 set(SPROKIT_CMAKE_DIR  "${sprokit_source_dir}/conf")


### PR DESCRIPTION
Use `CMAKE_CXX_VISIBILITY_PRESET` rather than trying to specify visibility flags manually, as the old approach seems to not work consistently¹. Also remove no-longer-needed attempts to set C++ language support flags (not needed since we use `CMAKE_CXX_STANDARD`), and remove an unneeded call to cmake_minimum_required in a subfolder that was requesting a much older version (3.0 vs. 3.15) and was causing policy warnings.

(¹ In particular, I discovered due to a recent PR where I forgot an export declaration that my build was not setting visibility via the old mechanism.)