### PR TITLE
Reverted change to MACOSX_RPATH

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -238,7 +238,7 @@ function(kwiver_add_library     name)
   if ( APPLE )
     set( props
       MACOSX_RPATH         TRUE
-      INSTALL_NAME_DIR     "@executable_path/${lib_subdir_path_to_root}${lib_dir_path_to_root}/${KWIVER_DEFAULT_LIBRARY_DIR}"
+      INSTALL_NAME_DIR     "@executable_path/../${KWIVER_DEFAULT_LIBRARY_DIR}"
       )
   else()
     if ( NOT no_version ) # optional versioning


### PR DESCRIPTION
This was breaking the packaging of TeleSculptor.

I'm not sure what `${lib_subdir_path_to_root}${lib_dir_path_to_root}` was supposed to be doing here, but in my build it evaluated to the empty string.  The results was `@executable_path//lib` when it needs to be `@executable_path/../lib`.  Basically this is telling the linker where to find the libraries relative to the executable, which we assume is in `bin`.

Is is possible that we want `@executable_path/../${lib_subdir_path_to_root}${lib_dir_path_to_root}/${KWIVER_DEFAULT_LIBRARY_DIR}` or some other combination?  I don't understand what the use cases are when `KWIVER_DEFAULT_LIBRARY_DIR` is not just `lib`.

I'm not sure how to handle this fix in terms of releases.  I need to make a patch release of TeleSculptor against the patch release of KWIVER to pick up bug fixes in KWIVER, but I can't build against v1.5.1 with this bug.  I suppose we should have made a release candidate of KWIVER and tested packaging of downstream packages against it before release.  Unfortunately, I rarely run the packaging on MacOS.  I suppose what we really need to do is fix TeleSculptor CI, which has been broken for years, and then we might catch these things earlier.