### PR TITLE
Add working computation of GSD and VNIIRs

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -16,6 +16,7 @@ set( plugin_core_headers
   convert_image_bypass.h
   create_detection_grid.h
   depth_utils.h
+  derive_metadata.h
   detect_features_filtered.h
   detected_object_set_input_kw18.h
   detected_object_set_output_kw18.h
@@ -86,6 +87,7 @@ set( plugin_core_sources
   convert_image_bypass.cxx
   create_detection_grid.cxx
   depth_utils.cxx
+  derive_metadata.cxx
   detect_features_filtered.cxx
   detected_object_set_input_kw18.cxx
   detected_object_set_output_kw18.cxx

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -8,37 +8,25 @@
  */
 
 #include <arrows/core/derive_metadata.h>
+
+#include <vital/math_constants.h>
 #include <vital/types/geo_point.h>
 #include <vital/types/metadata.h>
 #include <vital/types/metadata_tags.h>
 #include <vital/types/metadata_traits.h>
 
 #include <cmath>
+#include <memory>
 
 namespace kv = kwiver::vital;
 using namespace kwiver::vital::algo;
 
 namespace kwiver {
-
 namespace arrows {
-
 namespace core {
-
 namespace {
 
 static ::kwiver::vital::metadata_traits meta_traits;
-
-double
-deg2rad( double deg )
-{
-  return deg * M_PI / 180.0;
-}
-
-double
-rad2deg( double rad )
-{
-  return rad * 180.0 / M_PI;
-}
 
 /*
  * Rotations needed to compute view angle
@@ -51,7 +39,7 @@ RotRoll( double* in, double theta, double* out )
   double in2 = in[ 2 ];
   double sint, cost;
 
-  theta = deg2rad( theta );
+  theta = theta * kv::deg_to_rad;
   sint = sin( theta );
   cost = cos( theta );
 
@@ -70,7 +58,7 @@ RotPitch( double* in, double theta, double* out )
   double in2 = in[ 2 ];
   double sint, cost;
 
-  theta = deg2rad( theta );
+  theta = theta * kv::deg_to_rad;
   sint = sin( theta );
   cost = cos( theta );
 
@@ -89,7 +77,7 @@ RotYaw( double* in, double theta, double* out )
   double in2 = in[ 2 ];
   double sint, cost;
 
-  theta = deg2rad( theta );
+  theta = theta * kv::deg_to_rad;
   sint = sin( theta );
   cost = cos( theta );
 
@@ -136,7 +124,7 @@ view_pitch(
                   right_unrotated ), 0, -platform_pitch, -platform_roll,
           right_unrotated );
 
-  return rad2deg( asin( -forward_unrotated[ 2 ] ) );
+  return asin( -forward_unrotated[ 2 ] ) * kv::rad_to_deg;
 }
 
 double
@@ -148,19 +136,19 @@ compute_gsd( int rows, int cols, kwiver::vital::metadata_sptr md )
   }
 
   /* RP1201 method */
-  auto const platform_pitch_angle = md->find(
+  auto const platform_pitch_deg = md->find(
     kv::VITAL_META_PLATFORM_PITCH_ANGLE ).as_double();
-  auto const platform_roll_angle =
+  auto const platform_roll_deg =
     md->find( kv::VITAL_META_PLATFORM_ROLL_ANGLE ).as_double();
-  auto const sensor_relative_azimuth_angle = md->find(
+  auto const sensor_relative_azimuth_deg = md->find(
     kv::VITAL_META_SENSOR_REL_AZ_ANGLE ).as_double();
-  auto const sensor_relative_elevation_angle = md->find(
+  auto const sensor_relative_elevation_deg = md->find(
     kv::VITAL_META_SENSOR_REL_EL_ANGLE ).as_double();
-  auto const sensor_relative_roll_angle = md->find(
+  auto const sensor_relative_roll_deg = md->find(
     kv::VITAL_META_SENSOR_REL_ROLL_ANGLE ).as_double();
-  auto const fov_h_deg =
+  auto const sensor_horizontal_fov =
     md->find( kv::VITAL_META_SENSOR_HORIZONTAL_FOV ).as_double();
-  auto const fov_v_deg =
+  auto const sensor_vertical_fov =
     md->find( kv::VITAL_META_SENSOR_VERTICAL_FOV ).as_double();
   auto slant_range = md->find( kv::VITAL_META_SLANT_RANGE ).as_double();
   auto const sensor_location = kv::any_cast< kv::geo_point >(
@@ -172,30 +160,31 @@ compute_gsd( int rows, int cols, kwiver::vital::metadata_sptr md )
   auto const target_width =
     md->find( kv::VITAL_META_TARGET_WIDTH ).as_double();
 
-  if( platform_pitch_angle >= -20 && platform_pitch_angle <= 20 &&
-      platform_roll_angle >= -50 && platform_roll_angle <= 50 &&
-      sensor_relative_azimuth_angle >= 0 &&
-      sensor_relative_azimuth_angle <= 360 &&
-      sensor_relative_elevation_angle >= -180 &&
-      sensor_relative_elevation_angle <= 180 &&
-      sensor_relative_roll_angle >= 0 && sensor_relative_roll_angle <= 360 &&
-      fov_h_deg >= 0 && fov_h_deg <= 180 &&
-      fov_v_deg >= 0 && fov_v_deg <= 180 &&
+  if( platform_pitch_deg >= -20 && platform_pitch_deg <= 20 &&
+      platform_roll_deg >= -50 && platform_roll_deg <= 50 &&
+      sensor_relative_azimuth_deg >= 0 &&
+      sensor_relative_azimuth_deg <= 360 &&
+      sensor_relative_elevation_deg >= -180 &&
+      sensor_relative_elevation_deg <= 180 &&
+      sensor_relative_roll_deg >= 0 && sensor_relative_roll_deg <= 360 &&
+      sensor_horizontal_fov >= 0 && sensor_horizontal_fov <= 180 &&
+      sensor_vertical_fov >= 0 && sensor_vertical_fov <= 180 &&
       slant_range > 0 && slant_range <= 5000000 )
   {
-    double gsd_horiz, gsd_vert;
-
-    double const absolute_elevation_angle = view_pitch(
-      platform_pitch_angle,
-      platform_roll_angle,
-      sensor_relative_azimuth_angle,
-      sensor_relative_elevation_angle,
-      sensor_relative_roll_angle );
+    double const absolute_elevation_deg = view_pitch(
+      platform_pitch_deg,
+      platform_roll_deg,
+      sensor_relative_azimuth_deg,
+      sensor_relative_elevation_deg,
+      sensor_relative_roll_deg );
 
     // Convert angles to radians
-    auto const fov_h_rad = deg2rad( fov_h_deg );
-    auto const fov_v_rad = deg2rad( fov_v_deg );
-    auto const elev_rad = deg2rad( absolute_elevation_angle );
+    auto const sensor_horizontal_fov_rad =
+      sensor_horizontal_fov * kv::deg_to_rad;
+    auto const sensor_vertical_fov_rad =
+      sensor_vertical_fov  * kv::deg_to_rad;
+    auto const absolute_elevation_rad =
+      absolute_elevation_deg * kv::deg_to_rad;
 
     // If Slant Range is missing, compute from Elevation Angle and Sensor
     // Altitude */
@@ -205,27 +194,30 @@ compute_gsd( int rows, int cols, kwiver::vital::metadata_sptr md )
         19000 )
     {
       slant_range = ( sensor_altitude - frame_center_elevation ) /
-                    sin( -elev_rad );
+                    sin( -absolute_elevation_rad );
     }
 
     // GSD horizontal
-    gsd_horiz = 2.0 * slant_range * tan( ( fov_h_rad / 2.0 ) / cols );
+    double const gsd_horizontal = 2.0 * slant_range *
+                     tan( ( sensor_horizontal_fov_rad / 2.0 ) / cols );
 
     // GSD vertical
-    gsd_vert  = ( 2.0 * slant_range * tan( ( fov_v_rad / 2.0 ) / rows ) ) /
-                sin( -elev_rad );
+    double const gsd_vertical = ( 2.0 * slant_range *
+                     tan( ( sensor_vertical_fov_rad / 2.0 ) / rows ) ) /
+                   sin( -absolute_elevation_rad );
 
     // GSD = Geometric mean of horiz & vert GSD
-    return 1000.0 * sqrt( gsd_horiz * gsd_vert );
+    return 1000.0 * sqrt( gsd_horizontal * gsd_vertical );
   }
 
   /* RP 1201 horizontal axis only */
 
   if( slant_range > 0 && slant_range <= 5000000 &&
-      fov_h_deg >= 0 && fov_h_deg <= 180 )
+      sensor_horizontal_fov >= 0 && sensor_horizontal_fov <= 180 )
   {
     return 2000.0 * slant_range *
-           tan( ( deg2rad( fov_h_deg ) / 2.0 ) / (float) cols );
+           tan( ( sensor_horizontal_fov * kv::deg_to_rad / 2.0 ) /
+                (float) cols );
   }
 
   /* Target width horizontal axis only */
@@ -249,30 +241,35 @@ giqe5( double gsd )
   return vniirs;
 }
 
-} // namespace
+} // end namespace
 
 kwiver::vital::metadata_vector
 compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
                           int frame_width, int frame_height )
 {
+  kv::metadata_vector updated_values;
+
   for( auto const md : metadata_vec )
   {
+    auto updated_metadata =
+      std::shared_ptr< kv::metadata >( new kv::metadata( md->deep_copy() ) );
+
+    // Compute derived values
     auto const gsd_value = compute_gsd( frame_height, frame_width, md );
     auto vniirs_value = giqe5( gsd_value );
+    // The lower bound on VNIIRs is 2
+    // TODO check if there should be an upper one
     vniirs_value = std::max( 2.0, vniirs_value );
 
-    const auto& vniirs_trait = meta_traits.find( kv::VITAL_META_VNIIRS );
-    const auto& gsd_trait = meta_traits.find( kv::VITAL_META_AVERAGE_GSD );
-
     // Add the new fields
-    md->add( vniirs_trait.create_metadata_item( vniirs_value ) );
-    md->add( gsd_trait.create_metadata_item( gsd_value ) );
+    const auto& vniirs_trait = meta_traits.find( kv::VITAL_META_VNIIRS );
+    updated_metadata->add( vniirs_trait.create_metadata_item( vniirs_value ) );
+    const auto& gsd_trait = meta_traits.find( kv::VITAL_META_AVERAGE_GSD );
+    updated_metadata->add( gsd_trait.create_metadata_item( gsd_value ) );
+
+    updated_values.push_back( updated_metadata );
   }
-  return metadata_vec;
+  return updated_values;
 }
 
-} // end namespace core
-
-} // end namespace arrows
-
-} // end namespace kwiver
+} } } // end namespace

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -1,0 +1,278 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/**
+ * \file
+ * \brief Compute derived metadata fields.
+ */
+
+#include <arrows/core/derive_metadata.h>
+#include <vital/types/geo_point.h>
+#include <vital/types/metadata.h>
+#include <vital/types/metadata_tags.h>
+#include <vital/types/metadata_traits.h>
+
+#include <cmath>
+
+namespace kv = kwiver::vital;
+using namespace kwiver::vital::algo;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+namespace {
+
+static ::kwiver::vital::metadata_traits meta_traits;
+
+double
+deg2rad( double deg )
+{
+  return deg * M_PI / 180.0;
+}
+
+double
+rad2deg( double rad )
+{
+  return rad * 180.0 / M_PI;
+}
+
+/*
+ * Rotations needed to compute view angle
+ */
+static double*
+RotRoll( double* in, double theta, double* out )
+{
+  double in0 = in[ 0 ];
+  double in1 = in[ 1 ];
+  double in2 = in[ 2 ];
+  double sint, cost;
+
+  theta = deg2rad( theta );
+  sint = sin( theta );
+  cost = cos( theta );
+
+  out[ 0 ] = in0;
+  out[ 1 ] = cost * in1 + sint * in2;
+  out[ 2 ] = -sint * in1 + cost * in2;
+
+  return out;
+}
+
+static double*
+RotPitch( double* in, double theta, double* out )
+{
+  double in0 = in[ 0 ];
+  double in1 = in[ 1 ];
+  double in2 = in[ 2 ];
+  double sint, cost;
+
+  theta = deg2rad( theta );
+  sint = sin( theta );
+  cost = cos( theta );
+
+  out[ 0 ] = cost * in0 + -sint * in2;
+  out[ 1 ] = in1;
+  out[ 2 ] = sint * in0 + cost * in2;
+
+  return out;
+}
+
+static double*
+RotYaw( double* in, double theta, double* out )
+{
+  double in0 = in[ 0 ];
+  double in1 = in[ 1 ];
+  double in2 = in[ 2 ];
+  double sint, cost;
+
+  theta = deg2rad( theta );
+  sint = sin( theta );
+  cost = cos( theta );
+
+  out[ 0 ] = cost * in0 + sint * in1;
+  out[ 1 ] = -sint * in0 + cost * in1;
+  out[ 2 ] = in2;
+
+  return out;
+}
+
+static double*
+RotYPR( double* in, double yaw, double pitch, double roll, double* out )
+{
+  return RotYaw( RotPitch( RotRoll( in, roll, out ), pitch, out ), yaw, out );
+}
+
+static double
+view_pitch(
+  double platform_pitch,
+  double platform_roll,
+  double sensor_rel_az,
+  double sensor_rel_el,
+  double sensor_rel_roll )
+{
+  double forward[] = { 1, 0, 0 };
+  double forward_unrotated[ 3 ];
+  double right[] = { 0, 1, 0 };
+  double right_unrotated[ 3 ];
+
+  /* Start with camera view as unit vector, back out all rotations of sensor
+   * and platform
+   *  Initial frame of reference, X axis is perpendicular to image plane
+   * (depth), Y is horizontal axis of image, Z is vertical axis of image
+   *  Final frame of reference, X axis is forward direction relateive to
+   * platform, Y axis is perpendicular to platform (direction of wingspan),
+   *  and Z is up/down relative to platform.  Abolute view pitch theta
+   * (negative below horizon) is sin(theta) = -Z/(unit), theta = arcsin(Z)
+   */
+
+  RotYPR( RotYPR( forward, -sensor_rel_az, -sensor_rel_el, -sensor_rel_roll,
+                  forward_unrotated ), 0, -platform_pitch, -platform_roll,
+          forward_unrotated );
+  RotYPR( RotYPR( right, -sensor_rel_az, -sensor_rel_el, -sensor_rel_roll,
+                  right_unrotated ), 0, -platform_pitch, -platform_roll,
+          right_unrotated );
+
+  return rad2deg( asin( -forward_unrotated[ 2 ] ) );
+}
+
+double
+compute_gsd( int rows, int cols, kwiver::vital::metadata_sptr md )
+{
+  if( rows < 1 || cols < 1 )
+  {
+    return 0;
+  }
+
+  /* RP1201 method */
+  auto const platform_pitch_angle = md->find(
+    kv::VITAL_META_PLATFORM_PITCH_ANGLE ).as_double();
+  auto const platform_roll_angle =
+    md->find( kv::VITAL_META_PLATFORM_ROLL_ANGLE ).as_double();
+  auto const sensor_relative_azimuth_angle = md->find(
+    kv::VITAL_META_SENSOR_REL_AZ_ANGLE ).as_double();
+  auto const sensor_relative_elevation_angle = md->find(
+    kv::VITAL_META_SENSOR_REL_EL_ANGLE ).as_double();
+  auto const sensor_relative_roll_angle = md->find(
+    kv::VITAL_META_SENSOR_REL_ROLL_ANGLE ).as_double();
+  auto const fov_h_deg =
+    md->find( kv::VITAL_META_SENSOR_HORIZONTAL_FOV ).as_double();
+  auto const fov_v_deg =
+    md->find( kv::VITAL_META_SENSOR_VERTICAL_FOV ).as_double();
+  auto slant_range = md->find( kv::VITAL_META_SLANT_RANGE ).as_double();
+  auto const sensor_location = kv::any_cast< kv::geo_point >(
+    md->find( kv::VITAL_META_SENSOR_LOCATION ).data() );
+  auto const sensor_altitude = sensor_location.location()[ 2 ];
+  auto const frame_center = kv::any_cast< kv::geo_point >(
+    md->find( kv::VITAL_META_SENSOR_LOCATION ).data() );
+  auto const frame_center_elevation = frame_center.location()[ 2 ];
+  auto const target_width =
+    md->find( kv::VITAL_META_TARGET_WIDTH ).as_double();
+
+  if( platform_pitch_angle >= -20 && platform_pitch_angle <= 20 &&
+      platform_roll_angle >= -50 && platform_roll_angle <= 50 &&
+      sensor_relative_azimuth_angle >= 0 &&
+      sensor_relative_azimuth_angle <= 360 &&
+      sensor_relative_elevation_angle >= -180 &&
+      sensor_relative_elevation_angle <= 180 &&
+      sensor_relative_roll_angle >= 0 && sensor_relative_roll_angle <= 360 &&
+      fov_h_deg >= 0 && fov_h_deg <= 180 &&
+      fov_v_deg >= 0 && fov_v_deg <= 180 &&
+      slant_range > 0 && slant_range <= 5000000 )
+  {
+    double gsd_horiz, gsd_vert;
+
+    double const absolute_elevation_angle = view_pitch(
+      platform_pitch_angle,
+      platform_roll_angle,
+      sensor_relative_azimuth_angle,
+      sensor_relative_elevation_angle,
+      sensor_relative_roll_angle );
+
+    // Convert angles to radians
+    auto const fov_h_rad = deg2rad( fov_h_deg );
+    auto const fov_v_rad = deg2rad( fov_v_deg );
+    auto const elev_rad = deg2rad( absolute_elevation_angle );
+
+    // If Slant Range is missing, compute from Elevation Angle and Sensor
+    // Altitude */
+    if( ( slant_range == 0 || std::isnan( slant_range ) ) &&
+        sensor_altitude >= -900 && sensor_altitude <= 19000 &&
+        frame_center_elevation >= -900 && frame_center_elevation <=
+        19000 )
+    {
+      slant_range = ( sensor_altitude - frame_center_elevation ) /
+                    sin( -elev_rad );
+    }
+
+    // GSD horizontal
+    gsd_horiz = 2.0 * slant_range * tan( ( fov_h_rad / 2.0 ) / cols );
+
+    // GSD vertical
+    gsd_vert  = ( 2.0 * slant_range * tan( ( fov_v_rad / 2.0 ) / rows ) ) /
+                sin( -elev_rad );
+
+    // GSD = Geometric mean of horiz & vert GSD
+    return 1000.0 * sqrt( gsd_horiz * gsd_vert );
+  }
+
+  /* RP 1201 horizontal axis only */
+
+  if( slant_range > 0 && slant_range <= 5000000 &&
+      fov_h_deg >= 0 && fov_h_deg <= 180 )
+  {
+    return 2000.0 * slant_range *
+           tan( ( deg2rad( fov_h_deg ) / 2.0 ) / (float) cols );
+  }
+
+  /* Target width horizontal axis only */
+  if( target_width > 0 && target_width <= 10000 )
+  {
+    return static_cast< float >( target_width ) /
+           static_cast< float >( cols ) * 1000.0;
+  }
+
+  return 0;
+}
+
+// General Image Quality Equation v5 (GIQE5)
+static double
+giqe5( double gsd )
+{
+  constexpr double A0 = 9.57;
+  constexpr double A1 = -3.32;
+
+  auto const vniirs = A0 + A1 * log10( gsd / 25.4 );
+  return vniirs;
+}
+
+} // namespace
+
+kwiver::vital::metadata_vector
+compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
+                          int frame_width, int frame_height )
+{
+  for( auto const md : metadata_vec )
+  {
+    auto const gsd_value = compute_gsd( frame_height, frame_width, md );
+    auto vniirs_value = giqe5( gsd_value );
+    vniirs_value = std::max( 2.0, vniirs_value );
+
+    const auto& vniirs_trait = meta_traits.find( kv::VITAL_META_VNIIRS );
+    const auto& gsd_trait = meta_traits.find( kv::VITAL_META_AVERAGE_GSD );
+
+    // Add the new fields
+    md->add( vniirs_trait.create_metadata_item( vniirs_value ) );
+    md->add( gsd_trait.create_metadata_item( gsd_value ) );
+  }
+  return metadata_vec;
+}
+
+} // end namespace core
+
+} // end namespace arrows
+
+} // end namespace kwiver

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -14,6 +14,7 @@
 #include <vital/types/metadata.h>
 #include <vital/types/metadata_tags.h>
 #include <vital/types/metadata_traits.h>
+#include <vital/types/rotation.h>
 
 #include <cmath>
 #include <memory>
@@ -22,249 +23,307 @@ namespace kv = kwiver::vital;
 using namespace kwiver::vital::algo;
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
+
 namespace {
 
 static ::kwiver::vital::metadata_traits meta_traits;
 
-/*
- * Rotations needed to compute view angle
- */
-static double*
-RotRoll( double* in, double theta, double* out )
+kwiver::vital::rotation_d
+get_platform_rotation( kwiver::vital::metadata_sptr metadata )
 {
-  double in0 = in[ 0 ];
-  double in1 = in[ 1 ];
-  double in2 = in[ 2 ];
-  double sint, cost;
+  kv::metadata_item const& yaw_item = metadata->find(
+    kv::VITAL_META_PLATFORM_HEADING_ANGLE );
+  kv::metadata_item const& pitch_item = metadata->find(
+    kv::VITAL_META_PLATFORM_PITCH_ANGLE );
+  kv::metadata_item const& roll_item = metadata->find(
+    kv::VITAL_META_PLATFORM_ROLL_ANGLE );
 
-  theta = theta * kv::deg_to_rad;
-  sint = sin( theta );
-  cost = cos( theta );
+  if( !yaw_item || !pitch_item || !roll_item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain platform orientation" );
+  }
 
-  out[ 0 ] = in0;
-  out[ 1 ] = cost * in1 + sint * in2;
-  out[ 2 ] = -sint * in1 + cost * in2;
+  auto const yaw = yaw_item.as_double() * kv::deg_to_rad;
+  auto const pitch = pitch_item.as_double() * kv::deg_to_rad;
+  auto const roll = roll_item.as_double() * kv::deg_to_rad;
 
-  return out;
+  return kv::rotation_d( yaw, pitch, roll );
 }
 
-static double*
-RotPitch( double* in, double theta, double* out )
+kwiver::vital::rotation_d
+get_sensor_rotation( kwiver::vital::metadata_sptr metadata )
 {
-  double in0 = in[ 0 ];
-  double in1 = in[ 1 ];
-  double in2 = in[ 2 ];
-  double sint, cost;
+  kv::metadata_item const& yaw_item = metadata->find(
+    kv::VITAL_META_SENSOR_REL_AZ_ANGLE );
+  kv::metadata_item const& pitch_item = metadata->find(
+    kv::VITAL_META_SENSOR_REL_EL_ANGLE );
+  kv::metadata_item const& roll_item = metadata->find(
+    kv::VITAL_META_SENSOR_REL_ROLL_ANGLE );
 
-  theta = theta * kv::deg_to_rad;
-  sint = sin( theta );
-  cost = cos( theta );
+  if( !yaw_item || !pitch_item || !roll_item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain sensor orientation" );
+  }
 
-  out[ 0 ] = cost * in0 + -sint * in2;
-  out[ 1 ] = in1;
-  out[ 2 ] = sint * in0 + cost * in2;
+  auto const yaw = yaw_item.as_double() * kv::deg_to_rad;
+  auto const pitch = pitch_item.as_double() * kv::deg_to_rad;
+  auto const roll = roll_item.as_double() * kv::deg_to_rad;
 
-  return out;
+  return kv::rotation_d( yaw, pitch, roll );
 }
 
-static double*
-RotYaw( double* in, double theta, double* out )
+kwiver::vital::rotation_d
+get_total_rotation( kwiver::vital::metadata_sptr metadata )
 {
-  double in0 = in[ 0 ];
-  double in1 = in[ 1 ];
-  double in2 = in[ 2 ];
-  double sint, cost;
-
-  theta = theta * kv::deg_to_rad;
-  sint = sin( theta );
-  cost = cos( theta );
-
-  out[ 0 ] = cost * in0 + sint * in1;
-  out[ 1 ] = -sint * in0 + cost * in1;
-  out[ 2 ] = in2;
-
-  return out;
+  kv::rotation_d const platform_rotation = get_platform_rotation( metadata );
+  kv::rotation_d const sensor_rotation = get_sensor_rotation( metadata );
+  kv::rotation_d const total_rotation = platform_rotation * sensor_rotation;
+  return total_rotation;
 }
 
-static double*
-RotYPR( double* in, double yaw, double pitch, double roll, double* out )
+kwiver::vital::vector_2d
+get_sensor_fov( kwiver::vital::metadata_sptr metadata )
 {
-  return RotYaw( RotPitch( RotRoll( in, roll, out ), pitch, out ), yaw, out );
+  kv::metadata_item const& x_fov_item = metadata->find(
+    kv::VITAL_META_SENSOR_HORIZONTAL_FOV );
+  kv::metadata_item const& y_fov_item = metadata->find(
+    kv::VITAL_META_SENSOR_VERTICAL_FOV );
+
+  if( !x_fov_item && !y_fov_item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain sensor fov" );
+  }
+
+  auto const x_fov = x_fov_item.as_double() * kv::deg_to_rad;
+  auto const y_fov = y_fov_item.as_double() * kv::deg_to_rad;
+
+  return kv::vector_2d( x_fov, y_fov );
 }
 
-static double
-view_pitch(
-  double platform_pitch,
-  double platform_roll,
-  double sensor_rel_az,
-  double sensor_rel_el,
-  double sensor_rel_roll )
+// meters
+double
+get_slant_range( kwiver::vital::metadata_sptr metadata )
 {
-  double forward[] = { 1, 0, 0 };
-  double forward_unrotated[ 3 ];
-  double right[] = { 0, 1, 0 };
-  double right_unrotated[ 3 ];
+  kv::metadata_item const& item = metadata->find(
+    kv::VITAL_META_SLANT_RANGE );
 
-  /* Start with camera view as unit vector, back out all rotations of sensor
-   * and platform
-   *  Initial frame of reference, X axis is perpendicular to image plane
-   * (depth), Y is horizontal axis of image, Z is vertical axis of image
-   *  Final frame of reference, X axis is forward direction relateive to
-   * platform, Y axis is perpendicular to platform (direction of wingspan),
-   *  and Z is up/down relative to platform.  Abolute view pitch theta
-   * (negative below horizon) is sin(theta) = -Z/(unit), theta = arcsin(Z)
-   */
+  if( !item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain slant range" );
+  }
 
-  RotYPR( RotYPR( forward, -sensor_rel_az, -sensor_rel_el, -sensor_rel_roll,
-                  forward_unrotated ), 0, -platform_pitch, -platform_roll,
-          forward_unrotated );
-  RotYPR( RotYPR( right, -sensor_rel_az, -sensor_rel_el, -sensor_rel_roll,
-                  right_unrotated ), 0, -platform_pitch, -platform_roll,
-          right_unrotated );
+  auto const slant_range = item.as_double();
 
-  return asin( -forward_unrotated[ 2 ] ) * kv::rad_to_deg;
+  return slant_range;
+}
+
+kv::geo_point
+get_sensor_location( kwiver::vital::metadata_sptr metadata )
+{
+  kv::metadata_item const& item = metadata->find(
+    kv::VITAL_META_SENSOR_LOCATION );
+
+  if( !item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain sensor location" );
+  }
+
+  auto const sensor_location = kv::any_cast< kv::geo_point >( item.data() );
+
+  return sensor_location;
+}
+
+kv::geo_point
+get_frame_center( kwiver::vital::metadata_sptr metadata )
+{
+  kv::metadata_item const& item = metadata->find(
+    kv::VITAL_META_FRAME_CENTER );
+
+  if( !item )
+  {
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain frame center" );
+  }
+
+  auto const frame_center = kv::any_cast< kv::geo_point >( item.data() );
+
+  return frame_center;
 }
 
 double
-compute_gsd( int rows, int cols, kwiver::vital::metadata_sptr md )
+get_target_width( kwiver::vital::metadata_sptr metadata )
 {
-  if( rows < 1 || cols < 1 )
+  kv::metadata_item const& item = metadata->find(
+    kv::VITAL_META_TARGET_WIDTH );
+
+  if( !item )
   {
-    return 0;
+    VITAL_THROW( kv::invalid_value,
+                 "metadata does not contain target width" );
   }
 
-  /* RP1201 method */
-  auto const platform_pitch_deg = md->find(
-    kv::VITAL_META_PLATFORM_PITCH_ANGLE ).as_double();
-  auto const platform_roll_deg =
-    md->find( kv::VITAL_META_PLATFORM_ROLL_ANGLE ).as_double();
-  auto const sensor_relative_azimuth_deg = md->find(
-    kv::VITAL_META_SENSOR_REL_AZ_ANGLE ).as_double();
-  auto const sensor_relative_elevation_deg = md->find(
-    kv::VITAL_META_SENSOR_REL_EL_ANGLE ).as_double();
-  auto const sensor_relative_roll_deg = md->find(
-    kv::VITAL_META_SENSOR_REL_ROLL_ANGLE ).as_double();
-  auto const sensor_horizontal_fov =
-    md->find( kv::VITAL_META_SENSOR_HORIZONTAL_FOV ).as_double();
-  auto const sensor_vertical_fov =
-    md->find( kv::VITAL_META_SENSOR_VERTICAL_FOV ).as_double();
-  auto slant_range = md->find( kv::VITAL_META_SLANT_RANGE ).as_double();
-  auto const sensor_location = kv::any_cast< kv::geo_point >(
-    md->find( kv::VITAL_META_SENSOR_LOCATION ).data() );
-  auto const sensor_altitude = sensor_location.location()[ 2 ];
-  auto const frame_center = kv::any_cast< kv::geo_point >(
-    md->find( kv::VITAL_META_SENSOR_LOCATION ).data() );
-  auto const frame_center_elevation = frame_center.location()[ 2 ];
-  auto const target_width =
-    md->find( kv::VITAL_META_TARGET_WIDTH ).as_double();
+  auto const target_width = item.as_double();
 
-  if( platform_pitch_deg >= -20 && platform_pitch_deg <= 20 &&
-      platform_roll_deg >= -50 && platform_roll_deg <= 50 &&
-      sensor_relative_azimuth_deg >= 0 &&
-      sensor_relative_azimuth_deg <= 360 &&
-      sensor_relative_elevation_deg >= -180 &&
-      sensor_relative_elevation_deg <= 180 &&
-      sensor_relative_roll_deg >= 0 && sensor_relative_roll_deg <= 360 &&
-      sensor_horizontal_fov >= 0 && sensor_horizontal_fov <= 180 &&
-      sensor_vertical_fov >= 0 && sensor_vertical_fov <= 180 &&
-      slant_range > 0 && slant_range <= 5000000 )
+  return target_width;
+}
+
+double
+compute_slant_range( kwiver::vital::metadata_sptr metadata )
+{
+  double slant_range = 0.0;
+  try
   {
-    double const absolute_elevation_deg = view_pitch(
-      platform_pitch_deg,
-      platform_roll_deg,
-      sensor_relative_azimuth_deg,
-      sensor_relative_elevation_deg,
-      sensor_relative_roll_deg );
+    // Attempt to acquire slant range directly
+    slant_range = get_slant_range( metadata );
+  }
+  catch ( kv::invalid_value const& e )
+  {
+    // Slant range must be calculated from other values
+    kv::rotation_d const total_rotation = get_total_rotation( metadata );
+    double yaw, pitch, roll;
+    total_rotation.get_yaw_pitch_roll( yaw, pitch, roll );
 
-    // Convert angles to radians
-    auto const sensor_horizontal_fov_rad =
-      sensor_horizontal_fov * kv::deg_to_rad;
-    auto const sensor_vertical_fov_rad =
-      sensor_vertical_fov  * kv::deg_to_rad;
-    auto const absolute_elevation_rad =
-      absolute_elevation_deg * kv::deg_to_rad;
+    // Determine the altitude of the sensor above the frame center
+    kv::geo_point const sensor_location = get_sensor_location( metadata );
+    double const sensor_altitude = sensor_location.location()[ 2 ];
+    kv::geo_point const frame_center = get_frame_center( metadata );
+    double const frame_center_altitude = frame_center.location()[ 2 ];
+    double const altitude_difference = sensor_altitude - frame_center_altitude;
 
-    // If Slant Range is missing, compute from Elevation Angle and Sensor
-    // Altitude */
-    if( ( slant_range == 0 || std::isnan( slant_range ) ) &&
-        sensor_altitude >= -900 && sensor_altitude <= 19000 &&
-        frame_center_elevation >= -900 && frame_center_elevation <=
-        19000 )
-    {
-      slant_range = ( sensor_altitude - frame_center_elevation ) /
-                    sin( -absolute_elevation_rad );
-    }
-
-    // GSD horizontal
-    double const gsd_horizontal = 2.0 * slant_range *
-                     tan( ( sensor_horizontal_fov_rad / 2.0 ) / cols );
-
-    // GSD vertical
-    double const gsd_vertical = ( 2.0 * slant_range *
-                     tan( ( sensor_vertical_fov_rad / 2.0 ) / rows ) ) /
-                   sin( -absolute_elevation_rad );
-
-    // GSD = Geometric mean of horiz & vert GSD
-    return 1000.0 * sqrt( gsd_horizontal * gsd_vertical );
+    slant_range = altitude_difference / std::sin( pitch );
   }
 
-  /* RP 1201 horizontal axis only */
+  return slant_range;
+}
 
-  if( slant_range > 0 && slant_range <= 5000000 &&
-      sensor_horizontal_fov >= 0 && sensor_horizontal_fov <= 180 )
+// Returns meters
+double
+compute_gsd( kwiver::vital::metadata_sptr metadata, size_t frame_width,
+             size_t frame_height )
+{
+  kv::vector_2d sensor_fov;
+  try
   {
-    return 2000.0 * slant_range *
-           tan( ( sensor_horizontal_fov * kv::deg_to_rad / 2.0 ) /
-                (float) cols );
+    // Attempt to acquire sensor FOV
+    sensor_fov = get_sensor_fov( metadata );
+  }
+  catch ( kv::invalid_value const& e )
+  {
+    // Fall back to calculating GSD from target width
+    double const target_width = get_target_width( metadata );
+
+    return target_width / frame_width;
   }
 
-  /* Target width horizontal axis only */
-  if( target_width > 0 && target_width <= 10000 )
+  // Fill in possibly missing sensor FOV dimension
+  if( !sensor_fov[ 0 ] )
   {
-    return static_cast< float >( target_width ) /
-           static_cast< float >( cols ) * 1000.0;
+    sensor_fov[ 0 ] = sensor_fov[ 1 ] * frame_width / frame_height;
+  }
+  else if( !sensor_fov[ 1 ] )
+  {
+    sensor_fov[ 1 ] = sensor_fov[ 0 ] * frame_height / frame_width;
   }
 
-  return 0;
+  kv::rotation_d const total_rotation = get_total_rotation( metadata );
+  double yaw, pitch, roll;
+  total_rotation.get_yaw_pitch_roll( yaw, pitch, roll );
+
+  double const slant_range = get_slant_range( metadata );
+  double const altitude_difference = slant_range * sin( pitch );
+
+  double const target_width = 2.0 * slant_range *
+                              std::tan( sensor_fov[ 0 ] / 2.0 );
+  double const target_height =
+    2.0 * ( slant_range * std::cos( pitch ) - altitude_difference *
+            std::tan( kv::pi_over_2 - sensor_fov[ 1 ] / 2 ) );
+
+  double const x_gsd = target_width / frame_width;
+  double const y_gsd = target_height / frame_height;
+  double const gsd = std::sqrt( x_gsd * y_gsd );
+  return gsd;
 }
 
 // General Image Quality Equation v5 (GIQE5)
-static double
-giqe5( double gsd )
+// See https://gwg.nga.mil/ntb/baseline/docs/GIQE-5_for_Public_Release.pdf
+// gsd: meters per pixel
+double
+compute_vniirs( double gsd, double rer, double snr )
 {
-  constexpr double A0 = 9.57;
-  constexpr double A1 = -3.32;
+  // Taken from Table 2
+  constexpr double a0 = 9.57, a1 = -3.32, a2 = 3.32,
+                   a3 = -1.9, a4 = -2.0,  a5 = -1.8;
 
-  auto const vniirs = A0 + A1 * log10( gsd / 25.4 );
+  constexpr double meters_to_inches = 1.0 / 0.0254;
+  gsd *= meters_to_inches;
+
+  double const log10_gsd = std::log10( gsd );
+  double const log10_rer = std::log10( rer );
+
+  auto const vniirs = a0 +
+                      a1 * log10_gsd +
+                      a2 * ( 1.0 - std::exp( a3 / snr ) ) * log10_rer +
+                      a4 * std::pow( log10_rer, 4 ) +
+                      a5 / snr;
   return vniirs;
+}
+
+// TODO: implement (should take in image as sole param)
+double compute_rer()
+{
+  return 0.3; // Dummy value within reasonable range
+}
+
+// TODO: implement (should take in image as sole param)
+double compute_snr()
+{
+  return 10.0; // Dummy value within reasonable range
 }
 
 } // end namespace
 
 kwiver::vital::metadata_vector
 compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
-                          int frame_width, int frame_height )
+                          size_t frame_width, size_t frame_height )
 {
   kv::metadata_vector updated_values;
 
-  for( auto const md : metadata_vec )
+  for( auto const metadata : metadata_vec )
   {
     auto updated_metadata =
-      std::shared_ptr< kv::metadata >( new kv::metadata( md->deep_copy() ) );
+      std::shared_ptr< kv::metadata >(
+        new kv::metadata( metadata->deep_copy() ) );
 
     // Compute derived values
-    auto const gsd_value = compute_gsd( frame_height, frame_width, md );
-    auto vniirs_value = giqe5( gsd_value );
+    auto const slant_range_value = compute_slant_range( updated_metadata );
+    auto const& slant_range_trait = meta_traits.find(
+                                      kv::VITAL_META_SLANT_RANGE );
+    updated_metadata->add( slant_range_trait.create_metadata_item(
+                             slant_range_value ) );
+
+    auto const gsd_value = compute_gsd( updated_metadata, frame_width,
+                                        frame_height );
+    auto const rer_value = compute_rer();
+    auto const snr_value = compute_snr();
+    auto vniirs_value = compute_vniirs( gsd_value, rer_value, snr_value );
     // The lower bound on VNIIRs is 2
     // TODO check if there should be an upper one
     vniirs_value = std::max( 2.0, vniirs_value );
 
     // Add the new fields
-    const auto& vniirs_trait = meta_traits.find( kv::VITAL_META_VNIIRS );
+    auto const& vniirs_trait = meta_traits.find( kv::VITAL_META_VNIIRS );
     updated_metadata->add( vniirs_trait.create_metadata_item( vniirs_value ) );
-    const auto& gsd_trait = meta_traits.find( kv::VITAL_META_AVERAGE_GSD );
+
+    auto const& gsd_trait = meta_traits.find( kv::VITAL_META_AVERAGE_GSD );
     updated_metadata->add( gsd_trait.create_metadata_item( gsd_value ) );
 
     updated_values.push_back( updated_metadata );
@@ -272,4 +331,8 @@ compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
   return updated_values;
 }
 
-} } } // end namespace
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -99,7 +99,7 @@ get_sensor_fov( kwiver::vital::metadata_sptr metadata )
   kv::metadata_item const& y_fov_item =
     metadata->find( kv::VITAL_META_SENSOR_VERTICAL_FOV );
 
-  if( !x_fov_item && !y_fov_item )
+  if( !x_fov_item || !y_fov_item )
   {
     VITAL_THROW( kv::invalid_value,
                  "metadata does not contain sensor fov" );
@@ -226,16 +226,6 @@ compute_gsd( kwiver::vital::metadata_sptr const& metadata,
     double const target_width = get_target_width( metadata );
 
     return target_width / frame_width;
-  }
-
-  // Fill in possibly missing sensor FOV dimension
-  if( !sensor_fov[ 0 ] )
-  {
-    sensor_fov[ 0 ] = sensor_fov[ 1 ] * frame_width / frame_height;
-  }
-  else if( !sensor_fov[ 1 ] )
-  {
-    sensor_fov[ 1 ] = sensor_fov[ 0 ] * frame_height / frame_width;
   }
 
   // Intermediate Values

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -233,7 +233,8 @@ compute_gsd( kwiver::vital::metadata_sptr const& metadata,
   double yaw, pitch, roll;
   total_rotation.get_yaw_pitch_roll( yaw, pitch, roll );
 
-  double const slant_range = get_slant_range( metadata );
+  // Ideally slant range should be pre-calculated
+  double const slant_range = compute_slant_range( metadata );
   double const altitude_difference = slant_range * sin( -pitch );
 
   // Approximate dimensions of image on ground plane
@@ -273,6 +274,8 @@ compute_vniirs( double gsd, double rer, double snr )
                 a2 * ( 1.0 - std::exp( a3 / snr ) ) * log10_rer +
                 a4 * std::pow( log10_rer, 4 ) +
                 a5 / snr;
+  // 2.0 is defined as the lower bound for VNIIRs
+  vniirs = std::max( vniirs, 2.0 );
   return vniirs;
 }
 
@@ -296,7 +299,7 @@ compute_snr()
 
 // ----------------------------------------------------------------------------
 kwiver::vital::metadata_vector
-compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
+compute_derived_metadata( kwiver::vital::metadata_vector const& metadata_vec,
                           size_t frame_width, size_t frame_height )
 {
   kv::metadata_vector updated_values;

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -308,7 +308,7 @@ compute_derived_metadata( kwiver::vital::metadata_vector const& metadata_vec,
   {
     // Deep copy metadata
     auto updated_metadata =
-      std::make_shared< kv::metadata >( metadata->deep_copy() );
+      std::make_shared< kv::metadata >( *metadata );
 
     try
     {

--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -210,7 +210,8 @@ double
 compute_gsd( kwiver::vital::metadata_sptr const& metadata,
              size_t frame_width, size_t frame_height )
 {
-  if ( frame_width == 0 || frame_height == 0 ) {
+  if ( frame_width == 0 || frame_height == 0 )
+  {
     VITAL_THROW( kv::invalid_value, "frame dimensions cannot be zero" );
   }
 
@@ -304,11 +305,10 @@ compute_derived_metadata( kwiver::vital::metadata_vector const& metadata_vec,
 {
   kv::metadata_vector updated_values;
 
-  for( auto const metadata : metadata_vec )
+  for( auto const& metadata : metadata_vec )
   {
     // Deep copy metadata
-    auto updated_metadata =
-      std::make_shared< kv::metadata >( *metadata );
+    auto updated_metadata = std::make_shared< kv::metadata >( *metadata );
 
     try
     {

--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -2,17 +2,16 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header for metadata derivation utility functions.
- */
+/// \file
+/// \brief Header for metadata derivation utility functions.
 
-#ifndef DERIVE_METADATA_H_
-#define DERIVE_METADATA_H_
+#ifndef KWIVER_ARROWS_CORE_DERIVE_METADATA_H_
+#define KWIVER_ARROWS_CORE_DERIVE_METADATA_H_
 
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <vital/algo/video_input.h>
+
 #include <vital/types/bounding_box.h>
 #include <vital/types/camera_perspective.h>
 #include <vital/types/camera_perspective_map.h>
@@ -27,13 +26,21 @@ namespace arrows {
 
 namespace core {
 
-/**
- * \param metadata_vec a vector of metadata packets
- * TODO fix the fact that a shallow copy is being updated
- */
+/// Fills in metadata values which can be calculated from other metadata.
+///
+/// \param metadata_vec A vector of metadata packets.
+/// \param frame_width Width of the image in pixels.
+/// \param frame_height Height of the image in pixels.
+///
+/// \returns An amended metadata vector.
+///
+/// \todo
+///   Eventually this should be replaced with a version which takes in an image
+///   as a parameter instead of just frame dimensions and incorporates pixel
+///   data into computations.
 KWIVER_ALGO_CORE_EXPORT
 kwiver::vital::metadata_vector
-compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
+compute_derived_metadata( kwiver::vital::metadata_vector const& metadata_vec,
                           size_t frame_width, size_t frame_height );
 
 } // namespace core

--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -1,0 +1,46 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/**
+ * \file
+ * \brief Header for metadata derivation utility functions.
+ */
+
+#ifndef DERIVE_METADATA_H_
+#define DERIVE_METADATA_H_
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <functional>
+#include <vector>
+
+#include <vital/algo/video_input.h>
+#include <vital/types/bounding_box.h>
+#include <vital/types/camera_perspective.h>
+#include <vital/types/camera_perspective_map.h>
+#include <vital/types/landmark.h>
+
+using namespace kwiver::vital;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+/**
+ * \param metadata_vec a vector of metadata packets
+ * TODO fix the fact that a shallow copy is being updated
+ */
+KWIVER_ALGO_CORE_EXPORT
+kwiver::vital::metadata_vector
+compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec );
+
+} // end namespace core
+
+} // end namespace arrows
+
+} // end namespace kwiver
+
+#endif

--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -12,21 +12,17 @@
 
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <functional>
-#include <vector>
-
 #include <vital/algo/video_input.h>
 #include <vital/types/bounding_box.h>
 #include <vital/types/camera_perspective.h>
 #include <vital/types/camera_perspective_map.h>
 #include <vital/types/landmark.h>
 
-using namespace kwiver::vital;
+#include <functional>
+#include <vector>
 
 namespace kwiver {
-
 namespace arrows {
-
 namespace core {
 
 /**
@@ -37,10 +33,6 @@ KWIVER_ALGO_CORE_EXPORT
 kwiver::vital::metadata_vector
 compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec );
 
-} // end namespace core
-
-} // end namespace arrows
-
-} // end namespace kwiver
+} } } // end namespace
 
 #endif

--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -22,7 +22,9 @@
 #include <vector>
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
 
 /**
@@ -31,8 +33,13 @@ namespace core {
  */
 KWIVER_ALGO_CORE_EXPORT
 kwiver::vital::metadata_vector
-compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec );
+compute_derived_metadata( kwiver::vital::metadata_vector metadata_vec,
+                          size_t frame_width, size_t frame_height );
 
-} } } // end namespace
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver
 
 #endif

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set( test_libraries    kwiver_algo_core vital vital_vpm )
 ##############################
 # Algorithms core plugin tests
 ##############################
+kwiver_discover_gtests(core derive_metadata           LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core detected_object_io        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core dynamic_configuration     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core feature_descriptor_io     LIBRARIES ${test_libraries})

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -1,0 +1,127 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief test derivation of new metadata traits
+
+#include <arrows/core/derive_metadata.h>
+
+#include <vital/types/geo_point.h>
+#include <vital/types/geodesy.h>
+#include <vital/types/metadata.h>
+#include <vital/types/metadata_traits.h>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+namespace kv = kwiver::vital;
+
+static kwiver::vital::metadata_traits meta_traits;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+namespace {
+
+// ----------------------------------------------------------------------------
+kwiver::vital::metadata_vector
+make_metadata()
+{
+  kv::metadata_sptr m1 = std::make_shared< kv::metadata >();
+
+  // Add the double-valued traits
+  std::map< kwiver::vital::vital_metadata_tag, double >
+  double_metadata{ { kv::VITAL_META_PLATFORM_HEADING_ANGLE, 60 },
+    { kv::VITAL_META_PLATFORM_PITCH_ANGLE, 3 },
+    { kv::VITAL_META_PLATFORM_ROLL_ANGLE, 1.2 },
+    { kv::VITAL_META_SENSOR_REL_AZ_ANGLE, 5 },
+    { kv::VITAL_META_SENSOR_REL_EL_ANGLE, 4 },
+    { kv::VITAL_META_SENSOR_REL_ROLL_ANGLE, 5 },
+    { kv::VITAL_META_PLATFORM_ROLL_ANGLE, 0.5 },
+    { kv::VITAL_META_SENSOR_VERTICAL_FOV, 30 },
+    { kv::VITAL_META_SENSOR_HORIZONTAL_FOV, 40 },
+    { kv::VITAL_META_SLANT_RANGE, 300 },
+    { kv::VITAL_META_TARGET_WIDTH, 100 } };
+
+  for( auto const& elem : double_metadata )
+  {
+    auto const& trait = meta_traits.find( elem.first );
+    m1->add( trait.create_metadata_item( elem.second ) );
+  }
+
+  // Add the geo point traits
+  m1->add< kv::VITAL_META_SENSOR_LOCATION >(
+    { kv::geo_point::geo_3d_point_t{ 0, 0, 12 },
+      kv::SRID::lat_lon_WGS84 } );
+
+  auto const& frame_center_trait =
+    meta_traits.find( kv::VITAL_META_FRAME_CENTER );
+  m1->add( frame_center_trait.create_metadata_item(
+             kv::geo_point( kv::geo_point::geo_3d_point_t{ 0, 0, 0 },
+                            kv::SRID::lat_lon_WGS84 ) ) );
+
+  // Replicate these values except without the slant range field
+  auto const m2 = std::make_shared< kv::metadata >( m1->deep_copy() );
+  m2->erase( kv::VITAL_META_SLANT_RANGE );
+  return { m1, m2 };
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+class derive_metadata : public ::testing::Test
+{
+  void
+  SetUp()
+  {
+    auto meta = make_metadata();
+    constexpr auto frame_height = size_t{ 720 };
+    constexpr auto frame_width = size_t{ 1080 };
+
+    derived_metadata = kwiver::arrows::core::compute_derived_metadata(
+      meta, frame_width, frame_height );
+  }
+
+public:
+  kv::metadata_vector derived_metadata;
+};
+
+// ----------------------------------------------------------------------------
+TEST_F(derive_metadata, compute_derived)
+{
+  kv::metadata_item const& gsd_value =
+    derived_metadata.at( 0 )->find( kv::VITAL_META_AVERAGE_GSD );
+  kv::metadata_item const& vniirs_value =
+    derived_metadata.at( 0 )->find( kv::VITAL_META_VNIIRS );
+  kv::metadata_item const& slant_range_value =
+    derived_metadata.at( 0 )->find( kv::VITAL_META_SLANT_RANGE );
+
+  EXPECT_DOUBLE_EQ( 0.38253304, gsd_value.as_double() );
+  EXPECT_DOUBLE_EQ( 5.183558, vniirs_value.as_double() );
+  EXPECT_DOUBLE_EQ( 300, slant_range_value.as_double() );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F(derive_metadata, compute_derived_no_slant)
+{
+  // Use the estimated slant range
+  kv::metadata_item const& gsd_value = derived_metadata.at( 1 )->find(
+    kv::VITAL_META_AVERAGE_GSD );
+  kv::metadata_item const& vniirs_value = derived_metadata.at( 1 )->find(
+    kv::VITAL_META_VNIIRS );
+  kv::metadata_item const& slant_range_value = derived_metadata.at( 1 )->find(
+    kv::VITAL_META_SLANT_RANGE );
+
+  EXPECT_FLOAT_EQ( gsd_value.as_double(), 0.43601143 );
+  EXPECT_FLOAT_EQ( vniirs_value.as_double(), 4.9948859 );
+  EXPECT_FLOAT_EQ( slant_range_value.as_double(), 341.94022 );
+}

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -22,14 +22,6 @@ namespace kv = kwiver::vital;
 
 static kwiver::vital::metadata_traits meta_traits;
 
-// ----------------------------------------------------------------------------
-int
-main( int argc, char** argv )
-{
-  ::testing::InitGoogleTest( &argc, argv );
-  return RUN_ALL_TESTS();
-}
-
 namespace {
 
 // ----------------------------------------------------------------------------
@@ -38,44 +30,40 @@ make_metadata()
 {
   kv::metadata_sptr m1 = std::make_shared< kv::metadata >();
 
-  // Add the double-valued traits
-  std::map< kwiver::vital::vital_metadata_tag, double >
-  double_metadata{ { kv::VITAL_META_PLATFORM_HEADING_ANGLE, 60 },
-    { kv::VITAL_META_PLATFORM_PITCH_ANGLE, 3 },
-    { kv::VITAL_META_PLATFORM_ROLL_ANGLE, 1.2 },
-    { kv::VITAL_META_SENSOR_REL_AZ_ANGLE, 5 },
-    { kv::VITAL_META_SENSOR_REL_EL_ANGLE, 4 },
-    { kv::VITAL_META_SENSOR_REL_ROLL_ANGLE, 5 },
-    { kv::VITAL_META_PLATFORM_ROLL_ANGLE, 0.5 },
-    { kv::VITAL_META_SENSOR_VERTICAL_FOV, 30 },
-    { kv::VITAL_META_SENSOR_HORIZONTAL_FOV, 40 },
-    { kv::VITAL_META_SLANT_RANGE, 300 },
-    { kv::VITAL_META_TARGET_WIDTH, 100 } };
-
-  for( auto const& elem : double_metadata )
-  {
-    auto const& trait = meta_traits.find( elem.first );
-    m1->add( trait.create_metadata_item( elem.second ) );
-  }
+  // Add the double traits
+  m1->add< kv::VITAL_META_PLATFORM_HEADING_ANGLE >( 60 );
+  m1->add< kv::VITAL_META_PLATFORM_PITCH_ANGLE >( 3 );
+  m1->add< kv::VITAL_META_PLATFORM_ROLL_ANGLE >( 1.2 );
+  m1->add< kv::VITAL_META_SENSOR_REL_AZ_ANGLE >( 5 );
+  m1->add< kv::VITAL_META_SENSOR_REL_EL_ANGLE >( 4 );
+  m1->add< kv::VITAL_META_SENSOR_REL_ROLL_ANGLE >( 5 );
+  m1->add< kv::VITAL_META_PLATFORM_ROLL_ANGLE >( 0.5 );
+  m1->add< kv::VITAL_META_SENSOR_VERTICAL_FOV >( 30 );
+  m1->add< kv::VITAL_META_SENSOR_HORIZONTAL_FOV >( 40 );
+  m1->add< kv::VITAL_META_SLANT_RANGE >( 300 );
+  m1->add< kv::VITAL_META_TARGET_WIDTH >( 100 );
 
   // Add the geo point traits
   m1->add< kv::VITAL_META_SENSOR_LOCATION >(
-    { kv::geo_point::geo_3d_point_t{ 0, 0, 12 },
-      kv::SRID::lat_lon_WGS84 } );
-
-  auto const& frame_center_trait =
-    meta_traits.find( kv::VITAL_META_FRAME_CENTER );
-  m1->add( frame_center_trait.create_metadata_item(
-             kv::geo_point( kv::geo_point::geo_3d_point_t{ 0, 0, 0 },
-                            kv::SRID::lat_lon_WGS84 ) ) );
+    { kv::geo_point::geo_3d_point_t{ 0, 0, 12 }, kv::SRID::lat_lon_WGS84 } );
+  m1->add< kv::VITAL_META_FRAME_CENTER >( {
+      kv::geo_point::geo_3d_point_t{ 0, 0, 0 }, kv::SRID::lat_lon_WGS84 } );
 
   // Replicate these values except without the slant range field
-  auto const m2 = std::make_shared< kv::metadata >( m1->deep_copy() );
+  auto const m2 = std::make_shared< kv::metadata >( *m1.get() );
   m2->erase( kv::VITAL_META_SLANT_RANGE );
   return { m1, m2 };
 }
 
 } // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
 
 // ----------------------------------------------------------------------------
 class derive_metadata : public ::testing::Test
@@ -96,7 +84,7 @@ public:
 };
 
 // ----------------------------------------------------------------------------
-TEST_F(derive_metadata, compute_derived)
+TEST_F ( derive_metadata, compute_derived )
 {
   kv::metadata_item const& gsd_value =
     derived_metadata.at( 0 )->find( kv::VITAL_META_AVERAGE_GSD );
@@ -105,23 +93,23 @@ TEST_F(derive_metadata, compute_derived)
   kv::metadata_item const& slant_range_value =
     derived_metadata.at( 0 )->find( kv::VITAL_META_SLANT_RANGE );
 
-  EXPECT_DOUBLE_EQ( 0.38253304, gsd_value.as_double() );
-  EXPECT_DOUBLE_EQ( 5.183558, vniirs_value.as_double() );
+  EXPECT_DOUBLE_EQ( 0.38253304778779673, gsd_value.as_double() );
+  EXPECT_DOUBLE_EQ( 5.1835579391658815, vniirs_value.as_double() );
   EXPECT_DOUBLE_EQ( 300, slant_range_value.as_double() );
 }
 
 // ----------------------------------------------------------------------------
-TEST_F(derive_metadata, compute_derived_no_slant)
+TEST_F ( derive_metadata, compute_derived_no_slant )
 {
   // Use the estimated slant range
-  kv::metadata_item const& gsd_value = derived_metadata.at( 1 )->find(
-    kv::VITAL_META_AVERAGE_GSD );
-  kv::metadata_item const& vniirs_value = derived_metadata.at( 1 )->find(
-    kv::VITAL_META_VNIIRS );
-  kv::metadata_item const& slant_range_value = derived_metadata.at( 1 )->find(
-    kv::VITAL_META_SLANT_RANGE );
+  kv::metadata_item const& gsd_value =
+    derived_metadata.at( 1 )->find( kv::VITAL_META_AVERAGE_GSD );
+  kv::metadata_item const& vniirs_value =
+    derived_metadata.at( 1 )->find( kv::VITAL_META_VNIIRS );
+  kv::metadata_item const& slant_range_value =
+    derived_metadata.at( 1 )->find( kv::VITAL_META_SLANT_RANGE );
 
-  EXPECT_FLOAT_EQ( gsd_value.as_double(), 0.43601143 );
-  EXPECT_FLOAT_EQ( vniirs_value.as_double(), 4.9948859 );
-  EXPECT_FLOAT_EQ( slant_range_value.as_double(), 341.94022 );
+  EXPECT_DOUBLE_EQ( 0.43601144815947507, gsd_value.as_double() );
+  EXPECT_DOUBLE_EQ( 4.994885885506581, vniirs_value.as_double() );
+  EXPECT_DOUBLE_EQ( 341.9402198170427, slant_range_value.as_double() );
 }

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -50,7 +50,7 @@ make_metadata()
       kv::geo_point::geo_3d_point_t{ 0, 0, 0 }, kv::SRID::lat_lon_WGS84 } );
 
   // Replicate these values except without the slant range field
-  auto const m2 = std::make_shared< kv::metadata >( *m1.get() );
+  auto const m2 = std::make_shared< kv::metadata >( *m1 );
   m2->erase( kv::VITAL_META_SLANT_RANGE );
   return { m1, m2 };
 }

--- a/python/kwiver/vital/tests/test_metadata_tags.py
+++ b/python/kwiver/vital/tests/test_metadata_tags.py
@@ -113,6 +113,7 @@ class TestVitalMetadataTags(unittest.TestCase):
             mt.tags.VITAL_META_WEAPON_LOAD_0601,
             mt.tags.VITAL_META_WEAPON_FIRED_0601,
             mt.tags.VITAL_META_AVERAGE_GSD,
+            mt.tags.VITAL_META_VNIIRS,
             mt.tags.VITAL_META_GPS_SEC,
             mt.tags.VITAL_META_GPS_WEEK,
             mt.tags.VITAL_META_NORTHING_VEL,

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -105,7 +105,7 @@ metadata
   metadata copy;
   copy.set_timestamp( m_timestamp );
 
-  for( auto const& md_item: m_metadata_map )
+  for( auto const& md_item : m_metadata_map )
   {
     // Add a copy of the the other metadata map's items
     copy.add_copy( md_item.second );

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -99,18 +99,24 @@ metadata
 
 // ---------------------------------------------------------------------
 metadata
-metadata
-::deep_copy()
+::metadata( metadata const& other )
 {
-  metadata copy;
-  copy.set_timestamp( m_timestamp );
+  set_timestamp( other.m_timestamp );
 
-  for( auto const& md_item : m_metadata_map )
+  for( auto const& md_item : other.m_metadata_map )
   {
-    // Add a copy of the the other metadata map's items
-    copy.add_copy( md_item.second );
+    // Add a copy of the other metadata map's items
+    add_copy( md_item.second );
   }
-  return copy;
+}
+
+// ---------------------------------------------------------------------
+metadata&
+metadata::operator=( metadata const& other )
+{
+  auto copy = other;
+  *this = std::move( copy );
+  return *this;
 }
 
 // ---------------------------------------------------------------------

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -98,6 +98,22 @@ metadata
 { }
 
 // ---------------------------------------------------------------------
+metadata
+metadata
+::deep_copy()
+{
+  metadata copy;
+  copy.set_timestamp( m_timestamp );
+
+  for( auto const& md_item: m_metadata_map )
+  {
+    // Add a copy of the the other metadata map's items
+    copy.add_copy( md_item.second );
+  }
+  return copy;
+}
+
+// ---------------------------------------------------------------------
 void
 metadata
 ::add( std::unique_ptr< metadata_item >&& item )

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -380,6 +380,13 @@ public:
   ~metadata() = default;
 
   /**
+   * \brief Return a deep copy of the current metadata map.
+   *
+   * Metadata contains a map of pointers, so it needs to be deep copied
+   */
+  metadata deep_copy();
+
+  /**
    * \brief Add metadata item to collection.
    *
    * This method adds a metadata item to the collection. The collection takes

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -377,14 +377,11 @@ public:
   using const_iterator_t = metadata_map_t::const_iterator;
 
   metadata();
+  metadata( metadata const& other );
+  metadata( metadata&& other ) = default;
   ~metadata() = default;
-
-  /**
-   * \brief Return a deep copy of the current metadata map.
-   *
-   * Metadata contains a map of pointers, so it needs to be deep copied
-   */
-  metadata deep_copy();
+  metadata& operator=( metadata&& other ) = default;
+  metadata& operator=( metadata const& other );
 
   /**
    * \brief Add metadata item to collection.

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -353,6 +353,10 @@
         "Average GSD value (meters/pixel)",                             \
         double,                                                         \
         "" )                                                            \
+  CALL( VNIIRS,                                                         \
+        "VNIIRs image quality",                                         \
+        double,                                                         \
+        "Unitless metric computed from GSD and image quality" )         \
   CALL( GPS_SEC,                                                        \
         "GPS seconds",                                                  \
         double,                                                         \

--- a/vital/types/metadata_tags.h
+++ b/vital/types/metadata_tags.h
@@ -354,9 +354,12 @@
         double,                                                         \
         "" )                                                            \
   CALL( VNIIRS,                                                         \
-        "VNIIRs image quality",                                         \
+        "Video-National Imagery Interpretability Rating Scale",         \
         double,                                                         \
-        "Unitless metric computed from GSD and image quality" )         \
+        "A subjective quality scale from 2 to 11 for rating the "       \
+        "intelligence value of airborne motion imagery in the visible " \
+        "spectrum. "                                                    \
+        "See https://gwg.nga.mil/misb/docs/standards/ST0901.2.pdf" )    \
   CALL( GPS_SEC,                                                        \
         "GPS seconds",                                                  \
         double,                                                         \


### PR DESCRIPTION
This adds computation for GSD and VNIIRS based on the reference implementation provided by NGA. It needs style fixes and, as I understand it, should not modify the input metadata vector. I think this requires implementing the assignment operator for `metadata_item`. Also, some comment formatting needs to be brought in line with the style guide.  