### PR TITLE
Update burnout pipeline to add averaging, closing, and dilation

### DIFF
--- a/examples/pipelines/burnout_on_video.pipe.in
+++ b/examples/pipelines/burnout_on_video.pipe.in
@@ -14,27 +14,38 @@ process filter
   filter:vxl_pixel_feature_extractor:enable_gray = true # 1 channel
   filter:vxl_pixel_feature_extractor:enable_color_commonality = true # 1 channel
   filter:vxl_pixel_feature_extractor:enable_high_pass_box = true # 3 channels
-  filter:vxl_pixel_feature_extractor:enable_high_pass_bidir = true # 1 channel
-  filter:vxl_pixel_feature_extractor:enable_average = true # 3 channels
-  filter:vxl_pixel_feature_extractor:enable_aligned_edge = true # 3 channels
+  filter:vxl_pixel_feature_extractor:enable_high_pass_bidir = true # 3 channels
+  filter:vxl_pixel_feature_extractor:enable_average = true # 1 channel
+  filter:vxl_pixel_feature_extractor:enable_aligned_edge = true # 1 channel
+  filter:vxl_pixel_feature_extractor:enable_normalized_variance = true # 1 channel
+  filter:vxl_pixel_feature_extractor:enable_spatial_prior = true # 1 channel
 
   filter:vxl_pixel_feature_extractor:average:window_size = 25
   filter:vxl_pixel_feature_extractor:average:type = window
   filter:vxl_pixel_feature_extractor:average:output_variance = true
 
-  # TODO figure out what size kernel to use based on expected GSD
-  filter:vxl_pixel_feature_extractor:high_pass_box:kernel_width = 13
-  filter:vxl_pixel_feature_extractor:high_pass_box:kernel_height = 13
+  filter:vxl_pixel_feature_extractor:high_pass_box:kernel_width = 43
+  filter:vxl_pixel_feature_extractor:high_pass_box:kernel_height = 43
   filter:vxl_pixel_feature_extractor:high_pass_box:treat_as_interlaced = false
   filter:vxl_pixel_feature_extractor:high_pass_box:output_net_only = false
 
   filter:vxl_pixel_feature_extractor:high_pass_bidir:kernel_width = 27
   filter:vxl_pixel_feature_extractor:high_pass_bidir:kernel_height = 27
   filter:vxl_pixel_feature_extractor:high_pass_bidir:treat_as_interlaced = false
-  filter:vxl_pixel_feature_extractor:high_pass_bidir:output_net_only = true
+  filter:vxl_pixel_feature_extractor:high_pass_bidir:output_net_only = false
 
   filter:vxl_pixel_feature_extractor:color_commonality:smooth_image = false
   filter:vxl_pixel_feature_extractor:color_commonality:output_scale = 255
+
+# ================================================================
+# Optionally write out features for debugging
+# process filtered_writer
+#   :: image_writer
+#   image_writer:type                     = vxl
+#   file_name_template                    = filtered/image%06d.png
+#   image_writer:vxl:force_byte           = true
+#   image_writer:vxl:auto_stretch         = true
+#   image_writer:vxl:split_channels       = true
 
 # ================================================================
 process classifier
@@ -43,12 +54,33 @@ process classifier
   filter:vxl_hashed_image_classifier_filter:model_file = @EXAMPLE_DIR@/models/default_burnout_600_iters
 
 # ================================================================
+process averager
+  ::image_filter
+  filter:type                           = vxl_average
+  filter:vxl_average:type               = cumulative
+
+# ================================================================
 process thresholder
   ::image_filter
   filter:type                           = vxl_threshold
-  filter:vxl_threshold:type             = percentile
-  filter:vxl_threshold:threshold        = 0.95
+  filter:vxl_threshold:type             = absolute
+  filter:vxl_threshold:threshold        = 0.0
 
+# ================================================================
+process closer
+  ::image_filter
+  filter:type                           = vxl_morphology
+  filter:vxl_morphology:morphology      = close
+  filter:vxl_morphology:kernel_radius   = 2.0
+
+# ================================================================
+process dilater
+  ::image_filter
+  filter:type                           = vxl_morphology
+  filter:vxl_morphology:morphology      = dilate
+  filter:vxl_morphology:kernel_radius   = 2.0
+
+# ================================================================
 process converter
   ::image_filter
   filter:type                           = vxl_convert_image
@@ -60,7 +92,8 @@ process writer
   :: image_writer
   image_writer:type                     = vxl
   file_name_template                    = output/image%06d.png
-
+  image_writer:vxl:force_byte           = true
+  image_writer:vxl:auto_stretch         = true
 
 # connections
 connect from input.image
@@ -69,10 +102,23 @@ connect from input.image
 connect from filter.image
         to   classifier.image
 
+# Optionally write out features for debugging
+# connect from filter.image
+#         to filtered_writer.image
+
 connect from classifier.image
-        to thresholder.image
+        to averager.image
+
+connect from averager.image
+        to   thresholder.image
 
 connect from thresholder.image
+        to   closer.image
+
+connect from closer.image
+        to   dilater.image
+
+connect from dilater.image
         to   converter.image
 
 connect from converter.image


### PR DESCRIPTION
This makes the results significantly better. It seems like the original BurnOut used the following thresholding paramters for lines 55 and 56, but they seem to significantly undersegment representative data.
```
filter:vxl_threshold:type             = absolute
filter:vxl_threshold:threshold        = -0.037
```