### PR TITLE
Improve API for erasing track states

### DIFF
--- a/vital/tests/test_track.cxx
+++ b/vital/tests/test_track.cxx
@@ -28,6 +28,7 @@ TEST(track, id)
   EXPECT_EQ( 25, t->id() );
 }
 
+// ----------------------------------------------------------------------------
 TEST(track, insert_remove)
 {
   auto t = kwiver::vital::track::create();
@@ -58,4 +59,27 @@ TEST(track, insert_remove)
   EXPECT_EQ(1, t->size());
   EXPECT_TRUE(t->remove(ts7));
   EXPECT_FALSE(t->remove(ts7));
+}
+
+// ----------------------------------------------------------------------------
+TEST(track, remove_by_frame)
+{
+  auto t = kwiver::vital::track::create();
+  auto ts1 = std::make_shared< kwiver::vital::track_state >( 1 );
+  auto ts2 = std::make_shared< kwiver::vital::track_state >( 2 );
+  auto ts4 = std::make_shared< kwiver::vital::track_state >( 4 );
+
+  t->insert( ts1 );
+  t->insert( ts2 );
+  t->insert( ts4 );
+
+  EXPECT_EQ( 3, t->size() );
+  EXPECT_TRUE( t->remove( 2 ) );
+  EXPECT_EQ( 2, t->size() );
+  EXPECT_FALSE( t->remove( 2 ) );
+  EXPECT_EQ( 2, t->size() );
+
+  EXPECT_EQ( t, ts1->track() );
+  EXPECT_EQ( t, ts4->track() );
+  EXPECT_EQ( nullptr, ts2->track() );
 }

--- a/vital/tests/test_track.cxx
+++ b/vital/tests/test_track.cxx
@@ -83,3 +83,20 @@ TEST(track, remove_by_frame)
   EXPECT_EQ( t, ts4->track() );
   EXPECT_EQ( nullptr, ts2->track() );
 }
+
+// ----------------------------------------------------------------------------
+TEST(track, contains)
+{
+  auto t = kwiver::vital::track::create();
+  auto ts1 = std::make_shared< kwiver::vital::track_state >( 1 );
+  auto ts4 = std::make_shared< kwiver::vital::track_state >( 4 );
+
+  t->insert( ts1 );
+  t->insert( ts4 );
+
+  EXPECT_EQ( 2, t->size() );
+  EXPECT_TRUE( t->contains( 1 ) );
+  EXPECT_TRUE( t->contains( 4 ) );
+  EXPECT_FALSE( t->contains( 2 ) );
+  EXPECT_FALSE( t->contains( 5 ) );
+}

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -187,9 +187,34 @@ track
     return false;
   }
 
-  (*pos)->track_.reset();
-  this->history_.erase(pos);
+  this->erase(pos);
   return true;
+}
+
+// ----------------------------------------------------------------------------
+bool
+track
+::remove( frame_id_t frame )
+{
+  auto const iter = this->find( frame );
+  if( iter == this->end() )
+  {
+    return false;
+  }
+  this->erase( iter );
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+track::history_const_itr
+track
+::erase( history_const_itr iter )
+{
+  if( *iter )
+  {
+    ( *iter )->track_.reset();
+  }
+  return this->history_.erase( iter );
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -214,7 +214,13 @@ track
   {
     ( *iter )->track_.reset();
   }
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+  // GCC 4.8 is missing C++11 vector::erase(const_iterator)
+  auto const offset = iter - this->history_.cbegin();
+  return this->history_.erase( this->history_.begin() + offset );
+#else
   return this->history_.erase( iter );
+#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/track.h
+++ b/vital/types/track.h
@@ -211,8 +211,16 @@ public:
 
   /// Remove track state.
   ///
+  /// \param frame The state to remove.
   /// \returns \c true if the state was found and removed.
   bool remove( track_state_sptr const& state );
+
+  /// Remove track state by frame number.
+  ///
+  /// \param frame The frame number at which to remove a state.
+  /// \returns \c true if a state with the specified frame number was found and
+  ///          removed.
+  bool remove( frame_id_t frame );
 
   /// Remove all track states.
   void clear();
@@ -241,6 +249,11 @@ public:
   /// \return \c true if the track contains the specified \p frame,
   ///         otherwise \c false.
   bool contains( frame_id_t frame ) const;
+
+  /// Erase track state at iterator.
+  ///
+  /// \return An iterator to the item which followed the erased item.
+  history_const_itr erase( history_const_itr );
 
   /// Return the set of all frame identifiers covered by this track.
   std::set< frame_id_t > all_frame_ids() const;


### PR DESCRIPTION
Add additional methods to track to remove states by frame number, or using an iterator.