### PR TITLE
Clean up code style and logic of rgb_color

### DIFF
--- a/vital/types/color.h
+++ b/vital/types/color.h
@@ -13,76 +13,82 @@
 #include <iostream>
 
 namespace kwiver {
+
 namespace vital {
 
-/// Struct to represent an RGB tuple
+// ----------------------------------------------------------------------------
+/// Struct to represent an RGB tuple.
 struct rgb_color
 {
-  /// Default constructor - set the color to white
-  rgb_color() : r(255), g(255), b(255) {}
+  /// Construct with a default value (white).
+  rgb_color() = default;
 
-  /// Constructor
-  rgb_color(uint8_t const &cr,
-            uint8_t const &cg,
-            uint8_t const &cb)
-    : r(cr), g(cg), b(cb) {}
+  /// Construct with specified component values.
+  rgb_color( uint8_t cr, uint8_t cg, uint8_t cb )
+    : r{ cr }, g{ cg }, b{ cb } {}
 
-  /// Copy Constructor
-  rgb_color( rgb_color const &c )
-    : r(c.r), g(c.g), b(c.b) {}
+  rgb_color( rgb_color const& ) = default;
 
-  /// Serialization of the class data
-  template<class Archive>
-  void serialize(Archive & archive)
+  rgb_color& operator=( rgb_color const& ) = default;
+
+  template < class Archive >
+  void
+  serialize( Archive& archive )
   {
     archive( r, g, b );
   }
 
-  uint8_t r;
-  uint8_t g;
-  uint8_t b;
+  uint8_t r = 255;
+  uint8_t g = 255;
+  uint8_t b = 255;
 };
 
-/// comparison operator for an rgb_color
+// ----------------------------------------------------------------------------
+/// Comparison operator for an rgb_color.
 inline
 bool
 operator==( rgb_color const& c1, rgb_color const& c2 )
 {
-  return (c1.r == c2.r) && (c1.g == c2.g) && (c1.b == c2.b);
+  return ( c1.r == c2.r ) && ( c1.g == c2.g ) && ( c1.b == c2.b );
 }
 
-/// comparison operator for an rgb_color
+// ----------------------------------------------------------------------------
+/// Comparison operator for an rgb_color.
 inline
 bool
 operator!=( rgb_color const& c1, rgb_color const& c2 )
 {
-  return !(c1 == c2);
+  return !( c1 == c2 );
 }
 
-/// output stream operator for an rgb_color
+// ----------------------------------------------------------------------------
+/// Output stream operator for an rgb_color.
 inline
 std::ostream&
 operator<<( std::ostream& s, const rgb_color& c )
 {
-  // Note the '+' prefix here is used to print characters
-  // as decimal number, not ASCII characters
-  s << +c.r << " " << +c.g << " " << +c.b;
+  // Note the '+' prefix here is used to promote the members to int so they are
+  // printed as decimal numbers, rather than as characters (char)
+  s << +c.r << ' ' << +c.g << ' ' << +c.b;
   return s;
 }
 
-/// input stream operator for an rgb_color
+// ----------------------------------------------------------------------------
+/// Input stream operator for an rgb_color.
 inline
 std::istream&
 operator>>( std::istream& s, rgb_color& c )
 {
   int rv = 255, gv = 255, bv = 255;
   s >> rv >> gv >> bv;
-  c.r = static_cast<uint8_t>( rv );
-  c.g = static_cast<uint8_t>( gv );
-  c.b = static_cast<uint8_t>( bv );
+  c.r = static_cast< uint8_t >( rv );
+  c.g = static_cast< uint8_t >( gv );
+  c.b = static_cast< uint8_t >( bv );
   return s;
 }
 
-} } // end namespace vital
+} // namespace vital
 
-#endif // VITAL_COLOR_H_
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Clean up code style in `types/color.h`. Modify logic to add an explicit assignment operator (the implicit operator is deprecated by virtue of having an explicit copy constructor), and change most of the special members to be explicitly defaulted.

This reduces warnings generated by use of this type.