### PR TITLE
Fix to prevent infinite loop during video seek

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -275,31 +275,7 @@ public:
       this->f_frame_number_offset = 1;
     }
 
-    // Advance to first valid frame to get start time
-    this->f_start_time = 0;
-    if ( this->advance() )
-    {
-        this->f_start_time = this->f_pts;
-    }
-    else
-    {
-        LOG_ERROR(this->logger, "Error: failed to find valid frame to set start time");
-        this->f_start_time = -1;
-        return false;
-    }
-
-    // Now seek back to the start of the video
-    auto seek_rslt = av_seek_frame( this->f_format_context,
-                                    this->f_video_index,
-                                    0,
-                                    AVSEEK_FLAG_BACKWARD );
-    avcodec_flush_buffers( this->f_video_encoding );
-    if (seek_rslt < 0 )
-    {
-        LOG_ERROR(this->logger,
-                  "Error: failed to return to start after setting start time");
-        return false;
-    }
+    this->f_start_time = this->f_video_stream->start_time;
     this->frame_advanced = false;
     this->f_frame->data[0] = NULL;
     return true;

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -524,10 +524,9 @@ public:
       // Continue to make seek request further back until we land at a frame
       // that is before the requested frame.
       frame_ts -= this->f_backstep_size * this->stream_time_base_to_frame();
-      num_of_attempts++;
-      if ( num_of_attempts > this->max_seek_back_attempts )
+      if ( ++num_of_attempts > this->max_seek_back_attempts )
       {
-        LOG_ERROR( this->logger, "Seek failed, unable to seek back to early timestamp" );
+        LOG_ERROR( this->logger, "Seek failed: unable to seek back to early timestamp" );
         return false;
       }
     }

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -49,66 +49,43 @@ class ffmpeg_video_input::priv
 {
 public:
   /// Constructor
-  priv() :
-    f_format_context(avformat_alloc_context()),
-    f_video_index(-1),
-    f_video_encoding(nullptr),
-    f_video_stream(nullptr),
-    f_frame(nullptr),
-    f_filtered_frame(nullptr),
-    f_packet(nullptr),
-    f_software_context(nullptr),
-    f_filter_graph(nullptr),
-    f_filter_sink_context(nullptr),
-    f_filter_src_context(nullptr),
-    f_start_time(-1),
-    f_backstep_size(-1),
-    f_frame_number_offset(0),
-    video_path(""),
-    filter_desc("yadif=deint=1"),
-    frame_advanced(false),
-    end_of_video(true),
-    number_of_frames(0),
-    collected_all_metadata(false),
-    estimated_num_frames(false),
-    sync_metadata(true),
-    max_seek_back_attempts(10)
+  priv()
   { }
 
   // f_* variables are FFmpeg specific
 
-  AVFormatContext* f_format_context;
-  int f_video_index;
-  AVCodecContext* f_video_encoding;
-  AVStream* f_video_stream;
-  AVFrame* f_frame;
-  AVFrame* f_filtered_frame;
-  AVPacket* f_packet;
-  SwsContext* f_software_context;
-  AVFilterGraph* f_filter_graph;
-  AVFilterContext *f_filter_sink_context;
-  AVFilterContext *f_filter_src_context;
+  AVFormatContext* f_format_context = avformat_alloc_context();
+  int f_video_index = -1;
+  AVCodecContext* f_video_encoding = nullptr;
+  AVStream* f_video_stream = nullptr;
+  AVFrame* f_frame = nullptr;
+  AVFrame* f_filtered_frame = nullptr;
+  AVPacket* f_packet = nullptr;
+  SwsContext* f_software_context = nullptr;
+  AVFilterGraph* f_filter_graph = nullptr;
+  AVFilterContext* f_filter_sink_context = nullptr;
+  AVFilterContext* f_filter_src_context = nullptr;
 
   // Start time of the stream, to offset the pts when computing the frame number.
   // (in stream time base)
-  int64_t f_start_time;
+  int64_t f_start_time = -1;
 
   // Presentation timestamp (in stream time base)
   int64_t f_pts;
 
   // Number of frames to back step when seek fails to land on frame before request
-  int64_t f_backstep_size;
+  int64_t f_backstep_size = -1;
 
   // Some codec/file format combinations need a frame number offset.
   // These codecs have a delay between reading packets and generating frames.
-  unsigned f_frame_number_offset;
+  unsigned f_frame_number_offset = 0;
 
   // Name of video we opened
-  std::string video_path;
+  std::string video_path = "";
 
   // FFMPEG filter description string
   // What you put after -vf in the ffmpeg command line tool
-  std::string filter_desc;
+  std::string filter_desc = "yadif=deint=1";
 
   // the buffers of raw metadata from the data streams tagged with the timestamp
   std::map<int, std::multimap< int64_t, std::deque<uint8_t>>> metadata;
@@ -134,13 +111,13 @@ public:
   kwiver::vital::image_container_sptr current_image;
 
   // local state
-  bool frame_advanced;
-  bool end_of_video;
-  size_t number_of_frames;
-  bool collected_all_metadata;
-  bool estimated_num_frames;
-  bool sync_metadata;
-  size_t max_seek_back_attempts;
+  bool frame_advanced = false;
+  bool end_of_video = true;
+  size_t number_of_frames = 0;
+  bool collected_all_metadata = false;
+  bool estimated_num_frames = false;
+  bool sync_metadata = true;
+  size_t max_seek_back_attempts = 10;
 
   // ==================================================================
   /*


### PR DESCRIPTION
We have encountered some videos that ffmpeg does appear to be able to seek back to the start of the video. This triggers an infinite loop in our seek method. This is a simple fix to prevent that from happening.