### PR TITLE
Tolerate PROJ 6

### DIFF
--- a/CMake/kwiver-depends-PROJ.cmake
+++ b/CMake/kwiver-depends-PROJ.cmake
@@ -12,5 +12,4 @@ endif()
 
 if( KWIVER_ENABLE_PROJ )
   find_package( PROJ REQUIRED )
-  include_directories( SYSTEM ${PROJ_INCLUDE_DIR} )
 endif( KWIVER_ENABLE_PROJ )

--- a/arrows/proj/CMakeLists.txt
+++ b/arrows/proj/CMakeLists.txt
@@ -25,6 +25,10 @@ kwiver_add_library( kwiver_algo_proj
   ${proj_sources}
   )
 
+target_include_directories( kwiver_algo_proj
+  SYSTEM PRIVATE ${PROJ_INCLUDE_DIR}
+  )
+
 target_link_libraries( kwiver_algo_proj
   PUBLIC               vital_algo
                        ${PROJ_LIBRARY}

--- a/arrows/proj/geo_conv.cxx
+++ b/arrows/proj/geo_conv.cxx
@@ -9,6 +9,7 @@
 
 #include "geo_conv.h"
 
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #include <proj_api.h>
 
 #include <string>


### PR DESCRIPTION
Modify PROJ arrow to define the symbol to tell PROJ 6 to allow us to use the deprecated PROJ 4 API. Remove global addition of the PROJ include directories, and instead use them only as a target include in the actual arrow.