### PR TITLE
Don't try to read pipeline after end

### DIFF
--- a/arrows/qt/EmbeddedPipelineWorker.cxx
+++ b/arrows/qt/EmbeddedPipelineWorker.cxx
@@ -106,6 +106,8 @@ public:
   EmbeddedPipeline pipeline;
   Endcap endcap;
 
+  bool atEnd = false;
+
 protected:
   KQ_DECLARE_PUBLIC_PTR( EmbeddedPipelineWorker )
 
@@ -131,6 +133,7 @@ EmbeddedPipelineWorkerPrivate
 
   if( this->pipeline.hasOutput() )
   {
+    this->atEnd = false;
     this->endcap.start();
   }
 
@@ -157,6 +160,7 @@ EmbeddedPipelineWorkerPrivate
 
   if( output->is_end_of_data() )
   {
+    this->atEnd = true;
     emit q->finished();
     return;
   }
@@ -171,7 +175,7 @@ Endcap
 {
   KQ_Q();
 
-  for( int currentFrame = 0;; ++currentFrame )
+  for( int currentFrame = 0; !q->atEnd; ++currentFrame )
   {
     q->processOutput( q->pipeline.receive() );
   }

--- a/arrows/qt/EmbeddedPipelineWorker.cxx
+++ b/arrows/qt/EmbeddedPipelineWorker.cxx
@@ -175,7 +175,7 @@ Endcap
 {
   KQ_Q();
 
-  for( int currentFrame = 0; !q->atEnd; ++currentFrame )
+  while( !q->atEnd )
   {
     q->processOutput( q->pipeline.receive() );
   }


### PR DESCRIPTION
Tweak `EmbeddedPipelineWorker` to avoid attempting to read from the pipeline after `end_of_input` has been received. This seems to otherwise result in a deadlock in at least some instances.

(This fixes a bug that was introduced by f41c74b726c3.)