### PR TITLE
Actually use unique_ptr in metadata map

### DIFF
--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
@@ -495,13 +495,13 @@ TEST_F(ffmpeg_video_input, no_sync_metadata)
     EXPECT_TRUE(md_vect.size() > 0)
       << "Each frame tested should have metadata present";
 
-    for (auto md : md_vect)
+    for (auto const& md : md_vect)
     {
       EXPECT_TRUE(md->has(kwiver::vital::VITAL_META_UNIX_TIMESTAMP))
         << "Each of the first five frames should have a UNIX time stamp in"
         << " its metadata";
 
-      for (auto md_item : *md)
+      for (auto const& md_item : *md)
       {
         if (md_item.first == kwiver::vital::VITAL_META_UNIX_TIMESTAMP)
         {
@@ -565,7 +565,7 @@ TEST_F(ffmpeg_video_input, sync_metadata)
         << "Each of the first five frames should have a UNIX time stamp in"
         << " its metadata";
 
-      for (auto md_item : *md)
+      for (auto const& md_item : *md)
       {
         if (md_item.first == kwiver::vital::VITAL_META_UNIX_TIMESTAMP)
         {

--- a/arrows/serialize/json/load_save_metadata.cxx
+++ b/arrows/serialize/json/load_save_metadata.cxx
@@ -198,12 +198,11 @@ namespace cereal {
 void save( ::cereal::JSONOutputArchive& archive,
            kwiver::vital::metadata_vector const& meta_packets )
 {
-  std::vector< kwiver::vital::metadata > meta_packets_dereferenced;
+  archive( make_size_tag( static_cast< size_type >( meta_packets.size() ) ) );
   for( auto const& packet : meta_packets )
   {
-    meta_packets_dereferenced.push_back( *packet );
+    archive( *packet );
   }
-  save( archive, meta_packets_dereferenced );
 }
 
 // ----------------------------------------------------------------------------
@@ -213,10 +212,10 @@ void load( ::cereal::JSONInputArchive& archive,
   std::vector< kwiver::vital::metadata > meta_packets_dereferenced;
   load( archive, meta_packets_dereferenced );
 
-  for( auto const& meta_packet : meta_packets_dereferenced )
+  for( auto&& meta_packet : meta_packets_dereferenced )
   {
     meta.push_back(
-      std::make_shared< kwiver::vital::metadata >( meta_packet ) );
+      std::make_shared< kwiver::vital::metadata >( std::move( meta_packet ) ) );
   }
 }
 
@@ -231,7 +230,7 @@ void save( ::cereal::JSONOutputArchive& archive,
   {
     // element is <tag, any>
     const auto tag = item.first;
-    const auto metap = item.second;
+    const auto& metap = item.second;
     packet_vec.emplace_back( tag, metap->data() );
   }
 

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -427,7 +427,7 @@ void compare_meta_collection( const kwiver::vital::metadata& lhs,
   // Check to make sure they are the same
   for ( const auto& it : lhs )
   {
-    const auto lhs_item = it.second;
+    const auto& lhs_item = it.second;
 
     EXPECT_TRUE( rhs.has( lhs_item->tag() ) );
 

--- a/arrows/serialize/protobuf/convert_protobuf.cxx
+++ b/arrows/serialize/protobuf/convert_protobuf.cxx
@@ -590,7 +590,7 @@ void convert_protobuf( const ::kwiver::vital::metadata& metadata,
 
     // element is <tag, any>
     const auto tag = mi.first;
-    const auto metap = mi.second;
+    const auto& metap = mi.second;
     const auto& trait = traits.find( tag );
 
     proto_item->set_metadata_tag( tag );

--- a/python/kwiver/vital/types/detected_object.cxx
+++ b/python/kwiver/vital/types/detected_object.cxx
@@ -74,20 +74,10 @@ det_obj_const_safe_set_descriptor(detected_object& self, descriptor_sptr desc)
   }
 }
 
-
-// TODO: uncomment these when rebased on latest master with metadata API changes
-// Those changes will make copying metadata objects much easier.
-// metadata_sptr
-metadata_sptr copy_metadata(metadata_sptr m)
+metadata_sptr
+copy_metadata(metadata_sptr m)
 {
-  auto m_clone = std::make_shared<metadata>();
-  auto eix = m->end();
-  auto ix = m->begin();
-  for (; ix != eix; ix++)
-  {
-    m_clone->add_copy(ix->second);
-  }
-  return m_clone;
+  return std::make_shared<metadata>(*m);
 }
 
 image_container_sptr

--- a/vital/attribute_set.cxx
+++ b/vital/attribute_set.cxx
@@ -55,11 +55,7 @@ void
 attribute_set::
 add( const std::string& name, const kwiver::vital::any& val )
 {
-#ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  m_attr_map[name] = std::make_unique<kwiver::vital::any>(val);
-#else
-  m_attr_map[name] = std::make_shared<kwiver::vital::any>(val);
-#endif
+  m_attr_map[name] = make_map_unique<kwiver::vital::any>(val);
 }
 
 // ------------------------------------------------------------------

--- a/vital/attribute_set.h
+++ b/vital/attribute_set.h
@@ -13,13 +13,14 @@
 #include <vital/vital_export.h>
 #include <vital/vital_config.h>
 
+#include <vital/exceptions/base.h>
+
 #include <vital/any.h>
 #include <vital/noncopyable.h>
-#include <vital/exceptions/base.h>
+#include <vital/unique_map_ptr.h>
 
 #include <map>
 #include <string>
-#include <memory>
 
 namespace kwiver {
 namespace vital {
@@ -54,13 +55,9 @@ class VITAL_EXPORT attribute_set
   : private noncopyable
 {
 public:
-  #ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  typedef std::unique_ptr< kwiver::vital::any > item_ptr;
-#else
-  typedef std::shared_ptr< kwiver::vital::any > item_ptr;
-#endif
-  typedef std::map< std::string, item_ptr > attribute_map_t;
-  typedef attribute_map_t::const_iterator const_iterator_t;
+  using item_ptr = unique_map_ptr< kwiver::vital::any >;
+  using attribute_map_t = std::map< std::string, item_ptr >;
+  using const_iterator_t = attribute_map_t::const_iterator;
 
   attribute_set();
   ~attribute_set();

--- a/vital/tests/test_metadata.cxx
+++ b/vital/tests/test_metadata.cxx
@@ -56,8 +56,7 @@ TEST( metadata, add_metadata )
 {
   // create item
   using rmdi_t = typed_metadata< VITAL_META_UNIX_TIMESTAMP, uint64_t >;
-  auto rmdi =
-    std::make_shared< rmdi_t >( "test uint item", uint64_t{ 314159 } );
+  auto rmdi = rmdi_t{ "test uint item", uint64_t{ 314159 } };
 
   using umdd_t = typed_metadata< VITAL_META_PLATFORM_HEADING_ANGLE, double >;
   auto umdd = std::unique_ptr< umdd_t >{

--- a/vital/tests/test_metadata_io.cxx
+++ b/vital/tests/test_metadata_io.cxx
@@ -130,7 +130,7 @@ TEST_F(metadata_pos_io, output_format)
   EXPECT_EQ( input_md->size(), md->size() )
     << "Metadata does not have same size after IO!";
 
-  for (auto mdi : *input_md)
+  for (auto const& mdi : *input_md)
   {
     compare_tag( *mdi.second, md );
   }

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -130,27 +130,22 @@ metadata
   }
 
   auto const tag = item->tag();
-#ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  this->m_metadata_map[ tag ] = std::move( item );
-#else
+#ifdef VITAL_STD_MAP_NO_UNIQUE_PTR
   this->m_metadata_map[ tag ] = item_ptr{ item.release() };
+#else
+  this->m_metadata_map[ tag ] = std::move( item );
 #endif
 }
 
 // ---------------------------------------------------------------------
 void
 metadata
-::add_copy( std::shared_ptr<metadata_item const> const& item )
+::add_copy( metadata_item const& item )
 {
-  if ( !item )
-  {
-    throw std::invalid_argument{ "null pointer" };
-  }
-
   // Since the design intent for this map is that the metadata
   // collection owns the elements, we will clone the item passed in.
   // The original parameter will be freed eventually.
-  this->m_metadata_map[ item->tag() ] = item_ptr{ item->clone() };
+  this->m_metadata_map[ item.tag() ] = item_ptr{ item.clone() };
 }
 
 // -------------------------------------------------------------------
@@ -321,7 +316,7 @@ bool test_equal_content( const kwiver::vital::metadata& one,
   {
     // element is <tag, any>
     const auto tag = mi.first;
-    const auto metap = mi.second;
+    const auto& metap = mi.second;
 
     auto& omi = other.find( tag );
     if ( ! omi ) { return false; }

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -12,14 +12,16 @@
 
 #include <vital/vital_export.h>
 
-#include <vital/any.h>
 #include <vital/exceptions/metadata.h>
+
 #include <vital/types/metadata_tags.h>
 #include <vital/types/timestamp.h>
 
+#include <vital/any.h>
+#include <vital/unique_map_ptr.h>
+
 #include <iostream>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -363,16 +365,7 @@ private:
 class VITAL_EXPORT metadata
 {
 public:
-// The design for this collection requires that the elements in the
-// collection are owned by the collection and are only returned by
-// value. This is why the std::unique_ptr is used. Unfortunately, not
-// all stdc implementations support maps with unique_ptrs. The
-// following is done to work around this limitation.
-#ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  using item_ptr = std::unique_ptr< metadata_item >;
-#else
-  using item_ptr = std::shared_ptr< metadata_item >;
-#endif
+  using item_ptr = unique_map_ptr< metadata_item >;
   using metadata_map_t = std::map< vital_metadata_tag, item_ptr >;
   using const_iterator_t = metadata_map_t::const_iterator;
 
@@ -401,7 +394,7 @@ public:
    *
    * \param item New metadata item to be copied into the collection.
    */
-  void add_copy( std::shared_ptr<metadata_item const> const& item );
+  void add_copy( metadata_item const& item );
 
   //@{
   /**

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -9,17 +9,18 @@
 #ifndef KWIVER_VITAL_METADATA_TRAITS_H_
 #define KWIVER_VITAL_METADATA_TRAITS_H_
 
-#include <vital/vital_export.h>
+#include <vital/logger/logger.h>
 
 #include <vital/types/geo_point.h>
 #include <vital/types/geo_polygon.h>
 #include <vital/types/matrix.h>
 #include <vital/types/metadata.h>
 
-#include <vital/logger/logger.h>
+#include <vital/unique_map_ptr.h>
+
+#include <vital/vital_export.h>
 
 #include <type_traits>
-#include <memory>
 
 namespace kwiver {
 namespace vital {
@@ -40,7 +41,8 @@ struct vital_meta_trait_base
   virtual bool is_signed() const = 0;
   virtual bool is_floating_point() const = 0;
   virtual vital_metadata_tag tag() const = 0;
-  virtual std::unique_ptr<metadata_item> create_metadata_item( const kwiver::vital::any& data ) const = 0;
+  virtual std::unique_ptr<metadata_item> create_metadata_item(
+    any const& data ) const = 0;
 };
 
 // ------------------------------------------------------------------
@@ -85,6 +87,12 @@ class VITAL_EXPORT metadata_traits
 public:
   metadata_traits();
   ~metadata_traits();
+
+  metadata_traits( metadata_traits const& ) = delete;
+  metadata_traits( metadata_traits&& ) = default;
+
+  metadata_traits& operator=( metadata_traits const& ) = delete;
+  metadata_traits& operator=( metadata_traits&& ) = default;
 
   /// Find traits entry for specified tag.
   /**
@@ -159,16 +167,12 @@ public:
   std::string tag_to_description( vital_metadata_tag tag ) const;
 
 private:
-  kwiver::vital::logger_handle_t m_logger;
+  logger_handle_t m_logger;
 
-#ifdef VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
-  typedef std::unique_ptr< vital_meta_trait_base > trait_ptr;
-#else
-  typedef std::shared_ptr< vital_meta_trait_base > trait_ptr;
-#endif
-  std::map< kwiver::vital::vital_metadata_tag, trait_ptr> m_trait_table;
-  std::map< std::string, kwiver::vital::vital_metadata_tag > m_name_tag_table;
-  std::map< std::string, kwiver::vital::vital_metadata_tag > m_enum_name_tag_table;
+  using trait_ptr = unique_map_ptr< vital_meta_trait_base >;
+  std::map< vital_metadata_tag, trait_ptr> m_trait_table;
+  std::map< std::string, vital_metadata_tag > m_name_tag_table;
+  std::map< std::string, vital_metadata_tag > m_enum_name_tag_table;
 
 }; // end class metadata_traits
 

--- a/vital/unique_map_ptr.h
+++ b/vital/unique_map_ptr.h
@@ -1,0 +1,42 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef KWIVER_VITAL_UNIQUE_MAP_PTR_H
+#define KWIVER_VITAL_UNIQUE_MAP_PTR_H
+
+#include <memory>
+
+namespace kwiver {
+
+namespace vital {
+
+// The design for various collections requires that the elements in the
+// collection are owned by the collection and are only returned by value.
+// Typically, one uses std::unique_ptr to accomplish this. Unfortunately, not
+// all STL implementations support maps with unique_ptr elements. This type
+// alias exists to help work around this limitation.
+#ifdef VITAL_STD_MAP_NO_UNIQUE_PTR
+template< typename T >
+using unique_map_ptr = std::shared_ptr< T >;
+#else
+template< typename T >
+using unique_map_ptr = std::unique_ptr< T >;
+#endif
+
+// ----------------------------------------------------------------------------
+template< typename T, typename... Args >
+inline unique_map_ptr< T > make_map_unique( Args&&... args )
+{
+#ifdef VITAL_STD_MAP_NO_UNIQUE_PTR
+  return std::make_shared< T >( std::forward< Args >( args )... );
+#else
+  return unique_map_ptr< T >{ new T( std::forward< Args >( args )... ) };
+#endif
+}
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/vital/vital_config.h.in
+++ b/vital/vital_config.h.in
@@ -44,7 +44,7 @@
 #define VITAL_NO_RETURN [[noreturn]]
 
 #cmakedefine01  VITAL_USE_ABI_DEMANGLE
-#cmakedefine  VITAL_STD_MAP_UNIQUE_PTR_ALLOWED
+#cmakedefine  VITAL_STD_MAP_NO_UNIQUE_PTR
 
 #define VITAL_FINAL final
 


### PR DESCRIPTION
Add a small helper header for the couple of places in which we want to use `std::unique_ptr` in a `std::map`. Change the default to actually using `unique_ptr` rather than the work-around, which should only be needed on broken STL implementations. Fix the numerous bugs (mostly needing to avoid unnecessary copies) due to actually using `unique_ptr`.

I'm somewhat expecting this to fail on at least some platform, but I'd like to see us preferring to use the not-broken STL on at least one platform.