### PR TITLE
[VIAME] Various fixes for viame/next

### DIFF
--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -329,7 +329,7 @@ darknet_detector
   if( d->m_gs_to_rgb && cv_resized_image.channels() == 1 )
   {
     cv::Mat color_image;
-    cv::cvtColor( cv_resized_image, color_image, CV_GRAY2RGB );
+    cv::cvtColor( cv_resized_image, color_image, cv::COLOR_GRAY2RGB );
     cv_resized_image = color_image;
   }
 
@@ -397,7 +397,7 @@ darknet_detector
       if( d->m_gs_to_rgb && scaled_original.channels() == 1 )
       {
         cv::Mat color_image;
-        cv::cvtColor( scaled_original, color_image, CV_GRAY2RGB );
+        cv::cvtColor( scaled_original, color_image, cv::COLOR_GRAY2RGB );
         scaled_original = color_image;
       }
 

--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -674,7 +674,7 @@ darknet_trainer::priv
   if( m_gs_to_rgb && image.channels() == 1 )
   {
     cv::Mat color_image;
-    cv::cvtColor( image, color_image, CV_GRAY2RGB );
+    cv::cvtColor( image, color_image, cv::COLOR_GRAY2RGB );
     original_image = color_image;
   }
   else

--- a/arrows/database/write_object_track_set_db.cxx
+++ b/arrows/database/write_object_track_set_db.cxx
@@ -51,6 +51,7 @@ public:
     : m_parent( parent )
     , m_logger( kwiver::vital::get_logger( "write_object_track_set_db" ) )
     , m_commit_interval( 1 )
+    , m_matching_frames_only( true )
   { }
 
   ~priv() { }
@@ -61,6 +62,7 @@ public:
   std::string m_conn_str;
   std::string m_video_name;
   unsigned int m_commit_interval;
+  bool m_matching_frames_only;
   unsigned int m_commit_frame_counter;
   std::unique_ptr<cppdb::transaction> m_tran;
 };
@@ -89,6 +91,8 @@ write_object_track_set_db
   d->m_video_name = config->get_value< std::string > ( "video_name", "" );
   d->m_commit_interval =
     config->get_value<unsigned int>( "commit_interval", d->m_commit_interval );
+  d->m_matching_frames_only =
+    config->get_value<bool>( "matching_frames_only", d->m_matching_frames_only );
 }
 
 
@@ -187,7 +191,7 @@ write_object_track_set_db
         continue;
       }
 
-      if( trkstate->frame() != ts.get_frame() )
+      if( d->m_matching_frames_only && trkstate->frame() != ts.get_frame() )
       {
         continue;
       }

--- a/arrows/ocv/convert_color_space.cxx
+++ b/arrows/ocv/convert_color_space.cxx
@@ -35,17 +35,17 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::XYZ:
-          return CV_RGB2XYZ;
+          return cv::COLOR_RGB2XYZ;
         case vital::YCrCb:
-          return CV_RGB2YCrCb;
+          return cv::COLOR_RGB2YCrCb;
         case vital::HSV:
-          return CV_RGB2HSV;
+          return cv::COLOR_RGB2HSV;
         case vital::HLS:
-          return CV_RGB2HLS;
+          return cv::COLOR_RGB2HLS;
         case vital::Lab:
-          return CV_RGB2Lab;
+          return cv::COLOR_RGB2Lab;
         case vital::Luv:
-          return CV_RGB2Luv;
+          return cv::COLOR_RGB2Luv;
         default:
           return CV_Invalid;
       }
@@ -53,17 +53,17 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::XYZ:
-          return CV_BGR2XYZ;
+          return cv::COLOR_BGR2XYZ;
         case vital::YCrCb:
-          return CV_BGR2YCrCb;
+          return cv::COLOR_BGR2YCrCb;
         case vital::HSV:
-          return CV_BGR2HSV;
+          return cv::COLOR_BGR2HSV;
         case vital::HLS:
-          return CV_BGR2HLS;
+          return cv::COLOR_BGR2HLS;
         case vital::Lab:
-          return CV_BGR2Lab;
+          return cv::COLOR_BGR2Lab;
         case vital::Luv:
-          return CV_BGR2Luv;
+          return cv::COLOR_BGR2Luv;
         default:
           return CV_Invalid;
       }
@@ -71,9 +71,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_HSV2RGB;
+          return cv::COLOR_HSV2RGB;
         case vital::BGR:
-          return CV_HSV2BGR;
+          return cv::COLOR_HSV2BGR;
         default:
           return CV_Invalid;
       }
@@ -81,9 +81,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_HLS2RGB;
+          return cv::COLOR_HLS2RGB;
         case vital::BGR:
-          return CV_HLS2BGR;
+          return cv::COLOR_HLS2BGR;
         default:
           return CV_Invalid;
       }
@@ -91,9 +91,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_XYZ2RGB;
+          return cv::COLOR_XYZ2RGB;
         case vital::BGR:
-          return CV_XYZ2BGR;
+          return cv::COLOR_XYZ2BGR;
         default:
           return CV_Invalid;
       }
@@ -101,9 +101,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_Lab2RGB;
+          return cv::COLOR_Lab2RGB;
         case vital::BGR:
-          return CV_Lab2BGR;
+          return cv::COLOR_Lab2BGR;
         default:
           return CV_Invalid;
       }
@@ -111,9 +111,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_Luv2RGB;
+          return cv::COLOR_Luv2RGB;
         case vital::BGR:
-          return CV_Luv2BGR;
+          return cv::COLOR_Luv2BGR;
         default:
           return CV_Invalid;
       }
@@ -121,9 +121,9 @@ cv_convert_code lookup_cv_conversion_code(
       switch( space2 )
       {
         case vital::RGB:
-          return CV_YCrCb2RGB;
+          return cv::COLOR_YCrCb2RGB;
         case vital::BGR:
-          return CV_YCrCb2BGR;
+          return cv::COLOR_YCrCb2BGR;
         default:
           return CV_Invalid;
       }
@@ -144,7 +144,7 @@ public:
   priv()
    : input_color_space( vital::RGB )
    , output_color_space( vital::HLS )
-   , conversion_code( CV_RGB2HLS )
+   , conversion_code( cv::COLOR_RGB2HLS )
   {
   }
 

--- a/arrows/ocv/extract_descriptors_DAISY.cxx
+++ b/arrows/ocv/extract_descriptors_DAISY.cxx
@@ -79,7 +79,7 @@ public:
                        "amount of angular range division quantity" );
     config->set_value( "q_hist", q_hist,
                        "amount of gradient orientations range division quantity" );
-    config->set_value( "norm", norm,
+    config->set_value( "norm", static_cast< int >( norm ),
                        "descriptor normalization type. valid choices:\n"
                        + list_norm_options() );
     config->set_value( "interpolation", interpolation,
@@ -94,7 +94,7 @@ public:
     q_radius = config->get_value<int>( "q_radius" );
     q_theta = config->get_value<int>( "q_theta" );
     q_hist = config->get_value<int>( "q_hist" );
-    norm = config->get_value<int>( "norm" );
+    norm = static_cast< decltype( norm ) >( config->get_value<int>( "norm" ) );
     interpolation = config->get_value<bool>( "interpolation" );
     use_orientation = config->get_value<bool>( "use_orientation" );
   }
@@ -119,7 +119,11 @@ public:
   int q_radius;
   int q_theta;
   int q_hist;
+#if KWIVER_OPENCV_VERSION_MAJOR >= 4
+  cv::xfeatures2d::DAISY::NormalizationType norm;
+#else
   int norm;
+#endif
   bool interpolation;
   bool use_orientation;
 };

--- a/arrows/ocv/feature_detect_extract_SIFT.cxx
+++ b/arrows/ocv/feature_detect_extract_SIFT.cxx
@@ -13,16 +13,22 @@
 
 #if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
 
+#include <opencv2/core/version.hpp>
+
 // Include the correct file and unify different namespace locations of SIFT type
 // across versions
-#if KWIVER_OPENCV_VERSION_MAJOR < 3
+#if CV_VERSION_MAJOR < 3
 // 2.4.x header location
 #include <opencv2/nonfree/features2d.hpp>
 typedef cv::SIFT cv_SIFT_t;
-#else
-// 3.x header location
+#elif CV_VERSION_MAJOR < 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR < 3)
+// 3.x - 4.2 header location
 #include <opencv2/xfeatures2d/nonfree.hpp>
 typedef cv::xfeatures2d::SIFT cv_SIFT_t;
+#else
+// 4.4+ header location
+#include <opencv2/features2d.hpp>
+typedef cv::SIFT cv_SIFT_t;
 #endif
 
 using namespace kwiver::vital;

--- a/python/kwiver/sprokit/processes/pytorch/CMakeLists.txt
+++ b/python/kwiver/sprokit/processes/pytorch/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
   sprokit/processes/pytorch
-  __init__.py )
+  __init__ )
 
 kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/srnn_tracker.py
   sprokit/processes/pytorch

--- a/python/kwiver/sprokit/processes/pytorch/alexnet_descriptors.py
+++ b/python/kwiver/sprokit/processes/pytorch/alexnet_descriptors.py
@@ -139,7 +139,7 @@ class AlexNetDescriptors(KwiverProcess):
 
                 # get new track state from new frame and detections
                 for idx, item in enumerate(dos):
-                    bbox = item.bounding_box()
+                    bbox = item.bounding_box
                     fid = timestamp.get_frame()
                     ts = timestamp.get_time_usec()
                     d_obj = item

--- a/python/kwiver/sprokit/processes/pytorch/pysot_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/pysot_tracker.py
@@ -216,12 +216,12 @@ class PYSOTTracker(KwiverProcess):
               ( not trk.id in self._track_init_frames or \
               self._track_init_frames[ trk.id ] < self._last_ts.get_frame() ):
                 init_detection = trk[trk.last_frame].detection()
-                initialize_track(trk.id, init_detection.bounding_box(),
+                initialize_track(trk.id, init_detection.bounding_box,
                   self._last_ts, self._last_img, init_detection.type())
             # This track has an initialization signal for the current frame
             elif trk[trk.last_frame].frame_id == frame_id:
                 init_detection = trk[trk.last_frame].detection()
-                initialize_track(trk.id, init_detection.bounding_box(),
+                initialize_track(trk.id, init_detection.bounding_box,
                   ts, img, init_detection.type())
                 frame_boxes.append(bbox)
 
@@ -264,7 +264,7 @@ class PYSOTTracker(KwiverProcess):
             detections = detections.select(self._init_threshold)
             for det in detections:
                 # Check for overlap
-                cbox = det.bounding_box()
+                cbox = det.bounding_box
                 overlaps = False
                 for obox in frame_boxes:
                     if box_intersect(cbox, obox) > self._init_intersect:

--- a/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
@@ -399,7 +399,7 @@ class SRNNTracker(KwiverProcess):
 
                         if -similarity_mat[r, c] < self._similarity_threshold:
                             # initialize a new track
-                            if (track_state_list[c].detected_object.confidence()
+                            if (track_state_list[c].detected_object.confidence
                                    >= self._track_initialization_threshold):
                                 self._track_set.add_new_track_state(next_track_id,
                                         track_state_list[c])
@@ -412,7 +412,7 @@ class SRNNTracker(KwiverProcess):
                     if len(track_state_list) - len(col_idx_list) > 0:
                         for i in range(len(track_state_list)):
                             if (i not in col_idx_list
-                                and (track_state_list[i].detected_object.confidence()
+                                and (track_state_list[i].detected_object.confidence
                                      >= self._track_initialization_threshold)):
                                 self._track_set.add_new_track_state(next_track_id,
                                         track_state_list[i])

--- a/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
+++ b/python/kwiver/sprokit/processes/pytorch/srnn_tracker.py
@@ -334,7 +334,7 @@ class SRNNTracker(KwiverProcess):
                         ts = self._step_id
                         d_obj = DetectedObject(bbox=item, confidence=1.0)
                     else:
-                        bbox = item.bounding_box()
+                        bbox = item.bounding_box
                         fid = timestamp.get_frame()
                         ts = timestamp.get_time_usec()
                         d_obj = item

--- a/python/kwiver/sprokit/processes/pytorch/utils/CMakeLists.txt
+++ b/python/kwiver/sprokit/processes/pytorch/utils/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
   sprokit/processes/pytorch/utils
-  __init__.py )
+  __init__ )
 
 kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/siamese_feature_extractor.py
   sprokit/processes/pytorch/utils

--- a/python/kwiver/sprokit/processes/pytorch/utils/alexnet_feature_extractor.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/alexnet_feature_extractor.py
@@ -50,7 +50,7 @@ class AlexNetDataLoader( data.Dataset ):
         self._in_size = in_size
 
     def __getitem__( self, index ):
-        bb = self._bbox_list[index].bounding_box()
+        bb = self._bbox_list[index].bounding_box
 
         # unwrap
         min_x = float( bb.min_x() )

--- a/python/kwiver/sprokit/processes/pytorch/utils/augmented_resnet_feature_extractor.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/augmented_resnet_feature_extractor.py
@@ -88,7 +88,7 @@ class AugmentedResnetDataLoader(data.Dataset):
 
     def __getitem__(self, index):
         bid = int(math.floor(index / self._rot_shifts))
-        bb = self._bbox_list[bid].bounding_box()
+        bb = self._bbox_list[bid].bounding_box
         rot = float( 360.0 * ( index % self._rot_shifts ) ) / self._rot_shifts - 180.0
 
         # unwrap

--- a/python/kwiver/sprokit/processes/pytorch/utils/grid.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/grid.py
@@ -60,7 +60,7 @@ class Grid(object):
         bbox_id_centerIDX = []
         # build the grid for current image
         for item in bbox_list:
-            bb = item if mot_flag else item.bounding_box()
+            bb = item if mot_flag else item.bounding_box
 
             x = int(bb.min_x())
             y = int(bb.min_y())

--- a/python/kwiver/sprokit/processes/pytorch/utils/siamese_feature_extractor.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/siamese_feature_extractor.py
@@ -52,7 +52,7 @@ class SiameseDataLoader(data.Dataset):
         self._in_size = in_size
 
     def __getitem__(self, index):
-        bb = self._bbox_list[index] if self._mot_flag else self._bbox_list[index].bounding_box()
+        bb = self._bbox_list[index] if self._mot_flag else self._bbox_list[index].bounding_box
         im = self._frame_img.crop((float(bb.min_x()), float(bb.min_y()),
                       float(bb.max_x()), float(bb.max_y())))
         im = im.resize((self._in_size, self._in_size), pilImage.BILINEAR)

--- a/python/kwiver/sprokit/processes/pytorch/utils/track.py
+++ b/python/kwiver/sprokit/processes/pytorch/utils/track.py
@@ -55,7 +55,7 @@ class track_state(object):
 
         # FIXME: the detected_object confidence does not work
         # For now, I just set the confidence = 1.0
-        #self.conf = detectedObject.confidence()
+        #self.conf = detectedObject.confidence
         self.conf = 1.0
 
 
@@ -147,7 +147,7 @@ class track_set(object):
     def add_new_track_state_list(self, start_track_id, ts_list, thresh=0.0):
         track_id = start_track_id
         for ts in ts_list:
-            if ts.detected_object.confidence() >= thresh:
+            if ts.detected_object.confidence >= thresh:
                 self.add_new_track_state(track_id, ts)
                 track_id += 1
         return track_id


### PR DESCRIPTION
This adds various fixes for `viame/next`:
- Updates to the PyTorch-based processes to handle the upstream binding changes
- Fixes for OpenCV 4 compatibility
- An option `matching_frames_only` for `write_object_track_set_db`

~~Note that the fix to `extract_descriptors_DAISY` for OpenCV 4 breaks compatibility with earlier versions. Let me know if we want a  better fix. (It's already in upstream somewhere.)~~  **Edit:** Done.