### PR TITLE
Avoid some smart pointer copying

### DIFF
--- a/arrows/core/track_set_impl.cxx
+++ b/arrows/core/track_set_impl.cxx
@@ -113,13 +113,12 @@ frame_index_track_set_impl
 /// Insert a track shared pointer into this container
 void
 frame_index_track_set_impl
-::insert( vital::track_sptr t )
+::insert( vital::track_sptr const& t )
 {
   if (!t)
   {
     return;
   }
-  all_tracks_.insert(std::make_pair(t->id(), t));
 
   if (!frame_map_.empty())
   {
@@ -129,6 +128,30 @@ frame_index_track_set_impl
       frame_map_[ts->frame()].insert(ts);
     }
   }
+
+  all_tracks_.emplace(t->id(), t);
+}
+
+/// Insert a track shared pointer into this container
+void
+frame_index_track_set_impl
+::insert( vital::track_sptr&& t )
+{
+  if (!t)
+  {
+    return;
+  }
+
+  if (!frame_map_.empty())
+  {
+    // update the frame map with the new track
+    for (auto const& ts : *t)
+    {
+      frame_map_[ts->frame()].insert(ts);
+    }
+  }
+
+  all_tracks_.emplace(t->id(), std::move(t));
 }
 
 /// Notify the container that a new state has been added to an existing track

--- a/arrows/core/track_set_impl.h
+++ b/arrows/core/track_set_impl.h
@@ -55,7 +55,10 @@ public:
   virtual void set_tracks( std::vector< vital::track_sptr > const& tracks );
 
   /// Insert a track shared pointer into this container
-  virtual void insert( vital::track_sptr t );
+  //@{
+  virtual void insert( vital::track_sptr const& t );
+  virtual void insert( vital::track_sptr&& t );
+  //@}
 
   /// Notify the container that a new state has been added to an existing track
   virtual void notify_new_state( vital::track_state_sptr ts );

--- a/python/kwiver/vital/types/camera_perspective.cxx
+++ b/python/kwiver/vital/types/camera_perspective.cxx
@@ -4,6 +4,8 @@
 
 #include <vital/types/camera_perspective.h>
 
+#include <vital/overload.h>
+
 #include <python/kwiver/vital/util/pybind11.h>
 
 #include <pybind11/eigen.h>
@@ -91,7 +93,9 @@ PYBIND11_MODULE( camera_perspective, m )
   .def( "set_translation",  &kv::simple_camera_perspective::set_translation )
   .def( "set_center_covar", &kv::simple_camera_perspective::set_center_covar )
   .def( "set_rotation",     &kv::simple_camera_perspective::set_rotation )
-  .def( "set_intrinsics",   &kv::simple_camera_perspective::set_intrinsics )
+  .def( "set_intrinsics",
+        kv::overload< kv::camera_intrinsics_sptr const& >(
+          &kv::simple_camera_perspective::set_intrinsics ) )
   .def( "look_at",          &kv::simple_camera_perspective::look_at,
          py::arg( "stare_point" ), py::arg( "up_direction" ) = kv::vector_3d::UnitZ() )
 

--- a/python/kwiver/vital/types/camera_perspective_map.cxx
+++ b/python/kwiver/vital/types/camera_perspective_map.cxx
@@ -5,6 +5,8 @@
 #include <vital/types/camera_perspective.h>
 #include <vital/types/camera_perspective_map.h>
 
+#include <vital/overload.h>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -28,6 +30,8 @@ class camera_perspective_map_trampoline
 
 PYBIND11_MODULE( camera_perspective_map, m)
 {
+  using cam_sptr_t = std::shared_ptr< kv::camera_perspective >;
+
   py::class_< kv::camera_map_of_< kv::camera_perspective >,
               std::shared_ptr< kv::camera_map_of_< kv::camera_perspective > >,
               camera_perspective_map_trampoline >(m, "CameraPerspectiveMap" )
@@ -38,7 +42,9 @@ PYBIND11_MODULE( camera_perspective_map, m)
   .def( "get_frame_ids",              &kv::camera_map_of_< kv::camera_perspective >::get_frame_ids )
   .def( "find",                       &kv::camera_map_of_< kv::camera_perspective >::find )
   .def( "erase",                      &kv::camera_map_of_< kv::camera_perspective >::erase )
-  .def( "insert",                     &kv::camera_map_of_< kv::camera_perspective >::insert )
+  .def( "insert",
+        kv::overload< kv::frame_id_t, cam_sptr_t const& >(
+          &kv::camera_map_of_< kv::camera_perspective >::insert ) )
   .def( "clear",                      &kv::camera_map_of_< kv::camera_perspective >::clear )
   .def( "set_from_base_camera_map",   &kv::camera_map_of_< kv::camera_perspective >::set_from_base_camera_map )
   .def( "clone",                      &kv::camera_map_of_< kv::camera_perspective >::clone )

--- a/vital/overload.h
+++ b/vital/overload.h
@@ -1,0 +1,30 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef KWIVER_VITAL_OVERLOAD_H
+#define KWIVER_VITAL_OVERLOAD_H
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+template < class... Args, class T, class R >
+constexpr inline
+auto
+overload( R ( T::* m )( Args... ) ) -> decltype( m )
+{ return m; }
+
+// ----------------------------------------------------------------------------
+template < class T, class R >
+constexpr inline
+auto
+overload( R ( T::* m )() ) -> decltype( m )
+{ return m; }
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/vital/types/camera_map.h
+++ b/vital/types/camera_map.h
@@ -143,10 +143,17 @@ public:
   * \param [in] fid the frame id of the camera to insert
   * \param [in] cam the camera to insert
   */
-  void insert(frame_id_t fid, std::shared_ptr<T> cam)
+  //@{
+  void insert(frame_id_t fid, std::shared_ptr<T> const& cam)
   {
     data_[fid] = cam;
   }
+
+  void insert(frame_id_t fid, std::shared_ptr<T>&& cam)
+  {
+    data_[fid] = std::move(cam);
+  }
+  //@}
 
   /// Clear the map of all cameras
   void clear()

--- a/vital/types/camera_perspective.h
+++ b/vital/types/camera_perspective.h
@@ -232,12 +232,20 @@ public:
   void set_rotation( const rotation_d& rotation ) { orientation_ = rotation; }
 
   /// Set the intrinsics
+  //@{
   void set_intrinsics( const camera_intrinsics_sptr& intrinsics )
   {
     intrinsics_ = ! intrinsics
                   ? camera_intrinsics_sptr(new simple_camera_intrinsics())
                   : intrinsics;
   }
+  void set_intrinsics( camera_intrinsics_sptr&& intrinsics )
+  {
+    intrinsics_ = ! intrinsics
+                  ? std::make_shared< simple_camera_intrinsics >()
+                  : std::move( intrinsics );
+  }
+  //@}
 
   /// Rotate the camera about its center such that it looks at the given point.
   /**

--- a/vital/types/track_set.h
+++ b/vital/types/track_set.h
@@ -71,7 +71,10 @@ public:
   virtual void set_tracks( std::vector< track_sptr > const& tracks ) = 0;
 
   /// Insert a track shared pointer into this container
-  virtual void insert( track_sptr t ) = 0;
+  //@{
+  virtual void insert( track_sptr const& t ) = 0;
+  virtual void insert( track_sptr&& t ) = 0;
+  //@}
 
   /// Notify the container that a new state has been added to an existing track
   /**
@@ -468,10 +471,17 @@ public:
   }
 
   /// Insert a track shared pointer into this container
-  virtual void insert( track_sptr t )
+  //@{
+  virtual void insert( track_sptr const& t )
   {
     impl_->insert( t );
   }
+
+  virtual void insert( track_sptr&& t )
+  {
+    impl_->insert( std::move( t ) );
+  }
+  //@}
 
   /// Notify the container that a new state has been added to an existing track
   virtual void notify_new_state( track_state_sptr ts )
@@ -668,7 +678,8 @@ public:
   virtual void set_tracks( std::vector< track_sptr > const& tracks ) { data_ = tracks; }
 
   /// Insert a track shared pointer into this container
-  virtual void insert( track_sptr t ) { data_.push_back( t ); }
+  virtual void insert( track_sptr const& t ) { data_.push_back( t ); }
+  virtual void insert( track_sptr&& t ) { data_.push_back( std::move( t ) ); }
 
   /// Remove a track from the set and return true if successful
   virtual bool remove( track_sptr t );


### PR DESCRIPTION
Modify a handful of classes to add r-value reference overloads for methods that take ownership of an object via a smart pointer. Add a helper class to resolve overloads, which is needed for some of the Python bindings.

Fixes #1319.