### PR TITLE
Fix track_features API

### DIFF
--- a/arrows/core/track_features_augment_keyframes.cxx
+++ b/arrows/core/track_features_augment_keyframes.cxx
@@ -42,7 +42,7 @@ public:
 vital::feature_track_set_sptr
 track_features_augment_keyframes
 ::track(kwiver::vital::feature_track_set_sptr tracks,
-        unsigned int frame_number,
+        kwiver::vital::frame_id_t frame_number,
         kwiver::vital::image_container_sptr image_data,
         kwiver::vital::image_container_sptr mask) const
 {

--- a/arrows/core/track_features_augment_keyframes.h
+++ b/arrows/core/track_features_augment_keyframes.h
@@ -50,7 +50,7 @@ public:
    * \returns \c config_block containing the configuration for this algorithm
    *          and any nested components.
    */
-  virtual vital::config_block_sptr get_configuration() const;
+  vital::config_block_sptr get_configuration() const override;
 
   /// Set this algorithm's properties via a config block
   /**
@@ -63,7 +63,7 @@ public:
    * \param config  The \c config_block instance containing the configuration
    *                parameters for this algorithm
    */
-  virtual void set_configuration(vital::config_block_sptr config);
+  void set_configuration(vital::config_block_sptr config) override;
 
   /// Check that the algorithm's currently configuration is valid
   /**
@@ -75,7 +75,7 @@ public:
    *
    * \returns true if the configuration check passed and false if it didn't.
    */
-  virtual bool check_configuration(vital::config_block_sptr config) const;
+  bool check_configuration(vital::config_block_sptr config) const override;
 
   /// Augment existing tracks with additional features if a keyframe
   /**
@@ -101,12 +101,11 @@ public:
    *                  value).
    * \returns an updated set of feature tracks
    */
-  virtual kwiver::vital::feature_track_set_sptr
+  kwiver::vital::feature_track_set_sptr
   track(kwiver::vital::feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        kwiver::vital::frame_id_t frame_number,
         kwiver::vital::image_container_sptr image_data,
-        kwiver::vital::image_container_sptr mask =
-          kwiver::vital::image_container_sptr()) const;
+        kwiver::vital::image_container_sptr mask = {}) const override;
 
 protected:
 

--- a/arrows/core/track_features_core.cxx
+++ b/arrows/core/track_features_core.cxx
@@ -201,7 +201,7 @@ track_features_core
 feature_track_set_sptr
 track_features_core
 ::track(feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        frame_id_t frame_number,
         image_container_sptr image_data,
         image_container_sptr mask) const
 {

--- a/arrows/core/track_features_core.h
+++ b/arrows/core/track_features_core.h
@@ -43,7 +43,7 @@ public:
    * \returns \c config_block containing the configuration for this algorithm
    *          and any nested components.
    */
-  virtual vital::config_block_sptr get_configuration() const;
+  vital::config_block_sptr get_configuration() const override;
 
   /// Set this algorithm's properties via a config block
   /**
@@ -56,7 +56,7 @@ public:
    * \param config  The \c config_block instance containing the configuration
    *                parameters for this algorithm
    */
-  virtual void set_configuration(vital::config_block_sptr config);
+  void set_configuration(vital::config_block_sptr config) override;
 
   /// Check that the algorithm's currently configuration is valid
   /**
@@ -68,7 +68,7 @@ public:
    *
    * \returns true if the configuration check passed and false if it didn't.
    */
-  virtual bool check_configuration(vital::config_block_sptr config) const;
+  bool check_configuration(vital::config_block_sptr config) const override;
 
   /// Extend a previous set of feature tracks using the current frame
   /**
@@ -85,11 +85,11 @@ public:
    *                  value).
    * \returns an updated set of feature tracks including the current frame
    */
-  virtual vital::feature_track_set_sptr
+  vital::feature_track_set_sptr
   track(vital::feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        vital::frame_id_t frame_number,
         vital::image_container_sptr image_data,
-        vital::image_container_sptr mask = vital::image_container_sptr()) const;
+        vital::image_container_sptr mask = {}) const override;
 
 private:
   /// private implementation class

--- a/arrows/mvg/applets/track_features.cxx
+++ b/arrows/mvg/applets/track_features.cxx
@@ -405,10 +405,11 @@ public:
     }
     else
     {
-      auto const num_frames = static_cast<kv::frame_id_t>(
-        video_reader->num_frames());
+      auto const num_frames = video_reader->num_frames();
+      auto const max_frame = static_cast<kv::frame_id_t>(num_frames);
+
       valid_frames.reserve(num_frames);
-      for (kv::frame_id_t f = 1; f <= num_frames; ++f)
+      for (kv::frame_id_t f = 1; f <= max_frame; ++f)
       {
         valid_frames.push_back(f);
       }

--- a/arrows/ocv/track_features_klt.cxx
+++ b/arrows/ocv/track_features_klt.cxx
@@ -383,7 +383,7 @@ public:
   image_pyramid prev_pyramid;
   image_pyramid_map det_pyramids;
   detection_data_map det_data_map;
-  int prev_frame_num;
+  frame_id_t prev_frame_num;
   size_t last_detect_num_features;
   float redetect_threshold;
   cv::Mat tracked_feature_location_mask;
@@ -474,7 +474,7 @@ bool feat_stren_less(feature_sptr a, feature_sptr b)
 feature_track_set_sptr
 track_features_klt
 ::track(feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        frame_id_t frame_number,
         image_container_sptr image_data,
         image_container_sptr mask) const
 {

--- a/arrows/ocv/track_features_klt.h
+++ b/arrows/ocv/track_features_klt.h
@@ -42,7 +42,7 @@ public:
    * \returns \c config_block containing the configuration for this algorithm
    *          and any nested components.
    */
-  virtual vital::config_block_sptr get_configuration() const;
+  vital::config_block_sptr get_configuration() const override;
 
   /// Set this algorithm's properties via a config block
   /**
@@ -55,7 +55,7 @@ public:
    * \param config  The \c config_block instance containing the configuration
    *                parameters for this algorithm
    */
-  virtual void set_configuration(vital::config_block_sptr config);
+  void set_configuration(vital::config_block_sptr config) override;
 
   /// Check that the algorithm's currently configuration is valid
   /**
@@ -67,7 +67,7 @@ public:
    *
    * \returns true if the configuration check passed and false if it didn't.
    */
-  virtual bool check_configuration(vital::config_block_sptr config) const;
+  bool check_configuration(vital::config_block_sptr config) const override;
 
   /// Extend a previous set of feature tracks using the current frame
   /**
@@ -84,11 +84,11 @@ public:
    *                  value).
    * \returns an updated set of feature tracks including the current frame
    */
-  virtual vital::feature_track_set_sptr
+  vital::feature_track_set_sptr
   track(vital::feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        vital::frame_id_t frame_number,
         vital::image_container_sptr image_data,
-        vital::image_container_sptr mask = vital::image_container_sptr()) const;
+        vital::image_container_sptr mask = {}) const override;
 
 private:
   /// private implementation class

--- a/python/kwiver/vital/algo/trampoline/track_features_trampoline.txx
+++ b/python/kwiver/vital/algo/trampoline/track_features_trampoline.txx
@@ -78,7 +78,7 @@ class track_features_trampoline :
 
     kwiver::vital::feature_track_set_sptr
     track( kwiver::vital::feature_track_set_sptr prev_tracks,
-           unsigned int frame_number,
+           kwiver::vital::frame_id_t frame_number,
            kwiver::vital::image_container_sptr image_data,
            kwiver::vital::image_container_sptr mask ) const override
     {

--- a/vital/algo/track_features.h
+++ b/vital/algo/track_features.h
@@ -45,9 +45,9 @@ public:
    */
   virtual feature_track_set_sptr
   track(feature_track_set_sptr prev_tracks,
-        unsigned int frame_number,
+        frame_id_t frame_number,
         image_container_sptr image_data,
-        image_container_sptr mask = image_container_sptr()) const = 0;
+        image_container_sptr mask = {}) const = 0;
 
 protected:
     track_features();


### PR DESCRIPTION
Alter `track_features::track` to take the frame as a `frame_id_t` rather than as `unsigned`. Ironically, this isn't just "more correct", but algorithm implementations were already correctly operating with frames as `frame_id_t`.

Also, tweak implementations to use the override keyword, which helps ensure that the overrides are in fact the correct API, and will lead to more direct errors ('marked `override` but does not override' when parsing the class definition, rather than failures to instantiate the class due to abstract virtuals) in case something changes again.