### PR TITLE
minimize re-projection error over multiple focal scales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build
 *.swp
 *.swo
 *.swn
+compile_commands.json

--- a/arrows/ocv/resection_camera.cxx
+++ b/arrows/ocv/resection_camera.cxx
@@ -211,10 +211,12 @@ resection_camera
   MatD cv_K;
   eigen2cv( K, cv_K );
   auto const dc0 = dist_coeffs;
-  auto const focal_scales = {0.5, 1.0, 2.0};
-  auto focal_scale = 0.0; // preferred focal scale after optimization
+  auto const focal_scales = { 0.5, 1.0, 2.0 };
+  // focal scale search parameter for optimization
+  auto focal_scale = 0.0;
+  // minimize re-projection error over multiple focal scales
   for (auto const scale : focal_scales)
-  { // minimize re-projection error over multiple focal scales
+  {
     auto dc = dc0;
     vmat rv,tv;
     MatD cvK;
@@ -236,7 +238,7 @@ resection_camera
     }
   }
 
-  LOG_INFO( d_->m_logger, "re-projection error=" << err <<
+  LOG_DEBUG( d_->m_logger, "re-projection error=" << err <<
 	    ", focal scale=" << focal_scale);
   if( err > reproj_error )
   {

--- a/arrows/ocv/resection_camera.cxx
+++ b/arrows/ocv/resection_camera.cxx
@@ -105,7 +105,8 @@ resection_camera
                                                      d_->reproj_accuracy );
   d_->max_iterations = config->get_value< int >( "max_iterations",
                                                  d_->max_iterations );
-  std::stringstream ss(config->get_value< std::string > ( "focal_scales", "1" ));
+  std::stringstream ss( config->get_value< std::string > ( "focal_scales", "1" ) );
+  d_->focal_scales.clear();
   ss >> d_->focal_scales;
 }
 
@@ -114,7 +115,6 @@ bool
 resection_camera
 ::check_configuration( vital::config_block_sptr config ) const
 {
-  auto good_conf = true;
   auto const reproj_accuracy =
     config->get_value< double >( "reproj_accuracy", d_->reproj_accuracy );
   if( reproj_accuracy <= 0.0 )
@@ -122,7 +122,7 @@ resection_camera
     LOG_ERROR( d_->m_logger,
                "reproj_accuracy parameter is " << reproj_accuracy <<
                ", but needs to be positive." );
-    good_conf = false;
+    return false;
   }
 
   auto const max_iterations =
@@ -132,10 +132,22 @@ resection_camera
     LOG_ERROR( d_->m_logger,
                "max iterations is " << max_iterations <<
                ", needs to be greater than zero." );
-    good_conf = false;
+    return false;
   }
-  // TODO: focal_scales
-  return good_conf;
+
+  std::stringstream ss( config->get_value< std::string > ( "focal_scales", "1" ) );
+  vectorf focal_scales;
+  ss >> focal_scales;
+  auto m = std::min_element( focal_scales.begin(), focal_scales.end() );
+  if( m == focal_scales.end() || *m <= 0 )
+  {
+    LOG_ERROR( d_->m_logger,
+               "focal_scales: " << focal_scales <<
+               ", needs to be greater than zero." );
+    return false;
+  }
+
+  return true;
 }
 
 // ----------------------------------------------------------------------------
@@ -235,9 +247,6 @@ resection_camera
     flags |= cv::CALIB_FIX_K4 | cv::CALIB_FIX_K5 | cv::CALIB_FIX_K6;
   }
 
-  auto const reproj_error = d_->reproj_accuracy;
-
-  auto err = std::numeric_limits< double >::infinity();
   vital::matrix_3x3d K = cal->as_matrix();
   cv::TermCriteria term_criteria{
     cv::TermCriteria::COUNT + cv::TermCriteria::EPS,
@@ -251,6 +260,7 @@ resection_camera
   // focal scale search parameter for optimization
   auto focal_scale = 1.0;
   // minimize re-projection error over multiple focal scales
+  auto err = std::numeric_limits< double >::infinity();
   for( auto const scale : d_->focal_scales )
   {
     auto dc = dc0;
@@ -264,7 +274,7 @@ resection_camera
       world_points_vec, image_points_vec,
       image_size, cvK, dc, rv, tv,
       flags, term_criteria );
-    if( e < err )
+    if( e < err && fabs(e-err) > DBL_EPSILON )
     {
       cv_K = cvK;
       dist_coeffs = dc;
@@ -274,9 +284,10 @@ resection_camera
       err = e;
     }
   }
-
   LOG_DEBUG( d_->m_logger, "re-projection error=" << err <<
              ", focal scale=" << focal_scale );
+
+  auto const reproj_error = d_->reproj_accuracy;
   if( err > reproj_error )
   {
     LOG_WARN( d_->m_logger, "estimated re-projection error " <<

--- a/arrows/ocv/resection_camera.cxx
+++ b/arrows/ocv/resection_camera.cxx
@@ -40,26 +40,28 @@ struct resection_camera::priv : public mvg::camera_options
   // maximum number of iterations for camera calibration
   int max_iterations = 32;
   // focal length scales to optimize f*scale over
-  vectorf focal_scales { 1 };
+  vectorf focal_scales{ 1 };
 };
 
-std::ostream & operator<<(std::ostream & s, vectorf const & v)
+std::ostream&
+operator<<( std::ostream& s, vectorf const& v )
 {
-  for (unsigned i=0, n=v.size(); i<n; ++i)
+  for( unsigned i = 0, n = v.size(); i < n; ++i )
   {
-    if (i>0) s << ' ';
-    s << v[i];
+    if( i > 0 ) { s << ' '; }
+    s << v[ i ];
   }
   return s;
 }
 
-std::istream & operator>>(std::istream & s, vectorf & v)
+std::istream&
+operator>>( std::istream& s, vectorf& v )
 {
-  while (!s.eof())
+  while( !s.eof() )
   {
     float a = 0;
-	s >> a;
-	v.push_back(a);
+    s >> a;
+    v.push_back( a );
   }
   return s;
 }
@@ -88,6 +90,7 @@ resection_camera
                      "desired re-projection positive accuracy for inlier points" );
   config->set_value( "max_iterations", d_->max_iterations,
                      "maximum number of iterations to run optimization [1, INT_MAX]" );
+
   std::stringstream ss;
   ss << d_->focal_scales;
   config->set_value( "focal_scales", ss.str(),
@@ -105,7 +108,9 @@ resection_camera
                                                      d_->reproj_accuracy );
   d_->max_iterations = config->get_value< int >( "max_iterations",
                                                  d_->max_iterations );
-  std::stringstream ss( config->get_value< std::string > ( "focal_scales", "1" ) );
+
+  std::stringstream ss( config->get_value< std::string >( "focal_scales",
+                                                          "1" ) );
   d_->focal_scales.clear();
   ss >> d_->focal_scales;
 }
@@ -115,6 +120,7 @@ bool
 resection_camera
 ::check_configuration( vital::config_block_sptr config ) const
 {
+  auto good_conf = true;
   auto const reproj_accuracy =
     config->get_value< double >( "reproj_accuracy", d_->reproj_accuracy );
   if( reproj_accuracy <= 0.0 )
@@ -122,7 +128,7 @@ resection_camera
     LOG_ERROR( d_->m_logger,
                "reproj_accuracy parameter is " << reproj_accuracy <<
                ", but needs to be positive." );
-    return false;
+    good_conf = false;
   }
 
   auto const max_iterations =
@@ -132,22 +138,24 @@ resection_camera
     LOG_ERROR( d_->m_logger,
                "max iterations is " << max_iterations <<
                ", needs to be greater than zero." );
-    return false;
+    good_conf = false;
   }
 
-  std::stringstream ss( config->get_value< std::string > ( "focal_scales", "1" ) );
+  std::stringstream ss( config->get_value< std::string >( "focal_scales",
+                                                          "1" ) );
   vectorf focal_scales;
   ss >> focal_scales;
+
   auto m = std::min_element( focal_scales.begin(), focal_scales.end() );
-  if( m == focal_scales.end() || *m <= 0 )
+  if( *m <= 0 )
   {
     LOG_ERROR( d_->m_logger,
                "focal_scales: " << focal_scales <<
-               ", needs to be greater than zero." );
-    return false;
+               ", minimal value needs to be positive." );
+    good_conf = false;
   }
 
-  return true;
+  return good_conf;
 }
 
 // ----------------------------------------------------------------------------
@@ -274,7 +282,7 @@ resection_camera
       world_points_vec, image_points_vec,
       image_size, cvK, dc, rv, tv,
       flags, term_criteria );
-    if( e < err && fabs(e-err) > DBL_EPSILON )
+    if( e < err && fabs( e - err ) > DBL_EPSILON )
     {
       cv_K = cvK;
       dist_coeffs = dc;

--- a/arrows/ocv/resection_camera.cxx
+++ b/arrows/ocv/resection_camera.cxx
@@ -25,6 +25,8 @@ namespace arrows {
 namespace ocv {
 
 // ----------------------------------------------------------------------------
+using vectorf = std::vector< float >;
+
 struct resection_camera::priv : public mvg::camera_options
 {
 
@@ -38,8 +40,29 @@ struct resection_camera::priv : public mvg::camera_options
   // maximum number of iterations for camera calibration
   int max_iterations = 32;
   // focal length scales to optimize f*scale over
-  std::vector< float > focal_scales = { 0.5, 1.0, 2.0 };
+  vectorf focal_scales { 1 };
 };
+
+std::ostream & operator<<(std::ostream & s, vectorf const & v)
+{
+  for (unsigned i=0, n=v.size(); i<n; ++i)
+  {
+    if (i>0) s << ' ';
+    s << v[i];
+  }
+  return s;
+}
+
+std::istream & operator>>(std::istream & s, vectorf & v)
+{
+  while (!s.eof())
+  {
+    float a = 0;
+	s >> a;
+	v.push_back(a);
+  }
+  return s;
+}
 
 // ----------------------------------------------------------------------------
 resection_camera
@@ -65,7 +88,10 @@ resection_camera
                      "desired re-projection positive accuracy for inlier points" );
   config->set_value( "max_iterations", d_->max_iterations,
                      "maximum number of iterations to run optimization [1, INT_MAX]" );
-  // TODO: focal_scales
+  std::stringstream ss;
+  ss << d_->focal_scales;
+  config->set_value( "focal_scales", ss.str(),
+                     "focal length scales to optimize f*scale over" );
   return config;
 }
 
@@ -79,7 +105,8 @@ resection_camera
                                                      d_->reproj_accuracy );
   d_->max_iterations = config->get_value< int >( "max_iterations",
                                                  d_->max_iterations );
-  // TODO: focal_scales
+  std::stringstream ss(config->get_value< std::string > ( "focal_scales", "1" ));
+  ss >> d_->focal_scales;
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/ocv/resection_camera.cxx
+++ b/arrows/ocv/resection_camera.cxx
@@ -147,7 +147,13 @@ resection_camera
   ss >> focal_scales;
 
   auto m = std::min_element( focal_scales.begin(), focal_scales.end() );
-  if( *m <= 0 )
+  if( m == focal_scales.end() )
+  {
+    LOG_ERROR( d_->m_logger,
+               "expected non-empty focal_scales array" );
+    good_conf = false;
+  }
+  else if( *m <= 0 )
   {
     LOG_ERROR( d_->m_logger,
                "focal_scales: " << focal_scales <<


### PR DESCRIPTION
This small change makes our camera calibration more robust to initial focal lengths, and naturally slows it down a bit.