### PR TITLE
[VIAME] Add intersection and empty checks to refiners

### DIFF
--- a/arrows/ocv/refine_detections_grabcut.cxx
+++ b/arrows/ocv/refine_detections_grabcut.cxx
@@ -111,6 +111,7 @@ refine_detections_grabcut
   using ic = ocv::image_container;
   cv::Mat img = ic::vital_to_ocv( image_data->get_image(), ic::BGR_COLOR );
   cv::Rect img_rect( 0, 0, img.cols, img.rows );
+  bounding_box<double> vital_img_rect( 0, 0, img.cols, img.rows );
 
   if( !detections )
   {
@@ -120,7 +121,7 @@ refine_detections_grabcut
   auto result = std::make_shared< vital::detected_object_set >();
   for( auto const& det : *detections )
   {
-    auto&& bbox = det->bounding_box();
+    auto&& bbox = intersection( det->bounding_box(), vital_img_rect );
     // Determine context crop and translate the bounding box
     auto cbbox = vital::scale_about_center( bbox, d_->context_scale_factor );
     auto ctx_rect = bbox_to_mask_rect( cbbox ) & img_rect;


### PR DESCRIPTION
This fixes failures in the refiner pipelines caused by detections which extended past the border of the image by doing the following:
* Check that the input image isn't null
* Intersect the detection rectangle with the image boundary
* If the intersection in null, simply return the original detection. Otherwise, process as normal. 
 
It's possible there are better ways to implement this. 