### PR TITLE
Port mesh intersection routines from VXL

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -37,6 +37,7 @@ set( plugin_core_headers
   match_features_fundamental_matrix.h
   match_features_homography.h
   match_tracks.h
+  mesh_intersect.h
   mesh_operations.h
   metadata_map_io_csv.h
   read_object_track_set_kw18.h
@@ -109,6 +110,7 @@ set( plugin_core_sources
   match_features_fundamental_matrix.cxx
   match_features_homography.cxx
   match_tracks.cxx
+  mesh_intersect.cxx
   mesh_operations.cxx
   metadata_map_io_csv.cxx
   read_object_track_set_kw18.cxx

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -12,56 +12,61 @@
 #include <vital/logger/logger.h>
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
 
 using namespace kwiver::vital;
 
 /// Intersect the ray from point to a triangle
 bool
-mesh_intersect_triangle(const vital::point_3d &p,
-                        const vital::vector_3d& d,
-                        const vital::point_3d& a,
-                        const vital::point_3d& b,
-                        const vital::point_3d& c,
-                        double& dist,
-                        double& u, double& v)
+mesh_intersect_triangle( const vital::point_3d& p,
+                         const vital::vector_3d& d,
+                         const vital::point_3d& a,
+                         const vital::point_3d& b,
+                         const vital::point_3d& c,
+                         double& dist,
+                         double& u, double& v )
 {
-  vector_3d n((b.value() - a.value()).cross(c.value() - a.value()));
-  return mesh_intersect_triangle(p, d, a, b, c, n, dist, u, v);
+  vector_3d n( ( b.value() - a.value() ).cross( c.value() - a.value() ) );
+  return mesh_intersect_triangle( p, d, a, b, c, n, dist, u, v );
 }
 
 /// Intersect the ray from point to a triangle
 bool
-mesh_intersect_triangle(const vital::point_3d& p,
-                        const vital::vector_3d& d,
-                        const vital::point_3d& a,
-                        const vital::point_3d& b,
-                        const vital::point_3d& c,
-                        const vital::vector_3d& n,
-                        double& dist,
-                        double& u, double& v)
+mesh_intersect_triangle( const vital::point_3d& p,
+                         const vital::vector_3d& d,
+                         const vital::point_3d& a,
+                         const vital::point_3d& b,
+                         const vital::point_3d& c,
+                         const vital::vector_3d& n,
+                         double& dist,
+                         double& u, double& v )
 {
-  double denom = -d.dot(n);
-  if (denom <= 0) // back facing triangles
-    return false;
+  double denom = -d.dot( n );
 
-  vector_3d ap(p.value() - a.value());
-  vector_3d t(d.cross(ap));
-  v = (b.value() - p.value()).dot(t);
-  if (v < 0.0 || v > denom)
+  if( denom <= 0 ) // back facing triangles
   {
     return false;
   }
 
-  u = -(c.value() - p.value()).dot(t);
-  if (u < 0.0 || u+v > denom)
+  vector_3d ap( p.value() - a.value() );
+  vector_3d t( d.cross( ap ) );
+  v = ( b.value() - p.value() ).dot( t );
+  if( v < 0.0 || v > denom )
   {
     return false;
   }
 
-  dist = ap.dot(n);
-  if (dist < 0.0)
+  u = -( c.value() - p.value() ).dot( t );
+  if( u < 0.0 || u + v > denom )
+  {
+    return false;
+  }
+
+  dist = ap.dot( n );
+  if( dist < 0.0 )
   {
     return false;
   }
@@ -73,39 +78,42 @@ mesh_intersect_triangle(const vital::point_3d& p,
   return true;
 }
 
-/// Intersect the ray from point to a triangle and check if the distance is smaller
+/// Intersect the ray from point to a triangle and check if the distance is
+/// smaller
 bool
-mesh_intersect_triangle_min_dist(const vital::point_3d& p,
-                                 const vital::vector_3d& d,
-                                 const vital::point_3d& a,
-                                 const vital::point_3d& b,
-                                 const vital::point_3d& c,
-                                 const vital::vector_3d& n,
-                                 double& dist,
-                                 double& u, double& v)
+mesh_intersect_triangle_min_dist( const vital::point_3d& p,
+                                  const vital::vector_3d& d,
+                                  const vital::point_3d& a,
+                                  const vital::point_3d& b,
+                                  const vital::point_3d& c,
+                                  const vital::vector_3d& n,
+                                  double& dist,
+                                  double& u, double& v )
 {
-  double denom = -d.dot(n);
-  if (denom <= 0) // back facing triangles
+  double denom = -d.dot( n );
+
+  if( denom <= 0 ) // back facing triangles
   {
     return false;
   }
 
-  vector_3d ap(p.value() - a.value());
-  double new_dist = ap.dot(n)/denom;
-  if (new_dist < 0.0 || new_dist > dist)
+  vector_3d ap( p.value() - a.value() );
+  double new_dist = ap.dot( n ) / denom;
+
+  if( new_dist < 0.0 || new_dist > dist )
   {
     return false;
   }
 
-  vector_3d t(d.cross(ap));
-  v = (b.value() - p.value()).dot(t);
-  if (v < 0.0 || v > denom)
+  vector_3d t( d.cross( ap ) );
+  v = ( b.value() - p.value() ).dot( t );
+  if( v < 0.0 || v > denom )
   {
     return false;
   }
 
-  u = -(c.value() - p.value()).dot(t);
-  if (u < 0.0 || u + v > denom)
+  u = -( c.value() - p.value() ).dot( t );
+  if( u < 0.0 || u + v > denom )
   {
     return false;
   }
@@ -119,105 +127,113 @@ mesh_intersect_triangle_min_dist(const vital::point_3d& p,
 
 /// Find the closest point on the triangle to a reference point
 unsigned char
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            const vital::vector_3d& n,
-                            double& dist,
-                            double& u, double& v)
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             const vital::vector_3d& n,
+                             double& dist,
+                             double& u, double& v )
 {
-  double denom = 1.0/n.squaredNorm();
+  double denom = 1.0 / n.squaredNorm();
 
-  vector_3d ap(p.value() - a.value());
-  vector_3d bp(p.value() - b.value());
-  vector_3d cp(p.value() - c.value());
+  vector_3d ap( p.value() - a.value() );
+  vector_3d bp( p.value() - b.value() );
+  vector_3d cp( p.value() - c.value() );
 
-  vector_3d t(n.cross(ap));
-  v = bp.dot(t) * denom;
-  u = -cp.dot(t) * denom;
+  vector_3d t( n.cross( ap ) );
+  v = bp.dot( t ) * denom;
+  u = -cp.dot( t ) * denom;
 
-  vector_3d ab(b.value() - a.value());
-  vector_3d bc(c.value() - b.value());
-  vector_3d ca(a.value() - c.value());
+  vector_3d ab( b.value() - a.value() );
+  vector_3d bc( c.value() - b.value() );
+  vector_3d ca( a.value() - c.value() );
 
-  double eps = std::numeric_limits<double>::epsilon();
+  double eps = std::numeric_limits< double >::epsilon();
 
   unsigned char state = 0;
   double uv;
-  if (u <= eps)
+  if( u <= eps )
   {
-    double p_v = v - u * ab.dot(ca)/ca.squaredNorm();
-    if (p_v <= eps)
+    double p_v = v - u * ab.dot( ca ) / ca.squaredNorm();
+
+    if( p_v <= eps )
     {
       state = 1;
     }
-    else if (p_v >= 1.0)
+    else if( p_v >= 1.0 )
     {
       state = 4;
     }
     else
     {
-      u = 0.0; v = p_v;
-      dist = ((1 - v)*ap + v*cp).norm();
+      u = 0.0;
+      v = p_v;
+      dist = ( ( 1 - v ) * ap + v * cp ).norm();
       return 5;
     }
   }
-  if (v <= eps)
+  if( v <= eps )
   {
-    double p_u = u - v * ca.dot(ab)/ab.squaredNorm();
-    if (p_u <= eps)
+    double p_u = u - v * ca.dot( ab ) / ab.squaredNorm();
+
+    if( p_u <= eps )
     {
       state = 1;
     }
-    else if (p_u >= 1.0)
+    else if( p_u >= 1.0 )
     {
       state = 2;
     }
     else
     {
-      u = p_u; v = 0.0;
-      dist = ((1 - u)*ap + u*bp).norm();
+      u = p_u;
+      v = 0.0;
+      dist = ( ( 1 - u ) * ap + u * bp ).norm();
       return 3;
     }
   }
-  if ((uv = 1.0 - u - v) <= eps)
+  if( ( uv = 1.0 - u - v ) <= eps )
   {
-    double s = -ca.dot(bc)/bc.squaredNorm();
+    double s = -ca.dot( bc ) / bc.squaredNorm();
     double p_u = u + uv * s;
-    double p_v = v + uv * (1.0-s);
-    if (p_v <= eps)
+    double p_v = v + uv * ( 1.0 - s );
+    if( p_v <= eps )
     {
       state = 2;
     }
-    else if (p_u <= eps)
+    else if( p_u <= eps )
     {
       state = 4;
     }
     else
     {
-      u=p_u; v=p_v;
-      dist = (u*bp + v*cp).norm();
+      u = p_u;
+      v = p_v;
+      dist = ( u * bp + v * cp ).norm();
       return 6;
     }
   }
 
-  switch (state)
+  switch( state )
   {
     case 1:
-      u=0.0; v=0.0;
+      u = 0.0;
+      v = 0.0;
       dist = ap.norm();
       return 1;
     case 2:
-      u=1.0; v=0.0;
+      u = 1.0;
+      v = 0.0;
       dist = bp.norm();
       return 2;
     case 4:
-      u=0.0; v=1.0;
+      u = 0.0;
+      v = 1.0;
       dist = cp.norm();
       return 4;
     default:
-      dist = std::abs(ap.dot(n) * std::sqrt(denom));
+      dist = std::abs( ap.dot( n ) * std::sqrt( denom ) );
       return 7;
   }
 
@@ -226,64 +242,66 @@ mesh_triangle_closest_point(const vital::point_3d& p,
 
 /// Find the closest point on the triangle to a reference point
 unsigned char
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            double& dist,
-                            double& u, double& v)
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             double& dist,
+                             double& u, double& v )
 {
-  vector_3d n((b.value() - a.value()).cross(c.value() - a.value()));
-  return mesh_triangle_closest_point(p, a, b, c, n, dist, u, v);
+  vector_3d n( ( b.value() - a.value() ).cross( c.value() - a.value() ) );
+  return mesh_triangle_closest_point( p, a, b, c, n, dist, u, v );
 }
 
 /// Find the closest point on the triangle to a reference point
 vital::point_3d
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            double& dist)
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             double& dist )
 {
-  double u,v;
-  mesh_triangle_closest_point(p, a, b, c, dist, u, v);
+  double u, v;
+  mesh_triangle_closest_point( p, a, b, c, dist, u, v );
+
   double t = 1 - u - v;
-  return point_3d(t*a[0] + u*b[0] + v*c[0],
-                  t*a[1] + u*b[1] + v*c[1],
-                  t*a[2] + u*b[2] + v*c[2]);
+  return point_3d( t * a[ 0 ] + u * b[ 0 ] + v * c[ 0 ],
+                   t * a[ 1 ] + u * b[ 1 ] + v * c[ 1 ],
+                   t * a[ 2 ] + u * b[ 2 ] + v * c[ 2 ] );
 }
 
 /// Find the closest point on a triangulated mesh to a reference point
 int
-mesh_closest_point(const vital::point_3d& p,
-                   const vital::mesh& mesh,
-                   vital::point_3d& cp,
-                   double& u, double& v)
+mesh_closest_point( const vital::point_3d& p,
+                    const vital::mesh& mesh,
+                    vital::point_3d& cp,
+                    double& u, double& v )
 {
   // check for a triangular mesh
-  if (mesh.faces().regularity() != 3)
+  if( mesh.faces().regularity() != 3 )
   {
-    LOG_ERROR(vital::get_logger("arrows.core.mesh_closest_point"),
-      "Closest point calculation requires triangular mesh.");
+    LOG_ERROR( vital::get_logger( "arrows.core.mesh_closest_point" ),
+               "Closest point calculation requires triangular mesh." );
     return -1;
   }
 
-  const mesh_vertex_array<3>& verts = mesh.vertices<3>();
-  const mesh_regular_face_array<3>& faces =
-    static_cast<const mesh_regular_face_array<3>&>(mesh.faces());
+  const mesh_vertex_array< 3 >& verts = mesh.vertices< 3 >();
+  const mesh_regular_face_array< 3 >& faces =
+    static_cast< const mesh_regular_face_array< 3 >& >( mesh.faces() );
 
   int isect = -1;
   double u1, v1;
-  double shortest_dist = std::numeric_limits<double>::infinity();
-  for (unsigned int i=0; i<faces.size(); ++i)
+  double shortest_dist = std::numeric_limits< double >::infinity();
+
+  for( unsigned int i = 0; i < faces.size(); ++i )
   {
-    const mesh_regular_face<3>& f = faces[i];
-    vital::point_3d a(verts[f[0]]);
-    vital::point_3d b(verts[f[1]]);
-    vital::point_3d c(verts[f[2]]);
+    const mesh_regular_face< 3 >& f = faces[ i ];
+    vital::point_3d a( verts[ f[ 0 ] ] );
+    vital::point_3d b( verts[ f[ 1 ] ] );
+    vital::point_3d c( verts[ f[ 2 ] ] );
     double dist = shortest_dist;
-    if (mesh_triangle_closest_point(p, a, b, c, dist, u1, v1) &&
-        dist < shortest_dist)
+    if( mesh_triangle_closest_point( p, a, b, c, dist, u1, v1 ) &&
+        dist < shortest_dist )
     {
       u = u1;
       v = v1;
@@ -294,63 +312,65 @@ mesh_closest_point(const vital::point_3d& p,
 
   // Get the closest point in physical space from barycentric coordinates
   double t = 1 - u - v;
-  const mesh_regular_face<3>& f = faces[isect];
-  vital::point_3d a(verts[f[0]]);
-  vital::point_3d b(verts[f[1]]);
-  vital::point_3d c(verts[f[2]]);
-  cp.set_value(vector_3d(t*a[0] + u*b[0] + v*c[0],
-                         t*a[1] + u*b[1] + v*c[1],
-                         t*a[2] + u*b[2] + v*c[2]));
+  const mesh_regular_face< 3 >& f = faces[ isect ];
+  vital::point_3d a( verts[ f[ 0 ] ] );
+  vital::point_3d b( verts[ f[ 1 ] ] );
+  vital::point_3d c( verts[ f[ 2 ] ] );
+  cp.set_value( vector_3d( t * a[ 0 ] + u * b[ 0 ] + v * c[ 0 ],
+                           t * a[ 1 ] + u * b[ 1 ] + v * c[ 1 ],
+                           t * a[ 2 ] + u * b[ 2 ] + v * c[ 2 ] ) );
   return isect;
 }
 
 /// Intersect a ray from point to a triangulated mesh
 int
-mesh_intersect(const vital::point_3d& p,
-               const vital::vector_3d& d,
-               const vital::mesh& mesh,
-               double& dist,
-               double& u, double& v)
+mesh_intersect( const vital::point_3d& p,
+                const vital::vector_3d& d,
+                const vital::mesh& mesh,
+                double& dist,
+                double& u, double& v )
 {
   // check for a triangular mesh
-  if (mesh.faces().regularity() != 3)
+  if( mesh.faces().regularity() != 3 )
   {
-    LOG_ERROR(vital::get_logger("arrows.core.mesh_closest_point"),
-      "Closest point calculation requires triangular mesh.");
+    LOG_ERROR( vital::get_logger( "arrows.core.mesh_closest_point" ),
+               "Closest point calculation requires triangular mesh." );
     return -1;
   }
 
   // Calculate normals if needed
-  if (!mesh.faces().has_normals())
+  if( !mesh.faces().has_normals() )
   {
-    LOG_ERROR(vital::get_logger("arrows.core.mesh_closest_point"),
-      "Closest point calculation requires faces normals.");
+    LOG_ERROR( vital::get_logger( "arrows.core.mesh_closest_point" ),
+               "Closest point calculation requires faces normals." );
     return -1;
   }
 
-  const mesh_vertex_array<3>& verts = mesh.vertices<3>();
-  const mesh_regular_face_array<3>& faces =
-    static_cast<const mesh_regular_face_array<3>&>(mesh.faces());
+  const mesh_vertex_array< 3 >& verts = mesh.vertices< 3 >();
+  const mesh_regular_face_array< 3 >& faces =
+    static_cast< const mesh_regular_face_array< 3 >& >( mesh.faces() );
 
   // Check that normal magnitude corresponds to face area
-  if ( ((verts[faces[0][1]] - verts[faces[0][0]])
-        .cross(verts[faces[0][2]] - verts[faces[0][0]])
-               - 0.5*faces.normal(0)).norm() < 1e-14 )
+  if( ( ( verts[ faces[ 0 ][ 1 ] ] - verts[ faces[ 0 ][ 0 ] ] )
+        .cross( verts[ faces[ 0 ][ 2 ] ] - verts[ faces[ 0 ][ 0 ] ] ) -
+        0.5 * faces.normal( 0 ) ).norm() < 1e-14 )
   {
-    LOG_ERROR(vital::get_logger("arrows.core.mesh_closest_point"),
-      "Closest point calculation requires faces normal lengths be set to face area.");
+    LOG_ERROR( vital::get_logger(
+                 "arrows.core.mesh_closest_point" ),
+               "Closest point calculation requires faces normal lengths be set to face area." );
     return -1;
   }
 
   int isect = -1;
-  dist = std::numeric_limits<double>::infinity();
-  for (unsigned int i=0; i<faces.size(); ++i)
+  dist = std::numeric_limits< double >::infinity();
+  for( unsigned int i = 0; i < faces.size(); ++i )
   {
-    const mesh_regular_face<3>& f = faces[i];
-    vital::point_3d a(verts[f[0]]);
-    vital::point_3d b(verts[f[1]]);
-    vital::point_3d c(verts[f[2]]);
-    if (mesh_intersect_triangle_min_dist(p, d, a, b, c, faces.normal(i), dist, u, v))
+    const mesh_regular_face< 3 >& f = faces[ i ];
+    vital::point_3d a( verts[ f[ 0 ] ] );
+    vital::point_3d b( verts[ f[ 1 ] ] );
+    vital::point_3d c( verts[ f[ 2 ] ] );
+    if( mesh_intersect_triangle_min_dist( p, d, a, b, c, faces.normal( i ),
+                                          dist, u, v ) )
     {
       isect = i;
     }
@@ -358,6 +378,8 @@ mesh_intersect(const vital::point_3d& p,
   return isect;
 }
 
-}
-}
-}
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -2,13 +2,14 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of mesh operations
- */
+/// \file
+/// Operations to calculate closest points and ray intersections
+/// to triangles and meshes.
 
 #include "mesh_intersect.h"
+
 #include <limits>
+
 #include <vital/logger/logger.h>
 
 namespace kwiver {
@@ -19,30 +20,21 @@ namespace core {
 
 using namespace kwiver::vital;
 
-/// Intersect the ray from point to a triangle
+// ----------------------------------------------------------------------------
 bool
-mesh_intersect_triangle( const vital::point_3d& p,
-                         const vital::vector_3d& d,
-                         const vital::point_3d& a,
-                         const vital::point_3d& b,
-                         const vital::point_3d& c,
-                         double& dist,
-                         double& u, double& v )
+mesh_intersect_triangle(
+  const point_3d& p, const vector_3d& d, const point_3d& a, const point_3d& b,
+  const point_3d& c, double& dist, double& u, double& v )
 {
   vector_3d n( ( b.value() - a.value() ).cross( c.value() - a.value() ) );
   return mesh_intersect_triangle( p, d, a, b, c, n, dist, u, v );
 }
 
-/// Intersect the ray from point to a triangle
+// ----------------------------------------------------------------------------
 bool
-mesh_intersect_triangle( const vital::point_3d& p,
-                         const vital::vector_3d& d,
-                         const vital::point_3d& a,
-                         const vital::point_3d& b,
-                         const vital::point_3d& c,
-                         const vital::vector_3d& n,
-                         double& dist,
-                         double& u, double& v )
+mesh_intersect_triangle(
+  const point_3d& p, const vector_3d& d, const point_3d& a, const point_3d& b,
+  const point_3d& c, const vector_3d& n, double& dist, double& u, double& v )
 {
   double denom = -d.dot( n );
 
@@ -78,17 +70,11 @@ mesh_intersect_triangle( const vital::point_3d& p,
   return true;
 }
 
-/// Intersect the ray from point to a triangle and check if the distance is
-/// smaller
+// ----------------------------------------------------------------------------
 bool
-mesh_intersect_triangle_min_dist( const vital::point_3d& p,
-                                  const vital::vector_3d& d,
-                                  const vital::point_3d& a,
-                                  const vital::point_3d& b,
-                                  const vital::point_3d& c,
-                                  const vital::vector_3d& n,
-                                  double& dist,
-                                  double& u, double& v )
+mesh_intersect_triangle_min_dist(
+  const point_3d& p, const vector_3d& d, const point_3d& a, const point_3d& b,
+  const point_3d& c, const vector_3d& n, double& dist, double& u, double& v )
 {
   double denom = -d.dot( n );
 
@@ -125,15 +111,11 @@ mesh_intersect_triangle_min_dist( const vital::point_3d& p,
   return true;
 }
 
-/// Find the closest point on the triangle to a reference point
+// ----------------------------------------------------------------------------
 unsigned char
-mesh_triangle_closest_point( const vital::point_3d& p,
-                             const vital::point_3d& a,
-                             const vital::point_3d& b,
-                             const vital::point_3d& c,
-                             const vital::vector_3d& n,
-                             double& dist,
-                             double& u, double& v )
+mesh_triangle_closest_point(
+  const point_3d& p, const point_3d& a, const point_3d& b, const point_3d& c,
+  const vector_3d& n, double& dist, double& u, double& v )
 {
   double denom = 1.0 / n.squaredNorm();
 
@@ -240,26 +222,21 @@ mesh_triangle_closest_point( const vital::point_3d& p,
   return 0;
 }
 
-/// Find the closest point on the triangle to a reference point
+// ----------------------------------------------------------------------------
 unsigned char
-mesh_triangle_closest_point( const vital::point_3d& p,
-                             const vital::point_3d& a,
-                             const vital::point_3d& b,
-                             const vital::point_3d& c,
-                             double& dist,
-                             double& u, double& v )
+mesh_triangle_closest_point(
+  const point_3d& p, const point_3d& a, const point_3d& b, const point_3d& c,
+  double& dist, double& u, double& v )
 {
   vector_3d n( ( b.value() - a.value() ).cross( c.value() - a.value() ) );
   return mesh_triangle_closest_point( p, a, b, c, n, dist, u, v );
 }
 
-/// Find the closest point on the triangle to a reference point
+// ----------------------------------------------------------------------------
 vital::point_3d
-mesh_triangle_closest_point( const vital::point_3d& p,
-                             const vital::point_3d& a,
-                             const vital::point_3d& b,
-                             const vital::point_3d& c,
-                             double& dist )
+mesh_triangle_closest_point(
+  const point_3d& p, const point_3d& a, const point_3d& b, const point_3d& c,
+  double& dist )
 {
   double u, v;
   mesh_triangle_closest_point( p, a, b, c, dist, u, v );
@@ -270,12 +247,10 @@ mesh_triangle_closest_point( const vital::point_3d& p,
                    t * a[ 2 ] + u * b[ 2 ] + v * c[ 2 ] );
 }
 
-/// Find the closest point on a triangulated mesh to a reference point
+// ----------------------------------------------------------------------------
 int
-mesh_closest_point( const vital::point_3d& p,
-                    const vital::mesh& mesh,
-                    vital::point_3d& cp,
-                    double& u, double& v )
+mesh_closest_point(
+  const point_3d& p, const mesh& mesh, point_3d& cp, double& u, double& v )
 {
   // check for a triangular mesh
   if( mesh.faces().regularity() != 3 )
@@ -322,13 +297,11 @@ mesh_closest_point( const vital::point_3d& p,
   return isect;
 }
 
-/// Intersect a ray from point to a triangulated mesh
+// ----------------------------------------------------------------------------
 int
-mesh_intersect( const vital::point_3d& p,
-                const vital::vector_3d& d,
-                const vital::mesh& mesh,
-                double& dist,
-                double& u, double& v )
+mesh_intersect(
+  const point_3d& p, const vector_3d& d, const mesh& mesh, double& dist,
+  double& u, double& v )
 {
   // check for a triangular mesh
   if( mesh.faces().regularity() != 3 )

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -48,15 +48,21 @@ mesh_intersect_triangle(const vital::point_3d& p,
   vector_3d t(d.cross(ap));
   v = (b.value() - p.value()).dot(t);
   if (v < 0.0 || v > denom)
+  {
     return false;
+  }
 
   u = -(c.value() - p.value()).dot(t);
   if (u < 0.0 || u+v > denom)
+  {
     return false;
+  }
 
   dist = ap.dot(n);
   if (dist < 0.0)
+  {
     return false;
+  }
 
   u /= denom;
   v /= denom;
@@ -78,21 +84,29 @@ mesh_intersect_triangle_min_dist(const vital::point_3d& p,
 {
   double denom = -d.dot(n);
   if (denom <= 0) // back facing triangles
+  {
     return false;
+  }
 
   vector_3d ap(p.value() - a.value());
   double new_dist = ap.dot(n)/denom;
   if (new_dist < 0.0 || new_dist > dist)
+  {
     return false;
+  }
 
   vector_3d t(d.cross(ap));
   v = (b.value() - p.value()).dot(t);
   if (v < 0.0 || v > denom)
+  {
     return false;
+  }
 
   u = -(c.value() - p.value()).dot(t);
   if (u < 0.0 || u + v > denom)
+  {
     return false;
+  }
 
   dist = new_dist;
   u /= denom;
@@ -129,45 +143,57 @@ mesh_triangle_closest_point(const vital::point_3d& p,
 
   unsigned char state = 0;
   double uv;
-  if (u <= eps) {
+  if (u <= eps)
+  {
     double p_v = v - u * ab.dot(ca)/ca.squaredNorm();
-    if (p_v <= eps) {
+    if (p_v <= eps)
+    {
       state = 1;
     }
-    else if (p_v >= 1.0) {
+    else if (p_v >= 1.0)
+    {
       state = 4;
     }
-    else {
+    else
+    {
       u = 0.0; v = p_v;
       dist = ((1 - v)*ap + v*cp).norm();
       return 5;
     }
   }
-  if (v <= eps) {
+  if (v <= eps)
+  {
     double p_u = u - v * ca.dot(ab)/ab.squaredNorm();
-    if (p_u <= eps) {
+    if (p_u <= eps)
+    {
       state = 1;
     }
-    else if (p_u >= 1.0) {
+    else if (p_u >= 1.0)
+    {
       state = 2;
     }
-    else {
+    else
+    {
       u = p_u; v = 0.0;
       dist = ((1 - u)*ap + u*bp).norm();
       return 3;
     }
   }
-  if ((uv = 1.0 - u - v) <= eps) {
+  if ((uv = 1.0 - u - v) <= eps)
+  {
     double s = -ca.dot(bc)/bc.squaredNorm();
     double p_u = u + uv * s;
     double p_v = v + uv * (1.0-s);
-    if (p_v <= eps) {
+    if (p_v <= eps)
+    {
       state = 2;
     }
-    else if (p_u <= eps) {
+    else if (p_u <= eps)
+    {
       state = 4;
     }
-    else {
+    else
+    {
       u=p_u; v=p_v;
       dist = (u*bp + v*cp).norm();
       return 6;

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -1,0 +1,106 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/**
+ * \file
+ * \brief Implementation of mesh operations
+ */
+
+#include "mesh_intersect.h"
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+using namespace kwiver::vital;
+
+/// Intersect the ray from point to a triangle
+bool
+mesh_intersect_triangle(const vital::point_3d &p,
+                        const vital::vector_3d& d,
+                        const vital::point_3d& a,
+                        const vital::point_3d& b,
+                        const vital::point_3d& c,
+                        double& dist,
+                        double& u, double& v)
+{
+  vector_3d n((b.value() - a.value()).cross(c.value() - a.value()));
+  return mesh_intersect_triangle(p, d, a, b, c, n, dist, u, v);
+}
+
+/// Intersect the ray from point to a triangle
+bool
+mesh_intersect_triangle(const vital::point_3d& p,
+                        const vital::vector_3d& d,
+                        const vital::point_3d& a,
+                        const vital::point_3d& b,
+                        const vital::point_3d& c,
+                        const vital::vector_3d& n,
+                        double& dist,
+                        double& u, double& v)
+{
+  double denom = -d.dot(n);
+  if (denom <= 0) // back facing triangles
+    return false;
+
+  vector_3d ap(p.value() - a.value());
+  vector_3d t(d.cross(ap));
+  v = (b.value() - p.value()).dot(t);
+  if (v < 0.0 || v > denom)
+    return false;
+
+  u = -(c.value() - p.value()).dot(t);
+  if (u < 0.0 || u+v > denom)
+    return false;
+
+  dist = ap.dot(n);
+  if (dist < 0.0)
+    return false;
+
+  u /= denom;
+  v /= denom;
+  dist /= denom;
+
+  return true;
+}
+
+/// Intersect the ray from point to a triangle and check if the distance is smaller
+bool
+mesh_intersect_triangle_min_dist(const vital::point_3d& p,
+                                 const vital::vector_3d& d,
+                                 const vital::point_3d& a,
+                                 const vital::point_3d& b,
+                                 const vital::point_3d& c,
+                                 const vital::vector_3d& n,
+                                 double& dist,
+                                 double& u, double& v)
+{
+  double denom = -d.dot(n);
+  if (denom <= 0) // back facing triangles
+    return false;
+
+  vector_3d ap(p.value() - a.value());
+  double new_dist = ap.dot(n)/denom;
+  if (new_dist < 0.0 || new_dist > dist)
+    return false;
+
+  vector_3d t(d.cross(ap));
+  v = (b.value() - p.value()).dot(t);
+  if (v < 0.0 || v > denom)
+    return false;
+
+  u = -(c.value() - p.value()).dot(t);
+  if (u < 0.0 || u + v > denom)
+    return false;
+
+  dist = new_dist;
+  u /= denom;
+  v /= denom;
+
+  return true;
+}
+
+}
+}
+}

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -12,6 +12,8 @@
 
 #include <vital/logger/logger.h>
 
+#include <Eigen/Geometry>
+
 namespace kwiver {
 
 namespace arrows {

--- a/arrows/core/mesh_intersect.cxx
+++ b/arrows/core/mesh_intersect.cxx
@@ -101,6 +101,131 @@ mesh_intersect_triangle_min_dist(const vital::point_3d& p,
   return true;
 }
 
+/// Find the closest point on the triangle to a reference point
+unsigned char
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            const vital::vector_3d& n,
+                            double& dist,
+                            double& u, double& v)
+{
+  double denom = 1.0/n.squaredNorm();
+
+  vector_3d ap(p.value() - a.value());
+  vector_3d bp(p.value() - b.value());
+  vector_3d cp(p.value() - c.value());
+
+  vector_3d t(n.cross(ap));
+  v = bp.dot(t) * denom;
+  u = -cp.dot(t) * denom;
+
+  vector_3d ab(b.value() - a.value());
+  vector_3d bc(c.value() - b.value());
+  vector_3d ca(a.value() - c.value());
+
+  double eps = std::numeric_limits<double>::epsilon();
+
+  unsigned char state = 0;
+  double uv;
+  if (u <= eps) {
+    double p_v = v - u * ab.dot(ca)/ca.squaredNorm();
+    if (p_v <= eps) {
+      state = 1;
+    }
+    else if (p_v >= 1.0) {
+      state = 4;
+    }
+    else {
+      u = 0.0; v = p_v;
+      dist = ((1 - v)*ap + v*cp).norm();
+      return 5;
+    }
+  }
+  if (v <= eps) {
+    double p_u = u - v * ca.dot(ab)/ab.squaredNorm();
+    if (p_u <= eps) {
+      state = 1;
+    }
+    else if (p_u >= 1.0) {
+      state = 2;
+    }
+    else {
+      u = p_u; v = 0.0;
+      dist = ((1 - u)*ap + u*bp).norm();
+      return 3;
+    }
+  }
+  if ((uv = 1.0 - u - v) <= eps) {
+    double s = -ca.dot(bc)/bc.squaredNorm();
+    double p_u = u + uv * s;
+    double p_v = v + uv * (1.0-s);
+    if (p_v <= eps) {
+      state = 2;
+    }
+    else if (p_u <= eps) {
+      state = 4;
+    }
+    else {
+      u=p_u; v=p_v;
+      dist = (u*bp + v*cp).norm();
+      return 6;
+    }
+  }
+
+  switch (state)
+  {
+    case 1:
+      u=0.0; v=0.0;
+      dist = ap.norm();
+      return 1;
+    case 2:
+      u=1.0; v=0.0;
+      dist = bp.norm();
+      return 2;
+    case 4:
+      u=0.0; v=1.0;
+      dist = cp.norm();
+      return 4;
+    default:
+      dist = std::abs(ap.dot(n) * std::sqrt(denom));
+      return 7;
+  }
+
+  return 0;
+}
+
+/// Find the closest point on the triangle to a reference point
+unsigned char
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            double& dist,
+                            double& u, double& v)
+{
+  vector_3d n((b.value() - a.value()).cross(c.value() - a.value()));
+  return mesh_triangle_closest_point(p, a, b, c, n, dist, u, v);
+}
+
+/// Find the closest point on the triangle to a reference point
+vital::point_3d
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            double& dist)
+{
+  double u,v;
+  mesh_triangle_closest_point(p, a, b, c, dist, u, v);
+  double t = 1 - u - v;
+  return point_3d(t*a[0] + u*b[0] + v*c[0],
+                  t*a[1] + u*b[1] + v*c[1],
+                  t*a[2] + u*b[2] + v*c[2]);
+}
+
+
 }
 }
 }

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -29,7 +29,7 @@ namespace core {
  * \param [in]   a     corner point of triangle
  * \param [in]   b     corner point of triangle
  * \param [in]   c     corner point of triangle
- * \param [out]  dist  is the distance to the triangle
+ * \param [out]  dist  the distance to the triangle
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs
@@ -58,7 +58,7 @@ mesh_intersect_triangle(const vital::point_3d& p,
  * \param [in]   b     corner point of triangle
  * \param [in]   c     corner point of triangle
  * \param [in]   n     pre-computed normal for triangle
- * \param [out]  dist  is the distance to the triangle
+ * \param [out]  dist  the distance to the triangle
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs
@@ -87,7 +87,7 @@ mesh_intersect_triangle(const vital::point_3d& p,
  * \param [in]   b     corner point of triangle
  * \param [in]   c     corner point of triangle
  * \param [in]   n     pre-computed normal for triangle
- * \param [out]  dist  is the distance to the triangle
+ * \param [out]  dist  the distance to the triangle
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs and the new dist is less than the old distance (but > 0)
@@ -103,6 +103,88 @@ mesh_intersect_triangle_min_dist(const vital::point_3d& p,
                                  const vital::vector_3d& n,
                                  double& dist,
                                  double& u, double& v);
+
+/// Find the closest point on the triangle to a reference point
+/**
+ * Find the closest point on the triangle a,b,c to point p. The un-normalized
+ * normal vector (b-a)x(c-a) is precomputed and also passed in
+ *
+ * \param [in]   p     reference point to get closest distance to
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [in]   n     pre-computed normal for triangle
+ * \param [out]  dist  the distance to the triangle
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      a code indicating that the closest point:
+ *               - 0 does not exist (should not occur)
+ *               - 1 is \a a
+ *               - 2 is \a b
+ *               - 3 is on the edge from \a a to \a b
+ *               - 4 is \a c
+ *               - 5 is on the edge from \a a to \a c
+ *               - 6 is on the edge from \a b to \a c
+ *               - 7 is on the face of the triangle
+ */
+KWIVER_ALGO_CORE_EXPORT
+unsigned char
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            const vital::vector_3d& n,
+                            double& dist,
+                            double& u, double& v);
+
+/// Find the closest point on the triangle to a reference point
+/**
+ * Find the closest point on the triangle a,b,c to point p.
+ *
+ * \param [in]   p     reference point to get closest distance to
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [out]  dist  the distance to the triangle
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      a code indicating that the closest point:
+ *               - 0 does not exist (should not occur)
+ *               - 1 is \a a
+ *               - 2 is \a b
+ *               - 3 is on the edge from \a a to \a b
+ *               - 4 is \a c
+ *               - 5 is on the edge from \a a to \a c
+ *               - 6 is on the edge from \a b to \a c
+ *               - 7 is on the face of the triangle
+ */
+KWIVER_ALGO_CORE_EXPORT
+unsigned char
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            double& dist,
+                            double& u, double& v);
+
+/// Find the closest point on the triangle to a reference point
+/**
+ * Find the closest point on the triangle a,b,c to point p
+ *
+ * \param [in]   p     reference point to get closest distance to
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [out]  dist  the closest distance to the triangle
+ * \returns      the point on the triangle closest to the reference point
+ */
+KWIVER_ALGO_CORE_EXPORT
+vital::point_3d
+mesh_triangle_closest_point(const vital::point_3d& p,
+                            const vital::point_3d& a,
+                            const vital::point_3d& b,
+                            const vital::point_3d& c,
+                            double& dist);
 
 }
 }

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -2,11 +2,9 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Operations to calculate closest points and ray intersections
- *        to triangles and meshes
- */
+/// \file
+/// Operations to calculate closest points and ray intersections
+/// to triangles and meshes.
 
 #ifndef KWIVER_ARROWS_CORE_MESH_INTERSECT_H
 #define KWIVER_ARROWS_CORE_MESH_INTERSECT_H

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -21,24 +21,22 @@ namespace arrows {
 namespace core {
 
 /// Intersect the ray from point to a triangle
-
-/**
- * Intersect the ray from point p with direction d and the triangle
- * defined by a,b,c. Returns the distance to the mesh from the point
- * and the barycentric coordinates of the intersection on the triangle.
- *
- * \param [in]   p     point that is the start of the ray
- * \param [in]   d     direction of the ray
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [out]  dist  the distance to the triangle
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      true  if intersection occurs
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Intersect the ray from point p with direction d and the triangle
+/// defined by a,b,c. Returns the distance to the mesh from the point
+/// and the barycentric coordinates of the intersection on the triangle.
+///
+/// \param [in]   p     point that is the start of the ray
+/// \param [in]   d     direction of the ray
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [out]  dist  the distance to the triangle
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      true  if intersection occurs
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 bool
 mesh_intersect_triangle( const vital::point_3d& p,
@@ -50,26 +48,24 @@ mesh_intersect_triangle( const vital::point_3d& p,
                          double& u, double& v );
 
 /// Intersect a ray from point to a triangle
-
-/**
- * Intersect the ray from point p with direction d and the triangle defined
- * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
- * also passed in. Returns the distance to the mesh from the point
- * and the barycentric coordinates of the intersection on the triangle.
- *
- * \param [in]   p     point that is the start of the ray
- * \param [in]   d     direction of the ray
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [in]   n     pre-computed normal for triangle
- * \param [out]  dist  the distance to the triangle
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      true  if intersection occurs
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Intersect the ray from point p with direction d and the triangle defined
+/// by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
+/// also passed in. Returns the distance to the mesh from the point
+/// and the barycentric coordinates of the intersection on the triangle.
+///
+/// \param [in]   p     point that is the start of the ray
+/// \param [in]   d     direction of the ray
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [in]   n     pre-computed normal for triangle
+/// \param [out]  dist  the distance to the triangle
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      true  if intersection occurs
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 bool
 mesh_intersect_triangle( const vital::point_3d& p,
@@ -83,28 +79,26 @@ mesh_intersect_triangle( const vital::point_3d& p,
 
 /// Intersect the ray from point to a triangle and check if the distance is
 /// smaller
-
-/**
- * Intersect the ray from point p with direction d and the triangle defined
- * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
- * also passed in. Returns the distance to the mesh from the point
- * and the barycentric coordinates of the intersection on the triangle if
- * the distance is smaller.
- *
- * \param [in]   p     point that is the start of the ray
- * \param [in]   d     direction of the ray
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [in]   n     pre-computed normal for triangle
- * \param [out]  dist  the distance to the triangle
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      true  if intersection occurs and the new dist is less than the
- *                     old distance (but > 0)
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Intersect the ray from point p with direction d and the triangle defined
+/// by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
+/// also passed in. Returns the distance to the mesh from the point
+/// and the barycentric coordinates of the intersection on the triangle if
+/// the distance is smaller.
+///
+/// \param [in]   p     point that is the start of the ray
+/// \param [in]   d     direction of the ray
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [in]   n     pre-computed normal for triangle
+/// \param [out]  dist  the distance to the triangle
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      true  if intersection occurs and the new dist is less than the
+///                     old distance (but > 0)
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 bool
 mesh_intersect_triangle_min_dist( const vital::point_3d& p,
@@ -117,33 +111,31 @@ mesh_intersect_triangle_min_dist( const vital::point_3d& p,
                                   double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
-
-/**
- * Find the closest point on the triangle a,b,c to point p. The un-normalized
- * normal vector (b-a)x(c-a) is precomputed and also passed in. Returns the
- * distance to the mesh from the point and the barycentric coordinates on
- * the triangle of the intersection.
- *
- * \param [in]   p     reference point to get closest distance to
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [in]   n     pre-computed normal for triangle
- * \param [out]  dist  the distance to the triangle
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      a code indicating that the closest point:
- *               - 0 does not exist (should not occur)
- *               - 1 is \a a
- *               - 2 is \a b
- *               - 3 is on the edge from \a a to \a b
- *               - 4 is \a c
- *               - 5 is on the edge from \a a to \a c
- *               - 6 is on the edge from \a b to \a c
- *               - 7 is on the face of the triangle
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Find the closest point on the triangle a,b,c to point p. The un-normalized
+/// normal vector (b-a)x(c-a) is precomputed and also passed in. Returns the
+/// distance to the mesh from the point and the barycentric coordinates on
+/// the triangle of the intersection.
+///
+/// \param [in]   p     reference point to get closest distance to
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [in]   n     pre-computed normal for triangle
+/// \param [out]  dist  the distance to the triangle
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      a code indicating that the closest point:
+///               - 0 does not exist (should not occur)
+///               - 1 is \a a
+///               - 2 is \a b
+///               - 3 is on the edge from \a a to \a b
+///               - 4 is \a c
+///               - 5 is on the edge from \a a to \a c
+///               - 6 is on the edge from \a b to \a c
+///               - 7 is on the face of the triangle
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
 mesh_triangle_closest_point( const vital::point_3d& p,
@@ -155,31 +147,29 @@ mesh_triangle_closest_point( const vital::point_3d& p,
                              double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
-
-/**
- * Find the closest point on the triangle a,b,c to point p. Returns the
- * distance to the mesh from the point and the barycentric coordinates on
- * the triangle of the intersection.
- *
- * \param [in]   p     reference point to get closest distance to
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [out]  dist  the distance to the triangle
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      a code indicating that the closest point:
- *               - 0 does not exist (should not occur)
- *               - 1 is \a a
- *               - 2 is \a b
- *               - 3 is on the edge from \a a to \a b
- *               - 4 is \a c
- *               - 5 is on the edge from \a a to \a c
- *               - 6 is on the edge from \a b to \a c
- *               - 7 is on the face of the triangle
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Find the closest point on the triangle a,b,c to point p. Returns the
+/// distance to the mesh from the point and the barycentric coordinates on
+/// the triangle of the intersection.
+///
+/// \param [in]   p     reference point to get closest distance to
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [out]  dist  the distance to the triangle
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      a code indicating that the closest point:
+///               - 0 does not exist (should not occur)
+///               - 1 is \a a
+///               - 2 is \a b
+///               - 3 is on the edge from \a a to \a b
+///               - 4 is \a c
+///               - 5 is on the edge from \a a to \a c
+///               - 6 is on the edge from \a b to \a c
+///               - 7 is on the face of the triangle
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
 mesh_triangle_closest_point( const vital::point_3d& p,
@@ -190,18 +180,16 @@ mesh_triangle_closest_point( const vital::point_3d& p,
                              double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
-
-/**
- * Find the closest point on the triangle a,b,c to point p. Returns the
- * distance to the mesh from the point and the closest point.
- *
- * \param [in]   p     reference point to get closest distance to
- * \param [in]   a     corner point of triangle
- * \param [in]   b     corner point of triangle
- * \param [in]   c     corner point of triangle
- * \param [out]  dist  the closest distance to the triangle
- * \returns      the point on the triangle closest to the reference point
- */
+///
+/// Find the closest point on the triangle a,b,c to point p. Returns the
+/// distance to the mesh from the point and the closest point.
+///
+/// \param [in]   p     reference point to get closest distance to
+/// \param [in]   a     corner point of triangle
+/// \param [in]   b     corner point of triangle
+/// \param [in]   c     corner point of triangle
+/// \param [out]  dist  the closest distance to the triangle
+/// \returns      the point on the triangle closest to the reference point
 KWIVER_ALGO_CORE_EXPORT
 vital::point_3d
 mesh_triangle_closest_point( const vital::point_3d& p,
@@ -211,24 +199,22 @@ mesh_triangle_closest_point( const vital::point_3d& p,
                              double& dist );
 
 /// Find the closest point on a triangulated mesh to a reference point
-
-/**
- * Find the closest point on the triangulated mesh to point p. Returns the
- * distance to the mesh from the point, the index of the mesh triangle
- * that the closest point is on, the closest point, and the barycentric
- * coordinates of the intersection on the triangle.
- *
- * \param [in]   p     reference point to get closest distance to
- * \param [in]   mesh  the mesh
- * \param [out]  cp    the closest point on the mesh
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      the face index of the closest triangle (one of them
- *               if on an edge or vertex). If the operation failed or is
- *               not possible -1 is returned.
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Find the closest point on the triangulated mesh to point p. Returns the
+/// distance to the mesh from the point, the index of the mesh triangle
+/// that the closest point is on, the closest point, and the barycentric
+/// coordinates of the intersection on the triangle.
+///
+/// \param [in]   p     reference point to get closest distance to
+/// \param [in]   mesh  the mesh
+/// \param [out]  cp    the closest point on the mesh
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      the face index of the closest triangle (one of them
+///               if on an edge or vertex). If the operation failed or is
+///               not possible -1 is returned.
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 int
 mesh_closest_point( const vital::point_3d& p,
@@ -237,25 +223,23 @@ mesh_closest_point( const vital::point_3d& p,
                     double& u, double& v );
 
 /// Intersect a ray from point to a triangulated mesh
-
-/**
- * Intersect the ray from point p with direction d and a triangulated mesh.
- * Returns the distance to the mesh from the point, the index of the mesh
- * triangle that the closest point is on, and the barycentric coordinates
- * of the intersection on the triangle.
- *
- * \param [in]   p     point that is the start of the ray
- * \param [in]   d     direction of the ray
- * \param [in]   mesh  the mesh
- * \param [out]  dist  the distance to the mesh
- * \param [out]  u     barycentric coordinate of the intersection
- * \param [out]  v     barycentric coordinate of the intersection
- * \returns      the face index of the intersected triangle (one of them
- *               if on an edge or vertex). If the operation failed or is
- *               not possible -1 is returned.
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
- * p+dist*d
- */
+///
+/// Intersect the ray from point p with direction d and a triangulated mesh.
+/// Returns the distance to the mesh from the point, the index of the mesh
+/// triangle that the closest point is on, and the barycentric coordinates
+/// of the intersection on the triangle.
+///
+/// \param [in]   p     point that is the start of the ray
+/// \param [in]   d     direction of the ray
+/// \param [in]   mesh  the mesh
+/// \param [out]  dist  the distance to the mesh
+/// \param [out]  u     barycentric coordinate of the intersection
+/// \param [out]  v     barycentric coordinate of the intersection
+/// \returns      the face index of the intersected triangle (one of them
+///               if on an edge or vertex). If the operation failed or is
+///               not possible -1 is returned.
+/// Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+/// p+dist*d
 KWIVER_ALGO_CORE_EXPORT
 int
 mesh_intersect( const vital::point_3d& p,

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -4,7 +4,8 @@
 
 /**
  * \file
- * \brief Operations to modify meshes
+ * \brief Operations to calculate closest points and ray intersections
+ *        to triangles and meshes
  */
 
 #ifndef KWIVER_ARROWS_CORE_MESH_INTERSECT_H
@@ -25,7 +26,8 @@ namespace core {
 
 /**
  * Intersect the ray from point p with direction d and the triangle
- * defined by a,b,c.
+ * defined by a,b,c. Returns the distance to the mesh from the point
+ * and the barycentric coordinates of the intersection on the triangle.
  *
  * \param [in]   p     point that is the start of the ray
  * \param [in]   d     direction of the ray
@@ -54,7 +56,8 @@ mesh_intersect_triangle( const vital::point_3d& p,
 /**
  * Intersect the ray from point p with direction d and the triangle defined
  * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
- * also passed in.
+ * also passed in. Returns the distance to the mesh from the point
+ * and the barycentric coordinates of the intersection on the triangle.
  *
  * \param [in]   p     point that is the start of the ray
  * \param [in]   d     direction of the ray
@@ -86,7 +89,9 @@ mesh_intersect_triangle( const vital::point_3d& p,
 /**
  * Intersect the ray from point p with direction d and the triangle defined
  * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
- * also passed in.
+ * also passed in. Returns the distance to the mesh from the point
+ * and the barycentric coordinates of the intersection on the triangle if
+ * the distance is smaller.
  *
  * \param [in]   p     point that is the start of the ray
  * \param [in]   d     direction of the ray
@@ -98,7 +103,7 @@ mesh_intersect_triangle( const vital::point_3d& p,
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs and the new dist is less than the
- * old distance (but > 0)
+ *                     old distance (but > 0)
  * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
  * p+dist*d
  */
@@ -117,7 +122,9 @@ mesh_intersect_triangle_min_dist( const vital::point_3d& p,
 
 /**
  * Find the closest point on the triangle a,b,c to point p. The un-normalized
- * normal vector (b-a)x(c-a) is precomputed and also passed in
+ * normal vector (b-a)x(c-a) is precomputed and also passed in. Returns the
+ * distance to the mesh from the point and the barycentric coordinates on
+ * the triangle of the intersection.
  *
  * \param [in]   p     reference point to get closest distance to
  * \param [in]   a     corner point of triangle
@@ -136,6 +143,8 @@ mesh_intersect_triangle_min_dist( const vital::point_3d& p,
  *               - 5 is on the edge from \a a to \a c
  *               - 6 is on the edge from \a b to \a c
  *               - 7 is on the face of the triangle
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
@@ -150,7 +159,9 @@ mesh_triangle_closest_point( const vital::point_3d& p,
 /// Find the closest point on the triangle to a reference point
 
 /**
- * Find the closest point on the triangle a,b,c to point p.
+ * Find the closest point on the triangle a,b,c to point p. Returns the
+ * distance to the mesh from the point and the barycentric coordinates on
+ * the triangle of the intersection.
  *
  * \param [in]   p     reference point to get closest distance to
  * \param [in]   a     corner point of triangle
@@ -168,6 +179,8 @@ mesh_triangle_closest_point( const vital::point_3d& p,
  *               - 5 is on the edge from \a a to \a c
  *               - 6 is on the edge from \a b to \a c
  *               - 7 is on the face of the triangle
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
@@ -181,7 +194,8 @@ mesh_triangle_closest_point( const vital::point_3d& p,
 /// Find the closest point on the triangle to a reference point
 
 /**
- * Find the closest point on the triangle a,b,c to point p
+ * Find the closest point on the triangle a,b,c to point p. Returns the
+ * distance to the mesh from the point and the closest point.
  *
  * \param [in]   p     reference point to get closest distance to
  * \param [in]   a     corner point of triangle
@@ -201,7 +215,10 @@ mesh_triangle_closest_point( const vital::point_3d& p,
 /// Find the closest point on a triangulated mesh to a reference point
 
 /**
- * Find the closest point on the triangulated mesh to point p.
+ * Find the closest point on the triangulated mesh to point p. Returns the
+ * distance to the mesh from the point, the index of the mesh triangle
+ * that the closest point is on, the closest point, and the barycentric
+ * coordinates of the intersection on the triangle.
  *
  * \param [in]   p     reference point to get closest distance to
  * \param [in]   mesh  the mesh
@@ -211,6 +228,8 @@ mesh_triangle_closest_point( const vital::point_3d& p,
  * \returns      the face index of the closest triangle (one of them
  *               if on an edge or vertex). If the operation failed or is
  *               not possible -1 is returned.
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 int
@@ -223,6 +242,9 @@ mesh_closest_point( const vital::point_3d& p,
 
 /**
  * Intersect the ray from point p with direction d and a triangulated mesh.
+ * Returns the distance to the mesh from the point, the index of the mesh
+ * triangle that the closest point is on, and the barycentric coordinates
+ * of the intersection on the triangle.
  *
  * \param [in]   p     point that is the start of the ray
  * \param [in]   d     direction of the ray
@@ -233,6 +255,8 @@ mesh_closest_point( const vital::point_3d& p,
  * \returns      the face index of the intersected triangle (one of them
  *               if on an edge or vertex). If the operation failed or is
  *               not possible -1 is returned.
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 int

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -46,7 +46,7 @@ mesh_intersect_triangle(const vital::point_3d& p,
                         double& u, double& v);
 
 
-/// Intersect the ray from point to a triangle
+/// Intersect a ray from point to a triangle
 /**
  * Intersect the ray from point p with direction d and the triangle defined
  * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
@@ -185,6 +185,48 @@ mesh_triangle_closest_point(const vital::point_3d& p,
                             const vital::point_3d& b,
                             const vital::point_3d& c,
                             double& dist);
+
+/// Find the closest point on a triangulated mesh to a reference point
+/**
+ * Find the closest point on the triangulated mesh to point p.
+ *
+ * \param [in]   p     reference point to get closest distance to
+ * \param [in]   mesh  the mesh
+ * \param [out]  cp    the closest point on the mesh
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      the face index of the closest triangle (one of them
+ *               if on an edge or vertex). If the operation failed or is
+ *               not possible -1 is returned.
+ */
+KWIVER_ALGO_CORE_EXPORT
+int
+mesh_closest_point(const vital::point_3d& p,
+                   const vital::mesh& mesh,
+                   vital::point_3d& cp,
+                   double& u, double& v);
+
+/// Intersect a ray from point to a triangulated mesh
+/**
+ * Intersect the ray from point p with direction d and a triangulated mesh.
+ *
+ * \param [in]   p     point that is the start of the ray
+ * \param [in]   d     direction of the ray
+ * \param [in]   mesh  the mesh
+ * \param [out]  dist  the distance to the mesh
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      the face index of the intersected triangle (one of them
+ *               if on an edge or vertex). If the operation failed or is
+ *               not possible -1 is returned.
+ */
+KWIVER_ALGO_CORE_EXPORT
+int
+mesh_intersect(const vital::point_3d& p,
+               const vital::vector_3d& d,
+               const vital::mesh& mesh,
+               double& dist,
+               double& u, double& v);
 
 }
 }

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -16,10 +16,13 @@
 #include <vital/types/point.h>
 
 namespace kwiver {
+
 namespace arrows {
+
 namespace core {
 
 /// Intersect the ray from point to a triangle
+
 /**
  * Intersect the ray from point p with direction d and the triangle
  * defined by a,b,c.
@@ -33,20 +36,21 @@ namespace core {
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 bool
-mesh_intersect_triangle(const vital::point_3d& p,
-                        const vital::vector_3d& d,
-                        const vital::point_3d& a,
-                        const vital::point_3d& b,
-                        const vital::point_3d& c,
-                        double& dist,
-                        double& u, double& v);
-
+mesh_intersect_triangle( const vital::point_3d& p,
+                         const vital::vector_3d& d,
+                         const vital::point_3d& a,
+                         const vital::point_3d& b,
+                         const vital::point_3d& c,
+                         double& dist,
+                         double& u, double& v );
 
 /// Intersect a ray from point to a triangle
+
 /**
  * Intersect the ray from point p with direction d and the triangle defined
  * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
@@ -62,20 +66,23 @@ mesh_intersect_triangle(const vital::point_3d& p,
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
  * \returns      true  if intersection occurs
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 bool
-mesh_intersect_triangle(const vital::point_3d& p,
-                        const vital::vector_3d& d,
-                        const vital::point_3d& a,
-                        const vital::point_3d& b,
-                        const vital::point_3d& c,
-                        const vital::vector_3d& n,
-                        double& dist,
-                        double& u, double& v);
+mesh_intersect_triangle( const vital::point_3d& p,
+                         const vital::vector_3d& d,
+                         const vital::point_3d& a,
+                         const vital::point_3d& b,
+                         const vital::point_3d& c,
+                         const vital::vector_3d& n,
+                         double& dist,
+                         double& u, double& v );
 
-/// Intersect the ray from point to a triangle and check if the distance is smaller
+/// Intersect the ray from point to a triangle and check if the distance is
+/// smaller
+
 /**
  * Intersect the ray from point p with direction d and the triangle defined
  * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
@@ -90,21 +97,24 @@ mesh_intersect_triangle(const vital::point_3d& p,
  * \param [out]  dist  the distance to the triangle
  * \param [out]  u     barycentric coordinate of the intersection
  * \param [out]  v     barycentric coordinate of the intersection
- * \returns      true  if intersection occurs and the new dist is less than the old distance (but > 0)
- * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ * \returns      true  if intersection occurs and the new dist is less than the
+ * old distance (but > 0)
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c =
+ * p+dist*d
  */
 KWIVER_ALGO_CORE_EXPORT
 bool
-mesh_intersect_triangle_min_dist(const vital::point_3d& p,
-                                 const vital::vector_3d& d,
-                                 const vital::point_3d& a,
-                                 const vital::point_3d& b,
-                                 const vital::point_3d& c,
-                                 const vital::vector_3d& n,
-                                 double& dist,
-                                 double& u, double& v);
+mesh_intersect_triangle_min_dist( const vital::point_3d& p,
+                                  const vital::vector_3d& d,
+                                  const vital::point_3d& a,
+                                  const vital::point_3d& b,
+                                  const vital::point_3d& c,
+                                  const vital::vector_3d& n,
+                                  double& dist,
+                                  double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
+
 /**
  * Find the closest point on the triangle a,b,c to point p. The un-normalized
  * normal vector (b-a)x(c-a) is precomputed and also passed in
@@ -129,15 +139,16 @@ mesh_intersect_triangle_min_dist(const vital::point_3d& p,
  */
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            const vital::vector_3d& n,
-                            double& dist,
-                            double& u, double& v);
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             const vital::vector_3d& n,
+                             double& dist,
+                             double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
+
 /**
  * Find the closest point on the triangle a,b,c to point p.
  *
@@ -160,14 +171,15 @@ mesh_triangle_closest_point(const vital::point_3d& p,
  */
 KWIVER_ALGO_CORE_EXPORT
 unsigned char
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            double& dist,
-                            double& u, double& v);
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             double& dist,
+                             double& u, double& v );
 
 /// Find the closest point on the triangle to a reference point
+
 /**
  * Find the closest point on the triangle a,b,c to point p
  *
@@ -180,13 +192,14 @@ mesh_triangle_closest_point(const vital::point_3d& p,
  */
 KWIVER_ALGO_CORE_EXPORT
 vital::point_3d
-mesh_triangle_closest_point(const vital::point_3d& p,
-                            const vital::point_3d& a,
-                            const vital::point_3d& b,
-                            const vital::point_3d& c,
-                            double& dist);
+mesh_triangle_closest_point( const vital::point_3d& p,
+                             const vital::point_3d& a,
+                             const vital::point_3d& b,
+                             const vital::point_3d& c,
+                             double& dist );
 
 /// Find the closest point on a triangulated mesh to a reference point
+
 /**
  * Find the closest point on the triangulated mesh to point p.
  *
@@ -201,12 +214,13 @@ mesh_triangle_closest_point(const vital::point_3d& p,
  */
 KWIVER_ALGO_CORE_EXPORT
 int
-mesh_closest_point(const vital::point_3d& p,
-                   const vital::mesh& mesh,
-                   vital::point_3d& cp,
-                   double& u, double& v);
+mesh_closest_point( const vital::point_3d& p,
+                    const vital::mesh& mesh,
+                    vital::point_3d& cp,
+                    double& u, double& v );
 
 /// Intersect a ray from point to a triangulated mesh
+
 /**
  * Intersect the ray from point p with direction d and a triangulated mesh.
  *
@@ -222,13 +236,15 @@ mesh_closest_point(const vital::point_3d& p,
  */
 KWIVER_ALGO_CORE_EXPORT
 int
-mesh_intersect(const vital::point_3d& p,
-               const vital::vector_3d& d,
-               const vital::mesh& mesh,
-               double& dist,
-               double& u, double& v);
+mesh_intersect( const vital::point_3d& p,
+                const vital::vector_3d& d,
+                const vital::mesh& mesh,
+                double& dist,
+                double& u, double& v );
 
-}
-}
-}
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver
 #endif // KWIVER_ARROWS_CORE_MESH_INTERSECT_H

--- a/arrows/core/mesh_intersect.h
+++ b/arrows/core/mesh_intersect.h
@@ -1,0 +1,110 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/**
+ * \file
+ * \brief Operations to modify meshes
+ */
+
+#ifndef KWIVER_ARROWS_CORE_MESH_INTERSECT_H
+#define KWIVER_ARROWS_CORE_MESH_INTERSECT_H
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/types/mesh.h>
+#include <vital/types/point.h>
+
+namespace kwiver {
+namespace arrows {
+namespace core {
+
+/// Intersect the ray from point to a triangle
+/**
+ * Intersect the ray from point p with direction d and the triangle
+ * defined by a,b,c.
+ *
+ * \param [in]   p     point that is the start of the ray
+ * \param [in]   d     direction of the ray
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [out]  dist  is the distance to the triangle
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      true  if intersection occurs
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ */
+KWIVER_ALGO_CORE_EXPORT
+bool
+mesh_intersect_triangle(const vital::point_3d& p,
+                        const vital::vector_3d& d,
+                        const vital::point_3d& a,
+                        const vital::point_3d& b,
+                        const vital::point_3d& c,
+                        double& dist,
+                        double& u, double& v);
+
+
+/// Intersect the ray from point to a triangle
+/**
+ * Intersect the ray from point p with direction d and the triangle defined
+ * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
+ * also passed in.
+ *
+ * \param [in]   p     point that is the start of the ray
+ * \param [in]   d     direction of the ray
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [in]   n     pre-computed normal for triangle
+ * \param [out]  dist  is the distance to the triangle
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      true  if intersection occurs
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ */
+KWIVER_ALGO_CORE_EXPORT
+bool
+mesh_intersect_triangle(const vital::point_3d& p,
+                        const vital::vector_3d& d,
+                        const vital::point_3d& a,
+                        const vital::point_3d& b,
+                        const vital::point_3d& c,
+                        const vital::vector_3d& n,
+                        double& dist,
+                        double& u, double& v);
+
+/// Intersect the ray from point to a triangle and check if the distance is smaller
+/**
+ * Intersect the ray from point p with direction d and the triangle defined
+ * by a,b,c. The un-normalized normal vector (b-a)x(c-a) is precomputed and
+ * also passed in.
+ *
+ * \param [in]   p     point that is the start of the ray
+ * \param [in]   d     direction of the ray
+ * \param [in]   a     corner point of triangle
+ * \param [in]   b     corner point of triangle
+ * \param [in]   c     corner point of triangle
+ * \param [in]   n     pre-computed normal for triangle
+ * \param [out]  dist  is the distance to the triangle
+ * \param [out]  u     barycentric coordinate of the intersection
+ * \param [out]  v     barycentric coordinate of the intersection
+ * \returns      true  if intersection occurs and the new dist is less than the old distance (but > 0)
+ * Barycentric coordinates are u and v such that (1-u-v)*a + u*b + v*c = p+dist*d
+ */
+KWIVER_ALGO_CORE_EXPORT
+bool
+mesh_intersect_triangle_min_dist(const vital::point_3d& p,
+                                 const vital::vector_3d& d,
+                                 const vital::point_3d& a,
+                                 const vital::point_3d& b,
+                                 const vital::point_3d& c,
+                                 const vital::vector_3d& n,
+                                 double& dist,
+                                 double& u, double& v);
+
+}
+}
+}
+#endif // KWIVER_ARROWS_CORE_MESH_INTERSECT_H

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ kwiver_discover_gtests(core detected_object_io        LIBRARIES ${test_libraries
 kwiver_discover_gtests(core dynamic_configuration     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core feature_descriptor_io     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core interpolate_track_spline  LIBRARIES ${test_libraries})
+kwiver_discover_gtests(core mesh_intersect            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core mesh_operations           LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core render_mesh_depth_map     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core track_set_impl            LIBRARIES ${test_libraries})

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -45,3 +45,60 @@ TEST(mesh_intersect, intersect_triangle)
 
   EXPECT_FALSE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
 }
+
+// ----------------------------------------------------------------------------
+TEST(mesh_intersect, triangle_closest_point)
+{
+  point_3d a(0,0,0), b(3,0,0), c(-1,1,0);
+  point_3d p1(0,0.25,2); // cp inside
+  point_3d p2(0.5,-1,-1); // cp on ab
+  point_3d p3(-0.5,-1,-1); // cp on a
+  point_3d p4(4,-1,2); // cp on b
+  point_3d p5(3,1,-2); // cp on bc
+  point_3d p6(-1,2,-2); // cp on c
+  point_3d p7(-1,0,-3); // cp on ac
+  double u,v,dist;
+
+  unsigned char i = mesh_triangle_closest_point(p1, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 7);
+  EXPECT_NEAR(dist, 2., 1e-14);
+  point_3d cp = mesh_triangle_closest_point(p1, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  point_3d(0,0.25,0).value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p2, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 3);
+  EXPECT_NEAR(dist, std::sqrt(2.), 1e-14);
+  cp = mesh_triangle_closest_point(p2, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  point_3d(0.5,0,0).value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p3, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 1);
+  EXPECT_NEAR(dist, 1.5, 1e-14);
+  cp = mesh_triangle_closest_point(p3, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  a.value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p4, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 2);
+  EXPECT_NEAR(dist, std::sqrt(6.), 1e-14);
+  cp = mesh_triangle_closest_point(p4, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  b.value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p5, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 6);
+  point_3d exp_cp(2.75 + 0.25/17., 1./17., 0);
+  EXPECT_NEAR(dist, (exp_cp.value() - p5.value()).norm(), 1e-14);
+  cp = mesh_triangle_closest_point(p5, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p6, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 4);
+  EXPECT_NEAR(dist, std::sqrt(5.), 1e-14);
+  cp = mesh_triangle_closest_point(p6, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  c.value()).norm(), 0., 1e-14);
+
+  i = mesh_triangle_closest_point(p7, a, b, c, dist, u, v);
+  EXPECT_EQ(i, 5);
+  EXPECT_NEAR(dist, std::sqrt(9.5), 1e-14);
+  cp = mesh_triangle_closest_point(p7, a, b, c, dist);
+  EXPECT_NEAR( (cp.value() -  point_3d(-0.5,0.5,0).value()).norm(), 0., 1e-14);
+}

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -20,6 +20,30 @@ int main(int argc, char** argv)
 }
 
 // ----------------------------------------------------------------------------
+kwiver::vital::mesh_sptr generate_mesh()
+{
+  std::unique_ptr<mesh_vertex_array_base>
+    verts(new mesh_vertex_array<3>(
+  {
+    {0, 0, 0},
+    {2, 0, 0},
+    {0, 1, 0},
+    {0, 0, 1}
+  }));
+
+  std::unique_ptr<mesh_regular_face_array<3>>
+    faces(new mesh_regular_face_array<3>(
+  {
+    {0, 2, 1},
+    {0, 1, 3},
+    {0, 3, 2},
+    {1, 2, 3}
+  }));
+
+  return std::make_shared<mesh>(std::move(verts), std::move(faces));
+}
+
+// ----------------------------------------------------------------------------
 TEST(mesh_intersect, intersect_triangle)
 {
   point_3d p(2,3,4);
@@ -115,4 +139,90 @@ TEST(mesh_intersect, triangle_closest_point)
   EXPECT_NEAR(dist, std::sqrt(9.5), 1e-14);
   cp = mesh_triangle_closest_point(p7, a, b, c, dist);
   EXPECT_NEAR( (cp.value() -  point_3d(-0.5,0.5,0).value()).norm(), 0., 1e-14);
+}
+
+// ----------------------------------------------------------------------------
+TEST(mesh_intersect, mesh_closest_point)
+{
+  // Mesh
+  mesh_sptr mesh = generate_mesh();
+
+  point_3d p1(1, 1, 1); // On face 3
+  point_3d p2(1, 0, -1); // On edge of face 0 and 1
+  point_3d p3(0, 1, 1); // On edge of face 2
+  point_3d p4(-0.1, -0.1, -0.1); // At corner shared by 0, 1, and 2
+  point_3d p5(0.1, 0.25, 0.25); // Inside mesh, on face 2
+  point_3d cp(0, 0, 0);
+  double u = 0., v = 0.;
+
+  EXPECT_EQ(mesh_closest_point(p1, *mesh, cp, u, v), 3);
+  EXPECT_NEAR(u, 1./3., 1e-14);
+  EXPECT_NEAR(v, 1./3., 1e-14);
+  point_3d exp_cp(2./3., 1./3., 1./3.);
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+
+  EXPECT_EQ(mesh_closest_point(p2, *mesh, cp, u, v), 0);
+  EXPECT_NEAR(u, 0.0, 1e-14);
+  EXPECT_NEAR(v, 0.5, 1e-14);
+  exp_cp.set_value({1., 0., 0.});
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+
+  EXPECT_EQ(mesh_closest_point(p3, *mesh, cp, u, v), 2);
+  EXPECT_NEAR(u, 0.5, 1e-14);
+  EXPECT_NEAR(v, 0.5, 1e-14);
+  exp_cp.set_value({0.0, 0.5, 0.5});
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+
+  EXPECT_EQ(mesh_closest_point(p4, *mesh, cp, u, v), 0);
+  EXPECT_NEAR(u, 0.0, 1e-14);
+  EXPECT_NEAR(v, 0.0, 1e-14);
+  exp_cp.set_value({0.0, 0.0, 0.0});
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+
+  EXPECT_EQ(mesh_closest_point(p5, *mesh, cp, u, v), 2);
+  EXPECT_NEAR(u, 0.25, 1e-14);
+  EXPECT_NEAR(v, 0.25, 1e-14);
+  exp_cp.set_value({0.0, 0.25, 0.25});
+  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+}
+
+// ----------------------------------------------------------------------------
+TEST(mesh_intersect, mesh_intersect)
+{
+  // Mesh
+  mesh_sptr mesh = generate_mesh();
+
+  point_3d p1(1, 1, 1); // Intersects face 3
+  vector_3d d1(0, -1, -1);
+  d1.normalize();
+  point_3d p2(-1, 0.5, 0.5); // Intersects edge of face 2
+  vector_3d d2(1, 0, 0);
+  point_3d p3(1, 0.4, -0.5); // Intersects face 0
+  vector_3d d3(0, 0, 1);
+  point_3d p4(2, 1, 1); // Parallel to face 3
+  vector_3d d4(-2, 1, 1);
+  d4.normalize();
+  double dist = std::numeric_limits<double>::infinity();
+  double u = 0., v = 0.;
+
+  // Errors out due to lack of normals
+  EXPECT_EQ(mesh_intersect(p1, d1, *mesh, dist, u, v), -1);
+
+  mesh->compute_face_normals(false);
+  EXPECT_EQ(mesh_intersect(p1, d1, *mesh, dist, u, v), 3);
+  EXPECT_NEAR(u, 0.25, 1e-14);
+  EXPECT_NEAR(v, 0.25, 1e-14);
+  EXPECT_NEAR(dist, 0.75*std::sqrt(2.), 1e-14);
+
+  EXPECT_EQ(mesh_intersect(p2, d2, *mesh, dist, u, v), 2);
+  EXPECT_NEAR(u, 0.5, 1e-14);
+  EXPECT_NEAR(v, 0.5, 1e-14);
+  EXPECT_NEAR(dist, 1.0, 1e-14);
+
+  EXPECT_EQ(mesh_intersect(p3, d3, *mesh, dist, u, v), 0);
+  EXPECT_NEAR(u, 0.4, 1e-14);
+  EXPECT_NEAR(v, 0.5, 1e-14);
+  EXPECT_NEAR(dist, 0.5, 1e-14);
+
+  EXPECT_EQ(mesh_intersect(p4, d4, *mesh, dist, u, v), -1);
 }

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -44,6 +44,20 @@ TEST(mesh_intersect, intersect_triangle)
   dist2 -= 0.001;
 
   EXPECT_FALSE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
+
+  // Test triangle in different plane
+  p = {2,1,1};
+  d = {-1,0,0};
+  a = {0,0,0}, b = {0,3,0}, c = {0,0,2};
+  n = (b.value()-a.value()).cross(c.value()-a.value());
+  dist = std::numeric_limits<double>::infinity();
+
+  EXPECT_TRUE( mesh_intersect_triangle(p, d, a, b, c, n, dist, u1, v1) );
+
+  r1 = p.value() + dist*d;
+  r2 = (1 - u1 - v1)*a.value() + u1*b.value() + v1*c.value();
+
+  EXPECT_NEAR( (r2 - r1).norm(), 0.0, 1e-14 );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -1,0 +1,47 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#include <gtest/gtest.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <arrows/core/mesh_intersect.h>
+#include <Eigen/Geometry>
+
+using namespace kwiver::vital;
+using namespace kwiver::arrows::core;
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(mesh_intersect, intersect_triangle)
+{
+  point_3d p(2,3,4);
+  vector_3d d(-2,-3,-4);
+  d.normalize();
+  point_3d a(2,0,0), b(-1,1,0), c(0,-3,0);
+
+  vector_3d n((b.value()-a.value()).cross(c.value()-a.value()));
+  double dist = std::numeric_limits<double>::infinity();
+  double dist2 = dist;
+  double u1, v1, u2, v2;
+
+  EXPECT_TRUE( mesh_intersect_triangle(p, d, a, b, c, n, dist, u1, v1) );
+
+  vector_3d r1 = p.value() + dist*d;
+  vector_3d r2 = (1 - u1 - v1)*a.value() + u1*b.value() + v1*c.value();
+
+  EXPECT_NEAR( (r2 - r1).norm(), 0.0, 1e-14 );
+
+  EXPECT_TRUE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
+
+  dist2 -= 0.001;
+
+  EXPECT_FALSE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
+}

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -7,6 +7,7 @@
 #include <vital/plugin_loader/plugin_manager.h>
 
 #include <arrows/core/mesh_intersect.h>
+
 #include <Eigen/Geometry>
 
 using namespace kwiver::vital;
@@ -141,7 +142,6 @@ TEST ( mesh_intersect, triangle_closest_point )
 // ----------------------------------------------------------------------------
 TEST ( mesh_intersect, mesh_closest_point )
 {
-  // Mesh
   mesh_sptr mesh = generate_mesh();
 
   point_3d p1( 1, 1, 1 ); // On face 3
@@ -187,7 +187,6 @@ TEST ( mesh_intersect, mesh_closest_point )
 
 TEST ( mesh_intersect, mesh_intersect )
 {
-  // Mesh
   mesh_sptr mesh = generate_mesh();
 
   point_3d p1( 1, 1, 1 ); // Intersects face 3

--- a/arrows/core/tests/test_mesh_intersect.cxx
+++ b/arrows/core/tests/test_mesh_intersect.cxx
@@ -13,216 +13,214 @@ using namespace kwiver::vital;
 using namespace kwiver::arrows::core;
 
 // ----------------------------------------------------------------------------
-int main(int argc, char** argv)
+int
+main( int argc, char** argv )
 {
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
 }
 
 // ----------------------------------------------------------------------------
-kwiver::vital::mesh_sptr generate_mesh()
+kwiver::vital::mesh_sptr
+generate_mesh()
 {
-  std::unique_ptr<mesh_vertex_array_base>
-    verts(new mesh_vertex_array<3>(
-  {
-    {0, 0, 0},
-    {2, 0, 0},
-    {0, 1, 0},
-    {0, 0, 1}
-  }));
+  std::unique_ptr< mesh_vertex_array_base >
+  verts( new mesh_vertex_array< 3 >( { { 0, 0, 0 }, { 2, 0, 0 }, { 0, 1, 0 },
+                                       { 0, 0, 1 } } ) );
 
-  std::unique_ptr<mesh_regular_face_array<3>>
-    faces(new mesh_regular_face_array<3>(
-  {
-    {0, 2, 1},
-    {0, 1, 3},
-    {0, 3, 2},
-    {1, 2, 3}
-  }));
+  std::unique_ptr< mesh_regular_face_array< 3 > >
+  faces( new mesh_regular_face_array< 3 >( { { 0, 2, 1 }, { 0, 1, 3 },
+                                             { 0, 3, 2 }, { 1, 2, 3 } } ) );
 
-  return std::make_shared<mesh>(std::move(verts), std::move(faces));
+  return std::make_shared< mesh >( std::move( verts ), std::move( faces ) );
 }
 
 // ----------------------------------------------------------------------------
-TEST(mesh_intersect, intersect_triangle)
+TEST ( mesh_intersect, intersect_triangle )
 {
-  point_3d p(2,3,4);
-  vector_3d d(-2,-3,-4);
+  point_3d p( 2, 3, 4 );
+  vector_3d d( -2, -3, -4 );
   d.normalize();
-  point_3d a(2,0,0), b(-1,1,0), c(0,-3,0);
+  point_3d a( 2, 0, 0 ), b( -1, 1, 0 ), c( 0, -3, 0 );
 
-  vector_3d n((b.value()-a.value()).cross(c.value()-a.value()));
-  double dist = std::numeric_limits<double>::infinity();
+  vector_3d n( ( b.value() - a.value() ).cross( c.value() - a.value() ) );
+  double dist = std::numeric_limits< double >::infinity();
   double dist2 = dist;
   double u1, v1, u2, v2;
 
-  EXPECT_TRUE( mesh_intersect_triangle(p, d, a, b, c, n, dist, u1, v1) );
+  EXPECT_TRUE( mesh_intersect_triangle( p, d, a, b, c, n, dist, u1, v1 ) );
 
-  vector_3d r1 = p.value() + dist*d;
-  vector_3d r2 = (1 - u1 - v1)*a.value() + u1*b.value() + v1*c.value();
+  vector_3d r1 = p.value() + dist * d;
+  vector_3d r2 = ( 1 - u1 - v1 ) * a.value() + u1 * b.value() + v1 * c.value();
 
-  EXPECT_NEAR( (r2 - r1).norm(), 0.0, 1e-14 );
+  EXPECT_NEAR( ( r2 - r1 ).norm(), 0.0, 1e-14 );
 
-  EXPECT_TRUE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
+  EXPECT_TRUE( mesh_intersect_triangle_min_dist( p, d, a, b, c, n, dist2, u2,
+                                                 v2 ) );
 
   dist2 -= 0.001;
 
-  EXPECT_FALSE( mesh_intersect_triangle_min_dist(p, d, a, b, c, n, dist2, u2, v2) );
+  EXPECT_FALSE( mesh_intersect_triangle_min_dist( p, d, a, b, c, n, dist2, u2,
+                                                  v2 ) );
 
   // Test triangle in different plane
-  p = {2,1,1};
-  d = {-1,0,0};
-  a = {0,0,0}, b = {0,3,0}, c = {0,0,2};
-  n = (b.value()-a.value()).cross(c.value()-a.value());
-  dist = std::numeric_limits<double>::infinity();
+  p = { 2, 1, 1 };
+  d = { -1, 0, 0 };
+  a = { 0, 0, 0 }, b = { 0, 3, 0 }, c = { 0, 0, 2 };
+  n = ( b.value() - a.value() ).cross( c.value() - a.value() );
+  dist = std::numeric_limits< double >::infinity();
 
-  EXPECT_TRUE( mesh_intersect_triangle(p, d, a, b, c, n, dist, u1, v1) );
+  EXPECT_TRUE( mesh_intersect_triangle( p, d, a, b, c, n, dist, u1, v1 ) );
 
-  r1 = p.value() + dist*d;
-  r2 = (1 - u1 - v1)*a.value() + u1*b.value() + v1*c.value();
+  r1 = p.value() + dist * d;
+  r2 = ( 1 - u1 - v1 ) * a.value() + u1 * b.value() + v1 * c.value();
 
-  EXPECT_NEAR( (r2 - r1).norm(), 0.0, 1e-14 );
+  EXPECT_NEAR( ( r2 - r1 ).norm(), 0.0, 1e-14 );
 }
 
 // ----------------------------------------------------------------------------
-TEST(mesh_intersect, triangle_closest_point)
+TEST ( mesh_intersect, triangle_closest_point )
 {
-  point_3d a(0,0,0), b(3,0,0), c(-1,1,0);
-  point_3d p1(0,0.25,2); // cp inside
-  point_3d p2(0.5,-1,-1); // cp on ab
-  point_3d p3(-0.5,-1,-1); // cp on a
-  point_3d p4(4,-1,2); // cp on b
-  point_3d p5(3,1,-2); // cp on bc
-  point_3d p6(-1,2,-2); // cp on c
-  point_3d p7(-1,0,-3); // cp on ac
-  double u,v,dist;
+  point_3d a( 0, 0, 0 ), b( 3, 0, 0 ), c( -1, 1, 0 );
+  point_3d p1( 0, 0.25, 2 ); // cp inside
+  point_3d p2( 0.5, -1, -1 ); // cp on ab
+  point_3d p3( -0.5, -1, -1 ); // cp on a
+  point_3d p4( 4, -1, 2 ); // cp on b
+  point_3d p5( 3, 1, -2 ); // cp on bc
+  point_3d p6( -1, 2, -2 ); // cp on c
+  point_3d p7( -1, 0, -3 ); // cp on ac
+  double u, v, dist;
 
-  unsigned char i = mesh_triangle_closest_point(p1, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 7);
-  EXPECT_NEAR(dist, 2., 1e-14);
-  point_3d cp = mesh_triangle_closest_point(p1, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  point_3d(0,0.25,0).value()).norm(), 0., 1e-14);
+  unsigned char i = mesh_triangle_closest_point( p1, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 7 );
+  EXPECT_NEAR( dist, 2., 1e-14 );
+  point_3d cp = mesh_triangle_closest_point( p1, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  point_3d( 0, 0.25,
+                                         0 ).value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p2, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 3);
-  EXPECT_NEAR(dist, std::sqrt(2.), 1e-14);
-  cp = mesh_triangle_closest_point(p2, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  point_3d(0.5,0,0).value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p2, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 3 );
+  EXPECT_NEAR( dist, std::sqrt( 2. ), 1e-14 );
+  cp = mesh_triangle_closest_point( p2, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  point_3d( 0.5, 0,
+                                         0 ).value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p3, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 1);
-  EXPECT_NEAR(dist, 1.5, 1e-14);
-  cp = mesh_triangle_closest_point(p3, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  a.value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p3, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 1 );
+  EXPECT_NEAR( dist, 1.5, 1e-14 );
+  cp = mesh_triangle_closest_point( p3, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  a.value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p4, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 2);
-  EXPECT_NEAR(dist, std::sqrt(6.), 1e-14);
-  cp = mesh_triangle_closest_point(p4, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  b.value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p4, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 2 );
+  EXPECT_NEAR( dist, std::sqrt( 6. ), 1e-14 );
+  cp = mesh_triangle_closest_point( p4, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  b.value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p5, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 6);
-  point_3d exp_cp(2.75 + 0.25/17., 1./17., 0);
-  EXPECT_NEAR(dist, (exp_cp.value() - p5.value()).norm(), 1e-14);
-  cp = mesh_triangle_closest_point(p5, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p5, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 6 );
+  point_3d exp_cp( 2.75 + 0.25 / 17., 1. / 17., 0 );
+  EXPECT_NEAR( dist, ( exp_cp.value() - p5.value() ).norm(), 1e-14 );
+  cp = mesh_triangle_closest_point( p5, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p6, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 4);
-  EXPECT_NEAR(dist, std::sqrt(5.), 1e-14);
-  cp = mesh_triangle_closest_point(p6, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  c.value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p6, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 4 );
+  EXPECT_NEAR( dist, std::sqrt( 5. ), 1e-14 );
+  cp = mesh_triangle_closest_point( p6, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  c.value() ).norm(), 0., 1e-14 );
 
-  i = mesh_triangle_closest_point(p7, a, b, c, dist, u, v);
-  EXPECT_EQ(i, 5);
-  EXPECT_NEAR(dist, std::sqrt(9.5), 1e-14);
-  cp = mesh_triangle_closest_point(p7, a, b, c, dist);
-  EXPECT_NEAR( (cp.value() -  point_3d(-0.5,0.5,0).value()).norm(), 0., 1e-14);
+  i = mesh_triangle_closest_point( p7, a, b, c, dist, u, v );
+  EXPECT_EQ( i, 5 );
+  EXPECT_NEAR( dist, std::sqrt( 9.5 ), 1e-14 );
+  cp = mesh_triangle_closest_point( p7, a, b, c, dist );
+  EXPECT_NEAR( ( cp.value() -  point_3d( -0.5, 0.5,
+                                         0 ).value() ).norm(), 0., 1e-14 );
 }
 
 // ----------------------------------------------------------------------------
-TEST(mesh_intersect, mesh_closest_point)
+TEST ( mesh_intersect, mesh_closest_point )
 {
   // Mesh
   mesh_sptr mesh = generate_mesh();
 
-  point_3d p1(1, 1, 1); // On face 3
-  point_3d p2(1, 0, -1); // On edge of face 0 and 1
-  point_3d p3(0, 1, 1); // On edge of face 2
-  point_3d p4(-0.1, -0.1, -0.1); // At corner shared by 0, 1, and 2
-  point_3d p5(0.1, 0.25, 0.25); // Inside mesh, on face 2
-  point_3d cp(0, 0, 0);
+  point_3d p1( 1, 1, 1 ); // On face 3
+  point_3d p2( 1, 0, -1 ); // On edge of face 0 and 1
+  point_3d p3( 0, 1, 1 ); // On edge of face 2
+  point_3d p4( -0.1, -0.1, -0.1 ); // At corner shared by 0, 1, and 2
+  point_3d p5( 0.1, 0.25, 0.25 ); // Inside mesh, on face 2
+  point_3d cp( 0, 0, 0 );
   double u = 0., v = 0.;
 
-  EXPECT_EQ(mesh_closest_point(p1, *mesh, cp, u, v), 3);
-  EXPECT_NEAR(u, 1./3., 1e-14);
-  EXPECT_NEAR(v, 1./3., 1e-14);
-  point_3d exp_cp(2./3., 1./3., 1./3.);
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  EXPECT_EQ( mesh_closest_point( p1, *mesh, cp, u, v ), 3 );
+  EXPECT_NEAR( u, 1. / 3., 1e-14 );
+  EXPECT_NEAR( v, 1. / 3., 1e-14 );
+  point_3d exp_cp( 2. / 3., 1. / 3., 1. / 3. );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 
-  EXPECT_EQ(mesh_closest_point(p2, *mesh, cp, u, v), 0);
-  EXPECT_NEAR(u, 0.0, 1e-14);
-  EXPECT_NEAR(v, 0.5, 1e-14);
-  exp_cp.set_value({1., 0., 0.});
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  EXPECT_EQ( mesh_closest_point( p2, *mesh, cp, u, v ), 0 );
+  EXPECT_NEAR( u, 0.0, 1e-14 );
+  EXPECT_NEAR( v, 0.5, 1e-14 );
+  exp_cp.set_value( { 1., 0., 0. } );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 
-  EXPECT_EQ(mesh_closest_point(p3, *mesh, cp, u, v), 2);
-  EXPECT_NEAR(u, 0.5, 1e-14);
-  EXPECT_NEAR(v, 0.5, 1e-14);
-  exp_cp.set_value({0.0, 0.5, 0.5});
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  EXPECT_EQ( mesh_closest_point( p3, *mesh, cp, u, v ), 2 );
+  EXPECT_NEAR( u, 0.5, 1e-14 );
+  EXPECT_NEAR( v, 0.5, 1e-14 );
+  exp_cp.set_value( { 0.0, 0.5, 0.5 } );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 
-  EXPECT_EQ(mesh_closest_point(p4, *mesh, cp, u, v), 0);
-  EXPECT_NEAR(u, 0.0, 1e-14);
-  EXPECT_NEAR(v, 0.0, 1e-14);
-  exp_cp.set_value({0.0, 0.0, 0.0});
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  EXPECT_EQ( mesh_closest_point( p4, *mesh, cp, u, v ), 0 );
+  EXPECT_NEAR( u, 0.0, 1e-14 );
+  EXPECT_NEAR( v, 0.0, 1e-14 );
+  exp_cp.set_value( { 0.0, 0.0, 0.0 } );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 
-  EXPECT_EQ(mesh_closest_point(p5, *mesh, cp, u, v), 2);
-  EXPECT_NEAR(u, 0.25, 1e-14);
-  EXPECT_NEAR(v, 0.25, 1e-14);
-  exp_cp.set_value({0.0, 0.25, 0.25});
-  EXPECT_NEAR( (cp.value() -  exp_cp.value()).norm(), 0., 1e-14);
+  EXPECT_EQ( mesh_closest_point( p5, *mesh, cp, u, v ), 2 );
+  EXPECT_NEAR( u, 0.25, 1e-14 );
+  EXPECT_NEAR( v, 0.25, 1e-14 );
+  exp_cp.set_value( { 0.0, 0.25, 0.25 } );
+  EXPECT_NEAR( ( cp.value() -  exp_cp.value() ).norm(), 0., 1e-14 );
 }
 
 // ----------------------------------------------------------------------------
-TEST(mesh_intersect, mesh_intersect)
+
+TEST ( mesh_intersect, mesh_intersect )
 {
   // Mesh
   mesh_sptr mesh = generate_mesh();
 
-  point_3d p1(1, 1, 1); // Intersects face 3
-  vector_3d d1(0, -1, -1);
+  point_3d p1( 1, 1, 1 ); // Intersects face 3
+  vector_3d d1( 0, -1, -1 );
   d1.normalize();
-  point_3d p2(-1, 0.5, 0.5); // Intersects edge of face 2
-  vector_3d d2(1, 0, 0);
-  point_3d p3(1, 0.4, -0.5); // Intersects face 0
-  vector_3d d3(0, 0, 1);
-  point_3d p4(2, 1, 1); // Parallel to face 3
-  vector_3d d4(-2, 1, 1);
+  point_3d p2( -1, 0.5, 0.5 ); // Intersects edge of face 2
+  vector_3d d2( 1, 0, 0 );
+  point_3d p3( 1, 0.4, -0.5 ); // Intersects face 0
+  vector_3d d3( 0, 0, 1 );
+  point_3d p4( 2, 1, 1 ); // Parallel to face 3
+  vector_3d d4( -2, 1, 1 );
   d4.normalize();
-  double dist = std::numeric_limits<double>::infinity();
+  double dist = std::numeric_limits< double >::infinity();
   double u = 0., v = 0.;
 
   // Errors out due to lack of normals
-  EXPECT_EQ(mesh_intersect(p1, d1, *mesh, dist, u, v), -1);
+  EXPECT_EQ( mesh_intersect( p1, d1, *mesh, dist, u, v ), -1 );
 
-  mesh->compute_face_normals(false);
-  EXPECT_EQ(mesh_intersect(p1, d1, *mesh, dist, u, v), 3);
-  EXPECT_NEAR(u, 0.25, 1e-14);
-  EXPECT_NEAR(v, 0.25, 1e-14);
-  EXPECT_NEAR(dist, 0.75*std::sqrt(2.), 1e-14);
+  mesh->compute_face_normals( false );
+  EXPECT_EQ( mesh_intersect( p1, d1, *mesh, dist, u, v ), 3 );
+  EXPECT_NEAR( u, 0.25, 1e-14 );
+  EXPECT_NEAR( v, 0.25, 1e-14 );
+  EXPECT_NEAR( dist, 0.75 * std::sqrt( 2. ), 1e-14 );
 
-  EXPECT_EQ(mesh_intersect(p2, d2, *mesh, dist, u, v), 2);
-  EXPECT_NEAR(u, 0.5, 1e-14);
-  EXPECT_NEAR(v, 0.5, 1e-14);
-  EXPECT_NEAR(dist, 1.0, 1e-14);
+  EXPECT_EQ( mesh_intersect( p2, d2, *mesh, dist, u, v ), 2 );
+  EXPECT_NEAR( u, 0.5, 1e-14 );
+  EXPECT_NEAR( v, 0.5, 1e-14 );
+  EXPECT_NEAR( dist, 1.0, 1e-14 );
 
-  EXPECT_EQ(mesh_intersect(p3, d3, *mesh, dist, u, v), 0);
-  EXPECT_NEAR(u, 0.4, 1e-14);
-  EXPECT_NEAR(v, 0.5, 1e-14);
-  EXPECT_NEAR(dist, 0.5, 1e-14);
+  EXPECT_EQ( mesh_intersect( p3, d3, *mesh, dist, u, v ), 0 );
+  EXPECT_NEAR( u, 0.4, 1e-14 );
+  EXPECT_NEAR( v, 0.5, 1e-14 );
+  EXPECT_NEAR( dist, 0.5, 1e-14 );
 
-  EXPECT_EQ(mesh_intersect(p4, d4, *mesh, dist, u, v), -1);
+  EXPECT_EQ( mesh_intersect( p4, d4, *mesh, dist, u, v ), -1 );
 }


### PR DESCRIPTION
Ported several routines from VXL to calculate the closest point and ray intersections with triangles and full meshes. All the tests were ported as well. The ```mesh_intersect``` and ```mesh_closest_point``` routines were renamed to better reflect what those routines are doing. New tests had to be created for those routines since no tests existed for those routines in VXL. 