### PR TITLE
Turn derive_metadata into an algorithm

### DIFF
--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -10,15 +10,7 @@
 
 #include <arrows/core/kwiver_algo_core_export.h>
 
-#include <vital/algo/video_input.h>
-
-#include <vital/types/bounding_box.h>
-#include <vital/types/camera_perspective.h>
-#include <vital/types/camera_perspective_map.h>
-#include <vital/types/landmark.h>
-
-#include <functional>
-#include <vector>
+#include <vital/algo/metadata_filter.h>
 
 namespace kwiver {
 
@@ -26,22 +18,33 @@ namespace arrows {
 
 namespace core {
 
-/// Fills in metadata values which can be calculated from other metadata.
-///
-/// \param metadata_vec A vector of metadata packets.
-/// \param frame_width Width of the image in pixels.
-/// \param frame_height Height of the image in pixels.
-///
-/// \returns An amended metadata vector.
-///
-/// \todo
-///   Eventually this should be replaced with a version which takes in an image
-///   as a parameter instead of just frame dimensions and incorporates pixel
-///   data into computations.
-KWIVER_ALGO_CORE_EXPORT
-kwiver::vital::metadata_vector
-compute_derived_metadata( kwiver::vital::metadata_vector const& metadata_vec,
-                          size_t frame_width, size_t frame_height );
+class KWIVER_ALGO_CORE_EXPORT derive_metadata
+  : public vital::algo::metadata_filter
+{
+public:
+  derive_metadata();
+  virtual ~derive_metadata();
+
+  PLUGIN_INFO( "derive_metadata",
+               "Fills in metadata values which can be calculated "
+               "from other metadata." )
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration(vital::config_block_sptr config) override;
+  bool check_configuration(vital::config_block_sptr config) const override;
+
+  bool uses_image() const override;
+
+  /// Fills in metadata values which can be calculated from other metadata.
+  ///
+  /// \param input_metadata Input vector of metadata packets.
+  /// \param input_image Associated video image.
+  ///
+  /// \returns An amended metadata vector.
+  kwiver::vital::metadata_vector filter(
+    kwiver::vital::metadata_vector const& input_metadata,
+    kwiver::vital::image_container_scptr const& input_image ) override;
+};
 
 } // namespace core
 

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -22,6 +22,7 @@
 #include <arrows/core/compute_ref_homography_core.h>
 #include <arrows/core/convert_image_bypass.h>
 #include <arrows/core/create_detection_grid.h>
+#include <arrows/core/derive_metadata.h>
 #include <arrows/core/detect_features_filtered.h>
 #include <arrows/core/detected_object_set_input_csv.h>
 #include <arrows/core/detected_object_set_input_kw18.h>
@@ -86,6 +87,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_algorithm< compute_ref_homography_core >();
   reg.register_algorithm< convert_image_bypass >();
   reg.register_algorithm< create_detection_grid >();
+  reg.register_algorithm< derive_metadata >();
   reg.register_algorithm< detect_features_filtered >();
   reg.register_algorithm< detected_object_set_input_csv >();
   reg.register_algorithm< detected_object_set_input_kw18 >();

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -20,12 +20,12 @@
 
 namespace kv = kwiver::vital;
 
-static kwiver::vital::metadata_traits meta_traits;
+static kv::metadata_traits meta_traits;
 
 namespace {
 
 // ----------------------------------------------------------------------------
-kwiver::vital::metadata_vector
+kv::metadata_vector
 make_metadata()
 {
   kv::metadata_sptr m1 = std::make_shared< kv::metadata >();
@@ -55,6 +55,17 @@ make_metadata()
   return { m1, m2 };
 }
 
+// ----------------------------------------------------------------------------
+kv::image_container_scptr
+make_image()
+{
+  constexpr auto frame_height = size_t{ 720 };
+  constexpr auto frame_width = size_t{ 1080 };
+
+  auto image = kv::image{ frame_width, frame_height };
+  return std::make_shared< kv::simple_image_container >( image );
+}
+
 } // namespace <anonymous>
 
 // ----------------------------------------------------------------------------
@@ -71,12 +82,8 @@ class derive_metadata : public ::testing::Test
   void
   SetUp()
   {
-    auto meta = make_metadata();
-    constexpr auto frame_height = size_t{ 720 };
-    constexpr auto frame_width = size_t{ 1080 };
-
-    derived_metadata = kwiver::arrows::core::compute_derived_metadata(
-      meta, frame_width, frame_height );
+    auto algo = kwiver::arrows::core::derive_metadata{};
+    derived_metadata = algo.filter( make_metadata(), make_image() );
   }
 
 public:

--- a/vital/algo/CMakeLists.txt
+++ b/vital/algo/CMakeLists.txt
@@ -48,6 +48,7 @@ set( public_headers
   integrate_depth_maps.h
   interpolate_track.h
   keyframe_selection.h
+  metadata_filter.h
   metadata_map_io.h
   match_descriptor_sets.h
   match_features.h
@@ -111,6 +112,7 @@ set( sources
   integrate_depth_maps.cxx
   interpolate_track.cxx
   keyframe_selection.cxx
+  metadata_filter.cxx
   metadata_map_io.cxx
   match_descriptor_sets.cxx
   match_features.cxx

--- a/vital/algo/metadata_filter.cxx
+++ b/vital/algo/metadata_filter.cxx
@@ -1,0 +1,31 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief metadata_filter algorithm instantiation
+
+#include <vital/algo/algorithm.txx>
+#include <vital/algo/metadata_filter.h>
+
+namespace kwiver {
+
+namespace vital {
+
+namespace algo {
+
+metadata_filter
+::metadata_filter()
+{
+  attach_logger( "algo.metadata_filter" ); // specify a logger
+}
+
+} // namespace algo
+
+} // namespace vital
+
+} // namespace kwiver
+
+/// \cond DoxygenSuppress
+INSTANTIATE_ALGORITHM_DEF( kwiver::vital::algo::metadata_filter );
+/// \endcond

--- a/vital/algo/metadata_filter.h
+++ b/vital/algo/metadata_filter.h
@@ -1,0 +1,69 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/**
+ * \file
+ * \brief Interface to abstract filter metadata algorithm
+ */
+
+#ifndef VITAL_ALGO_METADATA_FILTER_H
+#define VITAL_ALGO_METADATA_FILTER_H
+
+#include <vital/algo/algorithm.h>
+
+#include <vital/types/image_container.h>
+#include <vital/types/metadata.h>
+
+#include <vital/vital_config.h>
+
+namespace kwiver {
+
+namespace vital {
+
+namespace algo {
+
+/// Abstract base class for metadata filter algorithms.
+///
+/// This interface supports arrows/algorithms that modify image metadata.
+class VITAL_ALGO_EXPORT metadata_filter
+  : public kwiver::vital::algorithm_def< metadata_filter >
+{
+public:
+  /// Return the name of this algorithm.
+  static std::string static_type_name() { return "metadata_filter"; }
+
+  /// Return if this filter uses the image for filtering.
+  ///
+  /// This method returns whether the algorithm uses the image in its
+  /// implementation. It may be more efficient to not obtain the image if the
+  /// algorithm does not use it.
+  virtual bool uses_image() const = 0;
+
+  /// Filter metadata and return resulting metadata.
+  ///
+  /// This method implements the filtering operation. The method does not
+  /// modify the metadata in place.
+  ///
+  /// \param input_metadata Metadata to filter.
+  /// \param input_image Image associated with the metadata (may be null).
+  ///
+  /// \returns Filtered version of the input metadata.
+  virtual kwiver::vital::metadata_vector filter(
+    kwiver::vital::metadata_vector const& input_metadata,
+    kwiver::vital::image_container_scptr const& input_image ) = 0;
+
+protected:
+  metadata_filter();
+};
+
+/// Type alias for shared pointer to a metadata_filter algorithm.
+using metadata_filter_sptr = std::shared_ptr< metadata_filter >;
+
+} // namespace algo
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Create interface for an algorithm that filters/transforms video metadata, using both the original metadata and (optionally) the video frame image. Modify `derive_metadata` to make it an implementation of the same.