### PR TITLE
Add column ordering config to CSV metadata writer

### DIFF
--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -275,7 +275,7 @@ metadata_map_io_csv
 
   for( auto const& name : d_->column_names )
   {
-    auto const trait_id = d_->md_traits.name_to_tag( name );
+    auto const trait_id = d_->md_traits.enum_name_to_tag( name );
     if( trait_id == kv::VITAL_META_UNKNOWN )
     {
       // TODO Consider whether UNKNOWN is the right tag or if something to show

--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -22,9 +22,8 @@
 #include <typeinfo>
 #include <vector>
 
-using kwiver::vital::range::iota;
-
 namespace kv = kwiver::vital;
+namespace kvr = kv::range;
 
 namespace kwiver {
 
@@ -284,21 +283,25 @@ metadata_map_io_csv
       // Avoid duplicating present columns
       present_metadata_ids.erase( trait_id );
     }
-    else if( kv::VITAL_META_UNKNOWN !=
-             ( trait_id = d_->md_traits.name_to_tag( name ) ) )
+    else // Try matching the description
     {
-      // This is a placeholder to keep the two vectors aligned
-      metadata_names.push_back( "" );
-      // Avoid duplicating present columns
-      present_metadata_ids.erase( trait_id );
-      LOG_INFO(
-        logger(),
-        "Description "  << name << " matched enum "
-                        << d_->md_traits.tag_to_enum_name( trait_id ) );
-    }
-    else
-    {
-      metadata_names.push_back( name );
+      trait_id = d_->md_traits.name_to_tag( name );
+
+      if( trait_id != kv::VITAL_META_UNKNOWN )
+      {
+        // This is a placeholder to keep the two vectors aligned
+        metadata_names.push_back( "" );
+        // Avoid duplicating present columns
+        present_metadata_ids.erase( trait_id );
+        LOG_INFO(
+          logger(),
+          "Description \""  << name << "\" matched enum "
+                            << d_->md_traits.tag_to_enum_name( trait_id ) );
+      }
+      else
+      {
+        metadata_names.push_back( name );
+      }
     }
     ordered_metadata_ids.push_back( trait_id );
   }
@@ -318,7 +321,7 @@ metadata_map_io_csv
   // Write out the csv header
   fout << "\"frame ID\",";
   assert( ordered_metadata_ids.size() == metadata_names.size() );
-  for( auto const& i : iota( ordered_metadata_ids.size() ) )
+  for( auto const& i : kvr::iota( ordered_metadata_ids.size() ) )
   {
     auto const& metadata_id = ordered_metadata_ids[ i ];
     auto const& metadata_name = metadata_names[ i ];

--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -124,7 +124,7 @@ metadata_map_io_csv::priv
                     std::ostream& fout,
                     std::string const& field_name )
 {
-  if( csv_field == kv::VITAL_META_LAST_TAG )
+  if( csv_field == kv::VITAL_META_UNKNOWN )
   {
     fout << "\"" << field_name << "\",";
   }
@@ -299,9 +299,6 @@ metadata_map_io_csv
     else
     {
       metadata_names.push_back( name );
-      // Force `name` to be used by setting this to tag that won't be in the
-      // metadata which is being serialized
-      trait_id = kv::VITAL_META_LAST_TAG;
     }
     ordered_metadata_ids.push_back( trait_id );
   }

--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -50,6 +50,7 @@ public:
   kv::metadata_traits md_traits;
   bool write_remaining_columns{ true };
   bool write_enum_names{ false };
+  std::string names_string;
   std::vector< std::string > column_names;
 };
 
@@ -193,14 +194,42 @@ metadata_map_io_csv
     "write_remaining_columns" );
   d_->write_enum_names = config->get_value< bool >( "write_enum_names" );
 
-  auto const names_string = config->get_value< std::string >( "column_names" );
+  d_->names_string = config->get_value< std::string >( "column_names" );
   std::vector< std::string > untrimmed_column_names;
-  kwiver::vital::tokenize( names_string, untrimmed_column_names, "," );
+  kwiver::vital::tokenize( d_->names_string, untrimmed_column_names, "," );
 
   for( auto name : untrimmed_column_names )
   {
     d_->column_names.push_back( kwiver::vital::string_trim( name ) );
   }
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_map_io_csv
+::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
+{
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+metadata_map_io_csv
+::get_configuration() const
+{
+  // get base config from base class
+  auto config = algorithm::get_configuration();
+
+  config->set_value( "column_names", d_->names_string,
+                     "Comma-seperated values specified column order. Can "
+                     "either be the enum names, e.g. VIDEO_KEY_FRAME or the "
+                     "description, e.g. 'Is frame a key frame'" );
+  config->set_value( "write_enum_names", d_->write_enum_names,
+                     "Write enum names rather than descriptive names" );
+  config->set_value( "write_remaining_columns", d_->write_remaining_columns,
+                     "Write columns present in the metadata but not in the "
+                     "manually-specified list." );
+  return config;
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -276,21 +276,20 @@ metadata_map_io_csv
 
   for( auto const& name : d_->column_names )
   {
-    if( /* TODO name is valid metadata name*/ false )
-    {
-      kv::vital_metadata_tag id;
-      ordered_metadata_ids.push_back( id );
-      // This is a placeholder to keep the two vectors aligned
-      metadata_names.push_back( "" );
-      present_metadata_ids.erase( id ); // Avoid duplicating present columns
-    }
-    else
+    auto const trait_id = d_->md_traits.name_to_tag( name );
+    if( trait_id == kv::VITAL_META_UNKNOWN )
     {
       // TODO Consider whether UNKNOWN is the right tag or if something to show
       // explicitly that this is not in our set of tags is better
-      ordered_metadata_ids.push_back( kv::VITAL_META_UNKNOWN );
       metadata_names.push_back( name );
     }
+    else
+    {
+      // This is a placeholder to keep the two vectors aligned
+      metadata_names.push_back( "" );
+      present_metadata_ids.erase( trait_id ); // Avoid duplicating present columns
+    }
+    ordered_metadata_ids.push_back( trait_id );
   }
 
   // TODO consider checking whether the last feature is an * to determine

--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -34,9 +34,9 @@ namespace core {
 namespace {
 
 // ----------------------------------------------------------------------------
-template < typename Out >
+template < typename out >
 void
-split( const std::string& s, char delim, Out result )
+split( std::string const& s, char delim, out result )
 {
   std::istringstream iss( s );
   std::string item;
@@ -49,7 +49,7 @@ split( const std::string& s, char delim, Out result )
 
 // ----------------------------------------------------------------------------
 std::vector< std::string >
-split( const std::string& s, char delim )
+split( std::string const& s, char delim )
 {
   std::vector< std::string > elems;
   split( s, delim, std::back_inserter( elems ) );
@@ -58,19 +58,18 @@ split( const std::string& s, char delim )
 
 // ----------------------------------------------------------------------------
 std::string
-trim( const std::string& str,
-      const std::string& whitespace = " \t" )
+trim( std::string const& str, std::string const& whitespace = " \t" )
 {
-  const auto strBegin = str.find_first_not_of( whitespace );
+  auto const str_begin = str.find_first_not_of( whitespace );
 
-  if( strBegin == std::string::npos )
+  if( str_begin == std::string::npos )
   {
-    return "";     // no content
+    return ""; // no content
   }
-  const auto strEnd = str.find_last_not_of( whitespace );
-  const auto strRange = strEnd - strBegin + 1;
+  auto const str_end = str.find_last_not_of( whitespace );
+  auto const str_range = str_end - str_begin + 1;
 
-  return str.substr( strBegin, strRange );
+  return str.substr( str_begin, str_range );
 }
 
 } // namespace
@@ -287,7 +286,8 @@ metadata_map_io_csv
     {
       // This is a placeholder to keep the two vectors aligned
       metadata_names.push_back( "" );
-      present_metadata_ids.erase( trait_id ); // Avoid duplicating present columns
+      // Avoid duplicating present columns
+      present_metadata_ids.erase( trait_id );
     }
     ordered_metadata_ids.push_back( trait_id );
   }

--- a/arrows/core/metadata_map_io_csv.h
+++ b/arrows/core/metadata_map_io_csv.h
@@ -49,6 +49,9 @@ public:
               kwiver::vital::metadata_map_sptr data,
               std::string const& filename ) const override;
 
+   ///  Set configuration values, namely the column ordering
+   void set_configuration( vital::config_block_sptr config ) override;
+
 private:
   class priv;
 

--- a/arrows/core/metadata_map_io_csv.h
+++ b/arrows/core/metadata_map_io_csv.h
@@ -49,8 +49,8 @@ public:
               kwiver::vital::metadata_map_sptr data,
               std::string const& filename ) const override;
 
-   ///  Set configuration values, namely the column ordering
-   void set_configuration( vital::config_block_sptr config ) override;
+  ///  Set configuration values
+  void set_configuration( vital::config_block_sptr config ) override;
 
 private:
   class priv;

--- a/arrows/core/metadata_map_io_csv.h
+++ b/arrows/core/metadata_map_io_csv.h
@@ -52,6 +52,12 @@ public:
   ///  Set configuration values
   void set_configuration( vital::config_block_sptr config ) override;
 
+  /// Check supplied configuration
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  /// Get current configuration
+  vital::config_block_sptr get_configuration() const override;
+
 private:
   class priv;
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -6,3 +6,8 @@ over the previous v1.6.0 release.
 
 Bug Fixes over 1.6.0
 --------------------
+
+Arrows: Core
+
+ * Add additional config options to the CSV metadata writer. Primarily, allow
+   the column ordering of the output to be specified.

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -73,16 +73,14 @@ metadata_traits
 
   // Create name table
 #define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
-  m_name_trait_table[NAME] = trait_ptr(        \
-    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
+  m_name_tag_table[NAME] = VITAL_META_ ## TAG;
 
   KWIVER_VITAL_METADATA_TAGS( NAME_TABLE_ENTRY )
 #undef NAME_TABLE_ENTRY
 
   // Create enum name table
 #define ENUM_NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
-  m_enum_name_trait_table[#TAG] = trait_ptr(        \
-    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
+  m_enum_name_tag_table[#TAG] = VITAL_META_ ## TAG;
 
   KWIVER_VITAL_METADATA_TAGS( ENUM_NAME_TABLE_ENTRY )
 #undef ENUM_NAME_TABLE_ENTRY
@@ -107,36 +105,6 @@ metadata_traits
   {
     LOG_INFO( m_logger, "Could not find trait for tag: " << tag );
     ix = m_trait_table.find(VITAL_META_UNKNOWN);
-  }
-  return *ix->second;
-}
-
-// ----------------------------------------------------------------------------
-vital_meta_trait_base const&
-metadata_traits
-::find_name( std::string name ) const
-{
-  auto ix = m_name_trait_table.find( name );
-  if ( ix == m_name_trait_table.end() )
-  {
-    LOG_INFO( m_logger, "Could not find trait for name: " << name );
-    auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
-    return *defualt_ix->second;
-  }
-  return *ix->second;
-}
-
-// ----------------------------------------------------------------------------
-vital_meta_trait_base const&
-metadata_traits
-::find_enum_name( std::string name ) const
-{
-  auto ix = m_enum_name_trait_table.find( name );
-  if ( ix == m_enum_name_trait_table.end() )
-  {
-    LOG_INFO( m_logger, "Could not find trait for enum name: " << name );
-    auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
-    return *defualt_ix->second;
   }
   return *ix->second;
 }
@@ -174,10 +142,9 @@ metadata_traits
 // ----------------------------------------------------------------------------
 vital_metadata_tag
 metadata_traits
-::name_to_tag( std::string name ) const
+::name_to_tag( std::string const& name ) const
 {
-  auto const& trait = find_name( name );
-  return trait.tag();
+  return m_name_tag_table.find( name )->second;
 }
 
 // ----------------------------------------------------------------------------
@@ -194,8 +161,7 @@ vital_metadata_tag
 metadata_traits
 ::enum_name_to_tag( std::string name ) const
 {
-  auto const& trait = find_enum_name( name );
-  return trait.tag();
+  return m_enum_name_tag_table.find( name )->second;
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -132,7 +132,13 @@ vital_metadata_tag
 metadata_traits
 ::name_to_tag( std::string const& name ) const
 {
-  return m_name_tag_table.find( name )->second;
+  auto ix = m_name_tag_table.find( name );
+  if ( ix == m_name_tag_table.end() )
+  {
+    LOG_INFO( m_logger, "Could not find tag for name: " << name );
+    return VITAL_META_UNKNOWN;
+  }
+  return ix->second;
 }
 
 // ----------------------------------------------------------------------------
@@ -149,7 +155,13 @@ vital_metadata_tag
 metadata_traits
 ::enum_name_to_tag( std::string name ) const
 {
-  return m_enum_name_tag_table.find( name )->second;
+  auto ix = m_enum_name_tag_table.find( name );
+  if ( ix == m_enum_name_tag_table.end() )
+  {
+    LOG_INFO( m_logger, "Could not find tag for enum name: " << name );
+    return VITAL_META_UNKNOWN;
+  }
+  return ix->second;
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -70,8 +70,8 @@ metadata_traits
 
 #undef TABLE_ENTRY
 
-#define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...)        \
-  m_name_trait_table[NAME] = trait_ptr( \
+#define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
+  m_name_trait_table[NAME] = trait_ptr(        \
     static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
 
   KWIVER_VITAL_METADATA_TAGS( NAME_TABLE_ENTRY )
@@ -85,7 +85,6 @@ metadata_traits
 metadata_traits
 ::~metadata_traits()
 {
-
 }
 
 // ------------------------------------------------------------------
@@ -152,7 +151,7 @@ vital_metadata_tag
 metadata_traits
 ::name_to_tag( std::string name ) const
 {
-  vital_meta_trait_base const& trait = find_name( name );
+  auto const& trait = find_name( name );
   return trait.tag();
 }
 

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -39,6 +39,7 @@ struct vital_meta_trait_object
   {                                                                     \
     virtual std::string name() const override { return std::string(NAME); } \
     virtual std::string description() const override { return std::string(TD); } \
+    virtual std::string enum_name() const override { return #TAG; } \
     virtual std::type_info const& tag_type() const override { return typeid(T); } \
     virtual bool is_integral() const override { return std::is_integral<T>::value; } \
     virtual bool is_signed() const override { return std::is_signed<T>::value; } \
@@ -118,7 +119,7 @@ metadata_traits
   auto ix = m_name_trait_table.find( name );
   if ( ix == m_name_trait_table.end() )
   {
-    LOG_INFO( m_logger, "Could not find trait for tag: " << name );
+    LOG_INFO( m_logger, "Could not find trait for name: " << name );
     auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
     return *defualt_ix->second;
   }
@@ -133,7 +134,7 @@ metadata_traits
   auto ix = m_enum_name_trait_table.find( name );
   if ( ix == m_enum_name_trait_table.end() )
   {
-    LOG_INFO( m_logger, "Could not find trait for tag: " << name );
+    LOG_INFO( m_logger, "Could not find trait for enum name: " << name );
     auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
     return *defualt_ix->second;
   }
@@ -177,6 +178,15 @@ metadata_traits
 {
   auto const& trait = find_name( name );
   return trait.tag();
+}
+
+// ----------------------------------------------------------------------------
+std::string
+metadata_traits
+::tag_to_enum_name( vital_metadata_tag tag ) const
+{
+  auto const& trait = find( tag );
+  return trait.enum_name();
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -56,7 +56,7 @@ struct vital_meta_trait_object
 
   KWIVER_VITAL_METADATA_TAGS( DEFINE_VITAL_META_TRAIT )
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 metadata_traits
 ::metadata_traits()
   : m_logger( kwiver::vital::get_logger( "vital.metadata_traits" ) )
@@ -70,6 +70,7 @@ metadata_traits
 
 #undef TABLE_ENTRY
 
+  // Create name table
 #define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
   m_name_trait_table[NAME] = trait_ptr(        \
     static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
@@ -77,17 +78,25 @@ metadata_traits
   KWIVER_VITAL_METADATA_TAGS( NAME_TABLE_ENTRY )
 #undef NAME_TABLE_ENTRY
 
+  // Create enum name table
+#define ENUM_NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
+  m_enum_name_trait_table[#TAG] = trait_ptr(        \
+    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
+
+  KWIVER_VITAL_METADATA_TAGS( ENUM_NAME_TABLE_ENTRY )
+#undef ENUM_NAME_TABLE_ENTRY
+
 #undef DEFINE_VITAL_META_TRAIT
 
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 metadata_traits
 ::~metadata_traits()
 {
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 vital_meta_trait_base const&
 metadata_traits
 ::find( vital_metadata_tag tag ) const
@@ -101,7 +110,7 @@ metadata_traits
   return *ix->second;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 vital_meta_trait_base const&
 metadata_traits
 ::find_name( std::string name ) const
@@ -116,7 +125,22 @@ metadata_traits
   return *ix->second;
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+vital_meta_trait_base const&
+metadata_traits
+::find_enum_name( std::string name ) const
+{
+  auto ix = m_enum_name_trait_table.find( name );
+  if ( ix == m_enum_name_trait_table.end() )
+  {
+    LOG_INFO( m_logger, "Could not find trait for tag: " << name );
+    auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
+    return *defualt_ix->second;
+  }
+  return *ix->second;
+}
+
+// ----------------------------------------------------------------------------
 std::string
 metadata_traits
 ::tag_to_symbol( vital_metadata_tag tag ) const
@@ -137,7 +161,7 @@ metadata_traits
 #undef TAG_CASE
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 std::string
 metadata_traits
 ::tag_to_name( vital_metadata_tag tag ) const
@@ -146,7 +170,7 @@ metadata_traits
   return trait.name();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 vital_metadata_tag
 metadata_traits
 ::name_to_tag( std::string name ) const
@@ -155,7 +179,16 @@ metadata_traits
   return trait.tag();
 }
 
-// ------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+vital_metadata_tag
+metadata_traits
+::enum_name_to_tag( std::string name ) const
+{
+  auto const& trait = find_enum_name( name );
+  return trait.tag();
+}
+
+// ----------------------------------------------------------------------------
 std::string
 metadata_traits
 ::tag_to_description( vital_metadata_tag tag ) const

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -69,6 +69,14 @@ metadata_traits
   KWIVER_VITAL_METADATA_TAGS( TABLE_ENTRY )
 
 #undef TABLE_ENTRY
+
+#define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...)        \
+  m_name_trait_table[NAME] = trait_ptr( \
+    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
+
+  KWIVER_VITAL_METADATA_TAGS( NAME_TABLE_ENTRY )
+#undef NAME_TABLE_ENTRY
+
 #undef DEFINE_VITAL_META_TRAIT
 
 }
@@ -90,6 +98,21 @@ metadata_traits
   {
     LOG_INFO( m_logger, "Could not find trait for tag: " << tag );
     ix = m_trait_table.find(VITAL_META_UNKNOWN);
+  }
+  return *ix->second;
+}
+
+// ------------------------------------------------------------------
+vital_meta_trait_base const&
+metadata_traits
+::find_name( std::string name ) const
+{
+  auto ix = m_name_trait_table.find( name );
+  if ( ix == m_name_trait_table.end() )
+  {
+    LOG_INFO( m_logger, "Could not find trait for tag: " << name );
+    auto const defualt_ix = m_trait_table.find(VITAL_META_UNKNOWN);
+    return *defualt_ix->second;
   }
   return *ix->second;
 }
@@ -122,6 +145,15 @@ metadata_traits
 {
   vital_meta_trait_base const& trait = find( tag );
   return trait.name();
+}
+
+// ------------------------------------------------------------------
+vital_metadata_tag
+metadata_traits
+::name_to_tag( std::string name ) const
+{
+  vital_meta_trait_base const& trait = find_name( name );
+  return trait.tag();
 }
 
 // ------------------------------------------------------------------

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -62,28 +62,16 @@ metadata_traits
 ::metadata_traits()
   : m_logger( kwiver::vital::get_logger( "vital.metadata_traits" ) )
 {
-  // Create trait table
-#define TABLE_ENTRY(TAG, NAME, TYPE, ...)        \
-  m_trait_table[VITAL_META_ ## TAG] = trait_ptr( \
-    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) );
+  // Create trait, tag, and enum name tables
+#define TABLE_ENTRY(TAG, NAME, TYPE, ...)           \
+  m_trait_table[VITAL_META_ ## TAG] = trait_ptr(    \
+    static_cast< vital_meta_trait_base* >(new vital_meta_trait_object<VITAL_META_ ## TAG>() ) ); \
+  m_name_tag_table[NAME] = VITAL_META_ ## TAG;      \
+  m_enum_name_tag_table[#TAG] = VITAL_META_ ## TAG; \
 
   KWIVER_VITAL_METADATA_TAGS( TABLE_ENTRY )
 
 #undef TABLE_ENTRY
-
-  // Create name table
-#define NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
-  m_name_tag_table[NAME] = VITAL_META_ ## TAG;
-
-  KWIVER_VITAL_METADATA_TAGS( NAME_TABLE_ENTRY )
-#undef NAME_TABLE_ENTRY
-
-  // Create enum name table
-#define ENUM_NAME_TABLE_ENTRY(TAG, NAME, TYPE, ...) \
-  m_enum_name_tag_table[#TAG] = VITAL_META_ ## TAG;
-
-  KWIVER_VITAL_METADATA_TAGS( ENUM_NAME_TABLE_ENTRY )
-#undef ENUM_NAME_TABLE_ENTRY
 
 #undef DEFINE_VITAL_META_TRAIT
 

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -106,6 +106,17 @@ public:
    */
   vital_meta_trait_base const& find_name( std::string name ) const;
 
+  /// Find traits entry for the enum name.
+  /**
+   * This method returns the metadata trait entry for the
+   * specified tag. A default entry is returned if an invalid tag value is specified.
+   *
+   * @param tag Metadata enum name, e.g. UNIX_TIMESTAMP.
+   *
+   * @return Metadata traits entry.
+   */
+  vital_meta_trait_base const& find_enum_name( std::string name ) const;
+
   /// Convert tag value to enum symbol
   /**
    * This method returns the symbol name for the supplied tag.
@@ -136,6 +147,16 @@ public:
    */
   vital_metadata_tag name_to_tag( std::string name ) const;
 
+  /// Get tag for metadata enum name.
+  /**
+   * This method returns the tag for the enum name.
+   *
+   * @param name Metadata enum name value.
+   *
+   * @return Metadata tag.
+   */
+  vital_metadata_tag enum_name_to_tag( std::string name ) const;
+
   // Get metadata tag description
   /**
    * This method returns the long description string for the specified
@@ -157,6 +178,7 @@ private:
 #endif
   std::map< kwiver::vital::vital_metadata_tag, trait_ptr> m_trait_table;
   std::map< std::string, trait_ptr> m_name_trait_table;
+  std::map< std::string, trait_ptr> m_enum_name_trait_table;
 
 }; // end class metadata_traits
 

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -95,6 +95,17 @@ public:
    */
   vital_meta_trait_base const& find( vital_metadata_tag tag ) const;
 
+  /// Find traits entry for name.
+  /**
+   * This method returns the metadata trait entry for the
+   * specified tag. A default entry is returned if an invalid tag value is specified.
+   *
+   * @param tag Metadata name.
+   *
+   * @return Metadata traits entry.
+   */
+  vital_meta_trait_base const& find_name( std::string name ) const;
+
   /// Convert tag value to enum symbol
   /**
    * This method returns the symbol name for the supplied tag.
@@ -114,6 +125,16 @@ public:
    * @return Long name for this tag.
    */
   std::string tag_to_name( vital_metadata_tag tag ) const;
+
+  /// Get tag for metadata name.
+  /**
+   * This method returns the tag for the short name.
+   *
+   * @param name Metadata name value.
+   *
+   * @return Metadata tag.
+   */
+  vital_metadata_tag name_to_tag( std::string name ) const;
 
   // Get metadata tag description
   /**
@@ -135,6 +156,7 @@ private:
   typedef std::shared_ptr< vital_meta_trait_base > trait_ptr;
 #endif
   std::map< kwiver::vital::vital_metadata_tag, trait_ptr> m_trait_table;
+  std::map< std::string, trait_ptr> m_name_trait_table;
 
 }; // end class metadata_traits
 

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -97,7 +97,7 @@ public:
    */
   vital_meta_trait_base const& find( vital_metadata_tag tag ) const;
 
-  /// Convert tag value to enum symbol
+  /// Convert tag value to enum symbol.
   /**
    * This method returns the symbol name for the supplied tag.
    *
@@ -147,7 +147,7 @@ public:
    */
   vital_metadata_tag enum_name_to_tag( std::string name ) const;
 
-  // Get metadata tag description
+  // Get metadata tag description.
   /**
    * This method returns the long description string for the specified
    * tag.

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -97,28 +97,6 @@ public:
    */
   vital_meta_trait_base const& find( vital_metadata_tag tag ) const;
 
-  /// Find traits entry for name.
-  /**
-   * This method returns the metadata trait entry for the
-   * specified tag. A default entry is returned if an invalid tag value is specified.
-   *
-   * @param tag Metadata name.
-   *
-   * @return Metadata traits entry.
-   */
-  vital_meta_trait_base const& find_name( std::string name ) const;
-
-  /// Find traits entry for the enum name.
-  /**
-   * This method returns the metadata trait entry for the
-   * specified tag. A default entry is returned if an invalid tag value is specified.
-   *
-   * @param tag Metadata enum name, e.g. UNIX_TIMESTAMP.
-   *
-   * @return Metadata traits entry.
-   */
-  vital_meta_trait_base const& find_enum_name( std::string name ) const;
-
   /// Convert tag value to enum symbol
   /**
    * This method returns the symbol name for the supplied tag.
@@ -147,7 +125,7 @@ public:
    *
    * @return Metadata tag.
    */
-  vital_metadata_tag name_to_tag( std::string name ) const;
+  vital_metadata_tag name_to_tag( std::string const& name ) const;
 
   /// Get tag for metadata enum name.
   /**
@@ -189,8 +167,8 @@ private:
   typedef std::shared_ptr< vital_meta_trait_base > trait_ptr;
 #endif
   std::map< kwiver::vital::vital_metadata_tag, trait_ptr> m_trait_table;
-  std::map< std::string, trait_ptr> m_name_trait_table;
-  std::map< std::string, trait_ptr> m_enum_name_trait_table;
+  std::map< std::string, kwiver::vital::vital_metadata_tag > m_name_tag_table;
+  std::map< std::string, kwiver::vital::vital_metadata_tag > m_enum_name_tag_table;
 
 }; // end class metadata_traits
 

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -34,6 +34,7 @@ struct vital_meta_trait_base
   virtual ~vital_meta_trait_base() = default;
   virtual std::string name() const = 0;
   virtual std::string description() const = 0;
+  virtual std::string enum_name() const = 0;
   virtual std::type_info const& tag_type() const = 0;
   virtual bool is_integral() const = 0;
   virtual bool is_signed() const = 0;
@@ -54,7 +55,8 @@ struct vital_meta_trait_base
   struct vital_meta_trait<TAG>                                          \
   {                                                                     \
     static std::string name() { return std::string(NAME); }             \
-    static std::string  description() { return std::string(LD); }       \
+    static std::string description() { return std::string(LD); }        \
+    static std::string enum_name() { return #TAG; }                     \
     static std::type_info const& tag_type() { return typeid(T); }       \
     static bool is_integral() { return std::is_integral<T>::value; }    \
     static bool is_signed() { return std::is_signed<T>::value; }        \
@@ -146,6 +148,16 @@ public:
    * @return Metadata tag.
    */
   vital_metadata_tag name_to_tag( std::string name ) const;
+
+  /// Get tag for metadata enum name.
+  /**
+   * This method returns the enum name for the given tag.
+   *
+   * @param tag Metadata tag value.
+   *
+   * @return Enum name string.
+   */
+  std::string tag_to_enum_name( vital_metadata_tag tag ) const;
 
   /// Get tag for metadata enum name.
   /**


### PR DESCRIPTION
Add a `column_names` parameter to the CSV writer which controls the order in which column names are written. Column names not found in the current set of metadata names will have headers but will not have values. Otherwise, the column will be moved from its current, arbitrary location, to the specified one.

The one caveat is this will break if there is a metadata map item with tag `VITAL_META_UNKNOWN` in the map we wish to serialize. Every field which does not appear in our spec will contain the value from this metadata item tagged `VITAL_META_UNKNOWN`. However, it sounds like this is a non-issue in practice. 