### PR TITLE
Use metadata filter algorithm

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -375,6 +375,7 @@ compute_snr( kwiver::vital::image_container_scptr const& image )
 derive_metadata
 ::derive_metadata()
 {
+  this->set_capability( CAN_USE_FRAME_IMAGE, true );
 }
 
 // ----------------------------------------------------------------------------
@@ -406,14 +407,6 @@ derive_metadata
 ::check_configuration( vital::config_block_sptr ) const
 {
   // No configuration, so always return true
-  return true;
-}
-
-// ----------------------------------------------------------------------------
-bool
-derive_metadata
-::uses_image() const
-{
   return true;
 }
 

--- a/arrows/core/derive_metadata.h
+++ b/arrows/core/derive_metadata.h
@@ -33,8 +33,6 @@ public:
   void set_configuration(vital::config_block_sptr config) override;
   bool check_configuration(vital::config_block_sptr config) const override;
 
-  bool uses_image() const override;
-
   /// Fills in metadata values which can be calculated from other metadata.
   ///
   /// \param input_metadata Input vector of metadata packets.

--- a/arrows/core/register_algorithms.cxx
+++ b/arrows/core/register_algorithms.cxx
@@ -53,6 +53,7 @@
 #include <arrows/core/uv_unwrap_mesh.h>
 #include <arrows/core/video_input_filter.h>
 #include <arrows/core/video_input_image_list.h>
+#include <arrows/core/video_input_metadata_filter.h>
 #include <arrows/core/video_input_pos.h>
 #include <arrows/core/video_input_splice.h>
 #include <arrows/core/video_input_split.h>
@@ -118,6 +119,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_algorithm< uv_unwrap_mesh >();
   reg.register_algorithm< video_input_filter >();
   reg.register_algorithm< video_input_image_list >();
+  reg.register_algorithm< video_input_metadata_filter >();
   reg.register_algorithm< video_input_pos >();
   reg.register_algorithm< video_input_splice >();
   reg.register_algorithm< video_input_split >();

--- a/arrows/core/video_input_metadata_filter.h
+++ b/arrows/core/video_input_metadata_filter.h
@@ -54,10 +54,6 @@ public:
   kwiver::vital::metadata_vector frame_metadata() override;
   kwiver::vital::metadata_map_sptr metadata_map() override;
 
-protected:
-  virtual kwiver::vital::metadata_vector transform_frame_metadata(
-    kwiver::vital::metadata_vector const& ) = 0;
-
 private:
   class priv;
 

--- a/vital/algo/metadata_filter.cxx
+++ b/vital/algo/metadata_filter.cxx
@@ -14,10 +14,31 @@ namespace vital {
 
 namespace algo {
 
+const algorithm_capabilities::capability_name_t
+metadata_filter::CAN_USE_FRAME_IMAGE( "can-use-frame-image" );
+
+// ----------------------------------------------------------------------------
 metadata_filter
 ::metadata_filter()
 {
   attach_logger( "algo.metadata_filter" ); // specify a logger
+}
+
+// ----------------------------------------------------------------------------
+algorithm_capabilities const&
+metadata_filter
+::get_implementation_capabilities() const
+{
+  return m_capabilities;
+}
+
+// ----------------------------------------------------------------------------
+void
+metadata_filter
+::set_capability(
+  algorithm_capabilities::capability_name_t const& name, bool value )
+{
+  m_capabilities.set_capability( name, value );
 }
 
 } // namespace algo

--- a/vital/algo/metadata_filter.h
+++ b/vital/algo/metadata_filter.h
@@ -12,6 +12,8 @@
 
 #include <vital/algo/algorithm.h>
 
+#include <vital/algorithm_capabilities.h>
+
 #include <vital/types/image_container.h>
 #include <vital/types/metadata.h>
 
@@ -30,15 +32,16 @@ class VITAL_ALGO_EXPORT metadata_filter
   : public kwiver::vital::algorithm_def< metadata_filter >
 {
 public:
+  /// Algorithm can use the frame image for its operation.
+  ///
+  /// This capability indicates if the algorithm is able to make use of the
+  /// frame image. If this is not set, it implies that passing a null pointer
+  /// as the input image to #filter will not affect the results, which may
+  /// afford significant optimization opportunities to users.
+  static const algorithm_capabilities::capability_name_t CAN_USE_FRAME_IMAGE;
+
   /// Return the name of this algorithm.
   static std::string static_type_name() { return "metadata_filter"; }
-
-  /// Return if this filter uses the image for filtering.
-  ///
-  /// This method returns whether the algorithm uses the image in its
-  /// implementation. It may be more efficient to not obtain the image if the
-  /// algorithm does not use it.
-  virtual bool uses_image() const = 0;
 
   /// Filter metadata and return resulting metadata.
   ///
@@ -53,8 +56,21 @@ public:
     kwiver::vital::metadata_vector const& input_metadata,
     kwiver::vital::image_container_scptr const& input_image ) = 0;
 
+  /// Return capabilities of concrete implementation.
+  ///
+  /// This method returns the capabilities of the algorithm implementation.
+  ///
+  /// \return Reference to supported algorithm capabilities.
+  algorithm_capabilities const& get_implementation_capabilities() const;
+
 protected:
   metadata_filter();
+
+  void set_capability(
+    algorithm_capabilities::capability_name_t const& name, bool value );
+
+private:
+  algorithm_capabilities m_capabilities;
 };
 
 /// Type alias for shared pointer to a metadata_filter algorithm.


### PR DESCRIPTION
Modify `metadata_filter` to use the capabilities system rather than a specific function to indicate whether an implementation "wants" the frame image. Modify `video_input_metadata_filter` to use the `metadata_filter` algorithm rather than a pure virtual method, allowing it to be made an instantiable algorithm.