### PR TITLE
Refactor klv_parse

### DIFF
--- a/arrows/klv/klv_parse.cxx
+++ b/arrows/klv/klv_parse.cxx
@@ -2,433 +2,479 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief This file contains the implementation for the klv parser.
- */
+/// \file
+/// \brief This file contains the implementation for the klv parser.
 
-#include "klv_parse.h"
+#include "klv_0104.h"
+#include "klv_0601.h"
 #include "klv_data.h"
 #include "klv_key.h"
-#include "klv_0601.h"
-#include "klv_0104.h"
+#include "klv_parse.h"
 
 #include <vital/exceptions/metadata.h>
 
 #include <vital/logger/logger.h>
 
+#include <iomanip>
+#include <numeric>
+#include <sstream>
+
 #include <cctype>
 
+namespace kv = kwiver::vital;
+
 namespace kwiver {
+
 namespace arrows {
+
 namespace klv {
 
 namespace {
 
-std::string
-FormatString( std::string const& val )
+// ---------------------------------------------------------------------------
+// Reads a big-endian-encoded unsigned integer from a sequence of bytes
+template < class T, class Iterator >
+T
+read_uint_msb( Iterator data_begin, Iterator data_end )
 {
-  const char hex_chars[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
-                               '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-  const size_t len( val.size() );
-  bool unprintable_found(false);
-  std::string ascii;
-  std::string hex;
+  // Ensure types are compatible with our assumptions
+  static_assert( std::is_integral<T>::value, "T must be an integer type" );
+  static_assert( std::is_unsigned<T>::value, "T must be an unsigned type" );
+  static_assert(
+    std::is_same< typename std::decay< decltype( *data_begin ) >::type,
+                  uint8_t >::value, "Iterator must point to uint8_t" );
 
-  for (size_t i = 0; i < len; i++)
+  // Ensure iterators are compatible with our assumptions
+  ptrdiff_t const distance = std::distance( data_begin, data_end );
+  if ( distance < 0 )
   {
-    char const byte = val[i];
-    if ( ! isprint( byte ) )
+    VITAL_THROW( kv::invalid_value, "end iterator cannot be before begin" );
+  }
+
+  auto const length = static_cast< size_t >( distance );
+  if ( sizeof( T ) <= length )
+  {
+    VITAL_THROW( kv::invalid_value, std::string() +
+                 "specified type too small too hold data (" +
+                 std::to_string( sizeof(T) ) + " < " +
+                 std::to_string(length) + ")" );
+  }
+
+  // Functor to insert each successive byte into the output value
+  auto const accumulator = [ ]( T value, uint8_t byte ) {
+                             return ( value << 8 ) | byte;
+                           };
+
+  // Reduce span to final result
+  return std::accumulate( data_begin, data_end, static_cast< T >( 0 ),
+                          accumulator );
+}
+
+// ---------------------------------------------------------------------------
+// If unprintable chars detected, replaces them with '.' and appends hex of
+// entire string
+std::string
+format_string( std::string const& value )
+{
+  // Prints value, but with any unprintable chars replaced with '.'
+  bool print_hex = false;
+  std::stringstream ss;
+  for( char c : value )
+  {
+    // See https://en.cppreference.com/w/cpp/string/byte/isprint for rationale
+    // for static_cast
+    if( std::isprint( static_cast< unsigned char >( c ) ) )
     {
-      ascii.append( 1, '.' );
-      unprintable_found = true;
+      ss << c;
     }
     else
     {
-      ascii.append( 1, byte );
+      ss << '.';
+      print_hex = true;
     }
-
-    // format as hex
-    if (i > 0)
-    {
-      hex += " ";
-    }
-
-    hex += hex_chars[ ( byte & 0xF0 ) >> 4 ];
-    hex += hex_chars[ ( byte & 0x0F ) >> 0 ];
-
-  } // end for
-
-  if (unprintable_found)
-  {
-    ascii += " (" + hex + ")";
   }
 
-  return ascii;
+  // Outputs like " (01 5A 2C 00)"
+  if( print_hex )
+  {
+    ss << " (";
+    ss << std::hex << std::uppercase << std::setfill( '0' ) << std::setw( 2 );
+    for( auto it = value.cbegin(); it != value.cend(); ++it )
+    {
+      if( it != value.cbegin() )
+      {
+        ss << ' ';
+      }
+      ss << static_cast< unsigned int >( *it );
+    }
+    ss << ')';
+  }
+
+  return ss.str();
+}
+
+// ---------------------------------------------------------------------------
+// Extract an unsigned integer using BER (basic encoding rules)
+// Modifies data iterator to end of the data just parsed, or leaves it as given
+// on error
+template < class Iterator >
+size_t
+read_ber_encoded( Iterator& data, size_t length )
+{
+  // Make sure we're reading bytes
+  static_assert(
+    std::is_same< typename std::decay< decltype( *data ) >::type,
+                  uint8_t >::value, "Iterator must point to uint8_t" );
+
+  // Short form - first bit is 0, remaining bits are the value itself
+  if( !( 0x80 & *data ) )
+  {
+    return *( data++ );
+  }
+
+  // Long form - first bit is 1, remaining bits are the length of value
+  size_t const value_length = ( 0x7F & *data );
+
+  // + 1 for the initial byte we just read
+  if( value_length + 1 > length )
+  {
+    VITAL_THROW( kv::metadata_exception,
+                 "insufficient buffer length for complete BER decoding" );
+  }
+
+  auto const data_end = ++data + value_length;
+  auto const value = read_uint_msb< size_t >( data, data_end );
+  data = data_end;
+
+  return value;
 }
 
 } // end namespace
 
-// ----------------------------------------------------------------
-/** Extract a KLV length using BER (basic encoding rules)
- *
- * @param[in] buffer the buffer of bytes to parse
- * @param[in] buffer_len the length of the buffer
- * @param[out] offset the number of bytes representing the length
- * @param[out] value_len the length: number of bytes representing the value
- *
- * @returns True if successful. False if invalid or insufficient data.
- */
-template < class ITERATOR >
+// ---------------------------------------------------------------------------
+// Pop the first KLV UDS key-value pair found in the data buffer.
+// TODO: Possibly change to work on templated iterator references instead of
+//       forcing data type to deque - potential for greater efficiency
 bool
-klv_ber_length( ITERATOR buffer,
-                size_t buffer_len,
-                uint8_t& offset,
-                unsigned int& value_len )
+klv_pop_next_packet( std::deque< uint8_t >& data, klv_data& klv_packet )
 {
-  // handle the short form with 1 byte length description, first bit is 0
-  if ( ! ( 0x80 & *buffer ) )
+  auto const key_length = klv_uds_key::size();
+
+  // Key (key_length bytes) with no Length or Value - must be in Label category
+  auto const min_packet_length = key_length;
+
+  while( data.size() >= min_packet_length )
   {
-    offset = 1;
-    value_len = *buffer;
-    return true;
-  }
-
-  offset = ( 0x7F & *buffer ) + 1;
-
-  if ( offset > 5 )
-  {
-    kwiver::vital::logger_handle_t logger( kwiver::vital::get_logger( "vital.klv_parse" ) );
-    LOG_WARN( logger, "BER encoded length more then 4 bytes: "
-               << static_cast< int > ( offset ) );
-    return false;
-  }
-
-  if ( offset > buffer_len )
-  {
-    // not enough data in the buffer to fully parse length
-    return false;
-  }
-
-  value_len = 0;
-  for ( uint8_t i = 1; i < offset; ++i )
-  {
-    value_len <<= 8;
-    value_len += *( buffer + i );
-  }
-  return true;
-}
-
-// ----------------------------------------------------------------
-/** @brief Pop the first KLV UDS key-value pair found in the data buffer.
- *
- * The first valid KLV packet found in the data stream is returned.
- * Leading bytes that do not belong to a KLV pair are dropped. The
- * input byte stream is modified internally and unprocessed partial
- * packets are left there so more raw data can be added to the stream
- * and packet parsing can be attempted later.
- *
- * @param[in,out] data Byte stream to be parsed.
- * @param[out] klv_packet Full klv packet with key and data fields
- * specified.
- *
- * @return \c true if packet returned; \c false if no packet returned.
- */
-bool
-klv_pop_next_packet( std::deque< uint8_t >&  data,
-                     klv_data&               klv_packet )
-{
-  const std::size_t klv_key_length = klv_uds_key::size();
-
-  while ( data.size() > klv_key_length + 1 )
-  {
-    // The buffer must start with key prefix for best results.
-    // Would be nice if this could be done by method call
-    // if (uds_key::matches_prefix(data) ) ...
-    if ( ( data[0] == klv_uds_key::prefix[0] ) &&
-         ( data[1] == klv_uds_key::prefix[1] ) &&
-         ( data[2] == klv_uds_key::prefix[2] ) &&
-         ( data[3] == klv_uds_key::prefix[3] ) )
+    // The buffer must start with key prefix
+    if( std::equal( data.cbegin(), data.cbegin() + 4, klv_uds_key::prefix ) )
     {
-      // This is a little wierd, but it is this approach or I write
-      // another constructor signature. The data needs to be copied
-      // from the dqueue one element at a time because &data[1] is not
-      // always equal to (&data[0] +1) due to memory management
-      // practices in the dqueue (although sometimes it is).
-      //
-      // We are guaranteed enough bytes in the dqueue because of the
+      // Must copy to vector to guarantee contiguous memory
+      // We are guaranteed enough bytes in the deque because of the
       // preceeding test in while()
-      uint8_t temp[16];
-      for ( int i = 0; i < 16; ++i )
-      {
-        temp[i] = data[i];
-      } // end for
+      auto const key_bytes =
+        std::vector< uint8_t >{ data.cbegin(), data.cbegin() + key_length };
+      auto const key = klv_uds_key{ key_bytes.data() };
 
-      klv_uds_key temp_key( temp );
-
-      if ( temp_key.is_valid() )
+      if( key.is_valid() )
       {
-        if ( temp_key.category() == klv_uds_key::CATEGORY_LABEL )
+        if( key.category() == klv_uds_key::CATEGORY_LABEL )
         {
-          // collect bytes that make up the key
-          klv_data::container_t raw_data( data.begin(), data.begin() + klv_key_length );
-          klv_packet = klv_data( raw_data, 0, klv_key_length, 0, 0 );
-
+          // Collect bytes that make up the key only
           // Keys with category "Label" have no length or value data
-          data.erase( data.begin(), data.begin() + klv_key_length );
+          auto const raw_data =
+            klv_data::container_t{ data.begin(), data.begin() + key_length };
+          klv_packet = { raw_data, 0, key_length, 0, 0 };
+
+          data.erase( data.begin(), data.begin() + key_length );
+
           return true;
         }
 
-        uint8_t offset;
-        unsigned int length;
-        if ( klv_ber_length( data.begin() + klv_key_length,
-                             data.size() - klv_key_length,
-                             offset, length ) )
+        try
         {
-          size_t total_len = klv_key_length + offset + length;
+          // Determine offset and length of value
+          // value_begin not const because it is modified by read_ber_encoded()
+          auto value_begin = data.cbegin() + key_length;
+          auto const value_length =
+            read_ber_encoded( value_begin, data.size() - key_length );
+          auto const value_offset =
+            static_cast< size_t >(
+              std::distance( data.cbegin(), value_begin ) );
+          auto const total_length = value_offset + value_length;
 
           // Is the full packet in the input buffer?
-          if ( data.size() >= total_len )
+          if( data.size() >= total_length )
           {
-            klv_data::container_t raw_data( data.begin(), data.begin() + total_len ); // extract the key bytes
-            klv_packet = klv_data( raw_data,       // total raw data
-                                   0,              // key offset
-                                   klv_key_length, // length of key in bytes
-                                   klv_key_length + offset, // value offset (start of value bytes)
-                                   length );                // length of value in bytes
+            // Collect bytes that make up the key, length, and value
+            auto const raw_data =
+              klv_data::container_t{ data.begin(),
+                                     data.begin() + total_length };
+            klv_packet = { raw_data, 0, key_length, value_offset,
+                           value_length };
 
-            data.erase( data.begin(), data.begin() + total_len );
+            data.erase( data.begin(), data.begin() + total_length );
+
             return true;
           }
         }
-        break;
+        catch ( kv::metadata_exception const& e )
+        {
+          // Could not read length - data buffer too short
+        }
+
+        // Buffer too short - no point in continuing
+        return false;
       }
+    }
 
-    } // end valid key
-
-    // If prefix does not match or key not valid
-    // Delete byte from top of input and try again
-    kwiver::vital::logger_handle_t logger( kwiver::vital::get_logger( "vital.klv_parse" ) );
-    LOG_DEBUG( logger, "discarding klv byte - 0x" << std::hex << int(data[0])
-               //  << " rest of prefix: 0x"
-               // << int(data[1]) << " 0x"
-               // << int(data[2]) << " 0x"
-               // << int(data[3]) << " -- 0x"
-               // << int(data[4]) << " 0x"
-               // << int(data[5]) << " 0x"
-               // << int(data[6]) << " 0x"
-               // << int(data[7])
-             );
+    // If prefix does not match or key not valid, delete byte from top of input
+    // and try again
+    auto logger = kwiver::vital::get_logger( "vital.klv_parse" );
+    LOG_DEBUG( logger, "discarding klv byte - 0x" << std::hex
+                         << static_cast< int >( data.front() ) );
     data.pop_front();
-
-  } // end while
+  }
 
   return false;
-} // pop_klv_uds_pair
+}
 
 // ----------------------------------------------------------------
-/** Parse out Local Data Set (LDS) packet.
- *
- * The data portion of the raw KLV packet is parsed into LDS packets.
- */
+// Parse out Local Data Set (LDS) packet
 std::vector< klv_lds_pair >
 parse_klv_lds( klv_data const& data )
 {
   std::vector< klv_lds_pair > lds_pairs;
-  uint8_t offset;
-  unsigned int value_len;
-  size_t len = data.value_size();
-  klv_data::const_iterator_t it = data.value_begin();
 
-  while ( ( len > 3 ) &&
-          klv_ber_length( it + 1, len - 1, offset, value_len ) &&
-          ( offset + 1 + value_len <= len ) )
+  auto remaining_length = data.value_size();
+  auto it = data.value_begin();
+
+  // Key (1 byte), Length (1 byte), Value (0 bytes)
+  constexpr size_t min_packet_length = 2;
+
+  while( remaining_length >= min_packet_length )
   {
-    klv_lds_key key( *it ); // one byte key
-    std::vector< uint8_t > value( it + offset + 1, it + offset + 1 + value_len );
-    lds_pairs.push_back( klv_lds_pair( key, value ) );
+    try
+    {
+      // Parse key
+      auto const key = klv_lds_key { *( it++ ) }; // 1 byte key; TODO: expand
+      --remaining_length;
 
-    // update pointer into data
-    it = it + 1 + offset + value_len;
-    len -= 1 + offset + value_len;
+      // Parse length
+      auto const length_begin = it;
+      auto const value_length = read_ber_encoded( it, remaining_length );
+      remaining_length -= std::distance( length_begin, it );
+      if ( remaining_length < value_length )
+      {
+        VITAL_THROW( kv::metadata_exception,
+                     "insufficient buffer length for complete LDS packet" );
+      }
+
+      // Parse value
+      auto const value = std::vector< uint8_t >{ it, it + value_length };
+      remaining_length -= value_length;
+      it += value_length;
+
+      lds_pairs.push_back( { key, value } );
+    }
+    catch ( kv::metadata_exception const& e )
+    {
+      auto logger = kwiver::vital::get_logger( "vital.klv_parse" );
+      LOG_WARN( logger, "too few bytes while parsing LDS" );
+      break;
+    }
   }
 
-  if ( len != 0 )
+  if( remaining_length != 0 )
   {
-    kwiver::vital::logger_handle_t logger( kwiver::vital::get_logger( "vital.klv_parse" ) );
-    LOG_WARN( logger, len << " bytes left over when parsing LDS" );
+    auto logger = kwiver::vital::get_logger( "vital.klv_parse" );
+    LOG_WARN( logger, remaining_length << " bytes left over when parsing LDS" );
   }
 
   return lds_pairs;
 }
 
-// ----------------------------------------------------------------
-/** Parse data set with universal keys */
+// ---------------------------------------------------------------------------
+// Parse data set with universal keys
+// TODO: We copy each data packet twice here - once into the deque, once into
+//       the vector. Suggestion to use iterators instead
 klv_uds_vector_t
-parse_klv_uds( klv_data const& data )
+parse_klv_uds( klv_data const& klv )
 {
   std::vector< klv_uds_pair > uds_pairs;
 
-  klv_data pk;
+  // Create queue of data portion of packet
+  auto data = std::deque< uint8_t >( klv.value_begin(), klv.value_end() );
 
-  // create queue of data portion of packet.
-  std::deque< uint8_t > deq( data.value_begin(), data.value_end() );
-
-  while ( klv_pop_next_packet( deq, pk ) )
+  for( klv_data packet; klv_pop_next_packet( data, packet ); )
   {
-    klv_uds_key uds_key( pk ); // 16 byte key
-    uds_pairs.push_back( klv_uds_pair( uds_key,
-         std::vector< uint8_t > ( pk.value_begin(), pk.value_end() ) ) );
+    auto const key = klv_uds_key{ packet }; // 16 byte key
+    auto const value =
+      std::vector< uint8_t >{ packet.value_begin(), packet.value_end() };
+    uds_pairs.push_back( { key, value } );
+  }
+
+  if( data.size() != 0 )
+  {
+    auto logger = kwiver::vital::get_logger( "vital.klv_parse" );
+    LOG_WARN( logger, data.size() << " bytes left over when parsing UDS" );
   }
 
   return uds_pairs;
 }
 
-// ----------------------------------------------------------------
+// ---------------------------------------------------------------------------
 std::ostream&
 print_klv( std::ostream& str, klv_data const& klv )
 {
-  klv_uds_key uds_key( klv ); // create key from raw data
+  auto const uds_key = klv_uds_key{ klv }; // create key from raw data
 
-  if ( is_klv_0601_key( uds_key ) )
+  if( is_klv_0601_key( uds_key ) )
   {
     str << "0601 Universal Key of size " << klv.value_size() << std::endl;
-    if ( ! klv_0601_checksum( klv ) )
+    if( !klv_0601_checksum( klv ) )
     {
-      str << "checksum failed" << std::endl;
+      str << "Checksum failed" << std::endl;
       str << "Raw hex of packet: " << klv << std::endl;
     }
 
     // Try to decode even if checksum failed.
     // This is useful when a valid packet has a bad checksum.
     // May fail badly if packet is really corrupt.
-    klv_lds_vector_t lds = parse_klv_lds( klv );
+    auto const lds = parse_klv_lds( klv );
 
     str << "  found " << lds.size() << " tags" << std::endl;
-    for ( auto itr = lds.begin(); itr != lds.end(); ++itr )
+    for( auto it = lds.begin(); it != lds.end(); ++it )
     {
-      if ( ( itr->first <= KLV_0601_UNKNOWN ) || ( itr->first >= KLV_0601_ENUM_END ) )
+      if( ( it->first <= KLV_0601_UNKNOWN ) ||
+          ( it->first >= KLV_0601_ENUM_END ) )
       {
-        str << "    #" << int(itr->first) << " is not supported" << std::endl;
+        str << "    #" << static_cast< int >( it->first ) << " is not supported"
+            << std::endl;
         continue;
       }
 
       // Convert a single tag
-      const klv_0601_tag tag( klv_0601_get_tag( itr->first ) ); // get tag code from key
+      auto const tag = klv_0601_get_tag( it->first );
 
       // Extract relevant data from associated data bytes.
-      kwiver::vital::any data = klv_0601_value( tag,
-                                                &itr->second[0], itr->second.size() );
+      auto const value =
+        klv_0601_value( tag, &it->second[ 0 ], it->second.size() );
 
       str << "    #" << tag << " - "
-          << klv_0601_tag_to_string( tag )
-          << ": " << klv_0601_value_string( tag, data ) << " "
-          << " [" << klv_0601_value_hex_string( tag, data ) << "]"
-          << std::endl;
-    } // end for
+          << klv_0601_tag_to_string( tag ) << ": "
+          << klv_0601_value_string( tag, value ) << "  ["
+          << klv_0601_value_hex_string( tag, value ) << "]" << std::endl;
+    }
   }
-  else if ( klv_0104::is_key( uds_key ) )
+  else if( klv_0104::is_key( uds_key ) )
   {
-    str << "Predator (0104) Universal Key of size " << klv.value_size() << std::endl;
+    str << "Predator (0104) Universal Key of size " << klv.value_size()
+        << std::endl;
 
-    klv_uds_vector_t uds = parse_klv_uds( klv );
+    auto const uds = parse_klv_uds( klv );
+
     str << "  found " << uds.size() << " tags" << std::endl;
-
-    // Vector has key and data
-    for ( auto itr = uds.begin(); itr != uds.end(); ++itr )
+    for( auto it = uds.begin(); it != uds.end(); ++it )
     {
       try
       {
-        klv_0104::tag tag = klv_0104::instance()->get_tag( itr->first );
-        if ( tag == klv_0104::UNKNOWN )
+        auto const tag = klv_0104::instance()->get_tag( it->first );
+        if( tag == klv_0104::UNKNOWN )
         {
-          str << "Unknown key: " << itr->first << "Length: " << itr->second.size() << " bytes\n";
+          str << "Unknown key: " << it->first
+              << "Length: " << it->second.size() << " bytes\n";
           continue;
         }
 
-        kwiver::vital::any data = klv_0104::instance()->get_value( tag, &itr->second[0], itr->second.size() );
-        std::string str_val = FormatString( klv_0104::instance()->get_string( tag, data ) );
+        auto const value =
+          klv_0104::instance()->get_value( tag, &it->second[ 0 ],
+                                           it->second.size() );
+        auto const str_val =
+          format_string( klv_0104::instance()->get_string( tag, value ) );
 
         str << "    #" << tag << " - "
-            << klv_0104::instance()->get_tag_name( tag )
-            << "(" <<  itr->second.size() << " bytes): " << str_val << " "
-            << std::endl;
-
+            << klv_0104::instance()->get_tag_name( tag ) << "("
+            << it->second.size() << " bytes): "
+            << str_val << " " << std::endl;
       }
       catch ( kwiver::vital::metadata_exception const& e )
       {
         str << "Error in 0104 klv: " << e.what() << "\n";
       }
-    } // end for
+    }
   }
   else
   {
-    str << "Unsupported UDS Key: " << uds_key << " data size is "
-        << klv.value_size() << std::endl;
+    str << "Unsupported UDS Key: " << uds_key
+        << " data size is " << klv.value_size() << std::endl;
 
-    switch ( uds_key.category() )
+    switch( uds_key.category() )
     {
-    case klv_uds_key::CATEGORY_SINGLE:
-      str << "  Contains a single data item." << std::endl;
-      break;
-
-    case klv_uds_key::CATEGORY_GROUP:
-    {
-      switch ( uds_key.group_type() )
-      {
-      case klv_uds_key::GROUP_UNIVERSAL_SET:
-        str << "  Contains a universal set." << std::endl;
+      case klv_uds_key::CATEGORY_SINGLE:
+        str << "  Contains a single data item." << std::endl;
         break;
 
-      case klv_uds_key::GROUP_GLOBAL_SET:
-        str << "  Contains a global set." << std::endl;
-        break;
-
-      case klv_uds_key::GROUP_LOCAL_SET:
+      case klv_uds_key::CATEGORY_GROUP:
       {
-        str << "  Contains a local set." << std::endl;
-        typedef std::vector< klv_lds_pair > lds_data_t;
-        lds_data_t lds = parse_klv_lds( klv );
-        str << "    found " << lds.size() << " tags" << std::endl;
-        str << "    local keys:";
-        for ( lds_data_t::const_iterator itr = lds.begin(); itr != lds.end(); ++itr )
+        switch( uds_key.group_type() )
         {
-          str << " " << itr->first;
+          case klv_uds_key::GROUP_UNIVERSAL_SET:
+            str << "  Contains a universal set." << std::endl;
+            break;
+
+          case klv_uds_key::GROUP_GLOBAL_SET:
+            str << "  Contains a global set." << std::endl;
+            break;
+
+          case klv_uds_key::GROUP_LOCAL_SET:
+          {
+            str << "  Contains a local set." << std::endl;
+
+            auto const lds = parse_klv_lds( klv );
+            str << "    found " << lds.size() << " tags" << std::endl;
+            str << "    local keys:";
+            for( auto it = lds.begin(); it != lds.end(); ++it )
+            {
+              str << " " << it->first;
+            }
+            str << std::endl;
+            break;
+          }
+
+          case klv_uds_key::GROUP_VARIABLE_PACK:
+            str << "  Contains a variable length pack." << std::endl;
+            break;
+
+          case klv_uds_key::GROUP_FIXED_PACK:
+            str << "  Contains a fixed length pack." << std::endl;
+            break;
+
+          default:
+            str << "  Contains an invalid type of group." << std::endl;
+            break;
         }
-        str << std::endl;
         break;
       }
 
-      case klv_uds_key::GROUP_VARIABLE_PACK:
-        str << "  Contains a variable length pack." << std::endl;
+      case klv_uds_key::CATEGORY_WRAPPER:
+        str << "  Is a wrapper around another data format." << std::endl;
         break;
 
-      case klv_uds_key::GROUP_FIXED_PACK:
-        str << "  Contains a fixed length pack." << std::endl;
+      case klv_uds_key::CATEGORY_LABEL:
+        str << "  Is a label and contains no data." << std::endl;
         break;
 
       default:
-        str << "  Contains an invalid type of group." << std::endl;
+        str << "  Format is unknown." << std::endl;
         break;
-      }
-      break;
     }
-
-    case klv_uds_key::CATEGORY_WRAPPER:
-      str << "  Is a wrapper around another data format." << std::endl;
-      break;
-
-    case klv_uds_key::CATEGORY_LABEL:
-      str << "  Is a label and contains no data." << std::endl;
-      break;
-
-    default:
-      str << "  Format is unknown." << std::endl;
-      break;
-    }        // switch
   }
 
   return str;
-} // print_klv
+}
 
-} } }  // end namespace
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_parse.h
+++ b/arrows/klv/klv_parse.h
@@ -2,94 +2,100 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/** @file
- * Interface to the KLV parsing functions.
- */
+/// \file
+/// Interface to the KLV parsing functions.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_PARSE_H_
 #define KWIVER_ARROWS_KLV_KLV_PARSE_H_
 
-#include <arrows/klv/kwiver_algo_klv_export.h>
 #include <arrows/klv/klv_key.h>
+#include <arrows/klv/kwiver_algo_klv_export.h>
 
-#include <vector>
 #include <deque>
 #include <ostream>
+#include <vector>
+
 #include <cstdint>
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace klv {
 
 class klv_data;
 
 /// Define a type for KLV LDS key-value pairs
-typedef std::pair<klv_lds_key, std::vector<uint8_t> > klv_lds_pair;
+typedef std::pair< klv_lds_key, std::vector< uint8_t > > klv_lds_pair;
 typedef std::vector< klv_lds_pair > klv_lds_vector_t;
 
 /// Define a type for KLV UDS key-value pairs
-typedef std::pair<klv_uds_key, std::vector<uint8_t> > klv_uds_pair;
+typedef std::pair< klv_uds_key, std::vector< uint8_t > > klv_uds_pair;
 typedef std::vector< klv_uds_pair > klv_uds_vector_t;
 
-/**
- * @brief Pop the first KLV UDS key-value pair found in the data buffer.
- *
- * The first valid KLV packet found in the data stream is returned.
- * Leading bytes that do not belong to a KLV pair are dropped. If
- * there is a partial packet in the input data stream, it is left
- * there and no packet is returned.
- *
- * @param[in,out] data Byte stream to be parsed.
- * @param[out] klv_packet Full klv packet with key and data fields
- * specified.
- *
- * @return \c true if packet returned; \c false if no packet returned.
- */
-KWIVER_ALGO_KLV_EXPORT bool
-klv_pop_next_packet( std::deque< uint8_t >& data, klv_data& klv_packet);
+// ---------------------------------------------------------------------------
+/// Pop the first KLV UDS key-value pair found in the data buffer.
+///
+/// The first valid KLV packet found in the data stream is returned.
+/// Leading bytes that do not belong to a KLV pair are dropped. If
+/// there is a partial packet in the input data stream, it is left
+/// there and no packet is returned.
+///
+/// \param[in,out] data Byte stream to be parsed.
+/// \param[out] klv_packet Full klv packet with key and data fields
+/// specified.
+///
+/// \return \c true if packet returned; \c false if no packet returned.
+KWIVER_ALGO_KLV_EXPORT
+bool
+klv_pop_next_packet( std::deque< uint8_t >& data, klv_data& klv_packet );
 
-/**
- * @brief Parse KLV LDS (Local Data Set) from an array of bytes.
- *
- * The input array is the raw KLV packet. The output is a vector of
- * LDS packets. The raw packet is usually taken from the
- * klv_pop_next_packet() function.
- *
- * @param data KLV raw packet
- *
- * @return A vector of klv LDS packets.
- */
-KWIVER_ALGO_KLV_EXPORT klv_lds_vector_t
-parse_klv_lds(klv_data const& data);
+// ---------------------------------------------------------------------------
+/// Parse KLV LDS (Local Data Set) from an array of bytes.
+///
+/// The input array is the raw KLV packet. The output is a vector of
+/// LDS packets. The raw packet is usually taken from the
+/// klv_pop_next_packet() function.
+///
+/// \param data KLV raw packet
+///
+/// \return A vector of klv LDS packets.
+KWIVER_ALGO_KLV_EXPORT
+klv_lds_vector_t
+parse_klv_lds( klv_data const& data );
 
-/**
- * @brief Parse KLV UDS (Universal Data Set) from an array of bytes.
- *
- * The input array is the raw KLV packet. The output is a vector of
- * UDS packets. The raw packet is usually taken from the
- * klv_pop_next_packet() function.
- *
- * The UDS keys can be decoded using the klv_0104 class.
- *
- * @param[in] data KLV raw packet
- *
- * @return A vector of klv UDS packets.
- */
-KWIVER_ALGO_KLV_EXPORT klv_uds_vector_t
+// ---------------------------------------------------------------------------
+/// Parse KLV UDS (Universal Data Set) from an array of bytes.
+///
+/// The input array is the raw KLV packet. The output is a vector of
+/// UDS packets. The raw packet is usually taken from the
+/// klv_pop_next_packet() function.
+///
+/// The UDS keys can be decoded using the klv_0104 class.
+///
+/// \param data KLV raw packet
+///
+/// \return A vector of klv UDS packets.
+KWIVER_ALGO_KLV_EXPORT
+klv_uds_vector_t
 parse_klv_uds( klv_data const& data );
 
-/**
- * @brief Print KLV packet.
- *
- * The supplied KLV packet is decoded and printed. The raw packet is
- * usually taken from the klv_pop_next_packet() function.
- *
- * @param str stream to format on
- * @param klv packet to decode
- */
-KWIVER_ALGO_KLV_EXPORT std::ostream&
+// ---------------------------------------------------------------------------
+/// Print KLV packet.
+///
+/// The supplied KLV packet is decoded and printed. The raw packet is
+/// usually taken from the klv_pop_next_packet() function.
+///
+/// \param str stream to format on
+/// \param klv packet to decode
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
 print_klv( std::ostream& str, klv_data const& klv );
 
-} } } // end namespace
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
 
 #endif


### PR DESCRIPTION
In order to expand the functionality of the KLV reader to include all valid ST 0601 keys, I need to make a few changes to klv_parse. The nature of the changes is such that it would be difficult to maintain modern style / practice guidelines in the newly written code without changing much of the surrounding code. Thus, it seemed reasonable to split this into two PRs - this one to just refactor / update the files to current code style guidelines with minimal functional change, and a second PR later with the actual functional changes.

There are currently no KLV unit tests to verify this against, but I did pull this branch into a build of Burnout and a cursory test run yielded no crashes or immediately noticeable errors in the metadata read from the test video.