### PR TITLE
Allow read_object_track_process to successfully configure

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -1,0 +1,13 @@
+KWIVER v1.5.2 Release Notes
+===========================
+
+This is a patch release of KWIVER that provides fixes over the previous
+v1.5.1 release.
+
+Bug Fixes since v1.5.1
+----------------------
+
+Processes: Core
+
+ * Fix configuration check for read_object_track, enabling configuration to
+   succeed.

--- a/sprokit/processes/core/read_object_track_process.cxx
+++ b/sprokit/processes/core/read_object_track_process.cxx
@@ -101,8 +101,8 @@ void read_object_track_process
   kwiver::vital::config_block_sptr algo_config = get_config(); // config for process
 
   // validate configuration
-  if(  algo::read_object_track_set::check_nested_algo_configuration_using_trait(
-         reader, algo_config ) )
+  if( ! algo::read_object_track_set::check_nested_algo_configuration_using_trait(
+          reader, algo_config ) )
   {
     VITAL_THROW( sprokit::invalid_configuration_exception, name(),
                  "Configuration check failed." );


### PR DESCRIPTION
`read_object_track_process` currently throws when its `reader` algorithm *passes* a nested configuration check. This PR negates the throw condition so that it throws when the check fails.