### PR TITLE
Always guess install prefix if not specified

### DIFF
--- a/vital/config/config_block_io.cxx
+++ b/vital/config/config_block_io.cxx
@@ -12,7 +12,10 @@
 #include "config_parser.h"
 
 #include <vital/logger/logger.h>
+
+#include <vital/util/get_paths.h>
 #include <vital/util/wrap_text_block.h>
+
 #include <vital/version.h>
 
 #include <kwiversys/SystemTools.hxx>
@@ -30,8 +33,17 @@ namespace vital {
 
 namespace {
 
+// ----------------------------------------------------------------------------
+std::string guess_install_prefix()
+{
+  auto const& exe_path = get_executable_path();
+  auto const& last = kwiversys::SystemTools::GetFilenameName(exe_path);
+
+  return (last == "bin" ? exe_path + "/.." : exe_path);
+}
+
 #if defined(_WIN32)
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 // Helper method to add known special paths to a path list
 void add_windows_path( config_path_list_t & paths, int which )
 {
@@ -45,7 +57,7 @@ void add_windows_path( config_path_list_t & paths, int which )
 }
 #endif
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 // Helper method to get application specific paths from generic paths
 config_path_list_t
 application_paths( config_path_list_t const& paths,
@@ -67,7 +79,7 @@ application_paths( config_path_list_t const& paths,
   return result;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 /// Add paths in the KWIVER_CONFIG_PATH env variable to the given path vector
 /**
  * Appends the current working directory (".") and then the contents of the
@@ -83,9 +95,7 @@ void append_kwiver_config_paths( config_path_list_t &path_vector )
   kwiversys::SystemTools::GetPath( path_vector, "KWIVER_CONFIG_PATH" );
 }
 
-} //end anonymous namespace
-
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 // Helper method to get all possible locations of application config files
 config_path_list_t
 application_config_file_paths_helper(std::string const& application_name,
@@ -171,18 +181,23 @@ application_config_file_paths_helper(std::string const& application_name,
   return paths;
 }
 
-// ------------------------------------------------------------------
+} //end anonymous namespace
+
+// ----------------------------------------------------------------------------
 /// Get additional application configuration file paths
 config_path_list_t
 application_config_file_paths(std::string const& application_name,
                               std::string const& application_version,
                               config_path_t const& install_prefix)
 {
+  auto const& guessed_prefix =
+    (install_prefix.empty() ? guess_install_prefix() : install_prefix);
+
   return application_config_file_paths(application_name, application_version,
-                                       install_prefix, install_prefix);
+                                       guessed_prefix, guessed_prefix);
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 /// Get additional application configuration file paths
 config_path_list_t
 application_config_file_paths(std::string const& application_name,
@@ -226,7 +241,7 @@ application_config_file_paths(std::string const& application_name,
   return paths;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 /// Get KWIVER configuration file paths
 config_path_list_t
 kwiver_config_file_paths(config_path_t const& install_prefix)
@@ -235,9 +250,10 @@ kwiver_config_file_paths(config_path_t const& install_prefix)
   auto paths = config_path_list_t{};
   append_kwiver_config_paths(paths);
 
-  auto kwiver_paths = application_config_file_paths_helper("kwiver",
-                                                           KWIVER_VERSION,
-                                                           install_prefix);
+  auto kwiver_paths =
+    application_config_file_paths_helper(
+      "kwiver", KWIVER_VERSION,
+      (install_prefix.empty() ? guess_install_prefix() : install_prefix));
 
   for (auto const& path : kwiver_paths)
   {
@@ -247,7 +263,7 @@ kwiver_config_file_paths(config_path_t const& install_prefix)
   return paths;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 config_block_sptr
 read_config_file( config_path_t const&     file_path,
                   config_path_list_t const& search_paths,
@@ -279,7 +295,7 @@ read_config_file( config_path_t const&     file_path,
   return the_parser.get_config();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 config_block_sptr
 read_config_file( std::string const& file_name,
                   std::string const& application_name,
@@ -390,7 +406,7 @@ std::vector< config_path_t > find_config_file(
   return out;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 // Output to file the given \c config_block object to the specified file path
 void
 write_config_file( config_block_sptr const& config,
@@ -432,7 +448,7 @@ write_config_file( config_block_sptr const& config,
   ofile.close();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 void write_config( config_block_sptr const& config,
                    std::ostream&            ofile )
 {

--- a/vital/config/config_block_io.h
+++ b/vital/config/config_block_io.h
@@ -137,7 +137,9 @@ config_block_sptr VITAL_CONFIG_EXPORT read_config_file(
  *   locations to be searched.
  * \param install_prefix
  *   The prefix to which the application is installed (should be one directory
- *   higher than the location of the executing binary).
+ *   higher than the location of the executing binary).  If not specified
+ *   (empty), an attempt to guess the prefix based on the path of the running
+ *   executable will be made.
  * \param merge
  *   If \c true, search all locations for matching config files, merging their
  *   contents, with files earlier in the search order taking precedence. If
@@ -227,7 +229,9 @@ void VITAL_CONFIG_EXPORT write_config( config_block_sptr const& config,
  *   locations to be searched.
  * \param install_prefix
  *   The prefix to which the application and KWIVER are installed (should be
- *   one directory higher than the location of the executing binary).
+ *   one directory higher than the location of the executing binary).  If not
+ *   specified (empty), an attempt to guess the prefix based on the path of
+ *   the running executable will be made.
  *
  * \return
  *   List of additional application configuration search paths.
@@ -258,6 +262,9 @@ application_config_file_paths(std::string const& application_name,
  *
  * \return
  *   List of additional application configuration search paths.
+ *
+ * \note This is the only function that will not guess the install prefix if
+ *       an empty prefix is specified.
  */
 config_path_list_t VITAL_CONFIG_EXPORT
 application_config_file_paths(std::string const& application_name,
@@ -273,7 +280,9 @@ application_config_file_paths(std::string const& application_name,
  * installed configuration files for the current version of KWIVER
  *
  * \param install_prefix
- *   The prefix to which KWIVER is installed.
+ *   The prefix to which KWIVER is installed.  If not specified (empty), an
+ *   attempt to guess the prefix based on the path of the running executable
+ *   will be made.
  *
  * \return
  *   List of KWIVER configuration search paths.


### PR DESCRIPTION
Modify functions in `config_block_io` that determine or use search paths to always attempt to guess the install prefix from the location of the executing binary if no prefix is specified. (Note that this excludes the overload which takes the application and library/KWIVER prefixes separately.)

This addresses the need for every user of these APIs to replicate this logic. (However, those users which were already doing so are left alone, as they have superior mechanisms of determining the prefix.)