### PR TITLE
Allow pipeline includes in python, test

### DIFF
--- a/python/kwiver/sprokit/adapters/embedded_pipeline.cxx
+++ b/python/kwiver/sprokit/adapters/embedded_pipeline.cxx
@@ -38,7 +38,9 @@ public:
   void update_config(vital::config_block_sptr config) override;
 };
 
-void build_pipeline(embedded_pipeline& self, vital::path_t const& desc_file);
+void build_pipeline(embedded_pipeline& self,
+                    vital::path_t const& desc_file,
+                    std::string const& def_dir = "");
 
 }
 }
@@ -52,7 +54,9 @@ PYBIND11_MODULE(embedded_pipeline, m)
         std::shared_ptr<kwiver::embedded_pipeline>,
         ksp::embedded_pipeline_trampoline> ep(m, "EmbeddedPipeline");
   ep.def(init<>())
-  .def("build_pipeline", &ksp::build_pipeline)
+  .def("build_pipeline", &ksp::build_pipeline,
+    arg("desc_file"),
+    arg("def_dir") = "")
   .def("send", &kwiver::embedded_pipeline::send)
   .def("send_end_of_input", &kwiver::embedded_pipeline::send_end_of_input)
   .def("receive", &kwiver::embedded_pipeline::receive)
@@ -151,14 +155,16 @@ embedded_pipeline_trampoline
   );
 }
 
-void build_pipeline(embedded_pipeline& self, vital::path_t const& desc_file)
+void build_pipeline(embedded_pipeline& self,
+                    vital::path_t const& desc_file,
+                    std::string const& def_dir)
 {
   std::ifstream desc_stream(desc_file);
   if (! desc_stream )
   {
     throw ::sprokit::file_no_exist_exception(desc_file);
   }
-  self.build_pipeline(desc_stream);
+  self.build_pipeline(desc_stream, def_dir);
 }
 }
 }

--- a/python/kwiver/sprokit/tests/sprokit/adapters/pipelines/simple_input_adapter.pipe
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/pipelines/simple_input_adapter.pipe
@@ -1,0 +1,1 @@
+process ia  :: input_adapter

--- a/python/kwiver/sprokit/tests/sprokit/adapters/pipelines/test_includes.pipe
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/pipelines/test_includes.pipe
@@ -1,0 +1,4 @@
+include simple_input_adapter.pipe
+
+process oa  :: output_adapter
+connect from ia.port1  to  oa.port1

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-embedded_pipeline.py
@@ -30,6 +30,7 @@
 
 from kwiver.sprokit.util.test import find_tests, run_test, test_error
 
+
 def test_import(cpp_pipeline_dir, py_pipeline_dir):
     try:
         import kwiver.sprokit.adapters.embedded_pipeline
@@ -114,7 +115,6 @@ def test_api_calls(cpp_pipeline_dir, py_pipeline_dir):
         for (port, d) in ods:
             print("   port:", port, " value:", d.get_int())
 
-
     ep.wait()
 
     #######
@@ -127,8 +127,29 @@ def test_api_calls(cpp_pipeline_dir, py_pipeline_dir):
     ods = ep.receive()
     ep.stop()
 
+
+def _create_detected_object_set():
+    from kwiver.vital.types import (
+        DetectedObject,
+        DetectedObjectSet,
+        BoundingBoxD,
+    )
+
+    dos = DetectedObjectSet()
+    bbox = BoundingBoxD(0, 10, 100, 50)
+    dos.add(DetectedObject(bbox, 0.2))
+    dos.add(DetectedObject(bbox, 0.5))
+    dos.add(DetectedObject(bbox, 0.4))
+
+    return dos
+
+
 def run_roundtrip_pipeline(py_pipeline_dir, ads_in):
-    from kwiver.vital.types import DetectedObject, DetectedObjectSet, BoundingBoxD
+    from kwiver.vital.types import (
+        DetectedObject,
+        DetectedObjectSet,
+        BoundingBoxD,
+    )
     from kwiver.sprokit.adapters import adapter_data_set, embedded_pipeline
 
     pipeline_fname = "py_to_cpp_type_conversion.pipe"
@@ -151,22 +172,16 @@ def run_roundtrip_pipeline(py_pipeline_dir, ads_in):
 
     ep.wait()
 
-def _create_detected_object_set():
-    from kwiver.vital.types import DetectedObject, DetectedObjectSet, BoundingBoxD
-
-    dos = DetectedObjectSet()
-    bbox = BoundingBoxD(0, 10, 100, 50)
-    dos.add(DetectedObject(bbox, 0.2))
-    dos.add(DetectedObject(bbox, 0.5))
-    dos.add(DetectedObject(bbox, 0.4))
-
-    return dos
 
 # We need to check that objects added in a python process
 # are usable by raw C++ code. We'll use run_roundtrip_pipeline to make sure
 # C++ objects can be converted on both sides
 def test_cpp_conversion(cpp_pipeline_dir, py_pipeline_dir):
-    from kwiver.vital.types import DetectedObject, DetectedObjectSet, BoundingBoxD
+    from kwiver.vital.types import (
+        DetectedObject,
+        DetectedObjectSet,
+        BoundingBoxD,
+    )
     from kwiver.sprokit.adapters import adapter_data_set, embedded_pipeline
     from kwiver.sprokit.pipeline import datum
 
@@ -179,8 +194,44 @@ def test_cpp_conversion(cpp_pipeline_dir, py_pipeline_dir):
     # Create fresh objects. Make sure that this also works with adding datums directly
     ads_in = adapter_data_set.AdapterDataSet.create()
     ads_in["detected_object_set"] = datum.new(_create_detected_object_set())
-    print("Starting roundtrip pipeline with a datum containing a detected_object_set")
+    print(
+        "Starting roundtrip pipeline with a datum containing a detected_object_set"
+    )
     run_roundtrip_pipeline(py_pipeline_dir, ads_in)
+
+
+def test_including_pipe_files(cpp_pipeline_dir, py_pipeline_dir):
+    from kwiver.vital.types import (
+        DetectedObject,
+        DetectedObjectSet,
+        BoundingBoxD,
+    )
+    from kwiver.sprokit.adapters import adapter_data_set, embedded_pipeline
+
+    pipeline_fname = "test_includes.pipe"
+    path_to_pipe_file = os.path.join(py_pipeline_dir, pipeline_fname)
+
+    ep = embedded_pipeline.EmbeddedPipeline()
+
+    # Note that we include an extra parameter here. This is where
+    # to look for included pipe files
+    ep.build_pipeline(path_to_pipe_file, py_pipeline_dir)
+
+    ep.start()
+
+    ads_in = adapter_data_set.AdapterDataSet.create()
+    ads_in["port1"] = _create_detected_object_set()
+    print("Sending ads:", ads_in)
+    ep.send(ads_in)
+    ep.send_end_of_input()
+
+    while True:
+        ods = ep.receive()
+        if ods.is_end_of_data():
+            break
+        print("Recieved detected_object_set:", ods["port1"])
+
+    ep.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small PR that adds a missing parameter to the `embedded_pipeline::build_pipeline` binding. This new bound parameter allows users to set a directory where other included pipe files should be included. Also added a test.