### PR TITLE
Add default pipeline search path

### DIFF
--- a/sprokit/src/applets/pipeline_runner.cxx
+++ b/sprokit/src/applets/pipeline_runner.cxx
@@ -6,7 +6,9 @@
 
 #include <vital/config/config_block.h>
 #include <vital/config/config_block_formatter.h>
+#include <vital/config/config_block_io.h>
 #include <vital/plugin_loader/plugin_manager.h>
+#include <vital/util/get_paths.h>
 
 #include <sprokit/pipeline/scheduler.h>
 #include <sprokit/pipeline/scheduler_factory.h>
@@ -84,11 +86,15 @@ run()
 
   sprokit::pipeline_builder builder;
 
-  // Add search path to builder.
+  // Add user-provided paths
   if ( cmd_args.count("include") > 0 )
   {
     builder.add_search_path( cmd_args["include"].as<std::vector<std::string>>() );
   }
+
+  // Add standard search locations
+  const std::string prefix = kwiver::vital::get_executable_path() + "/..";
+  builder.add_search_path( kwiver::vital::kwiver_config_file_paths( prefix ) );
 
   if ( cmd_args.count("pipe-file") == 0 )
   {

--- a/sprokit/src/applets/pipeline_runner.cxx
+++ b/sprokit/src/applets/pipeline_runner.cxx
@@ -10,30 +10,32 @@
 #include <vital/plugin_loader/plugin_manager.h>
 #include <vital/util/get_paths.h>
 
+#include <sprokit/pipeline/pipeline.h>
 #include <sprokit/pipeline/scheduler.h>
 #include <sprokit/pipeline/scheduler_factory.h>
-#include <sprokit/pipeline/pipeline.h>
-#include <sprokit/pipeline_util/pipeline_builder.h>
 #include <sprokit/pipeline_util/pipe_display.h>
+#include <sprokit/pipeline_util/pipeline_builder.h>
 
 #include <cstdlib>
 #include <iostream>
 
 namespace sprokit {
+
 namespace tools {
 
-static const auto scheduler_block = kwiver::vital::config_block_key_t("_scheduler");
+static const auto scheduler_block =
+  kwiver::vital::config_block_key_t( "_scheduler" );
 
 // ----------------------------------------------------------------------------
-pipeline_runner::
-pipeline_runner()
+pipeline_runner
+::pipeline_runner()
 {
 }
 
 // ----------------------------------------------------------------------------
 void
-pipeline_runner::
-add_command_options()
+pipeline_runner
+::add_command_options()
 {
   m_cmd_options->custom_help( wrap_text( "[options] pipe-file\n"
            "This program runs the specified pipeline file."
@@ -67,36 +69,38 @@ add_command_options()
 
 // ----------------------------------------------------------------------------
 int
-pipeline_runner::
-run()
+pipeline_runner
+::run()
 {
   const std::string opt_app_name = applet_name();
 
   auto& cmd_args = command_args();
 
-  if ( cmd_args["help"].as<bool>() )
+  if( cmd_args[ "help" ].as< bool >() )
   {
     std::cout << m_cmd_options->help();
     return EXIT_SUCCESS;
   }
 
   // Load all known modules
-  kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
+  kwiver::vital::plugin_manager& vpm =
+    kwiver::vital::plugin_manager::instance();
   vpm.load_all_plugins();
 
   sprokit::pipeline_builder builder;
 
   // Add user-provided paths
-  if ( cmd_args.count("include") > 0 )
+  if( cmd_args.count( "include" ) > 0 )
   {
-    builder.add_search_path( cmd_args["include"].as<std::vector<std::string>>() );
+    builder.add_search_path(
+        cmd_args[ "include" ].as< std::vector< std::string > >() );
   }
 
   // Add standard search locations
   const std::string prefix = kwiver::vital::get_executable_path() + "/..";
   builder.add_search_path( kwiver::vital::kwiver_config_file_paths( prefix ) );
 
-  if ( cmd_args.count("pipe-file") == 0 )
+  if( cmd_args.count( "pipe-file" ) == 0 )
   {
     // error & exit
     std::cerr << "Required pipeline file missing\n "
@@ -105,25 +109,29 @@ run()
   }
 
   // Load the pipeline file.
-  kwiver::vital::path_t const pipe_file( cmd_args["pipe-file"].as<std::string>() );
+  kwiver::vital::path_t const pipe_file(
+    cmd_args[ "pipe-file" ].as< std::string >() );
   builder.load_pipeline( pipe_file );
 
   // Must be applied after pipe file is loaded.
   // To overwrite any existing settings
-  if ( cmd_args.count("config") > 0 )
+  if( cmd_args.count( "config" ) > 0 )
   {
-    std::vector< std::string > config_file_names = cmd_args["config"].as<std::vector<std::string>>();
-    for ( const auto& config : config_file_names )
+    std::vector< std::string > config_file_names =
+      cmd_args[ "config" ].as< std::vector< std::string > >();
+
+    for( const auto& config : config_file_names )
     {
       builder.load_supplement( config );
     }
   }
 
   // Add accumulated settings to the pipeline
-  if ( cmd_args.count("setting") > 0 )
+  if( cmd_args.count( "setting" ) > 0 )
   {
-    std::vector< std::string > config_settings = cmd_args["setting"].as<std::vector<std::string>>();
-    for ( const auto& setting : config_settings )
+    std::vector< std::string > config_settings =
+      cmd_args[ "setting" ].as< std::vector< std::string > >();
+    for( const auto& setting : config_settings )
     {
       builder.add_setting( setting );
     }
@@ -136,9 +144,10 @@ run()
   kwiver::vital::config_block_sptr const conf = builder.config();
 
   // nice to dump config at this point
-  if ( cmd_args["dump-pipe"].as<bool>() )
+  if( cmd_args[ "dump-pipe" ].as< bool >() )
   {
-    std::cout << "\nPipeline contents:\n";;
+    std::cout << "\nPipeline contents:\n";
+
     sprokit::pipe_display pd( std::cout );
     pd.print_loc();
     pd.display_pipe_blocks( builder.pipeline_blocks() );
@@ -146,7 +155,7 @@ run()
     return EXIT_SUCCESS;
   }
 
-  if (!pipe)
+  if( !pipe )
   {
     std::cerr << "Error: Unable to bake pipeline" << std::endl;
     return EXIT_FAILURE;
@@ -161,9 +170,9 @@ run()
   auto scheduler_type = sprokit::scheduler_factory::default_type;
 
   // Check if scheduler type was on the command line.
-  if ( cmd_args.count("scheduler") > 0 )
+  if( cmd_args.count( "scheduler" ) > 0 )
   {
-    scheduler_type = cmd_args["scheduler"].as<std::string>();
+    scheduler_type = cmd_args[ "scheduler" ].as< std::string >();
   }
   else
   {
@@ -175,13 +184,14 @@ run()
 
   // Get scheduler sub block based on selected scheduler type
   kwiver::vital::config_block_sptr const scheduler_config =
-             conf->subblock(scheduler_block +
-                            kwiver::vital::config_block::block_sep() +
-                            scheduler_type);
+    conf->subblock( scheduler_block +
+                    kwiver::vital::config_block::block_sep() +
+                    scheduler_type );
 
-  sprokit::scheduler_t scheduler = sprokit::create_scheduler(scheduler_type, pipe, scheduler_config);
+  auto scheduler =
+    sprokit::create_scheduler( scheduler_type, pipe, scheduler_config );
 
-  if (!scheduler)
+  if( !scheduler )
   {
     std::cerr << "Error: Unable to create scheduler" << std::endl;
 
@@ -194,4 +204,6 @@ run()
   return EXIT_SUCCESS;
 }
 
-} } // end namespace
+} // namespace tools
+
+} // namespace sprokit


### PR DESCRIPTION
This allows `kwiver runner` to `include` pipelines from the `<build dir>/share/kwiver/<kwiver version>/config` directory. These changes are lines 92-94 and correspond to the first commit. The rest is formatting, based on `uncrustify`, which I can roll back if desired.

This addresses #1254 with the change suggested there by @mleotta.