### PR TITLE
Add missing python bindings for metadata map IO

### DIFF
--- a/python/kwiver/vital/algo/CMakeLists.txt
+++ b/python/kwiver/vital/algo/CMakeLists.txt
@@ -44,6 +44,7 @@ kwiver_add_python_library(algos
   match_descriptor_sets.h
   match_features.h
   merge_images.h
+  metadata_map_io.h
   optimize_cameras.h
   read_object_track_set.h
   read_track_descriptor_set.h
@@ -98,6 +99,7 @@ kwiver_add_python_library(algos
   match_descriptor_sets.cxx
   match_features.cxx
   merge_images.cxx
+  metadata_map_io.cxx
   optimize_cameras.cxx
   read_object_track_set.cxx
   read_track_descriptor_set.cxx
@@ -152,6 +154,7 @@ kwiver_add_python_library(algos
   trampoline/match_descriptor_sets_trampoline.txx
   trampoline/match_features_trampoline.txx
   trampoline/merge_images_trampoline.txx
+  trampoline/metadata_map_io_trampoline.txx
   trampoline/optimize_cameras_trampoline.txx
   trampoline/read_object_track_set_trampoline.txx
   trampoline/read_track_descriptor_set_trampoline.txx

--- a/python/kwiver/vital/algo/metadata_map_io.cxx
+++ b/python/kwiver/vital/algo/metadata_map_io.cxx
@@ -1,0 +1,55 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#include <python/kwiver/vital/algo/metadata_map_io.h>
+#include <python/kwiver/vital/algo/trampoline/metadata_map_io_trampoline.txx>
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace kwiver {
+
+namespace vital {
+
+namespace python {
+
+void
+metadata_map_io( py::module& m )
+{
+  py::class_< kwiver::vital::algo::metadata_map_io,
+              std::shared_ptr< kwiver::vital::algo::metadata_map_io >,
+              kwiver::vital::algorithm_def< kwiver::vital::algo::metadata_map_io >,
+              metadata_map_io_trampoline<> >( m, "MetadataMapIO" )
+    .def( py::init() )
+    .def_static( "static_type_name",
+                 &kwiver::vital::algo::metadata_map_io::static_type_name )
+    .def( "load",
+          static_cast< kwiver::vital::metadata_map_sptr
+                       (kwiver::vital::algo::metadata_map_io::*)
+                       (std::string const&) const >
+          ( &kwiver::vital::algo::metadata_map_io::load ) )
+    .def( "load",
+          static_cast< kwiver::vital::metadata_map_sptr
+                       (kwiver::vital::algo::metadata_map_io::*)
+                       ( std::istream&,
+                         std::string const& ) const >
+          ( &kwiver::vital::algo::metadata_map_io::load ) )
+    .def( "save",
+          static_cast< void(kwiver::vital::algo::metadata_map_io::*)
+                       ( std::string const&,
+                         kwiver::vital::metadata_map_sptr ) const >
+          ( &kwiver::vital::algo::metadata_map_io::save ) )
+    .def( "save",
+          static_cast< void(kwiver::vital::algo::metadata_map_io::*)
+                       ( std::ostream&, kwiver::vital::metadata_map_sptr,
+                         std::string const& ) const >
+          ( &kwiver::vital::algo::metadata_map_io::save ) );
+}
+
+} // namespace python
+
+} // namespace vital
+
+} // namespace kwiver

--- a/python/kwiver/vital/algo/metadata_map_io.h
+++ b/python/kwiver/vital/algo/metadata_map_io.h
@@ -1,0 +1,26 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef KWIVER_VITAL_PYTHON_METADATA_MAP_IO_H_
+#define KWIVER_VITAL_PYTHON_METADATA_MAP_IO_H_
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace kwiver {
+
+namespace vital {
+
+namespace python {
+
+void metadata_map_io( py::module& m );
+
+} // namespace python
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/python/kwiver/vital/algo/trampoline/metadata_map_io_trampoline.txx
+++ b/python/kwiver/vital/algo/trampoline/metadata_map_io_trampoline.txx
@@ -1,0 +1,82 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file metadata_map_io_trampoline.txx
+///
+/// \brief trampoline for overriding virtual functions for
+///        \link kwiver::vital::algo::metadata_map_io \endlink
+
+#ifndef METADATA_MAP_IO_TRAMPOLINE_TXX
+#define METADATA_MAP_IO_TRAMPOLINE_TXX
+
+#include <python/kwiver/vital/algo/trampoline/algorithm_trampoline.txx>
+#include <python/kwiver/vital/util/pybind11.h>
+#include <vital/algo/metadata_map_io.h>
+#include <vital/types/vector.h>
+
+namespace kwiver {
+
+namespace vital {
+
+namespace python {
+
+template < class algorithm_def_metadata_map_io_base =
+             kwiver::vital::algorithm_def< kwiver::vital::algo::metadata_map_io > >
+class algorithm_def_metadata_map_io_trampoline
+  : public algorithm_trampoline< algorithm_def_metadata_map_io_base >
+{
+public:
+  using algorithm_trampoline< algorithm_def_metadata_map_io_base >
+  ::algorithm_trampoline;
+
+  std::string
+  type_name() const override
+  {
+    VITAL_PYBIND11_OVERLOAD(
+      std::string,
+      kwiver::vital::algorithm_def< kwiver::vital::algo::metadata_map_io >,
+      type_name, );
+  }
+};
+
+template < class metadata_map_io_base = kwiver::vital::algo::metadata_map_io >
+class metadata_map_io_trampoline
+  : public algorithm_def_metadata_map_io_trampoline< metadata_map_io_base >
+{
+public:
+  using algorithm_def_metadata_map_io_trampoline< metadata_map_io_base >
+  ::algorithm_def_metadata_map_io_trampoline;
+
+  kwiver::vital::metadata_map_sptr
+  load_( std::istream& fin, std::string const& filename ) const override
+  {
+    VITAL_PYBIND11_OVERLOAD_PURE(
+      kwiver::vital::metadata_map_sptr,
+      kwiver::vital::algo::metadata_map_io,
+      load_,
+      fin,
+      filename );
+  }
+
+  void
+  save_( std::ostream& fout, kwiver::vital::metadata_map_sptr data,
+         std::string const& filename ) const override
+  {
+    VITAL_PYBIND11_OVERLOAD_PURE(
+      void,
+      kwiver::vital::algo::metadata_map_io,
+      save_,
+      fout,
+      data,
+      filename );
+  }
+};
+
+} // namespace python
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/python/kwiver/vital/tests/alg/simple_metadata_map_io.py
+++ b/python/kwiver/vital/tests/alg/simple_metadata_map_io.py
@@ -1,0 +1,32 @@
+# This file is part of KWIVER, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+from __future__ import print_function
+
+from kwiver.vital.algo import MetadataMapIO
+from kwiver.vital.tests.py_helpers import CommonConfigurationMixin
+
+
+class SimpleMetadataMapIO(CommonConfigurationMixin,
+                            MetadataMapIO):
+    """
+    Implementation of MetadataMapIO to test it
+    Examples:
+    """
+    def __init__(self):
+        MetadataMapIO.__init__(self)
+
+
+def __vital_algorithm_register__():
+    from kwiver.vital.algo import algorithm_factory
+
+    # Register Algorithm
+    implementation_name  = "MetadataMapIO"
+    if algorithm_factory.has_algorithm_impl_name(
+                            SimpleMetadataMapIO.static_type_name(),
+                            implementation_name):
+        return
+    algorithm_factory.add_algorithm( implementation_name,
+                                "Test kwiver.vital.algo.MetadataMapIO",
+                                 SimpleMetadataMapIO )
+    algorithm_factory.mark_algorithm_as_loaded( implementation_name )


### PR DESCRIPTION
I added this algorithm a while ago and @mleotta pointed out I failed to add the bindings. This was my first stab at binding anything so I'm not convinced this is correct, but it seems to make sense based on the docs and other examples. 