### PR TITLE
Fix end_of_video for video_input_filter

### DIFF
--- a/arrows/core/video_input_filter.cxx
+++ b/arrows/core/video_input_filter.cxx
@@ -293,6 +293,7 @@ video_input_filter
 
     if ( ! status )
     {
+      d->d_at_eov = d->d_video_input->end_of_video();
       return false;
     }
 


### PR DESCRIPTION
Modify `video_input_filter` to check, when a seek fails, if the underlying algorithm is at end-of-video and set the internal flag accordingly. This fixes `video_input_filter` failing to ever set end-of-video.