### PR TITLE
Update python bindings for adapter_data_set

### DIFF
--- a/python/kwiver/sprokit/adapters/adapter_data_set.cxx
+++ b/python/kwiver/sprokit/adapters/adapter_data_set.cxx
@@ -209,9 +209,9 @@ PYBIND11_MODULE(adapter_data_set, m)
     .def("value", &kwiver::sprokit::python::get_port_data_correct_type,
           "This method is equivalent to using __getitem__")
     .def("value_or", &kwiver::sprokit::python::value_or_correct_type,
+          py::arg("port"), py::arg("value_if_missing") = py::none(),
           "This method is similar to the \"get\" method provided by "
            "python dictionaries")
-
     .def("__getitem__", &kwiver::sprokit::python::get_port_data_correct_type)
 
     // The add_value function is templated.

--- a/python/kwiver/sprokit/adapters/adapter_data_set.cxx
+++ b/python/kwiver/sprokit/adapters/adapter_data_set.cxx
@@ -59,7 +59,8 @@ void add_value_correct_type(ka::adapter_data_set &self, ::sprokit::process::port
   }
 
   ADS_ADD_OBJECT(py::int_, int)
-  ADS_ADD_OBJECT(py::float_, float)
+  ADS_ADD_OBJECT(py::float_, double) // Python floats have double precision
+  ADS_ADD_OBJECT(py::bool_, bool)
   ADS_ADD_OBJECT(py::str, std::string)
   ADS_ADD_OBJECT(kwiver::vital::image_container, std::shared_ptr<kwiver::vital::image_container>)
   ADS_ADD_OBJECT(kwiver::vital::descriptor_set, std::shared_ptr<kwiver::vital::descriptor_set>)
@@ -104,6 +105,8 @@ py::object get_port_data_correct_type(ka::adapter_data_set &self, ::sprokit::pro
 
   ADS_GET_OBJECT(int)
   ADS_GET_OBJECT(float)
+  ADS_GET_OBJECT(double)
+  ADS_GET_OBJECT(bool)
   ADS_GET_OBJECT(std::string)
   ADS_GET_OBJECT(std::shared_ptr<kwiver::vital::image_container>)
   ADS_GET_OBJECT(std::shared_ptr<kwiver::vital::descriptor_set>)
@@ -182,6 +185,8 @@ PYBIND11_MODULE(adapter_data_set, m)
     // First the native C++ types
     .def("_add_int", &ka::adapter_data_set::add_value<int>)
     .def("_add_float", &ka::adapter_data_set::add_value<float>)
+    .def("_add_double", &ka::adapter_data_set::add_value<double>)
+    .def("_add_bool", &ka::adapter_data_set::add_value<bool>)
     .def("_add_string", &ka::adapter_data_set::add_value<std::string>)
     // Next shared ptrs to kwiver vital types
     .def("_add_image_container", &ka::adapter_data_set::add_value<std::shared_ptr<kwiver::vital::image_container > >,
@@ -214,6 +219,8 @@ PYBIND11_MODULE(adapter_data_set, m)
     // get_port_data is also templated
     .def("_get_port_data_int", &ka::adapter_data_set::get_port_data<int>)
     .def("_get_port_data_float", &ka::adapter_data_set::get_port_data<float>)
+    .def("_get_port_data_double", &ka::adapter_data_set::get_port_data<double>)
+    .def("_get_port_data_bool", &ka::adapter_data_set::get_port_data<bool>)
     .def("_get_port_data_string", &ka::adapter_data_set::get_port_data<std::string>)
     // Next shared ptrs to kwiver vital types
     .def("_get_port_data_image_container", &ka::adapter_data_set::get_port_data<std::shared_ptr<kwiver::vital::image_container > >)

--- a/python/kwiver/sprokit/adapters/adapter_data_set.cxx
+++ b/python/kwiver/sprokit/adapters/adapter_data_set.cxx
@@ -219,7 +219,9 @@ PYBIND11_MODULE(adapter_data_set, m)
     // each with a different type.
     // First the native C++ types
     .def("_add_int", &ka::adapter_data_set::add_value<int>)
-    .def("_add_float", &ka::adapter_data_set::add_value<float>)
+    .def("_add_float", &ka::adapter_data_set::add_value<float>,
+      "Warning: Python floats have double precision. Adding them "
+      "to an adapter_data_set using this method will truncate.")
     .def("_add_double", &ka::adapter_data_set::add_value<double>)
     .def("_add_bool", &ka::adapter_data_set::add_value<bool>)
     .def("_add_string", &ka::adapter_data_set::add_value<std::string>)

--- a/python/kwiver/sprokit/pipeline/datum.cxx
+++ b/python/kwiver/sprokit/pipeline/datum.cxx
@@ -94,6 +94,12 @@ PYBIND11_MODULE(datum, m)
   m.def("new_float", &new_datum<float>
     , (arg("dat"))
     , "Creates a new datum packet containing a float.");
+  m.def("new_double", &new_datum<double>
+    , (arg("dat"))
+    , "Creates a new datum packet containing a double.");
+  m.def("new_bool", &new_datum<bool>
+    , (arg("dat"))
+    , "Creates a new datum packet containing a bool.");
   m.def("new_string", &new_datum<std::string>
     , (arg("dat"))
     , "Creates a new datum packet containing a string.");
@@ -164,8 +170,14 @@ PYBIND11_MODULE(datum, m)
       , "Get the data contained within the packet (if coming from a python process).")
     .def("get_datum_ptr", &datum_get_datum_ptr
       , "Get pointer to datum object as a PyCapsule.")
-    .def("get_int", &datum_get_object<int>)
-    .def("get_float", &datum_get_object<float>)
+    .def("get_int", &datum_get_object<int>
+      , "Convert the data to a int")
+    .def("get_float", &datum_get_object<float>
+      , "Convert the data to a float")
+    .def("get_double", &datum_get_object<double>
+      , "Convert the data to a double")
+    .def("get_bool", &datum_get_object<bool>
+      , "Convert the data to a bool")
     .def("get_image_container", &datum_get_object<std::shared_ptr<kwiver::vital::image_container>>
       , "Convert the data to an image container")
     .def("get_descriptor_set", &datum_get_object<std::shared_ptr<kwiver::vital::descriptor_set>>
@@ -221,7 +233,8 @@ new_datum_correct_type(object const& obj)
   }
 
   CHECK_TYPE_NEW_DATUM(int_, int)
-  CHECK_TYPE_NEW_DATUM(float_, float)
+  CHECK_TYPE_NEW_DATUM(float_, double)
+  CHECK_TYPE_NEW_DATUM(bool_, bool)
   CHECK_TYPE_NEW_DATUM(str, std::string)
   CHECK_TYPE_NEW_DATUM(kwiver::vital::image_container, std::shared_ptr<kwiver::vital::image_container>)
   CHECK_TYPE_NEW_DATUM(kwiver::vital::descriptor_set, std::shared_ptr<kwiver::vital::descriptor_set>)
@@ -306,6 +319,8 @@ datum_get_datum_correct_type(::sprokit::datum const& self)
 
   DATUM_GET_OBJECT(int)
   DATUM_GET_OBJECT(float)
+  DATUM_GET_OBJECT(double)
+  DATUM_GET_OBJECT(bool)
   DATUM_GET_OBJECT(std::string)
   DATUM_GET_OBJECT(std::shared_ptr<kwiver::vital::image_container>)
   DATUM_GET_OBJECT(std::shared_ptr<kwiver::vital::descriptor_set>)

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
@@ -28,9 +28,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from kwiver.sprokit.util.test import expect_exception, find_tests, run_test, test_error
+from kwiver.sprokit.util.test import (
+    expect_exception,
+    find_tests,
+    run_test,
+    test_error,
+)
 
 from kwiver.sprokit.pipeline import datum
+
 
 def test_import():
     try:
@@ -44,7 +50,9 @@ def test_create():
 
     adapter_data_set.AdapterDataSet.create()
     adapter_data_set.AdapterDataSet.create(adapter_data_set.DataSetType.data)
-    adapter_data_set.AdapterDataSet.create(adapter_data_set.DataSetType.end_of_input)
+    adapter_data_set.AdapterDataSet.create(
+        adapter_data_set.DataSetType.end_of_input
+    )
 
 
 def check_type():
@@ -53,19 +61,25 @@ def check_type():
     ads = (
         adapter_data_set.AdapterDataSet.create()
     )  # Check constructor with default argument
-    ads_data = adapter_data_set.AdapterDataSet.create(adapter_data_set.DataSetType.data)
+    ads_data = adapter_data_set.AdapterDataSet.create(
+        adapter_data_set.DataSetType.data
+    )
     ads_eoi = adapter_data_set.AdapterDataSet.create(
         adapter_data_set.DataSetType.end_of_input
     )
 
     if ads_def.type() != adapter_data_set.DataSetType.data:
-        test_error("adapter_data_set type mismatch: constructor with default arg")
+        test_error(
+            "adapter_data_set type mismatch: constructor with default arg"
+        )
 
     if ads_data.type() != adapter_data_set.DataSetType.data:
         test_error("adapter_data_set type mismatch: constructor with data arg")
 
     if ads_eoi.type() != adapter_data_set.DataSetType.end_of_input:
-        test_error("adapter_data_set type mismatch: constructor with end_of_input arg")
+        test_error(
+            "adapter_data_set type mismatch: constructor with end_of_input arg"
+        )
 
 
 def test_enums():
@@ -82,7 +96,9 @@ def test_is_end_of_data():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads_def = adapter_data_set.AdapterDataSet.create()  # test default argument
-    ads_data = adapter_data_set.AdapterDataSet.create(adapter_data_set.DataSetType.data)
+    ads_data = adapter_data_set.AdapterDataSet.create(
+        adapter_data_set.DataSetType.data
+    )
     ads_eoi = adapter_data_set.AdapterDataSet.create(
         adapter_data_set.DataSetType.end_of_input
     )
@@ -99,47 +115,6 @@ def test_is_end_of_data():
 
     if not ads_eoi.is_end_of_data():
         test_error('adapter_data_set of type "end_of_input" is not empty')
-
-
-def check_same_type(retrieved_val, val, portname):
-    from kwiver.sprokit.adapters import adapter_data_set
-
-    if isinstance(val, datum.Datum):
-        val = val.get_datum()
-    if not type(retrieved_val) is type(val):
-        msg = "Retrieved value of type: {} at port {}. Expected type: {}"
-        msg = msg.format(type(retrieved_val), portname, type(val))
-        test_error(msg)
-
-
-# adds and retrieves val to/from the
-# adapter_data_set instance 3 times
-# once with the add/get fxn specified,
-# once with the add/get function that automatically casts,
-# once with the index operator
-def add_get_helper(
-    instance, instance_add_fxn, instance_get_fxn, val, data_type_str,
-):
-    from kwiver.sprokit.adapters import adapter_data_set
-
-    # First the type specific add/get fxns
-    portname = data_type_str + "_port"
-    instance_add_fxn(portname, val)
-    retrieved_val = instance_get_fxn(portname)  # Throws if port not found
-    check_same_type(retrieved_val, val, portname)
-
-    # Next the automatic type handling add/get fxns
-    # First add_value and get_port_data
-    portname = "py_" + portname
-    instance.add_value(portname, val)
-    retrieved_val = instance.get_port_data(portname)
-    check_same_type(retrieved_val, val, portname)
-
-    # Now __getitem__ and __setitem__
-    portname += "2"
-    instance[portname] = val
-    retrieved_val = instance[portname]
-    check_same_type(retrieved_val, val, portname)
 
 
 def overwrite_helper(
@@ -179,7 +154,29 @@ def test_add_get_datum():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(ads, ads.add_datum, ads.get_port_data, datum.new("d1"), "datum")
+
+    val = "d1"
+    d = datum.new(val)
+    ads.add_datum("datum_port", d)
+    retrieved_val = ads.get_port_data("datum_port")
+    err_ne(val, retrieved_val)
+
+
+def err_ne(expected, actual):
+    if expected != actual:
+        test_error("Expected value of {}, got {}".format(expected, actual))
+
+
+def err_is_not(expected, actual):
+    if expected is not actual:
+        msg = "Expected {} and {} to point to same object"
+        test_error(msg.format(expected, actual))
+
+
+def err_is_not_none(actual):
+    if actual is not None:
+        msg = "Expected to get None, got {} instead"
+        test_error(msg.format(actual))
 
 
 # Next some basic types
@@ -187,11 +184,175 @@ def test_add_get_basic_types():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(ads, ads._add_int, ads._get_port_data_int, 10, "int")
-    add_get_helper(ads, ads._add_float, ads._get_port_data_float, 0.5, "float")
-    add_get_helper(ads, ads._add_double, ads._get_port_data_double, 3.14, "double")
-    add_get_helper(ads, ads._add_bool, ads._get_port_data_bool, True, "bool")
-    add_get_helper(ads, ads._add_string, ads._get_port_data_string, "str1", "string")
+
+    val = 10
+    # Typed methods
+    ads._add_int("int_port", val)
+    retrieved_val1 = ads._get_port_data_int("int_port")
+    retrieved_val2 = ads._value_int("int_port")
+    retrieved_val3 = ads._value_or_int("int_port")
+
+    # Non typed methods
+    ads.add_value("int_port2", val)
+    ads["int_port3"] = val
+    retrieved_val4 = ads.get_port_data("int_port2")
+    retrieved_val5 = ads.value("int_port3")
+    retrieved_val6 = ads.value_or("int_port3")
+    retrieved_val7 = ads["int_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = 0.5
+    # Typed methods
+    ads._add_float("float_port", val)
+    retrieved_val1 = ads._get_port_data_float("float_port")
+    retrieved_val2 = ads._value_float("float_port")
+    retrieved_val3 = ads._value_or_float("float_port")
+
+    # Non typed methods
+    ads.add_value("float_port2", val)
+    ads["float_port3"] = val
+    retrieved_val4 = ads.get_port_data("float_port2")
+    retrieved_val5 = ads.value("float_port3")
+    retrieved_val6 = ads.value_or("float_port3")
+    retrieved_val7 = ads["float_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = 3.14
+    # Typed methods
+    ads._add_double("double_port", val)
+    retrieved_val1 = ads._get_port_data_double("double_port")
+    retrieved_val2 = ads._value_double("double_port")
+    retrieved_val3 = ads._value_or_double("double_port")
+
+    # Non typed methods
+    ads.add_value("double_port2", val)
+    ads["double_port3"] = val
+    retrieved_val4 = ads.get_port_data("double_port2")
+    retrieved_val5 = ads.value("double_port3")
+    retrieved_val6 = ads.value_or("double_port3")
+    retrieved_val7 = ads["double_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = True
+    # Typed methods
+    ads._add_bool("bool_port", val)
+    retrieved_val1 = ads._get_port_data_bool("bool_port")
+    retrieved_val2 = ads._value_bool("bool_port")
+    retrieved_val3 = ads._value_or_bool("bool_port")
+
+    # Non typed methods
+    ads.add_value("bool_port2", val)
+    ads["bool_port3"] = val
+    retrieved_val4 = ads.get_port_data("bool_port2")
+    retrieved_val5 = ads.value("bool_port3")
+    retrieved_val6 = ads.value_or("bool_port3")
+    retrieved_val7 = ads["bool_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = "str1"
+    # Typed methods
+    ads._add_string("string_port", val)
+    retrieved_val1 = ads._get_port_data_string("string_port")
+    retrieved_val2 = ads._value_string("string_port")
+    retrieved_val3 = ads._value_or_string("string_port")
+
+    # Non typed methods
+    ads.add_value("string_port2", val)
+    ads["string_port3"] = val
+    retrieved_val4 = ads.get_port_data("string_port2")
+    retrieved_val5 = ads.value("string_port3")
+    retrieved_val6 = ads.value_or("string_port3")
+    retrieved_val7 = ads["string_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+
+# Make sure that value_or works as expected when data is not found
+def test_value_or_basic_types():
+    from kwiver.sprokit.adapters import adapter_data_set
+
+    ads = adapter_data_set.AdapterDataSet.create()
+
+    val = 10
+    # Typed
+    retrieved_val1 = ads._value_or_int("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    # Check default values
+    err_is_not_none(ads.value_or("nonexistant_port"))
+    err_is_not_none(ads._value_or_int("nonexistant_port"))
+
+    val = 0.5
+    # Typed
+    retrieved_val1 = ads._value_or_float("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_float("nonexistant_port"))
+
+    val = 3.14
+    # Typed
+    retrieved_val1 = ads._value_or_double("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_double("nonexistant_port"))
+
+    val = True
+    # Typed
+    retrieved_val1 = ads._value_or_bool("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_bool("nonexistant_port"))
+
+    val = "str1"
+    # Typed
+    retrieved_val1 = ads._value_or_string("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_string("nonexistant_port"))
 
 
 # Next some kwiver vital types that are handled with pointers
@@ -200,41 +361,179 @@ def test_add_get_vital_types_by_ptr():
     from kwiver.vital import types as kvt
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(
-        ads,
-        ads._add_image_container,
-        ads._get_port_data_image_container,
-        kvt.ImageContainer(kvt.Image()),
-        "image_container",
+
+    val = kvt.ImageContainer(kvt.Image())
+    # Typed methods
+    ads._add_image_container("image_container_port", val)
+    retrieved_val1 = ads._get_port_data_image_container("image_container_port")
+    retrieved_val2 = ads._value_image_container("image_container_port")
+    retrieved_val3 = ads._value_or_image_container("image_container_port")
+
+    # Non typed methods
+    ads.add_value("image_container_port2", val)
+    ads["image_container_port3"] = val
+    retrieved_val4 = ads.get_port_data("image_container_port2")
+    retrieved_val5 = ads.value("image_container_port3")
+    retrieved_val6 = ads.value_or("image_container_port3")
+    retrieved_val7 = ads["image_container_port3"]
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not(val, retrieved_val3)
+    err_is_not(val, retrieved_val4)
+    err_is_not(val, retrieved_val5)
+    err_is_not(val, retrieved_val6)
+    err_is_not(val, retrieved_val7)
+
+    val = kvt.DescriptorSet()
+    # Typed methods
+    ads._add_descriptor_set("descriptor_set_port", val)
+    retrieved_val1 = ads._get_port_data_descriptor_set("descriptor_set_port")
+    retrieved_val2 = ads._value_descriptor_set("descriptor_set_port")
+    retrieved_val3 = ads._value_or_descriptor_set("descriptor_set_port")
+
+    # Non typed methods
+    ads.add_value("descriptor_set_port2", val)
+    ads["descriptor_set_port3"] = val
+    retrieved_val4 = ads.get_port_data("descriptor_set_port2")
+    retrieved_val5 = ads.value("descriptor_set_port3")
+    retrieved_val6 = ads.value_or("descriptor_set_port3")
+    retrieved_val7 = ads["descriptor_set_port3"]
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not(val, retrieved_val3)
+    err_is_not(val, retrieved_val4)
+    err_is_not(val, retrieved_val5)
+    err_is_not(val, retrieved_val6)
+    err_is_not(val, retrieved_val7)
+
+    val = kvt.DetectedObjectSet()
+    # Typed methods
+    ads._add_detected_object_set("detected_object_set_port", val)
+    retrieved_val1 = ads._get_port_data_detected_object_set(
+        "detected_object_set_port"
     )
-    add_get_helper(
-        ads,
-        ads._add_descriptor_set,
-        ads._get_port_data_descriptor_set,
-        kvt.DescriptorSet(),
-        "descriptor_set",
+    retrieved_val2 = ads._value_detected_object_set("detected_object_set_port")
+    retrieved_val3 = ads._value_or_detected_object_set(
+        "detected_object_set_port"
     )
-    add_get_helper(
-        ads,
-        ads._add_detected_object_set,
-        ads._get_port_data_detected_object_set,
-        kvt.DetectedObjectSet(),
-        "detected_object_set",
+
+    # Non typed methods
+    ads.add_value("detected_object_set_port2", val)
+    ads["detected_object_set_port3"] = val
+    retrieved_val4 = ads.get_port_data("detected_object_set_port2")
+    retrieved_val5 = ads.value("detected_object_set_port3")
+    retrieved_val6 = ads.value_or("detected_object_set_port3")
+    retrieved_val7 = ads["detected_object_set_port3"]
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not(val, retrieved_val3)
+    err_is_not(val, retrieved_val4)
+    err_is_not(val, retrieved_val5)
+    err_is_not(val, retrieved_val6)
+    err_is_not(val, retrieved_val7)
+
+    val = kvt.TrackSet()
+    # Typed methods
+    ads._add_track_set("track_set_port", val)
+    retrieved_val1 = ads._get_port_data_track_set("track_set_port")
+    retrieved_val2 = ads._value_track_set("track_set_port")
+    retrieved_val3 = ads._value_or_track_set("track_set_port")
+
+    # Non typed methods
+    ads.add_value("track_set_port2", val)
+    ads["track_set_port3"] = val
+    retrieved_val4 = ads.get_port_data("track_set_port2")
+    retrieved_val5 = ads.value("track_set_port3")
+    retrieved_val6 = ads.value_or("track_set_port3")
+    retrieved_val7 = ads["track_set_port3"]
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not(val, retrieved_val3)
+    err_is_not(val, retrieved_val4)
+    err_is_not(val, retrieved_val5)
+    err_is_not(val, retrieved_val6)
+    err_is_not(val, retrieved_val7)
+
+    val = kvt.ObjectTrackSet()
+    # Typed methods
+    ads._add_object_track_set("object_track_set_port", val)
+    retrieved_val1 = ads._get_port_data_object_track_set(
+        "object_track_set_port"
     )
-    add_get_helper(
-        ads,
-        ads._add_track_set,
-        ads._get_port_data_track_set,
-        kvt.TrackSet(),
-        "track_set",
-    )
-    add_get_helper(
-        ads,
-        ads._add_object_track_set,
-        ads._get_port_data_object_track_set,
-        kvt.ObjectTrackSet(),
-        "object_track_set",
-    )
+    retrieved_val2 = ads._value_object_track_set("object_track_set_port")
+    retrieved_val3 = ads._value_or_object_track_set("object_track_set_port")
+
+    # Non typed methods
+    ads.add_value("object_track_set_port2", val)
+    ads["object_track_set_port3"] = val
+    retrieved_val4 = ads.get_port_data("object_track_set_port2")
+    retrieved_val5 = ads.value("object_track_set_port3")
+    retrieved_val6 = ads.value_or("object_track_set_port3")
+    retrieved_val7 = ads["object_track_set_port3"]
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not(val, retrieved_val3)
+    err_is_not(val, retrieved_val4)
+    err_is_not(val, retrieved_val5)
+    err_is_not(val, retrieved_val6)
+    err_is_not(val, retrieved_val7)
+
+
+def test_value_or_vital_types_by_ptr():
+    from kwiver.sprokit.adapters import adapter_data_set
+    import kwiver.vital.types as kvt
+
+    ads = adapter_data_set.AdapterDataSet.create()
+
+    val = kvt.ImageContainer(kvt.Image())
+    # Typed
+    retrieved_val1 = ads._value_or_image_container("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not_none(ads._value_or_image_container("nonexistant_port"))
+
+    val = kvt.DescriptorSet()
+    # Typed
+    retrieved_val1 = ads._value_or_descriptor_set("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not_none(ads._value_or_descriptor_set("nonexistant_port"))
+
+    val = kvt.DetectedObjectSet()
+    # Typed
+    retrieved_val1 = ads._value_or_detected_object_set("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not_none(ads._value_or_detected_object_set("nonexistant_port"))
+
+    val = kvt.TrackSet()
+    # Typed
+    retrieved_val1 = ads._value_or_track_set("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not_none(ads._value_or_track_set("nonexistant_port"))
+
+    val = kvt.ObjectTrackSet()
+    # Typed
+    retrieved_val1 = ads._value_or_object_track_set("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_is_not(val, retrieved_val1)
+    err_is_not(val, retrieved_val2)
+    err_is_not_none(ads._value_or_object_track_set("nonexistant_port"))
 
 
 # Next some bound native C++ types
@@ -242,27 +541,108 @@ def test_add_get_cpp_types():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(
-        ads,
-        ads._add_double_vector,
-        ads._get_port_data_double_vector,
-        adapter_data_set.VectorDouble([3.14, 4.14]),
-        "double_vector",
-    )
-    add_get_helper(
-        ads,
-        ads._add_string_vector,
-        ads._get_port_data_string_vector,
-        adapter_data_set.VectorString(["s00", "s01"]),
-        "string_vector",
-    )
-    add_get_helper(
-        ads,
-        ads._add_uchar_vector,
-        ads._get_port_data_uchar_vector,
-        adapter_data_set.VectorUChar([100, 101]),
-        "uchar_vector",
-    )
+
+    val = adapter_data_set.VectorDouble([3.14, 4.14])
+    # Typed methods
+    ads._add_double_vector("double_vector_port", val)
+    retrieved_val1 = ads._get_port_data_double_vector("double_vector_port")
+    retrieved_val2 = ads._value_double_vector("double_vector_port")
+    retrieved_val3 = ads._value_or_double_vector("double_vector_port")
+
+    # Non typed methods
+    ads.add_value("double_vector_port2", val)
+    ads["double_vector_port3"] = val
+    retrieved_val4 = ads.get_port_data("double_vector_port2")
+    retrieved_val5 = ads.value("double_vector_port3")
+    retrieved_val6 = ads.value_or("double_vector_port3")
+    retrieved_val7 = ads["double_vector_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = adapter_data_set.VectorString(["s00", "s01"])
+    # Typed methods
+    ads._add_string_vector("string_vector_port", val)
+    retrieved_val1 = ads._get_port_data_string_vector("string_vector_port")
+    retrieved_val2 = ads._value_string_vector("string_vector_port")
+    retrieved_val3 = ads._value_or_string_vector("string_vector_port")
+
+    # Non typed methods
+    ads.add_value("string_vector_port2", val)
+    ads["string_vector_port3"] = val
+    retrieved_val4 = ads.get_port_data("string_vector_port2")
+    retrieved_val5 = ads.value("string_vector_port3")
+    retrieved_val6 = ads.value_or("string_vector_port3")
+    retrieved_val7 = ads["string_vector_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = adapter_data_set.VectorUChar([100, 101])
+    # Typed methods
+    ads._add_uchar_vector("uchar_vector_port", val)
+    retrieved_val1 = ads._get_port_data_uchar_vector("uchar_vector_port")
+    retrieved_val2 = ads._value_uchar_vector("uchar_vector_port")
+    retrieved_val3 = ads._value_or_uchar_vector("uchar_vector_port")
+
+    # Non typed methods
+    ads.add_value("uchar_vector_port2", val)
+    ads["uchar_vector_port3"] = val
+    retrieved_val4 = ads.get_port_data("uchar_vector_port2")
+    retrieved_val5 = ads.value("uchar_vector_port3")
+    retrieved_val6 = ads.value_or("uchar_vector_port3")
+    retrieved_val7 = ads["uchar_vector_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+
+def test_value_or_cpp_types():
+    from kwiver.sprokit.adapters import adapter_data_set
+    import kwiver.vital.types as kvt
+
+    ads = adapter_data_set.AdapterDataSet.create()
+    val = adapter_data_set.VectorDouble([3.14, 4.14])
+    # Typed
+    retrieved_val1 = ads._value_or_double_vector("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_double_vector("nonexistant_port"))
+
+    val = adapter_data_set.VectorString(["s00", "s01"])
+    # Typed
+    retrieved_val1 = ads._value_or_string_vector("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_string_vector("nonexistant_port"))
+
+    val = adapter_data_set.VectorUChar([100, 101])
+    # Typed
+    retrieved_val1 = ads._value_or_uchar_vector("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(str(val), str(retrieved_val1))
+    err_ne(str(val), str(retrieved_val2))
+    err_is_not_none(ads._value_or_uchar_vector("nonexistant_port"))
 
 
 # Now try creating datums of these bound types
@@ -270,27 +650,64 @@ def test_add_get_cpp_types_with_datum():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(
-        ads,
-        ads.add_datum,
-        ads._get_port_data_double_vector,
-        datum.new_double_vector(datum.VectorDouble([6.3, 8.9])),
-        "datum_double_vector",
+
+    val = datum.VectorDouble([6.3, 8.9])
+    d = datum.new_double_vector(val)
+    ads.add_datum("datum_double_vector_port", d)
+    retrieved_val1 = ads._get_port_data_double_vector(
+        "datum_double_vector_port"
     )
-    add_get_helper(
-        ads,
-        ads.add_datum,
-        ads._get_port_data_string_vector,
-        datum.new_string_vector(datum.VectorString(["foo", "bar"])),
-        "datum_string_vector",
+    retrieved_val2 = ads._value_double_vector("datum_double_vector_port")
+    retrieved_val3 = ads._value_or_double_vector("datum_double_vector_port")
+    retrieved_val4 = ads.get_port_data("datum_double_vector_port")
+    retrieved_val5 = ads.value("datum_double_vector_port")
+    retrieved_val6 = ads.value_or("datum_double_vector_port")
+    retrieved_val7 = ads["datum_double_vector_port"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = datum.VectorString(["foo", "bar"])
+    d = datum.new_string_vector(val)
+    ads.add_datum("datum_string_vector_port", d)
+    retrieved_val1 = ads._get_port_data_string_vector(
+        "datum_string_vector_port"
     )
-    add_get_helper(
-        ads,
-        ads.add_datum,
-        ads._get_port_data_uchar_vector,
-        datum.new_uchar_vector(datum.VectorUChar([102, 103])),
-        "datum_uchar_vector",
-    )
+    retrieved_val2 = ads._value_string_vector("datum_string_vector_port")
+    retrieved_val3 = ads._value_or_string_vector("datum_string_vector_port")
+    retrieved_val4 = ads.get_port_data("datum_string_vector_port")
+    retrieved_val5 = ads.value("datum_string_vector_port")
+    retrieved_val6 = ads.value_or("datum_string_vector_port")
+    retrieved_val7 = ads["datum_string_vector_port"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = datum.VectorUChar([102, 103])
+    d = datum.new_uchar_vector(val)
+    ads.add_datum("datum_uchar_vector_port", d)
+    retrieved_val1 = ads._get_port_data_uchar_vector("datum_uchar_vector_port")
+    retrieved_val2 = ads._value_uchar_vector("datum_uchar_vector_port")
+    retrieved_val3 = ads._value_or_uchar_vector("datum_uchar_vector_port")
+    retrieved_val4 = ads.get_port_data("datum_uchar_vector_port")
+    retrieved_val5 = ads.value("datum_uchar_vector_port")
+    retrieved_val6 = ads.value_or("datum_uchar_vector_port")
+    retrieved_val7 = ads["datum_uchar_vector_port"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
 
 
 # Next kwiver vital types
@@ -299,27 +716,108 @@ def test_add_get_vital_types():
     from kwiver.sprokit.adapters import adapter_data_set
 
     ads = adapter_data_set.AdapterDataSet.create()
-    add_get_helper(
-        ads,
-        ads._add_bounding_box,
-        ads._get_port_data_bounding_box,
-        kvt.BoundingBoxD(1, 1, 2, 2),
-        "bounding_box",
-    )
-    add_get_helper(
-        ads,
-        ads._add_timestamp,
-        ads._get_port_data_timestamp,
-        kvt.Timestamp(),
-        "timestamp",
-    )
-    add_get_helper(
-        ads,
-        ads._add_f2f_homography,
-        ads._get_port_data_f2f_homography,
-        kvt.F2FHomography(1),
-        "f2f_homography",
-    )
+
+    val = kvt.BoundingBoxD(1, 1, 2, 2)
+    # Typed methods
+    ads._add_bounding_box("bounding_box_port", val)
+    retrieved_val1 = ads._get_port_data_bounding_box("bounding_box_port")
+    retrieved_val2 = ads._value_bounding_box("bounding_box_port")
+    retrieved_val3 = ads._value_or_bounding_box("bounding_box_port")
+
+    # Non typed methods
+    ads.add_value("bounding_box_port2", val)
+    ads["bounding_box_port3"] = val
+    retrieved_val4 = ads.get_port_data("bounding_box_port2")
+    retrieved_val5 = ads.value("bounding_box_port3")
+    retrieved_val6 = ads.value_or("bounding_box_port3")
+    retrieved_val7 = ads["bounding_box_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = kvt.Timestamp(100, 1)
+    # Typed methods
+    ads._add_timestamp("timestamp_port", val)
+    retrieved_val1 = ads._get_port_data_timestamp("timestamp_port")
+    retrieved_val2 = ads._value_timestamp("timestamp_port")
+    retrieved_val3 = ads._value_or_timestamp("timestamp_port")
+
+    # Non typed methods
+    ads.add_value("timestamp_port2", val)
+    ads["timestamp_port3"] = val
+    retrieved_val4 = ads.get_port_data("timestamp_port2")
+    retrieved_val5 = ads.value("timestamp_port3")
+    retrieved_val6 = ads.value_or("timestamp_port3")
+    retrieved_val7 = ads["timestamp_port3"]
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_ne(val, retrieved_val3)
+    err_ne(val, retrieved_val4)
+    err_ne(val, retrieved_val5)
+    err_ne(val, retrieved_val6)
+    err_ne(val, retrieved_val7)
+
+    val = kvt.F2FHomography(1)
+    # Typed methods
+    ads._add_f2f_homography("f2f_homography_port", val)
+    retrieved_val1 = ads._get_port_data_f2f_homography("f2f_homography_port")
+    retrieved_val2 = ads._value_f2f_homography("f2f_homography_port")
+    retrieved_val3 = ads._value_or_f2f_homography("f2f_homography_port")
+
+    # Non typed methods
+    ads.add_value("f2f_homography_port2", val)
+    ads["f2f_homography_port3"] = val
+    retrieved_val4 = ads.get_port_data("f2f_homography_port2")
+    retrieved_val5 = ads.value("f2f_homography_port3")
+    retrieved_val6 = ads.value_or("f2f_homography_port3")
+    retrieved_val7 = ads["f2f_homography_port3"]
+    err_ne(str(val), str(retrieved_val1))
+    err_ne(str(val), str(retrieved_val2))
+    err_ne(str(val), str(retrieved_val3))
+    err_ne(str(val), str(retrieved_val4))
+    err_ne(str(val), str(retrieved_val5))
+    err_ne(str(val), str(retrieved_val6))
+    err_ne(str(val), str(retrieved_val7))
+
+
+def test_value_or_vital_types():
+    from kwiver.sprokit.adapters import adapter_data_set
+    import kwiver.vital.types as kvt
+
+    ads = adapter_data_set.AdapterDataSet.create()
+    val = kvt.BoundingBoxD(1, 1, 2, 2)
+    # Typed
+    retrieved_val1 = ads._value_or_bounding_box("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_bounding_box("nonexistant_port"))
+
+    val = kvt.Timestamp(100, 1)
+    # Typed
+    retrieved_val1 = ads._value_or_timestamp("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(val, retrieved_val1)
+    err_ne(val, retrieved_val2)
+    err_is_not_none(ads._value_or_timestamp("nonexistant_port"))
+
+    val = kvt.F2FHomography(1)
+    # Typed
+    retrieved_val1 = ads._value_or_f2f_homography("nonexistant_port", val)
+
+    # Non typed
+    retrieved_val2 = ads.value_or("nonexistant_port", val)
+    err_ne(str(val), str(retrieved_val1))
+    err_ne(str(val), str(retrieved_val2))
+    err_is_not_none(ads._value_or_f2f_homography("nonexistant_port"))
 
 
 # Now test overwriting
@@ -342,7 +840,11 @@ def test_overwrite():
 
     # Overwriting with completely different types
     overwrite_helper(
-        ads.add_datum, ads.get_port_data, datum.new(12), "datum_int", OVERWRITE_PORT
+        ads.add_datum,
+        ads.get_port_data,
+        datum.new(12),
+        "datum_int",
+        OVERWRITE_PORT,
     )
     overwrite_helper(
         ads._add_string_vector,
@@ -358,7 +860,9 @@ def test_overwrite():
         "timestamp",
         OVERWRITE_PORT,
     )
-    overwrite_helper(ads.add_value, ads.get_port_data, 15, "int", OVERWRITE_PORT)
+    overwrite_helper(
+        ads.add_value, ads.get_port_data, 15, "int", OVERWRITE_PORT
+    )
     overwrite_helper(
         ads._add_double_vector,
         ads._get_port_data_double_vector,
@@ -380,40 +884,39 @@ def test_mix_add_and_get():
     # Try adding with generic adder first, retrieving with
     # type specific get function
     ads["string_port"] = "string_value"
-    check_same_type(
-        ads._get_port_data_string("string_port"), "string_value", "string_port"
+    err_ne(
+        ads._get_port_data_string("string_port"),
+        "string_value",
     )
 
     ads["timestamp_port"] = kvt.Timestamp(1000000000, 10)
-    check_same_type(
+    err_ne(
         ads._get_port_data_timestamp("timestamp_port"),
         kvt.Timestamp(1000000000, 10),
-        "timestamp_port",
     )
 
-    ads["vector_string_port"] = adapter_data_set.VectorString(["element1", "element2"])
-    check_same_type(
+    ads["vector_string_port"] = adapter_data_set.VectorString(
+        ["element1", "element2"]
+    )
+    err_ne(
         ads._get_port_data_string_vector("vector_string_port"),
         adapter_data_set.VectorString(["element1", "element2"]),
-        "vector_string_port",
     )
 
     # Now try the opposite
     ads._add_string("string_port", "string_value")
-    check_same_type(ads["string_port"], "string_value", "string_port")
+    err_ne(ads["string_port"], "string_value")
 
     ads._add_timestamp("timestamp_port", kvt.Timestamp(1000000000, 10))
-    check_same_type(
-        ads["timestamp_port"], kvt.Timestamp(1000000000, 10), "timestamp_port"
-    )
+    err_ne(ads["timestamp_port"], kvt.Timestamp(1000000000, 10))
 
     ads._add_string_vector(
-        "vector_string_port", adapter_data_set.VectorString(["element1", "element2"])
+        "vector_string_port",
+        adapter_data_set.VectorString(["element1", "element2"]),
     )
-    check_same_type(
+    err_ne(
         ads["vector_string_port"],
         adapter_data_set.VectorString(["element1", "element2"]),
-        "vector_string_port",
     )
 
 
@@ -467,7 +970,9 @@ def _create_ads():
     # Construct a few elements
     ads["string_port"] = "string_value"
     ads["timestamp_port"] = kvt.Timestamp(1000000000, 10)
-    ads["vector_string_port"] = adapter_data_set.VectorString(["element1", "element2"])
+    ads["vector_string_port"] = adapter_data_set.VectorString(
+        ["element1", "element2"]
+    )
 
     return ads
 
@@ -481,7 +986,9 @@ def test_iter():
     for port, dat in ads:
         if port == "string_port":
             if dat.get_datum() != "string_value":
-                test_error("Didn't retrieve correct string value on first iteration")
+                test_error(
+                    "Didn't retrieve correct string value on first iteration"
+                )
         elif port == "timestamp_port":
             if dat.get_datum() != kvt.Timestamp(1000000000, 10):
                 test_error(
@@ -489,14 +996,18 @@ def test_iter():
                 )
         elif port == "vector_string_port":
             if dat.get_datum() != datum.VectorString(["element1", "element2"]):
-                test_error("Didn't retrieve correct string vector on third iteration")
+                test_error(
+                    "Didn't retrieve correct string vector on third iteration"
+                )
         else:
             test_error("unknown port: {}".format(port))
 
 
 def check_formatting_fxn(exp, act, fxn_name):
     if not act == exp:
-        test_error("Expected {} to return '{}'. Got '{}'".format(fxn_name, exp, act))
+        test_error(
+            "Expected {} to return '{}'. Got '{}'".format(fxn_name, exp, act)
+        )
 
     print(act)
 
@@ -548,12 +1059,16 @@ def test_len():
 
     # Check initial
     if len(ads) != 0:
-        test_error("adapter_data_set with 0 values returned size {}".format(len(ads)))
+        test_error(
+            "adapter_data_set with 0 values returned size {}".format(len(ads))
+        )
 
     ads = _create_ads()
 
     if len(ads) != 3:
-        test_error("adapter_data_set with 3 values returned size {}".format(len(ads)))
+        test_error(
+            "adapter_data_set with 3 values returned size {}".format(len(ads))
+        )
 
 
 if __name__ == "__main__":

--- a/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
+++ b/python/kwiver/sprokit/tests/sprokit/adapters/test-adapter_data_set.py
@@ -189,6 +189,8 @@ def test_add_get_basic_types():
     ads = adapter_data_set.AdapterDataSet.create()
     add_get_helper(ads, ads._add_int, ads._get_port_data_int, 10, "int")
     add_get_helper(ads, ads._add_float, ads._get_port_data_float, 0.5, "float")
+    add_get_helper(ads, ads._add_double, ads._get_port_data_double, 3.14, "double")
+    add_get_helper(ads, ads._add_bool, ads._get_port_data_bool, True, "bool")
     add_get_helper(ads, ads._add_string, ads._get_port_data_string, "str1", "string")
 
 

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
@@ -150,6 +150,14 @@ def test_add_get_basic_types():
     retrieved_val = datum_inst.get_float()
     check_same_type(retrieved_val, 0.5)
 
+    datum_inst = datum.new_double(3.14)
+    retrieved_val = datum_inst.get_double()
+    check_same_type(retrieved_val, 3.14)
+
+    datum_inst = datum.new_bool(True)
+    retrieved_val = datum_inst.get_bool()
+    check_same_type(retrieved_val, True)
+
     datum_inst = datum.new_string("str1")
     retrieved_val = datum_inst.get_string()
     check_same_type(retrieved_val, "str1")
@@ -157,6 +165,7 @@ def test_add_get_basic_types():
     # Now the ones with automatic conversion
     check_automatic_conversion(10)
     check_automatic_conversion(0.5)
+    check_automatic_conversion(True)
     check_automatic_conversion("str1")
 
 # Next some kwiver vital types that are handled with pointers

--- a/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/test-datum.py
@@ -123,19 +123,26 @@ def test_error_():
     if p is not None:
         test_error("An error datum does not have None as its data")
 
-def check_same_type(retrieved_val, val):
-    if not type(retrieved_val) is type(val):
-        msg = "Retrieved value of type: {}. Expected type: {}"
-        msg = msg.format(type(retrieved_val), type(val))
-        test_error(msg)
+def err_ne(expected, actual):
+    if expected != actual:
+        test_error("Expected value of {}, got {}".format(expected, actual))
+
+
+def err_is_not(expected, actual):
+    if expected is not actual:
+        msg = "Expected {} and {} to point to same object"
+        test_error(msg.format(expected, actual))
+
+def err_str_ne(expected, actual):
+    err_ne(str(expected), str(actual))
 
 # Check the automatic type conversion done by new() and get_datum()
-def check_automatic_conversion(val):
+def check_automatic_conversion(val, compare_fxn):
     from kwiver.sprokit.pipeline import datum
 
     datum_inst = datum.new(val)
     retrieved_val = datum_inst.get_datum()
-    check_same_type(retrieved_val, val)
+    compare_fxn(retrieved_val, val)
 
 # Next some basic types
 def test_add_get_basic_types():
@@ -144,60 +151,65 @@ def test_add_get_basic_types():
     # Try the typed constructor/get fxns first
     datum_inst = datum.new_int(10)
     retrieved_val = datum_inst.get_int()
-    check_same_type(retrieved_val, 10)
+    err_ne(retrieved_val, 10)
 
     datum_inst = datum.new_float(0.5)
     retrieved_val = datum_inst.get_float()
-    check_same_type(retrieved_val, 0.5)
+    err_ne(retrieved_val, 0.5)
 
     datum_inst = datum.new_double(3.14)
     retrieved_val = datum_inst.get_double()
-    check_same_type(retrieved_val, 3.14)
+    err_ne(retrieved_val, 3.14)
 
     datum_inst = datum.new_bool(True)
     retrieved_val = datum_inst.get_bool()
-    check_same_type(retrieved_val, True)
+    err_ne(retrieved_val, True)
 
     datum_inst = datum.new_string("str1")
     retrieved_val = datum_inst.get_string()
-    check_same_type(retrieved_val, "str1")
+    err_ne(retrieved_val, "str1")
 
     # Now the ones with automatic conversion
-    check_automatic_conversion(10)
-    check_automatic_conversion(0.5)
-    check_automatic_conversion(True)
-    check_automatic_conversion("str1")
+    check_automatic_conversion(10, err_ne)
+    check_automatic_conversion(0.5, err_ne)
+    check_automatic_conversion(True, err_ne)
+    check_automatic_conversion("str1", err_ne)
 
 # Next some kwiver vital types that are handled with pointers
 def test_add_get_vital_types_by_ptr():
     from kwiver.sprokit.pipeline import datum
     from kwiver.vital import types as kvt
 
-    datum_inst = datum.new_image_container(kvt.ImageContainer(kvt.Image()))
+    val = kvt.ImageContainer(kvt.Image())
+    datum_inst = datum.new_image_container(val)
     retrieved_val = datum_inst.get_image_container()
-    check_same_type(retrieved_val, kvt.ImageContainer(kvt.Image()))
+    err_is_not(retrieved_val, val)
 
-    datum_inst = datum.new_descriptor_set(kvt.DescriptorSet())
+    val = kvt.DescriptorSet()
+    datum_inst = datum.new_descriptor_set(val)
     retrieved_val = datum_inst.get_descriptor_set()
-    check_same_type(retrieved_val, kvt.DescriptorSet())
+    err_is_not(retrieved_val, val)
 
-    datum_inst = datum.new_detected_object_set(kvt.DetectedObjectSet())
+    val = kvt.DetectedObjectSet()
+    datum_inst = datum.new_detected_object_set(val)
     retrieved_val = datum_inst.get_detected_object_set()
-    check_same_type(retrieved_val, kvt.DetectedObjectSet())
+    err_is_not(retrieved_val, val)
 
-    datum_inst = datum.new_track_set(kvt.TrackSet())
+    val = kvt.TrackSet()
+    datum_inst = datum.new_track_set(val)
     retrieved_val = datum_inst.get_track_set()
-    check_same_type(retrieved_val, kvt.TrackSet())
+    err_is_not(retrieved_val, val)
 
-    datum_inst = datum.new_object_track_set(kvt.ObjectTrackSet())
+    val = kvt.ObjectTrackSet()
+    datum_inst = datum.new_object_track_set(val)
     retrieved_val = datum_inst.get_object_track_set()
-    check_same_type(retrieved_val, kvt.ObjectTrackSet())
+    err_is_not(retrieved_val, val)
 
-    check_automatic_conversion(kvt.ImageContainer(kvt.Image()))
-    check_automatic_conversion(kvt.DescriptorSet())
-    check_automatic_conversion(kvt.DetectedObjectSet())
-    check_automatic_conversion(kvt.TrackSet())
-    check_automatic_conversion(kvt.ObjectTrackSet())
+    check_automatic_conversion(kvt.ImageContainer(kvt.Image()), err_is_not)
+    check_automatic_conversion(kvt.DescriptorSet(), err_is_not)
+    check_automatic_conversion(kvt.DetectedObjectSet(), err_is_not)
+    check_automatic_conversion(kvt.TrackSet(), err_is_not)
+    check_automatic_conversion(kvt.ObjectTrackSet(), err_is_not)
 
 # Next some bound native C++ types
 def test_add_get_cpp_types():
@@ -205,19 +217,19 @@ def test_add_get_cpp_types():
 
     datum_inst = datum.new_double_vector(datum.VectorDouble([3.14, 4.14]))
     retrieved_val = datum_inst.get_double_vector()
-    check_same_type(retrieved_val, datum.VectorDouble([3.14, 4.14]))
+    err_ne(retrieved_val, datum.VectorDouble([3.14, 4.14]))
 
     datum_inst = datum.new_string_vector(datum.VectorString(["s00", "s01"]))
     retrieved_val = datum_inst.get_string_vector()
-    check_same_type(retrieved_val, datum.VectorString(["s00", "s01"]))
+    err_ne(retrieved_val, datum.VectorString(["s00", "s01"]))
 
     datum_inst = datum.new_uchar_vector(datum.VectorUChar([100, 101]))
     retrieved_val = datum_inst.get_uchar_vector()
-    check_same_type(retrieved_val, datum.VectorUChar([100, 101]))
+    err_ne(retrieved_val, datum.VectorUChar([100, 101]))
 
-    check_automatic_conversion(datum.VectorDouble([3.14, 4.14]))
-    check_automatic_conversion(datum.VectorString(["s00", "s01"]))
-    check_automatic_conversion(datum.VectorUChar([100, 101]))
+    check_automatic_conversion(datum.VectorDouble([3.14, 4.14]), err_ne)
+    check_automatic_conversion(datum.VectorString(["s00", "s01"]), err_ne)
+    check_automatic_conversion(datum.VectorUChar([100, 101]), err_ne)
 
 # Next kwiver vital types
 def test_add_get_vital_types():
@@ -226,19 +238,19 @@ def test_add_get_vital_types():
 
     datum_inst = datum.new_bounding_box(kvt.BoundingBoxD(1, 1, 2, 2))
     retrieved_val = datum_inst.get_bounding_box()
-    check_same_type(retrieved_val, kvt.BoundingBoxD(1, 1, 2, 2))
+    err_ne(retrieved_val, kvt.BoundingBoxD(1, 1, 2, 2))
 
-    datum_inst = datum.new_timestamp(kvt.Timestamp())
+    datum_inst = datum.new_timestamp(kvt.Timestamp(123, 1))
     retrieved_val = datum_inst.get_timestamp()
-    check_same_type(retrieved_val, kvt.Timestamp())
+    err_ne(retrieved_val, kvt.Timestamp(123, 1))
 
     datum_inst = datum.new_f2f_homography(kvt.F2FHomography(1))
     retrieved_val = datum_inst.get_f2f_homography()
-    check_same_type(retrieved_val, kvt.F2FHomography(1))
+    err_str_ne(retrieved_val, kvt.F2FHomography(1))
 
-    check_automatic_conversion(kvt.BoundingBoxD(1, 1, 2, 2))
-    check_automatic_conversion(kvt.Timestamp())
-    check_automatic_conversion(kvt.F2FHomography(1))
+    check_automatic_conversion(kvt.BoundingBoxD(1, 1, 2, 2), err_ne)
+    check_automatic_conversion(kvt.Timestamp(123, 1), err_ne)
+    check_automatic_conversion(kvt.F2FHomography(1), err_str_ne)
 
 # Want to make sure data inside a datum created with the automatic
 # conversion constructor can be retrieved with a type specific getter, and
@@ -250,23 +262,23 @@ def test_mix_new_and_get():
     # Try creating with generic constructor first, retrieving with
     # type specific get function
     datum_inst = datum.new("string_value")
-    check_same_type(datum_inst.get_string(), "string_value")
+    err_ne(datum_inst.get_string(), "string_value")
 
     datum_inst = datum.new(kvt.Timestamp(1000000000, 10))
-    check_same_type(datum_inst.get_timestamp(), kvt.Timestamp(1000000000, 10))
+    err_ne(datum_inst.get_timestamp(), kvt.Timestamp(1000000000, 10))
 
     datum_inst = datum.new(datum.VectorString(["element1", "element2"]))
-    check_same_type(datum_inst.get_string_vector(), datum.VectorString(["element1", "element2"]))
+    err_ne(datum_inst.get_string_vector(), datum.VectorString(["element1", "element2"]))
 
     # Now try the opposite
     datum_inst = datum.new_string("string_value")
-    check_same_type(datum_inst.get_datum(), "string_value")
+    err_ne(datum_inst.get_datum(), "string_value")
 
     datum_inst = datum.new_timestamp(kvt.Timestamp(1000000000, 10))
-    check_same_type(datum_inst.get_datum(), kvt.Timestamp(1000000000, 10))
+    err_ne(datum_inst.get_datum(), kvt.Timestamp(1000000000, 10))
 
     datum_inst = datum.new_string_vector(datum.VectorString(["element1", "element2"]))
-    check_same_type(datum_inst.get_datum(), datum.VectorString(["element1", "element2"]))
+    err_ne(datum_inst.get_datum(), datum.VectorString(["element1", "element2"]))
 
 # Make sure that None isn't acceptable, even for pointers
 def test_new_with_none():


### PR DESCRIPTION
Updates the python bindings for `adapter_data_set` to include instantiations for `bool` and `double`. Also adds `value` and `value_or` bindings, and refactors some tests for `datum` and `adapter_data_set`.

See https://github.com/Kitware/kwiver/pull/1287 for the corresponding changes to the C++ API propagated here.

@mwoehlke-kitware One thing I'm not sure about. Whenever a Python user adds a `py::float` to a port, we store that as a C++ `double`, since python floats have double precision. This means that there is no way for a Python user to add a float to a port unless they use `_add_value_float`. Is this an issue? Thanks.