### PR TITLE
Update FindPROJ to find PROJ 5 (on Windows)

### DIFF
--- a/CMake/FindPROJ.cmake
+++ b/CMake/FindPROJ.cmake
@@ -33,7 +33,7 @@ elseif(NOT PROJ_FOUND)
     set(_PROJ_LIB_PATH_HINT HINTS "${proj_lib_dir}" "${proj_lib_dir}64" NO_CMAKE_SYSTEM_PATH)
   endif()
 
-  find_library(PROJ_LIBRARY NAMES proj proj_4_9 proj_4_9_d
+  find_library(PROJ_LIBRARY NAMES proj proj_4_9 proj_4_9_d proj_5_2 proj_5_2_d
     ${_PROJ_LIB_PATH_HINT}
     ${PROJ_FIND_OPTS}
     DOC "Path to the PROJ library."


### PR DESCRIPTION
Add additional names for the PROJ library to allow finding PROJ 5.2 on Windows.

This will hopefully fix the issues using KWIVER with Kitware/fletch#651.