### PR TITLE
Fix YPR rotation issues in GSD calculation

### DIFF
--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -60,7 +60,7 @@ kv::image_container_scptr
 make_image()
 {
   constexpr auto frame_height = size_t{ 720 };
-  constexpr auto frame_width = size_t{ 1080 };
+  constexpr auto frame_width = size_t{ 1280 };
 
   auto image = kv::image{ frame_width, frame_height };
   return std::make_shared< kv::simple_image_container >( image );
@@ -100,9 +100,7 @@ TEST_F( derive_metadata, compute_derived )
   kv::metadata_item const& slant_range_value =
     derived_metadata.at( 0 )->find( kv::VITAL_META_SLANT_RANGE );
 
-  // Reference value is 0.202224; we use current actual output value here to
-  //   detect regression (or confirm intentional change)
-  EXPECT_NEAR( 0.199086, gsd_value.as_double(), 0.000001 );
+  EXPECT_NEAR( 0.202224, gsd_value.as_double(), 0.000001);
 
   // This will not actualy be correct due to image terms
   // EXPECT_DOUBLE_EQ( 6.58, vniirs_value.as_double() );

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -8,6 +8,15 @@ over the previous v1.6.0 release.
 Updates
 -------
 
+Vital
+
+Vital Types
+
+* Modified rotation_ constructor from yaw-pitch-roll to keep the given
+  North-East-Down coordinate system as-is instead of automatically converting to
+  East-North-Up. Added utility functions which perform conversion between NED
+  and ENU coordinates.
+
 Build System
 
 * Removed some CMake statements and support for old CMake version predating the

--- a/python/kwiver/vital/tests/test_rotation.py
+++ b/python/kwiver/vital/tests/test_rotation.py
@@ -143,16 +143,30 @@ class TestVitalRotation(unittest.TestCase):
         rod = rot_f.rodrigues()
         numpy.testing.assert_equal(rod, ident_rod)
 
-    def test_to_ypr(self):
-        # ypr identity: (pi/2, 0, pi)
-        ident_ypr = (math.pi / 2, 0, -math.pi)
+    def test_enu_ned(self):
+        # ENU means x=east, y=north, z=up (default for general cv use)
+        # NED means x=north, y=east, z=down (convention for yaw-pitch-roll)
+        # Below are the ENU identity rotations in each coordinate system
+        ident_enu = (0, 0, 0)
+        ident_ned = (math.pi / 2, 0, math.pi)
 
-        rot_d = RotationD()
-        rot_f = RotationF()
+        # deals with equivalence of e.g. +pi and -pi with respect to orientation
+        def assert_angles_almost_equal(angles1, angles2, digits):
+            for angle1, angle2 in zip(angles1, angles2):
+                numpy.testing.assert_almost_equal(math.sin(angle1), math.sin(angle2), digits)
+                numpy.testing.assert_almost_equal(math.cos(angle1), math.cos(angle2), digits)
 
-        numpy.testing.assert_almost_equal(rot_d.yaw_pitch_roll(), ident_ypr, 15)
+        rot_d = rotation.enu_to_ned(RotationD())
+        rot_f = rotation.enu_to_ned(RotationF())
 
-        numpy.testing.assert_almost_equal(rot_f.yaw_pitch_roll(), ident_ypr)
+        assert_angles_almost_equal(rot_d.yaw_pitch_roll(), ident_ned, 14)
+        assert_angles_almost_equal(rot_f.yaw_pitch_roll(), ident_ned, 6)
+
+        rot_d = rotation.ned_to_enu(rot_d)
+        rot_f = rotation.ned_to_enu(rot_f)
+
+        assert_angles_almost_equal(rot_d.yaw_pitch_roll(), ident_enu, 14)
+        assert_angles_almost_equal(rot_f.yaw_pitch_roll(), ident_enu, 6)
 
     def test_from_rotation(self):
         r = RotationD()

--- a/python/kwiver/vital/types/rotation.cxx
+++ b/python/kwiver/vital/types/rotation.cxx
@@ -103,6 +103,8 @@ void declare_rotation( py::module &m,
 
   m.def( "interpolate_rotation", &kv::interpolate_rotation< T > );
   m.def( "interpolated_rotations", &rot_interpolated_rotations< T > );
+  m.def( "ned_to_enu", &ned_to_enu< T > );
+  m.def( "enu_to_ned", &enu_to_ned< T > );
 
 }
 }

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -327,10 +327,9 @@ update_camera_from_metadata(metadata const& md,
   {
     // Only set the camera's rotation if all metadata angles are present
 
-    auto platform_rotation =
-      rotation_d{ platform_yaw, platform_pitch, platform_roll };
-    auto sensor_rotation = rotation_d{ sensor_yaw, sensor_pitch, sensor_roll };
-    auto rotation = ned_to_enu( platform_rotation * sensor_rotation );
+    auto const rotation =
+      uas_ypr_to_rotation( platform_yaw, platform_pitch, platform_roll,
+                           sensor_yaw,   sensor_pitch,   sensor_roll );
     cam.set_rotation( rotation );
 
     rotation_set = true;

--- a/vital/tests/test_rotation.cxx
+++ b/vital/tests/test_rotation.cxx
@@ -98,6 +98,22 @@ TEST_P(rotation_yaw_pitch_roll, convert)
 }
 
 // ----------------------------------------------------------------------------
+TEST_P( rotation_yaw_pitch_roll, ned_enu_round_trip )
+{
+  auto const& p = GetParam();
+  rotation_d rot{ p.yaw, p.pitch, p.roll };
+  rot = ned_to_enu( rot );
+  rot = enu_to_ned( rot );
+
+  double yaw, pitch, roll;
+  rot.get_yaw_pitch_roll( yaw, pitch, roll );
+
+  EXPECT_NEAR( p.yaw,   yaw,   1e-14 );
+  EXPECT_NEAR( p.pitch, pitch, 1e-14 );
+  EXPECT_NEAR( p.roll,  roll,  1e-14 );
+}
+
+// ----------------------------------------------------------------------------
 INSTANTIATE_TEST_CASE_P(
   ,
   rotation_yaw_pitch_roll,
@@ -111,6 +127,20 @@ INSTANTIATE_TEST_CASE_P(
       ( ypr_test{ +1.2, +0.3,  0.0 } ),
       ( ypr_test{ +1.2, +0.3, -1.7 } )
   ) );
+
+// ----------------------------------------------------------------------------
+TEST( rotation, ypr_identity )
+{
+  rotation_d rot{ pi / 2.0, 0.0, pi };
+  rot = ned_to_enu( rot );
+
+  double yaw, pitch, roll;
+  rot.get_yaw_pitch_roll( yaw, pitch, roll );
+
+  EXPECT_NEAR( 0.0, yaw,   1e-14 );
+  EXPECT_NEAR( 0.0, pitch, 1e-14 );
+  EXPECT_NEAR( 0.0, roll,  1e-14 );
+}
 
 // ----------------------------------------------------------------------------
 TEST(rotation, compose)

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -50,6 +50,7 @@ template < typename T >
 rotation_< T >
 ::rotation_( const T& yaw, const T& pitch, const T& roll )
 {
+  // See https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Euler_angles_to_quaternion_conversion
   T const half_x = static_cast< T >( 0.5 ) * roll;
   T const half_y = static_cast< T >( 0.5 ) * pitch;
   T const half_z = static_cast< T >( 0.5 ) * yaw;
@@ -149,6 +150,7 @@ void
 rotation_< T >
 ::get_yaw_pitch_roll( T& yaw, T& pitch, T& roll ) const
 {
+  // See https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Quaternion_to_Euler_angles_conversion
   constexpr auto _1 = static_cast< T >( 1.0 );
   constexpr auto _2 = static_cast< T >( 2.0 );
   roll = std::atan2( _2 * ( q_.w() * q_.x() + q_.y() * q_.z() ),

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -50,9 +50,9 @@ template < typename T >
 rotation_< T >
 ::rotation_( const T& yaw, const T& pitch, const T& roll )
 {
-  T const half_x = T( 0.5 ) * roll;
-  T const half_y = T( 0.5 ) * pitch;
-  T const half_z = T( 0.5 ) * yaw;
+  T const half_x = static_cast< T >( 0.5 ) * roll;
+  T const half_y = static_cast< T >( 0.5 ) * pitch;
+  T const half_z = static_cast< T >( 0.5 ) * yaw;
   T const sin_x = std::sin( half_x );
   T const cos_x = std::cos( half_x );
   T const sin_y = std::sin( half_y );
@@ -149,11 +149,13 @@ void
 rotation_< T >
 ::get_yaw_pitch_roll( T& yaw, T& pitch, T& roll ) const
 {
-  roll = std::atan2( 2.0 * ( q_.w() * q_.x() + q_.y() * q_.z() ),
-                     1.0 - 2.0 * ( q_.x() * q_.x() + q_.y() * q_.y() ) );
-  pitch = std::asin( 2.0 * ( q_.w() * q_.y() - q_.x() * q_.z() ) );
-  yaw = std::atan2( 2.0 * ( q_.w() * q_.z() + q_.x() * q_.y() ),
-                    1.0 - 2.0 * ( q_.y() * q_.y() + q_.z() * q_.z() ) );
+  constexpr auto _1 = static_cast< T >( 1.0 );
+  constexpr auto _2 = static_cast< T >( 2.0 );
+  roll = std::atan2( _2 * ( q_.w() * q_.x() + q_.y() * q_.z() ),
+                     _1 - _2 * ( q_.x() * q_.x() + q_.y() * q_.y() ) );
+  pitch = std::asin( _2 * ( q_.w() * q_.y() - q_.x() * q_.z() ) );
+  yaw = std::atan2( _2 * ( q_.w() * q_.z() + q_.x() * q_.y() ),
+                    _1 - _2 * ( q_.y() * q_.y() + q_.z() * q_.z() ) );
 }
 
 /// Compose two rotations

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -224,7 +224,6 @@ interpolated_rotations( rotation_< T > const& A, rotation_< T > const& B, size_t
 }
 
 template < typename T >
-VITAL_EXPORT
 rotation_< T >
 ned_to_enu( rotation_< T > const& r )
 {
@@ -235,7 +234,6 @@ ned_to_enu( rotation_< T > const& r )
 }
 
 template < typename T >
-VITAL_EXPORT
 rotation_< T >
 enu_to_ned( rotation_< T > const& r )
 {

--- a/vital/types/rotation.cxx
+++ b/vital/types/rotation.cxx
@@ -247,6 +247,19 @@ enu_to_ned( rotation_< T > const& r )
   return adjustment * r;
 }
 
+template < typename T >
+rotation_< T >
+uas_ypr_to_rotation( T platform_yaw, T platform_pitch, T platform_roll,
+                     T sensor_yaw,   T sensor_pitch,   T sensor_roll )
+{
+  auto const platform_rotation =
+    rotation_< T >{ platform_yaw, platform_pitch, platform_roll };
+  auto const sensor_rotation =
+    rotation_< T >{ sensor_yaw, sensor_pitch, sensor_roll };
+
+  return ned_to_enu( platform_rotation * sensor_rotation );
+}
+
 /// \cond DoxygenSuppress
 #define INSTANTIATE_ROTATION( T )                                       \
   template class VITAL_EXPORT rotation_< T >;                           \
@@ -258,7 +271,10 @@ enu_to_ned( rotation_< T > const& r )
   template VITAL_EXPORT void                                            \
   interpolated_rotations( rotation_< T > const & A, rotation_< T > const & B, size_t n, std::vector< rotation_< T > > &interp_rots ); \
   template VITAL_EXPORT rotation_< T > ned_to_enu( rotation_< T > const& r ); \
-  template VITAL_EXPORT rotation_< T > enu_to_ned( rotation_< T > const& r )
+  template VITAL_EXPORT rotation_< T > enu_to_ned( rotation_< T > const& r ); \
+  template VITAL_EXPORT rotation_< T > uas_ypr_to_rotation(             \
+    T platform_yaw, T platform_pitch, T platform_roll,                  \
+    T sensor_yaw,   T sensor_pitch,   T sensor_roll )
 
 INSTANTIATE_ROTATION( double );
 INSTANTIATE_ROTATION( float );

--- a/vital/types/rotation.h
+++ b/vital/types/rotation.h
@@ -71,16 +71,15 @@ public:
   rotation_< T > ( T angle, const Eigen::Matrix< T, 3, 1 > &axis );
 
   /// Constructor - from yaw, pitch, and roll (radians)
-  /**
-   * This constructor is intended for use with yaw, pitch, and roll (in radians)
-   * output from an inertial navigation system, specifying the orientation of a
-   * moving coordinate system relative to an east/north/up (ENU) coordinate
-   * system. When all three angles are zero, the coordinate system's x, y, and
-   * z axes align with north, east, and down respectively.  Non-zero yaw, pitch,
-   * and roll define a sequence of intrinsic rotations around the z, y, and then
-   * x axes respectively.  The resulting rotation object takes a vector in ENU
-   * and rotates it into the moving coordinate system.
-   */
+  ///
+  /// This constructor creates a rotation representing the orientation of an
+  /// object as determined by the given \c yaw , \c pitch , and \c roll radian
+  /// values. In accordance with standard YPR convention, \c roll rotates along
+  /// the x axis, which is understood to be pointing north, \c pitch along the y
+  /// axis (east), and \c yaw along the z axis (down). To convert from this
+  /// North-East-Down coordinate system to one in which x, y, and z are facing
+  /// east, north, and up, respectively, call the \link ned_to_enu() \endlink
+  /// utility function on the constructed object.
   rotation_< T > ( const T &yaw, const T &pitch, const T &roll );
 
   /// Constructor - from a matrix
@@ -117,6 +116,12 @@ public:
   Eigen::Matrix< T, 3, 1 > rodrigues() const;
 
   /// Convert to yaw, pitch, and roll (radians)
+  ///
+  /// In accordance with standard YPR convention, \c roll rotates along
+  /// the x axis, which is understood to be pointing north, \c pitch along the y
+  /// axis (east), and \c yaw along the z axis (down). If this object currently
+  /// uses the ENU coordinate system, you must call \link enu_to_ned() \endlink
+  /// on it in order to get the correct values (NED is assumed).
   void get_yaw_pitch_roll( T& yaw, T& pitch, T& roll ) const;
 
   /// Compute the inverse rotation
@@ -208,31 +213,43 @@ VITAL_EXPORT
 void interpolated_rotations( rotation_< T > const& A, rotation_< T > const& B,
                              size_t n, std::vector< rotation_< T > >& interp_rots );
 
-// TODO: Consider moving these methods to a utilities header/directory
-/// Compose an aerial platform's orientation with sensor orientation
+/// Convert rotation \c r from ENU coordinate system to NED.
 ///
-/// \param platform_yaw yaw angle for aerial platform
-/// \param platform_pitch pitch angle for aerial platform
-/// \param platform_roll roll angle for aerial platform
-/// \param sensor_yaw yaw angle for aerial sensor
-/// \param sensor_pitch pitch angle for aerial sensor
-/// \param sensor_roll roll angle for aerial sensor
+/// The East-North-Up coordinate system is the convention for specifying yaw,
+/// pitch, and roll for aerial craft, while the North-East-Down coordinate
+/// system is common for computer vision applications on aerial photos. This
+/// function converts a rotation between the two conventions.
+///
+/// Inverse of \link ned_to_enu() \endlink.
+///
+/// \param r Rotation with the x axis pointing east, y axis pointing north,
+///          and z axis pointing up.
+///
+/// \returns A copy of \c r with the x axis pointing north, y axis pointing
+///          east, and z axis pointing down.
 template < typename T >
 VITAL_EXPORT
 rotation_< T >
-compose_rotations(
-  T platform_yaw, T platform_pitch, T platform_roll,
-  T sensor_yaw, T sensor_pitch, T sensor_roll );
+enu_to_ned( rotation_< T > const& r );
 
-/// Compose an aerial platform's orientation with sensor orientation.
+/// Convert rotation \c r from NED coordinate system to ENU.
 ///
-/// \param platform_rotation rotation for aerial platform
-/// \param sensor_rotation rotation for aerial sensor
+/// The East-North-Up coordinate system is the convention for specifying yaw,
+/// pitch, and roll for aerial craft, while the North-East-Down coordinate
+/// system is common for computer vision applications on aerial photos. This
+/// function converts a rotation between the two conventions.
+///
+/// Inverse of \link enu_to_ned() \endlink.
+///
+/// \param r Rotation with the x axis pointing north, y axis pointing east,
+///          and z axis pointing down.
+///
+/// \returns A copy of \c r with the x axis pointing east, y axis pointing
+///          north, and z axis pointing up.
 template < typename T >
 VITAL_EXPORT
 rotation_< T >
-compose_rotations( rotation_< T > const & platform_rotation,
-                   rotation_< T > const & sensor_rotation );
+ned_to_enu( rotation_< T > const& r );
 
 } } // end namespace vital
 

--- a/vital/types/rotation.h
+++ b/vital/types/rotation.h
@@ -251,6 +251,26 @@ VITAL_EXPORT
 rotation_< T >
 ned_to_enu( rotation_< T > const& r );
 
+/// Combine platform and sensor YPR from a UAS source into a single rotation.
+///
+/// This is a convenience function to compose the yaw, pitch, and roll of an
+/// unmanned aerial system's platform and sensor into a single rotation object
+/// in the ENU coordinate system.
+///
+/// \param platform_yaw z (down) rotation of the aerial platform
+/// \param platform_pitch y (east) rotation of the aerial platform
+/// \param platform_roll x (north) rotation of the aerial platform
+/// \param sensor_yaw z (down) rotation of the sensor relative to the platform
+/// \param sensor_pitch y (east) rotation of the sensor relative to the platform
+/// \param sensor_roll x (north) rotation of the sensor relative to the platform
+///
+/// \returns The total rotation of the sensor in East-North-Up coordinates
+template < typename T >
+VITAL_EXPORT
+rotation_< T >
+uas_ypr_to_rotation( T platform_yaw, T platform_pitch, T platform_roll,
+                     T sensor_yaw,   T sensor_pitch,   T sensor_roll );
+
 } } // end namespace vital
 
 #endif // VITAL_ROTATION_H_

--- a/vital/types/sfm_constraints.cxx
+++ b/vital/types/sfm_constraints.cxx
@@ -230,9 +230,9 @@ sfm_constraints
       return false;
     }
 
-    R_loc = rotation_d{ platform_heading, platform_pitch, platform_roll } *
-            rotation_d{ sensor_rel_az, sensor_rel_el, sensor_rel_roll };
-    R_loc = ned_to_enu( R_loc );
+    R_loc =
+      uas_ypr_to_rotation( platform_heading, platform_pitch, platform_roll,
+                           sensor_rel_az,    sensor_rel_el,  sensor_rel_roll );
 
     return true;
   }

--- a/vital/types/sfm_constraints.cxx
+++ b/vital/types/sfm_constraints.cxx
@@ -230,8 +230,9 @@ sfm_constraints
       return false;
     }
 
-    R_loc = compose_rotations<double>(platform_heading, platform_pitch, platform_roll,
-                                      sensor_rel_az, sensor_rel_el, sensor_rel_roll);
+    R_loc = rotation_d{ platform_heading, platform_pitch, platform_roll } *
+            rotation_d{ sensor_rel_az, sensor_rel_el, sensor_rel_roll };
+    R_loc = ned_to_enu( R_loc );
 
     return true;
   }


### PR DESCRIPTION
- Fixed GSD calculation - now passes reference test case exactly
- In process of doing above, modified conversions between `kwiver::vital::rotation_< T >` and the yaw-pitch-roll system. Yaw, pitch, and roll are conventionally understood to take place in a NED coordinate sytem, where the x axis is pointing north, y is pointing east, and z is pointing down. However, general computer vision practice when processing aerial imagery is to use the ENU system, where x is pointing east. y is north, and z is up. Previously, the `rotation_< T >` class had treated these systems inconsistently. Combining two YPR-derived `rotation_< T >`s would not produce the correct YPR output, and this was one of the things breaking our computation of GSD. It seems previous developers realized the problem and chose to create a workaround utility function `compose_rotations()`, manually writing the YPR rotation calculations independently of `rotation_< T >` or Eigen. This branch unifies YPR  with `rotation_< T >`, removing `compose_rotations()` and adding utility functions to convert `rotation_< T >`s between NED and ENU.
- **Note**: fixing `rotation_< T >`'s treatment of YPR does change the behavior of the YPR conversion functions - the constructor used to convert them to ENU, but now stores them in their native NED system, with the NED-to-ENU conversion moved to an optional external utility function. I think I found and fixed all references inside KWIVER, but this could potentially break external code which uses KWIVER's `rotation_< T >` for YPR, if any such code exists.