### PR TITLE
Add intermediate conversion step burnout

### DIFF
--- a/config/pipelines/detect_burnin.pipe
+++ b/config/pipelines/detect_burnin.pipe
@@ -79,6 +79,13 @@ process detect_burnin__out_mask
   :: image_filter
   filter:type                           = vxl_convert_image
   filter:vxl_convert_image:type         = byte
+  filter:vxl_convert_image:scale_factor = 1
+
+# =============================================================================
+process detect_burnin__out_mask_scaled
+  :: image_filter
+  filter:type                           = vxl_convert_image
+  filter:vxl_convert_image:type         = byte
   filter:vxl_convert_image:scale_factor = 255
 
 ###############################################################################
@@ -103,3 +110,6 @@ connect from detect_burnin__closer.image
 
 connect from detect_burnin__dilater.image
         to   detect_burnin__out_mask.image
+
+connect from detect_burnin__out_mask.image
+        to   detect_burnin__out_mask_scaled.image

--- a/examples/pipelines/burnout_on_video.pipe.in
+++ b/examples/pipelines/burnout_on_video.pipe.in
@@ -19,12 +19,20 @@ process input
 #   image_writer:vxl:split_channels       = true
 
 # ================================================================
-process writer
+process inpainted_writer
   :: image_writer
   image_writer:type                     = vxl
-  file_name_template                    = output/image%06d.png
-  image_writer:vxl:force_byte           = true
-  image_writer:vxl:auto_stretch         = true
+  file_name_template                    = inpainted/image%06d.png
+  image_writer:vxl:force_byte           = false
+  image_writer:vxl:auto_stretch         = false
+
+# ================================================================
+process mask_writer
+  :: image_writer
+  image_writer:type                     = vxl
+  file_name_template                    = mask/image%06d.png
+  image_writer:vxl:force_byte           = false
+  image_writer:vxl:auto_stretch         = false
 
 ###############################################################################
 
@@ -35,5 +43,8 @@ connect from input.image
 # connect from detect_burnin__filter.image
 #         to filtered_writer.image
 
+connect from detect_burnin__out_mask_scaled.image
+        to   mask_writer.image
+
 connect from inpaint_burnin__out_inpainted.image
-        to   writer.image
+        to   inpainted_writer.image


### PR DESCRIPTION
This is a slight cleanup and a potential fix to @mwoehlke-kitware 's ref-counting issue while using detection and inpainting in an embedded pipeline. From his description, it sounds possible the embedded pipeline cannot have data from a non-terminal pipeline port be consumed by an external application. This change addresses this issue by breaking the step which converts the mask from `bool` to a `byte` in the range `[0, 255]` into two steps. The unscaled `byte` output from `detect_burnout__out_mask` is used by the inpainter, which hopefully allows the scaled output, `detect_burnout__out_mask_scaled` to be uncorrupted when consumed by an external application. 

I can't easily test this in an embedded pipeline right now. The only thing I know is the example works, but I've never had issues with that. 