### PR TITLE
Use config paths for pipelines

### DIFF
--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -71,7 +71,6 @@ public:
   bool connect_input_adapter();
   bool connect_output_adapter();
 
-//---------------------------
   vital::logger_handle_t m_logger;
   bool m_at_end {false};
   bool m_stop_flag {false};
@@ -89,6 +88,9 @@ public:
   embedded_pipeline_extension_sptr m_hooks;
   std::shared_ptr< embedded_pipeline_extension::context> m_context;
 
+  std::string m_app_name;
+  std::string m_app_version;
+  std::string m_app_prefix;
 }; // end class embedded_pipeline::priv
 
 // ============================================================================
@@ -132,12 +134,25 @@ embedded_pipeline
   m_priv->m_context = std::make_shared< real_context >( m_priv );
 }
 
+// ----------------------------------------------------------------------------
 embedded_pipeline
 ::~embedded_pipeline()
 {
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+void
+embedded_pipeline
+::set_application_information( std::string const& app_name,
+                               std::string const& app_version,
+                               std::string const& app_prefix )
+{
+  m_priv->m_app_name = app_name;
+  m_priv->m_app_version = app_version;
+  m_priv->m_app_prefix = app_prefix;
+}
+
+// ----------------------------------------------------------------------------
 void
 embedded_pipeline
 ::build_pipeline( std::istream& istr, std::string const& def_dir )
@@ -146,7 +161,8 @@ embedded_pipeline
   sprokit::pipeline_builder builder;
 
   builder.add_search_path(
-    vital::application_config_file_paths( {}, {}, {} ) );
+    vital::application_config_file_paths(
+      m_priv->m_app_name, m_priv->m_app_version, m_priv->m_app_prefix ) );
 
   std::string cur_file( def_dir );
   if ( def_dir.empty() )

--- a/sprokit/processes/adapters/embedded_pipeline.cxx
+++ b/sprokit/processes/adapters/embedded_pipeline.cxx
@@ -11,6 +11,7 @@
 #include "embedded_pipeline_extension.h"
 
 #include <vital/config/config_block.h>
+#include <vital/config/config_block_io.h>
 #include <vital/logger/logger.h>
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/vital_config.h>
@@ -143,6 +144,9 @@ embedded_pipeline
 {
   // create a pipeline
   sprokit::pipeline_builder builder;
+
+  builder.add_search_path(
+    vital::application_config_file_paths( {}, {}, {} ) );
 
   std::string cur_file( def_dir );
   if ( def_dir.empty() )

--- a/sprokit/processes/adapters/embedded_pipeline.h
+++ b/sprokit/processes/adapters/embedded_pipeline.h
@@ -123,20 +123,34 @@ public:
   virtual ~embedded_pipeline();
 
   /**
+   * @brief Set application information
+   *
+   * This method sets the application information that will be used when
+   * searching for pipeline files. See kwiver::vital::read_config_file for a
+   * detailed explanation of the parameters and how search paths work.
+   *
+   * \sa build_pipeline
+   */
+  void set_application_information( std::string const& app_name,
+                                    std::string const& app_version,
+                                    std::string const& app_prefix = {} );
+
+  /**
    * @brief Build the embedded pipeline.
    *
-   * This method creates the pipeline based on the contents of the
-   * supplied stream.
+   * This method creates the pipeline based on the contents of the supplied
+   * stream. Inclusions will be resolved using the search paths in the same
+   * manner as kwiver::vital::read_config_file.
    *
    * @param istr Input stream containing the pipeline description.
    *
-   * @param def_dir The directory name used to report errors in the
-   * input stream and is used as the current directory to locate
-   * includes and to resolve relpath. Since the input stream being
-   * processed has no file name, the name "in-stream" is appended to
-   * the directory supplied so that errors in the stream can be
-   * differentiated from errors from other files. If this parameter is
-   * not supplied, the current directory is used.
+   * @param def_dir The directory name used to report errors in the input
+   * stream and as the location of the pipeline file when resolving include
+   * directives (if not resolved via the search paths) and relpath specifiers.
+   * Since the input stream being processed has no file name, the name
+   * "in-stream" is appended to the directory supplied so that errors in the
+   * stream can be differentiated from errors from other files. If this
+   * parameter is not supplied, the current directory is used.
    *
    * @throws std::runtime_error when there is a problem
    * constructing the pipeline or if there is a problem connecting


### PR DESCRIPTION
Modify `embedded_pipeline` to use the config search paths when building the pipeline. Add a method to allow specifying the application information (name, version, prefix) to use when building these paths. Modify `EmbeddedPipelineWorker` to use the Qt application information to automatically set appropriate search paths for building the pipeline.

This will allow pipelines, and Qt embedded pipelines in particular, to use includes that resolve to distributed pipeline files, rather than requiring that all includes are relative to the context performing the include.