### PR TITLE
GCC 11 warns us when we are making data copies in range for loop

### DIFF
--- a/arrows/ceres/optimize_cameras.cxx
+++ b/arrows/ceres/optimize_cameras.cxx
@@ -312,7 +312,7 @@ optimize_cameras
 
   // extract the landmark parameters
   std::vector<std::vector<double> > landmark_params;
-  for(const landmark_sptr lm : landmarks)
+  for(auto const& lm : landmarks)
   {
     vector_3d loc = lm->loc();
     landmark_params.push_back(std::vector<double>(loc.data(), loc.data()+3));

--- a/arrows/core/colorize.cxx
+++ b/arrows/core/colorize.cxx
@@ -76,7 +76,7 @@ vital::landmark_map_sptr compute_landmark_colors(
   auto colored_landmarks = landmarks.landmarks();
   auto const no_such_landmark = colored_landmarks.end();
 
-  for (auto const track : tracks.tracks())
+  for (auto const& track : tracks.tracks())
   {
     auto const lmid = static_cast<vital::landmark_id_t>(track->id());
     auto lmi = colored_landmarks.find(lmid);

--- a/arrows/core/detected_object_set_output_kw18.cxx
+++ b/arrows/core/detected_object_set_output_kw18.cxx
@@ -232,7 +232,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set,
 
       double f1 = 0.0, f2 = 0.0, f3 = 0.0;
 
-      for( const std::string id : d->m_parsed_tot_ids1 )
+      for( auto const& id : d->m_parsed_tot_ids1 )
       {
         if( clf->has_class_name( id ) )
         {
@@ -240,7 +240,7 @@ write_set( const kwiver::vital::detected_object_set_sptr set,
         }
       }
 
-      for( const std::string id : d->m_parsed_tot_ids2 )
+      for( auto const& id : d->m_parsed_tot_ids2 )
       {
         if( clf->has_class_name( id ) )
         {

--- a/arrows/core/feature_descriptor_io.cxx
+++ b/arrows/core/feature_descriptor_io.cxx
@@ -95,7 +95,7 @@ template <typename Archive, typename T>
 void
 save_features(Archive & ar, std::vector<feature_sptr> const& features)
 {
-  for( const feature_sptr f : features )
+  for( auto const& f : features )
   {
     if( !f )
     {

--- a/arrows/serialize/json/load_save.cxx
+++ b/arrows/serialize/json/load_save.cxx
@@ -497,7 +497,7 @@ void load( ::cereal::JSONInputArchive& archive, ::kwiver::vital::polygon& poly )
   std::vector< ::kwiver::vital::polygon::point_t > points;
   archive( CEREAL_NVP( points ) );
 
-  for ( const auto pt : points )
+  for ( auto const& pt : points )
   {
     poly.push_back( pt );
   }

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -696,7 +696,7 @@ void convert_protobuf( const ::kwiver::vital::geo_point& point,
 void convert_protobuf( const ::kwiver::protobuf::polygon&  proto_poly,
                        ::kwiver::vital::polygon& poly )
 {
-  for ( const auto vert : proto_poly.point_list() )
+  for ( auto const& vert : proto_poly.point_list() )
   {
     poly.push_back( vert.x(), vert.y() );
   }
@@ -707,7 +707,7 @@ void convert_protobuf( const ::kwiver::vital::polygon& poly,
                        ::kwiver::protobuf::polygon&  proto_poly )
 {
   const auto vertices = poly.get_vertices();
-  for ( const auto vert : vertices )
+  for ( auto const& vert : vertices )
   {
     auto* proto_item = proto_poly.add_point_list();
     proto_item->set_x( vert[0] );

--- a/sprokit/processes/adapters/output_adapter_process.cxx
+++ b/sprokit/processes/adapters/output_adapter_process.cxx
@@ -118,7 +118,7 @@ output_adapter_process
   auto data_set = kwiver::adapter::adapter_data_set::create();
 
   // The grab call is blocking, so it will wait until data is there.
-  for( auto const p : m_active_ports )
+  for( auto const& p : m_active_ports )
   {
     LOG_TRACE( logger(), "Getting data from port \"" << p <<"\"" );
 

--- a/sprokit/processes/core/deserializer_process.cxx
+++ b/sprokit/processes/core/deserializer_process.cxx
@@ -103,7 +103,7 @@ deserializer_process
   scoped_step_instrumentation();
 
   // Loop over all registered groups
-  for (const auto msg_spec_it : m_message_spec_list )
+  for (auto const& msg_spec_it : m_message_spec_list )
   {
     // Each iteration of this loop expects a multi-element message
     // with the following format

--- a/sprokit/processes/core/merge_detection_sets_process.cxx
+++ b/sprokit/processes/core/merge_detection_sets_process.cxx
@@ -68,7 +68,7 @@ merge_detection_sets_process
 
   auto set_out = std::make_shared< vital::detected_object_set > ();
 
-  for ( const auto port_name : d->p_port_list )
+  for ( auto const& port_name : d->p_port_list )
   {
     vital::detected_object_set_sptr set_in = grab_from_port_as<vital::detected_object_set_sptr>( port_name );
     set_out->add( set_in );

--- a/sprokit/processes/core/merge_images_process.cxx
+++ b/sprokit/processes/core/merge_images_process.cxx
@@ -83,7 +83,7 @@ merge_images_process
 {
   std::vector<kwiver::vital::image_container_sptr> image_list;
 
-  for ( const auto port_name : d->p_port_list )
+  for ( auto const& port_name : d->p_port_list )
   {
     kwiver::vital::image_container_sptr image_sptr =
         grab_from_port_as<kwiver::vital::image_container_sptr>( port_name );

--- a/sprokit/processes/core/print_config_process.cxx
+++ b/sprokit/processes/core/print_config_process.cxx
@@ -90,7 +90,7 @@ _step()
   }
 
   // The grab call is blocking, so it will wait until data is there.
-  for( auto const p : d->m_active_ports )
+  for( auto const& p : d->m_active_ports )
   {
     auto dtm = this->grab_datum_from_port( p );
   } // end foreach

--- a/sprokit/processes/core/serializer_base.cxx
+++ b/sprokit/processes/core/serializer_base.cxx
@@ -294,7 +294,7 @@ decode_message( const std::string& message )
 void serializer_base::
 dump_msg_spec()
 {
-  for ( const auto it : m_message_spec_list )
+  for ( auto const& it : m_message_spec_list )
   {
     std::cout << "Message tag: " << it.first << std::endl;
 
@@ -302,7 +302,7 @@ dump_msg_spec()
 
     std::cout << "   Serialized port name: " << msg_spec.m_serialized_port_name << std::endl;
 
-    for ( const auto elem_it : msg_spec.m_elements )
+    for ( auto const& elem_it : msg_spec.m_elements )
     {
       const auto& msg_elem = elem_it.second;
 

--- a/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
+++ b/sprokit/tests/sprokit/pipeline/test_process_introspection.cxx
@@ -48,7 +48,7 @@ main()
   //+ Check attribute kwiver::vital::plugin_factory::PLUGIN_NAME for duplicates
   // within the list
 
-  for( const auto fact : proc_list )
+  for( auto const& fact : proc_list )
   {
     sprokit::process::type_t type;
     if ( ! fact->get_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, type ) )

--- a/track_oracle/core/track_oracle_core_impl.cxx
+++ b/track_oracle/core/track_oracle_core_impl.cxx
@@ -147,7 +147,7 @@ track_oracle_core_impl
 {
  std::lock_guard< std::mutex > lock( this->api_lock );
  vector< field_handle_type > ret;
- for (const auto p: this->name_pool)
+ for (auto const& p: this->name_pool)
  {
    ret.push_back( p.second );
  }

--- a/vital/plugin_loader/plugin_filter_default.cxx
+++ b/vital/plugin_loader/plugin_filter_default.cxx
@@ -56,7 +56,7 @@ plugin_filter_default
   // Check the two types and name as a signature.
   if ( fact_list.size() > 0)
   {
-    for( auto const afact : fact_list )
+    for( auto const& afact : fact_list )
     {
       std::string interf;
       afact->get_attribute( plugin_factory::INTERFACE_TYPE, interf );

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -187,7 +187,7 @@ plugin_loader
 {
   std::vector< std::string > retval;
 
-  for( auto const it : m_impl->m_library_map )
+  for( auto const& it : m_impl->m_library_map )
   {
     retval.push_back( it.first );
   } // end foreach

--- a/vital/tools/plugin_explorer.cxx
+++ b/vital/tools/plugin_explorer.cxx
@@ -220,7 +220,7 @@ display_factory( kwiver::vital::plugin_factory_handle_t const fact )
 void display_by_category( const kwiver::vital::plugin_map_t& plugin_map,
                           const std::string& category )
 {
-  for( const auto it : plugin_map )
+  for( auto const& it : plugin_map )
   {
     std::string ds = kwiver::vital::demangle( it.first );
 
@@ -237,7 +237,7 @@ void display_by_category( const kwiver::vital::plugin_map_t& plugin_map,
     }
 
     // Get vector of factories
-    for( kwiver::vital::plugin_factory_handle_t const fact : facts )
+    for( auto const& fact : facts )
     {
       std::string cat;
       if ( ! fact->get_attribute( kvpf::PLUGIN_CATEGORY, cat )
@@ -714,7 +714,7 @@ main( int argc, char* argv[] )
   {
     pe_out() << "---- Registered module names:\n";
     auto module_list = vpm.module_map();
-    for( auto const name : module_list )
+    for( auto const& name : module_list )
     {
       pe_out() << "   " << name.first << "  loaded from: " << name.second << std::endl;
     }
@@ -774,7 +774,7 @@ main( int argc, char* argv[] )
 
       // Get vector of factories
       kwiver::vital::plugin_factory_vector_t const& facts = it.second;
-      for( kwiver::vital::plugin_factory_handle_t const fact : facts )
+      for( auto const& fact : facts )
       {
         // If regexp matching is enabled, and this does not match, skip it
         if ( G_context.opt_type_filt )

--- a/vital/types/feature_track_set.cxx
+++ b/vital/types/feature_track_set.cxx
@@ -72,7 +72,7 @@ feature_track_set
 {
   std::vector<feature_sptr> features;
   std::vector<track_state_sptr> fsd = this->frame_states(offset);
-  for( auto const data : fsd )
+  for( auto const& data : fsd )
   {
     feature_sptr f = nullptr;
     auto fdata = std::dynamic_pointer_cast<feature_track_state>(data);
@@ -92,7 +92,7 @@ feature_track_set
 {
   std::vector<descriptor_sptr> descriptors;
   std::vector<track_state_sptr> fsd = this->frame_states(offset);
-  for( auto const data : fsd )
+  for( auto const& data : fsd )
   {
     descriptor_sptr d = nullptr;
     auto fdata = std::dynamic_pointer_cast<feature_track_state>(data);
@@ -113,7 +113,7 @@ feature_track_set
 {
   std::vector<feature_track_state_sptr>  feat_states;
   std::vector<track_state_sptr> fsd = this->frame_states(offset);
-  for (auto const data : fsd)
+  for (auto const& data : fsd)
   {
     auto fdata = std::dynamic_pointer_cast<feature_track_state>(data);
     if (fdata)
@@ -135,7 +135,7 @@ feature_track_set
   std::vector<descriptor_sptr> descriptors;
   std::vector<track_state_sptr> fsd = this->frame_states(offset);
 
-  for (auto const data : fsd)
+  for (auto const& data : fsd)
   {
     feature_sptr f = nullptr;
     descriptor_sptr d = nullptr;

--- a/vital/types/track.cxx
+++ b/vital/types/track.cxx
@@ -269,7 +269,7 @@ track
 {
   std::set< frame_id_t > ids;
 
-  for( track_state_sptr const ts : this->history_ )
+  for( auto const& ts : this->history_ )
   {
     ids.insert( ts->frame() );
   }

--- a/vital/types/track_set.cxx
+++ b/vital/types/track_set.cxx
@@ -261,7 +261,7 @@ track_set_implementation
 {
   std::set<track_id_t> track_ids;
   std::vector<track_state_sptr> ts = this->frame_states(offset);
-  for (auto const data : ts)
+  for (auto const& data : ts)
   {
     track_ids.insert(data->track()->id());
   }


### PR DESCRIPTION
This PR fixes the range-loop-construct warnings in gcc 11. In all of these cases we are making copies of data in the for loop. I've investigated each instance and believe these changes are all safe to access as const&