### PR TITLE
Make kwiver::vital::unknown_metadata_item more coherent

### DIFF
--- a/python/kwiver/vital/tests/test_metadata.py
+++ b/python/kwiver/vital/tests/test_metadata.py
@@ -234,29 +234,28 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
         nt.assert_equals(inst.name, prop_info.name)
         nt.assert_equals(inst.tag, prop_info.tag)
 
-        if prop_info.data is not None:
-            # A few tests on inst.data
-            nt.ok_(isinstance(inst.data, type(prop_info.data)))
-            if isinstance(prop_info.data, GeoPoint):
-                nt.assert_equals(inst.data.crs(), prop_info.data.crs())
-                if prop_info.data.is_empty():
-                    nt.ok_(inst.data.is_empty())
-                else:
-                    inst_loc = inst.data.location()
-                    exp_loc = prop_info.data.location()
-                    np.testing.assert_array_almost_equal(inst_loc, exp_loc)
-
-            elif isinstance(prop_info.data, GeoPolygon):
-                nt.assert_equals(inst.data.crs(), prop_info.data.crs())
-                if prop_info.data.is_empty():
-                    nt.ok_(inst.data.is_empty())
-                else:
-                    inst_verts = inst.data.polygon().get_vertices()
-                    exp_verts = prop_info.data.polygon().get_vertices()
-                    np.testing.assert_array_almost_equal(inst_verts, exp_verts)
-
+        # A few tests on inst.data
+        nt.ok_(isinstance(inst.data, type(prop_info.data)))
+        if isinstance(prop_info.data, GeoPoint):
+            nt.assert_equals(inst.data.crs(), prop_info.data.crs())
+            if prop_info.data.is_empty():
+                nt.ok_(inst.data.is_empty())
             else:
-                nt.assert_equals(inst.data, prop_info.data)
+                inst_loc = inst.data.location()
+                exp_loc = prop_info.data.location()
+                np.testing.assert_array_almost_equal(inst_loc, exp_loc)
+
+        elif isinstance(prop_info.data, GeoPolygon):
+            nt.assert_equals(inst.data.crs(), prop_info.data.crs())
+            if prop_info.data.is_empty():
+                nt.ok_(inst.data.is_empty())
+            else:
+                inst_verts = inst.data.polygon().get_vertices()
+                exp_verts = prop_info.data.polygon().get_vertices()
+                np.testing.assert_array_almost_equal(inst_verts, exp_verts)
+
+        else:
+            nt.assert_equals(inst.data, prop_info.data)
 
     def check_is_valid(self, inst, is_valid):
         nt.assert_equals(bool(inst), is_valid)

--- a/python/kwiver/vital/tests/test_metadata.py
+++ b/python/kwiver/vital/tests/test_metadata.py
@@ -254,6 +254,9 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
                 exp_verts = prop_info.data.polygon().get_vertices()
                 np.testing.assert_array_almost_equal(inst_verts, exp_verts)
 
+        elif prop_info.data is None:
+            nt.ok_(inst.data is None)
+
         else:
             nt.assert_equals(inst.data, prop_info.data)
 

--- a/python/kwiver/vital/tests/test_metadata.py
+++ b/python/kwiver/vital/tests/test_metadata.py
@@ -216,8 +216,8 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
         # UnknownMetadataItem - This is a separate subclass of metadata_item
         # Can keep the tag the same
         inst = UnknownMetadataItem()
-        exp_name = "<UNKNOWN>"
-        exp_string = "<UNKNOWN>"
+        exp_name = "Requested metadata item is not in collection"
+        exp_string = "--Unknown metadata item--"
         prop_info = PropInfo(exp_name, tag, None)
         type_info = TypeInfo("kwiver::vital::unknown_metadata_item::unknown_t", as_string=exp_string)
         self.check_instance(inst, prop_info, type_info, is_valid=False)

--- a/python/kwiver/vital/tests/test_metadata.py
+++ b/python/kwiver/vital/tests/test_metadata.py
@@ -219,7 +219,7 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
         exp_name = "Requested metadata item is not in collection"
         exp_string = "--Unknown metadata item--"
         prop_info = PropInfo(exp_name, tag, None)
-        type_info = TypeInfo("kwiver::vital::unknown_metadata_item::unknown_t", as_string=exp_string)
+        type_info = TypeInfo(type(None), as_string=exp_string)
         self.check_instance(inst, prop_info, type_info, is_valid=False)
 
     def check_instance(self, inst, prop_info, type_info, is_valid=True):

--- a/python/kwiver/vital/tests/test_metadata.py
+++ b/python/kwiver/vital/tests/test_metadata.py
@@ -216,10 +216,10 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
         # UnknownMetadataItem - This is a separate subclass of metadata_item
         # Can keep the tag the same
         inst = UnknownMetadataItem()
-        exp_name = "Requested metadata item is not in collection"
-        exp_string = "--Unknown metadata item--"
-        prop_info = PropInfo(exp_name, tag, 0)
-        type_info = TypeInfo("void", as_string=exp_string, as_double=0, as_uint64=0)
+        exp_name = "<UNKNOWN>"
+        exp_string = "<UNKNOWN>"
+        prop_info = PropInfo(exp_name, tag, None)
+        type_info = TypeInfo("kwiver::vital::unknown_metadata_item::unknown_t", as_string=exp_string)
         self.check_instance(inst, prop_info, type_info, is_valid=False)
 
     def check_instance(self, inst, prop_info, type_info, is_valid=True):
@@ -234,28 +234,29 @@ class TestVitalMetadataItemSubclasses(unittest.TestCase):
         nt.assert_equals(inst.name, prop_info.name)
         nt.assert_equals(inst.tag, prop_info.tag)
 
-        # A few tests on inst.data
-        nt.ok_(isinstance(inst.data, type(prop_info.data)))
-        if isinstance(prop_info.data, GeoPoint):
-            nt.assert_equals(inst.data.crs(), prop_info.data.crs())
-            if prop_info.data.is_empty():
-                nt.ok_(inst.data.is_empty())
-            else:
-                inst_loc = inst.data.location()
-                exp_loc = prop_info.data.location()
-                np.testing.assert_array_almost_equal(inst_loc, exp_loc)
+        if prop_info.data is not None:
+            # A few tests on inst.data
+            nt.ok_(isinstance(inst.data, type(prop_info.data)))
+            if isinstance(prop_info.data, GeoPoint):
+                nt.assert_equals(inst.data.crs(), prop_info.data.crs())
+                if prop_info.data.is_empty():
+                    nt.ok_(inst.data.is_empty())
+                else:
+                    inst_loc = inst.data.location()
+                    exp_loc = prop_info.data.location()
+                    np.testing.assert_array_almost_equal(inst_loc, exp_loc)
 
-        elif isinstance(prop_info.data, GeoPolygon):
-            nt.assert_equals(inst.data.crs(), prop_info.data.crs())
-            if prop_info.data.is_empty():
-                nt.ok_(inst.data.is_empty())
-            else:
-                inst_verts = inst.data.polygon().get_vertices()
-                exp_verts = prop_info.data.polygon().get_vertices()
-                np.testing.assert_array_almost_equal(inst_verts, exp_verts)
+            elif isinstance(prop_info.data, GeoPolygon):
+                nt.assert_equals(inst.data.crs(), prop_info.data.crs())
+                if prop_info.data.is_empty():
+                    nt.ok_(inst.data.is_empty())
+                else:
+                    inst_verts = inst.data.polygon().get_vertices()
+                    exp_verts = prop_info.data.polygon().get_vertices()
+                    np.testing.assert_array_almost_equal(inst_verts, exp_verts)
 
-        else:
-            nt.assert_equals(inst.data, prop_info.data)
+            else:
+                nt.assert_equals(inst.data, prop_info.data)
 
     def check_is_valid(self, inst, is_valid):
         nt.assert_equals(bool(inst), is_valid)

--- a/python/kwiver/vital/types/metadata.cxx
+++ b/python/kwiver/vital/types/metadata.cxx
@@ -114,10 +114,14 @@ PYBIND11_MODULE( metadata, m )
   .def( "__nonzero__", &unknown_metadata_item::is_valid )
   .def( "__bool__",    &unknown_metadata_item::is_valid )
   .def_property_readonly( "tag",  &unknown_metadata_item::tag )
+  .def_property_readonly( "type", [] ( unknown_metadata_item const& self )
+  {
+    return py::none().get_type();
+  } )
   .def_property_readonly( "data", [] ( unknown_metadata_item const& self )
   {
     return py::none();
-  })
+  } )
   .def( "as_string",  &unknown_metadata_item::as_string )
   .def( "as_double",  &unknown_metadata_item::as_double )
   .def( "as_uint64",  &unknown_metadata_item::as_uint64 )

--- a/python/kwiver/vital/types/metadata.cxx
+++ b/python/kwiver/vital/types/metadata.cxx
@@ -116,13 +116,14 @@ PYBIND11_MODULE( metadata, m )
   .def_property_readonly( "tag",  &unknown_metadata_item::tag )
   .def_property_readonly( "data", [] ( unknown_metadata_item const& self )
   {
-    any dat = self.data();
-    return any_cast< int >( dat ); //data is int 0
+    return py::none();
   })
   .def( "as_string",  &unknown_metadata_item::as_string )
   .def( "as_double",  &unknown_metadata_item::as_double )
   .def( "as_uint64",  &unknown_metadata_item::as_uint64 )
   ;
+
+
 
   // Now the typed subclasses (around 100 of them)
   KWIVER_VITAL_METADATA_TAGS( REGISTER_TYPED_METADATA )

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -210,14 +210,17 @@ private:
   {
   public:
     unknown_metadata_item()
-      : metadata_item( "<UNKNOWN>", unknown_t{}, VITAL_META_UNKNOWN )
+      : metadata_item( "Requested metadata item is not in collection",
+                       unknown_t{}, VITAL_META_UNKNOWN )
     { }
 
     bool is_valid() const override { return false; }
 
     std::type_info const& type() const override { return typeid( unknown_t ); }
 
-    std::string as_string() const override { return "<UNKNOWN>"; }
+    std::string as_string() const override {
+      return "--Unknown metadata item--";
+    }
 
     std::ostream& print_value(std::ostream& os) const override
     {

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -209,9 +209,6 @@ private:
     : public metadata_item
   {
   public:
-    // Dummy class not convertible to any other type
-    class unknown_t {};
-
     unknown_metadata_item()
       : metadata_item( "<UNKNOWN>", unknown_t{}, VITAL_META_UNKNOWN )
     { }
@@ -229,6 +226,9 @@ private:
     }
 
 private:
+    // Dummy class not convertible to any other type
+    class unknown_t {};
+
     // never used - required to make python bindings valid
     metadata_item* clone() const override { return nullptr; }
   }; // end class unknown_metadata_item

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -209,22 +209,25 @@ private:
     : public metadata_item
   {
   public:
-    // -- CONSTRUCTORS --
+    // Dummy class not convertible to any other type
+    class unknown_t {};
+
     unknown_metadata_item()
-      : metadata_item( "Requested metadata item is not in collection", 0, VITAL_META_UNKNOWN )
+      : metadata_item( "<UNKNOWN>", unknown_t{}, VITAL_META_UNKNOWN )
     { }
 
-    virtual bool is_valid() const { return false; }
-    virtual vital_metadata_tag tag() const { return static_cast< vital_metadata_tag >(0); }
-    virtual std::type_info const& type() const { return typeid( void ); }
-    virtual std::string as_string() const { return "--Unknown metadata item--"; }
-    virtual double as_double() const { return 0; }
-    virtual double as_uint64() const { return 0; }
-    virtual std::ostream& print_value(std::ostream& os) const
+    bool is_valid() const override { return false; }
+
+    std::type_info const& type() const override { return typeid( unknown_t ); }
+
+    std::string as_string() const override { return "<UNKNOWN>"; }
+
+    std::ostream& print_value(std::ostream& os) const override
     {
       os << this->as_string();
       return os;
     }
+
 private:
     // never used - required to make python bindings valid
     metadata_item* clone() const override { return nullptr; }


### PR DESCRIPTION
The existing definition of `kwiver::vital:unknown_metadata_item` has a number of problems: it seems to try to override non-virtual member functions, silently returns a possibly valid value (0) for `to_double()` and `to_uint64()` when the purpose of the class is that it inherently has no valid value, and for some reason masks the existing non-virtual `to_uint64()` method with one that returns a `double`. This hopes to fix those problems by deleting code and using a unique dummy `unknown_t` class (not convertible to or useful for anything) as the internal type to provoke runtime errors when a cast is attempted.