### PR TITLE
Fixes to metadata extraction for ffmpeg reader

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -673,6 +673,9 @@ public:
         // If the metadata was even partially decided, then add to the list.
         if ( ! meta->empty() )
         {
+          // Add the data stream index
+          meta->add< vital::VITAL_META_VIDEO_DATA_STREAM_INDEX >( md.first );
+
           set_default_metadata( meta );
 
           retval.push_back( meta );

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -70,7 +70,8 @@ public:
     end_of_video(true),
     number_of_frames(0),
     collected_all_metadata(false),
-    estimated_num_frames(false)
+    estimated_num_frames(false),
+    sync_metadata(false)
   { }
 
   // f_* variables are FFmpeg specific
@@ -137,6 +138,7 @@ public:
   size_t number_of_frames;
   bool collected_all_metadata;
   bool estimated_num_frames;
+  bool sync_metadata;
 
   // ==================================================================
   /*
@@ -880,6 +882,12 @@ ffmpeg_video_input
     "deinterlacing only to frames which are interlaced.  "
     "See details at https://ffmpeg.org/ffmpeg-filters.html");
 
+  config->set_value("sync_metadata", d->sync_metadata,
+    "When set to true will attempt synchronizaton the metadata by "
+    "caching metadata packets whose timestamp is greater than the "
+    "current frame's timestamp until a frame is reached with timestamp "
+    "that is equal or greater than the metadata's timestamp.");
+
   return config;
 }
 
@@ -896,6 +904,8 @@ ffmpeg_video_input
   config->merge_config(in_config);
 
   d->filter_desc = config->get_value<std::string>("filter_desc", d->filter_desc);
+
+  d->sync_metadata = config->get_value<bool>("sync_metadata", d->sync_metadata);
 }
 
 // ------------------------------------------------------------------

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -110,10 +110,10 @@ public:
   std::string filter_desc;
 
   // the buffers of raw metadata from the data streams tagged with the timestamp
-  std::map<int, std::multimap<int64_t, std::deque<uint8_t> > > metadata;
+  std::map<int, std::multimap< int64_t, std::deque<uint8_t>>> metadata;
 
   // Storage for current frame's raw metadata
-  std::map<int, std::deque<uint8_t> > curr_metadata;
+  std::map<int, std::deque<uint8_t>> curr_metadata;
 
   // metadata converter object
   kwiver::vital::convert_metadata converter;
@@ -188,8 +188,8 @@ public:
       else if (params->codec_type == AVMEDIA_TYPE_DATA)
       {
         this->metadata.insert(
-          std::make_pair(i, std::multimap<int64_t, std::deque<uint8_t> >() ) );
-        this->curr_metadata.insert(std::make_pair(i, std::deque<uint8_t>() ) );
+          std::make_pair(i, std::multimap<int64_t, std::deque<uint8_t> >()));
+        this->curr_metadata.insert(std::make_pair(i, std::deque<uint8_t>()));
       }
     }
 
@@ -883,15 +883,17 @@ ffmpeg_video_input
   // get base config from base class
   vital::config_block_sptr config = vital::algo::video_input::get_configuration();
 
-  config->set_value("filter_desc", d->filter_desc,
+  config->set_value(
+    "filter_desc", d->filter_desc,
     "A string describing the libavfilter pipeline to apply when reading "
     "the video.  Only filters that operate on each frame independently "
     "will currently work.  The default \"yadif=deint=1\" filter applies "
     "deinterlacing only to frames which are interlaced.  "
     "See details at https://ffmpeg.org/ffmpeg-filters.html");
 
-  config->set_value("sync_metadata", d->sync_metadata,
-    "When set to true will attempt synchronizaton the metadata by "
+  config->set_value(
+    "sync_metadata", d->sync_metadata,
+    "When set to true will attempt to synchronize the metadata by "
     "caching metadata packets whose timestamp is greater than the "
     "current frame's timestamp until a frame is reached with timestamp "
     "that is equal or greater than the metadata's timestamp.");

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -71,7 +71,7 @@ public:
     number_of_frames(0),
     collected_all_metadata(false),
     estimated_num_frames(false),
-    sync_metadata(false)
+    sync_metadata(true)
   { }
 
   // f_* variables are FFmpeg specific

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -187,9 +187,8 @@ public:
       }
       else if (params->codec_type == AVMEDIA_TYPE_DATA)
       {
-        this->metadata.insert(
-          std::make_pair(i, std::multimap<int64_t, std::deque<uint8_t> >()));
-        this->curr_metadata.insert(std::make_pair(i, std::deque<uint8_t>()));
+        this->metadata.emplace(i, std::multimap<int64_t, std::deque<uint8_t> >());
+        this->curr_metadata.emplace(i, std::deque<uint8_t>());
       }
     }
 
@@ -208,8 +207,8 @@ public:
         AVCodecParameters* params = this->f_format_context->streams[i]->codecpar;
         if (params->codec_type == AVMEDIA_TYPE_UNKNOWN)
         {
-          this->metadata.insert(
-            std::make_pair(i, std::multimap<int64_t, std::deque<uint8_t> >() ) );
+          this->metadata.emplace(i, std::multimap<int64_t, std::deque<uint8_t> >());
+          this->curr_metadata.emplace(i, std::deque<uint8_t>());
           LOG_INFO(this->logger, "Using AVMEDIA_TYPE_UNKNOWN stream as a data stream");
         }
       }
@@ -495,9 +494,10 @@ public:
       auto md_iter = this->metadata.find(this->f_packet->stream_index);
       if (md_iter != this->metadata.end() )
       {
-        md_iter->second.insert(std::make_pair( this->f_packet->pts,
-            std::deque<uint8_t>(this->f_packet->data,
-              this->f_packet->data + this->f_packet->size) ) );
+        md_iter->second.emplace(
+          this->f_packet->pts,
+          std::deque<uint8_t>(this->f_packet->data,
+                              this->f_packet->data + this->f_packet->size));
       }
 
       // De-reference previous packet
@@ -739,15 +739,13 @@ public:
       // Add metadata for current frame
       if ( frame_advanced )
       {
-        this->metadata_map.insert(
-          std::make_pair( this->frame_number(), this->current_metadata() ) );
+        this->metadata_map.emplace(this->frame_number(), this->current_metadata());
       }
 
       // Advance video stream to end
       while ( this->advance() )
       {
-        this->metadata_map.insert(
-          std::make_pair( this->frame_number(), this->current_metadata() ) );
+        this->metadata_map.emplace(this->frame_number(), this->current_metadata());
       }
 
       // Close and reopen to reset
@@ -759,8 +757,7 @@ public:
       while ( frame_num < initial_frame_number && this->advance() )
       {
         ++frame_num;
-        this->metadata_map.insert(
-          std::make_pair( this->frame_number(), this->current_metadata() ) );
+        this->metadata_map.emplace(this->frame_number(), this->current_metadata());
       }
 
       collected_all_metadata = true;

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -441,7 +441,10 @@ public:
     this->frame_advanced = false;
 
     // clear the metadata from the previous frame
-    this->metadata.clear();
+    for (auto& md : this->metadata)
+    {
+      md.second.clear();
+    }
 
     while (!this->frame_advanced &&
            av_read_frame(this->f_format_context, this->f_packet) >= 0)

--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
@@ -468,6 +468,8 @@ TEST_F(ffmpeg_video_input, no_sync_metadata)
   kwiver::arrows::ffmpeg::ffmpeg_video_input vif;
 
   auto config = vif.get_configuration();
+  // Turn off metadata syncing
+  config->set_value("sync_metadata", "False");
   vif.set_configuration(config);
 
   kwiver::vital::path_t video_base_name = "aphill_short";
@@ -525,8 +527,6 @@ TEST_F(ffmpeg_video_input, sync_metadata)
   kwiver::arrows::ffmpeg::ffmpeg_video_input vif;
 
   auto config = vif.get_configuration();
-  // Set to synchronize metadata
-  config->set_value("sync_metadata", "True");
   vif.set_configuration(config);
 
   kwiver::vital::path_t video_base_name = "aphill_short";

--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
@@ -455,6 +455,122 @@ TEST_F(ffmpeg_video_input, metadata_map)
 }
 
 // ----------------------------------------------------------------------------
+TEST_F(ffmpeg_video_input, no_sync_metadata)
+{
+  std::map<int, std::set<uint64_t>> expected_md = {
+    {0, {1221515219356000, 1221515219396000, 1221515219426000}},
+    {1, {1221515219456000}},
+    {2, {1221515219486000}},
+    {3, {1221515219516000}},
+    {4, {1221515219556000}}
+  };
+
+  kwiver::arrows::ffmpeg::ffmpeg_video_input vif;
+
+  auto config = vif.get_configuration();
+  vif.set_configuration(config);
+
+  kwiver::vital::path_t video_base_name = "aphill_short";
+  kwiver::vital::path_t video_path = data_dir + "/" + video_base_name + ".ts";
+
+  // Open the video
+  vif.open(video_path);
+
+  kwiver::vital::timestamp ts;
+
+  unsigned int frame_num = 0;
+  while (vif.next_frame(ts))
+  {
+    auto md_vect = vif.frame_metadata();
+    for (auto md : md_vect)
+    {
+      EXPECT_TRUE(md->has(kwiver::vital::VITAL_META_UNIX_TIMESTAMP))
+        << "Each of the first five frames should have a UNIX time stamp in"
+        << " its metadata";
+
+      for (auto md_item : *md)
+      {
+        if (md_item.first == kwiver::vital::VITAL_META_UNIX_TIMESTAMP)
+        {
+          EXPECT_TRUE(expected_md[frame_num].find(md_item.second->as_uint64())
+                      != expected_md[frame_num].end())
+            << "UNIX time stamp " << md_item.second->as_uint64()
+            << " was not found in metadata for frame " << frame_num;
+        }
+      }
+    }
+
+    frame_num++;
+
+    if (frame_num >= expected_md.size())
+    {
+      break;
+    }
+  }
+
+  vif.close();
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(ffmpeg_video_input, sync_metadata)
+{
+  std::map<int, std::set<uint64_t>> expected_md = {
+    {0, {1221515219356000, 1221515219396000}},
+    {1, {1221515219426000}},
+    {2, {1221515219456000}},
+    {3, {1221515219486000}},
+    {4, {1221515219516000}}
+  };
+
+  kwiver::arrows::ffmpeg::ffmpeg_video_input vif;
+
+  auto config = vif.get_configuration();
+  // Set to synchronize metadata
+  config->set_value("sync_metadata", "True");
+  vif.set_configuration(config);
+
+  kwiver::vital::path_t video_base_name = "aphill_short";
+  kwiver::vital::path_t video_path = data_dir + "/" + video_base_name + ".ts";
+
+  // Open the video
+  vif.open(video_path);
+
+  kwiver::vital::timestamp ts;
+
+  unsigned int frame_num = 0;
+  while (vif.next_frame(ts))
+  {
+    auto md_vect = vif.frame_metadata();
+    for (auto md : md_vect)
+    {
+      EXPECT_TRUE(md->has(kwiver::vital::VITAL_META_UNIX_TIMESTAMP))
+        << "Each of the first five frames should have a UNIX time stamp in"
+        << " its metadata";
+
+      for (auto md_item : *md)
+      {
+        if (md_item.first == kwiver::vital::VITAL_META_UNIX_TIMESTAMP)
+        {
+          EXPECT_TRUE(expected_md[frame_num].find(md_item.second->as_uint64())
+                      != expected_md[frame_num].end())
+            << "UNIX time stamp " << md_item.second->as_uint64()
+            << " was not found in metadata for frame " << frame_num;
+        }
+      }
+    }
+
+    frame_num++;
+
+    if (frame_num >= expected_md.size())
+    {
+      break;
+    }
+  }
+
+  vif.close();
+}
+
+// ----------------------------------------------------------------------------
 TEST_F(ffmpeg_video_input, empty_filter_desc)
 {
   kwiver::arrows::ffmpeg::ffmpeg_video_input vif;

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -81,6 +81,14 @@ Arrows: CUDA
 
 Arrows: FFmpeg
 
+ * Now checks the timestamps of the metadata packets to catch packets
+   that are arriving early. Packets that arrive early are cached until the
+   timestamp of the current frame is larger than the timestamp of the
+   metadata packet. This synchronization can be disabled if desired.
+
+ * Fixed an issue where only metadata packets from the first data stream
+   are saved.
+
  * Added a libavfilter pipeline into the ffmpeg_video_input reader. This
    allows users to inject filters in the video reader, much the same as
    is possible in the ffmpeg command line with the -vf option.  The default

--- a/python/kwiver/vital/tests/test_metadata_tags.py
+++ b/python/kwiver/vital/tests/test_metadata_tags.py
@@ -59,6 +59,7 @@ class TestVitalMetadataTags(unittest.TestCase):
             mt.tags.VITAL_META_IMAGE_SOURCE_SENSOR,
             mt.tags.VITAL_META_IMAGE_COORDINATE_SYSTEM,
             mt.tags.VITAL_META_IMAGE_URI,
+            mt.tags.VITAL_META_VIDEO_DATA_STREAM_INDEX,
             mt.tags.VITAL_META_VIDEO_URI,
             mt.tags.VITAL_META_VIDEO_KEY_FRAME,
             mt.tags.VITAL_META_SENSOR_LOCATION,

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -92,6 +92,10 @@
         "Image URI",                                                    \
         std::string,                                                    \
         "" )                                                            \
+  CALL( VIDEO_DATA_STREAM_INDEX,                                        \
+        "Index of metadata stream",                                     \
+        int,                                                            \
+        "" )                                                            \
   CALL( VIDEO_URI,                                                      \
         "Video URI",                                                    \
         std::string,                                                    \


### PR DESCRIPTION
This fixes two issues with the metadata extraction from video sources using ffmpeg. The first fix allows the video reader to pull metadata from multiple video streams. The second fix associates the metadata with the correct video frame when it arrives early in the data stream.