### PR TITLE
Overhaul sfm_constraints API

### DIFF
--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -484,8 +484,9 @@ camera_options
   for (auto& ext_par : ext_params)
   {
     auto fid = ext_par.first;
-    vector_3d position_prior_local;
-    if(!constraints->get_camera_position_prior_local(fid,position_prior_local))
+    auto const& position_prior_local =
+      constraints->get_camera_position_prior_local(fid);
+    if(!position_prior_local)
     {
       continue;
     }
@@ -501,7 +502,7 @@ camera_options
     }
 
     auto position_prior_cost =
-      camera_position::create(position_prior_local);
+      camera_position::create(*position_prior_local);
 
     problem.AddResidualBlock(position_prior_cost,
       loss,

--- a/python/kwiver/vital/tests/test_sfm_constraints.py
+++ b/python/kwiver/vital/tests/test_sfm_constraints.py
@@ -98,8 +98,8 @@ class TestSFMConstraints(unittest.TestCase):
 
     def test_get_camera_position_prior_local(self):
       s = SFMConstraints(self.meta_, self.geo_)
-      nt.assert_false(s.get_camera_position_prior_local(0, np.array([0, 1, 3])))
-      nt.assert_false(s.get_camera_position_prior_local(0, RotationD([1, 2, 3, 4])))
+      nt.ok_(s.get_camera_position_prior_local(0) is None)
+      nt.ok_(s.get_camera_orientation_prior_local(0) is None)
 
     def test_camera_position_priors(self):
       s = SFMConstraints(self.meta_, self.geo_)
@@ -108,16 +108,11 @@ class TestSFMConstraints(unittest.TestCase):
     def test_image_properties(self):
       s = SFMConstraints(self.meta_, self.geo_)
       s.store_image_size(0, 1080, 720)
-      a,b = 0,0
-      founda, foundb = False, False
-      founda, a = s.get_image_width(0, a)
-      foundb, b = s.get_image_height(0, b)
-      nt.ok_(founda)
-      nt.ok_(foundb)
+      a = s.get_image_width(0)
+      b = s.get_image_height(0)
+      nt.ok_(a)
+      nt.ok_(b)
       nt.assert_equal(a, 1080)
       nt.assert_equal(b, 720)
-      found_focal = True
-      focal_len = 0.1
-      found_focal, focal_len = s.get_focal_length_prior(0, focal_len)
-      nt.assert_false(found_focal)
-      nt.assert_almost_equal(focal_len, 0.1)
+      focal_len = s.get_focal_length_prior(0)
+      nt.ok_(focal_len is None)

--- a/python/kwiver/vital/types/sfm_constraints.cxx
+++ b/python/kwiver/vital/types/sfm_constraints.cxx
@@ -4,6 +4,8 @@
 
 #include <vital/types/sfm_constraints.h>
 
+#include <python/kwiver/vital/types/type_casters.h>
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -27,29 +29,13 @@ PYBIND11_MODULE( sfm_constraints, m )
                   &kv::sfm_constraints::get_local_geo_cs,
                   &kv::sfm_constraints::set_local_geo_cs )
   .def( "get_camera_position_prior_local",
-        ( bool ( kv::sfm_constraints::* ) ( kv::frame_id_t, kv::vector_3d& ) const )
         &kv::sfm_constraints::get_camera_position_prior_local )
-  .def( "get_camera_position_prior_local",
-        ( bool ( kv::sfm_constraints::* ) ( kv::frame_id_t, kv::rotation_d& ) const )
-        &kv::sfm_constraints::get_camera_position_prior_local )
+  .def( "get_camera_orientation_prior_local",
+        &kv::sfm_constraints::get_camera_orientation_prior_local )
   .def( "get_camera_position_priors", &kv::sfm_constraints::get_camera_position_priors )
   .def( "store_image_size", &kv::sfm_constraints::store_image_size )
-  // Ints are immutable in python so simple bindings to get_image_width/height, get_focal_length_prior wont be sufficient
-  // lambda functions will return a tuple of the results as per https://pybind11.readthedocs.io/en/stable/faq.html#limitations-involving-reference-arguments
-  .def( "get_image_width", [](kv::sfm_constraints const &self, kv::frame_id_t fid, int &image_width )
-  {
-      bool found = self.get_image_width(fid, image_width);
-      return std::make_tuple(found, image_width);
-  })
-  .def( "get_image_height", [](kv::sfm_constraints const &self, kv::frame_id_t fid, int &image_height )
-  {
-      bool found = self.get_image_height(fid, image_height);
-      return std::make_tuple(found, image_height);
-  })
-  .def( "get_focal_length_prior", [](kv::sfm_constraints const &self, kv::frame_id_t fid, float &focal_length )
-  {
-      bool found = self.get_focal_length_prior(fid, focal_length);
-      return std::make_tuple(found, focal_length);
-  })
+  .def( "get_image_width", &kv::sfm_constraints::get_image_width)
+  .def( "get_image_height", &kv::sfm_constraints::get_image_height)
+  .def( "get_focal_length_prior", &kv::sfm_constraints::get_focal_length_prior)
   ;
 }

--- a/python/kwiver/vital/types/type_casters.h
+++ b/python/kwiver/vital/types/type_casters.h
@@ -1,0 +1,29 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef VITAL_TYPE_CASTER
+#define VTIAL_TYPE_CASTER
+
+#include <vital/optional.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace kw = kwiver::vital;
+
+namespace pybind11 {
+
+namespace detail {
+
+template < typename T >
+struct type_caster< kw::optional< T > >
+  : optional_caster< kw::optional< T > >
+{
+};
+
+} // namespace detail
+
+} // namespace pybind11
+
+#endif

--- a/vital/types/sfm_constraints.h
+++ b/vital/types/sfm_constraints.h
@@ -15,10 +15,13 @@
 #include <vital/types/rotation.h>
 #include <vital/types/local_geo_cs.h>
 
+#include <vital/optional.h>
+
 #ifndef KWIVER_VITAL_SFM_CONSTRAINTS_H_
 #define KWIVER_VITAL_SFM_CONSTRAINTS_H_
 
 namespace kwiver {
+
 namespace vital {
 
 class VITAL_EXPORT sfm_constraints {
@@ -58,67 +61,71 @@ public:
   */
   void set_local_geo_cs(local_geo_cs const& lgcs);
 
-  /// get the metadata specified camera position in the local coordinate frame
-  /**
-  * \param[in]  fid the frame to get the positionfor
-  * \pramm[out] pos_loc the local coordinate frame position prior
-  * \return true if position prior is recovered from metadata, false otherwise
-  */
-  bool get_camera_position_prior_local(frame_id_t fid, vector_3d &pos_loc) const;
+  /// Get the metadata specified camera position prior in the local coordinate
+  /// frame.
+  ///
+  /// \param fid The frame for which to get the position.
+  /// \return
+  ///   The local coordinate frame position prior if recoverable from the
+  ///   metadata, otherwise a disengaged optional.
+  optional<vector_3d> get_camera_position_prior_local(frame_id_t fid) const;
 
-  /// get the metadata specified camera orientation prior in the local coordinate frame
-  /**
-  * \param[in] fid the frame to get the orientaiton for
-  * \param[out] R_loc the rotation in the local frame according to the metadata
-  * \return return true if orientation prior is recovered from metadata, false otherwise
-  */
-  bool get_camera_orientation_prior_local(frame_id_t fid, rotation_d &R_loc) const;
+  /// Get the metadata specified camera orientation prior in the local
+  /// coordinate frame.
+  ///
+  /// \param fid The frame for which to get the orientation.
+  /// \return
+  ///   The local coordinate frame orientation prior (as rotation) if
+  ///   recoverable from the metadata, otherwise a disengaged optional.
+  optional<rotation_d> get_camera_orientation_prior_local(
+    frame_id_t fid) const;
 
   typedef std::map<frame_id_t, vector_3d> position_map;
 
   /// get the camera position prior map
   position_map get_camera_position_priors() const;
 
-  ///  store the image size for a particular frame
-  /**
-  * \param[in] fid the frame whose image size we will store
-  * \param[in] image_width the width of the image
-  * \param[in] image_height the height of the image
-  */
-  void store_image_size(frame_id_t fid, int image_width, int image_height);
+  /// Store the image size for a particular frame.
+  ///
+  /// \param fid The frame for which to store the image size.
+  /// \param image_width The width of the image.
+  /// \param image_height The height of the image.
+  void store_image_size(
+    frame_id_t fid, unsigned image_width, unsigned image_height);
 
-  /// get the image width
-  /**
-  * \param[in] fid the frame
-  * \param[out] image_width the width of the image with frame id fid
-  * \return true if the image width is recovered from the constraints, false otherwise
-  */
-  bool get_image_width(frame_id_t fid, int &image_width) const;
+  /// Get the image width.
+  ///
+  /// \param fid The frame for which to get the image width.
+  /// \return
+  ///   The width of the image with frame id \p fid if provided by the
+  ///   constraints, otherwise a disengaged optional.
+  optional<unsigned> get_image_width(frame_id_t fid) const;
 
-  /// get the image height
-  /**
-  * \param[in] fid the frame
-  * \param[out] image_height the height of the image with frame id fid
-  * \return true if the image height is recovered from the constraints, false otherwise
-  */
-  bool get_image_height(frame_id_t fid, int &image_height) const;
+  /// Get the image height.
+  ///
+  /// \param fid The frame for which to get the image height.
+  /// \return
+  ///   The height of the image with frame id \p fid if provided by the
+  ///   constraints, otherwise a disengaged optional.
+  optional<unsigned> get_image_height(frame_id_t fid) const;
 
-  /// get the focal length estimate from the metadata
-  /**
-  * \param[in] fid the frame whose focal length we want to recover
-  * \param[out] focal_length the focal length according to the metadata
-  * \return true if the focal length prior is found in the metadata, false otherwise
-  */
-  bool get_focal_length_prior(frame_id_t fid, float &focal_length) const;
+  /// Get the focal length estimate from the metadata.
+  ///
+  /// \param fid The frame whose focal length we want to recover.
+  /// \return
+  ///   The focal length according to the metadata, if provided, otherwise a
+  ///   disengaged optional.
+  optional<float> get_focal_length_prior(frame_id_t fid) const;
 
 protected:
-
   class priv;
   const std::unique_ptr<priv> m_priv;
-
 };
 
 typedef std::shared_ptr<sfm_constraints> sfm_constraints_sptr;
 
-}} ///end namespace kwiver vital
+} // namespace vital
+
+} // namespace kwiver
+
 #endif


### PR DESCRIPTION
Use `optional` instead of output parameters for `sfm_constraints` methods. Use `unsigned` rather than `int` for image sizes to match the type used by `camera_intrinsics`.

This currently breaks the Python bindings because I'd be blundering around a bit trying to fix those; maybe @johnwparent or @tao558 can help? A straight-forward remapping would be to return the value or `None` rather than returning a tuple. (In fact, I'm a little surprised the Python bindings weren't already implemented this way, as it certainly seems "more Pythonic".)