### PR TITLE
Implement reading and writing KLV integer formats

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -6,9 +6,9 @@ set( sources
   convert_metadata.cxx
   convert_0601_metadata.cxx
   convert_0104_metadata.cxx
-  klv_parse.cxx
   klv_data.cxx
   klv_key.cxx
+  klv_parse.cxx
   klv_0601.cxx
   klv_0104.cxx
   misp_time.cxx
@@ -16,9 +16,9 @@ set( sources
 
 set( public_headers
   convert_metadata.h
-  klv_parse.h
   klv_data.h
   klv_key.h
+  klv_parse.h
   klv_0601.h
   klv_0104.h
   misp_time.h

--- a/arrows/klv/klv_read_write.h
+++ b/arrows/klv/klv_read_write.h
@@ -1,0 +1,210 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Interface to the basic KLV read/write functions.
+
+// This file currently handles the serialization / deserialization of three
+// basic formats of KLV data:
+// - int : General signed or unsigned integer of any integral byte length up to
+// 8. Important to get this one precisely right because it's the base of most
+// KLV data. Written MSB first.
+// - BER : Unsigned integer which encodes its own length. Up to 127 is
+// identical to standard int, otherwise the first byte encodes the number of
+// following bytes.
+// - BER-OID : Unsigned integer which encodes its own length. First bit of each
+// byte signals whether there is another following byte; lower seven bits
+// concatenated together form the actual value.
+//
+// The functions are templated to be able to handle any iterator type (pointer,
+// std::vector, std::deque, etc), different native integer sizes (uint8_t ...
+// uint64_t), and different KLV integer sizes (1 ... 8). This hopefully allows
+// these functions to be reused in every KLV standard.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_READ_WRITE_H_
+#define KWIVER_ARROWS_KLV_KLV_READ_WRITE_H_
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <cstdlib>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ---------------------------------------------------------------------------
+/// Read an integer from a sequence of bytes (big-endian).
+///
+/// This function handles signed and unsigned integers as well as values of \p
+/// length which are not powers of 2. It assumes there are \p length bytes
+/// available in the source buffer pointed to by \p data.
+///
+/// \param[in,out] data Iterator to sequence of \c uint8_t. Set to end of read
+/// bytes on success, left as is on error.
+/// \param length Number of bytes to read.
+///
+/// \returns Integer read in from \p data.
+///
+/// \throws metadata_type_overflow When \p length is greater than the number of
+///         bytes in the return type \c T.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+T
+klv_read_int( Iterator& data, size_t length );
+
+// ---------------------------------------------------------------------------
+/// Write an integer to a sequence of bytes (big-endian).
+///
+/// This function handles signed and unsigned integers as well as values of \p
+/// length which are not powers of 2. Values of \p length which are greater
+/// than necessary to represent \p value will result in zero padding on the
+/// left. Assumes there are \p length bytes available in the destination buffer
+/// pointed to by \p data.
+///
+/// \param value Integer to write.
+/// \param[in,out] data Writeable iterator to sequence of \c uint8_t. Set to
+/// end of written bytes on success, left as is on error.
+/// \param length Number of bytes to write.
+///
+/// \throws metadata_type_overflow When \p value is too large to fit in \p
+/// length bytes.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+void
+klv_write_int( T value, Iterator& data, size_t length );
+
+// ---------------------------------------------------------------------------
+/// Return the number of bytes required to store the given signed or unsigned
+/// integer.
+///
+/// \param value Integer whose byte length is being queried.
+///
+/// \returns Bytes required to store \p value.
+template < class T >
+KWIVER_ALGO_KLV_EXPORT
+size_t
+klv_int_length( T value );
+
+// ---------------------------------------------------------------------------
+/// Read an integer from a sequence of bytes, decoding it from BER format.
+///
+/// For an explanation of BER, see the MISB Motion Imagery Handbook, Section
+/// 7.3.1.
+/// \see
+/// https://gwg.nga.mil/misb/docs/misp/MISP-2020.1_Motion_Imagery_Handbook.pdf
+///
+/// \param[in,out] data Iterator to sequence of \c uint8_t. Set to end of read
+/// bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to read.
+///
+/// \returns Integer decoded from \p data.
+///
+/// \throws metadata_buffer_overflow When decoding would require reading more
+/// than \p max_length bytes.
+/// \throws metadata_type_overflow When the decoded value is too large to fit
+/// in the return type \c T.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+T
+klv_read_ber( Iterator& data, size_t max_length );
+
+// ---------------------------------------------------------------------------
+/// Write an integer to a sequence of bytes, encoding it into BER format.
+///
+/// For an explanation of BER, see the MISB Motion Imagery Handbook, Section
+/// 7.3.1.
+/// \see
+/// https://gwg.nga.mil/misb/docs/misp/MISP-2020.1_Motion_Imagery_Handbook.pdf
+///
+/// \param[in,out] data Writeable iterator to sequence of \c uint8_t. Set to
+/// end of written bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to write.
+///
+/// \throws metadata_buffer_overflow When encoding would require writing more
+/// than \p max_length bytes.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+void
+klv_write_ber( T value, Iterator& data, size_t max_length );
+
+// ---------------------------------------------------------------------------
+/// Return the number of bytes required to store the given integer in BER
+/// format.
+///
+/// \param value Integer whose byte length is being queried.
+///
+/// \returns Bytes required to store \p value in BER format.
+template < class T >
+KWIVER_ALGO_KLV_EXPORT
+size_t
+klv_ber_length( T value );
+
+// ---------------------------------------------------------------------------
+/// Read an integer from a sequence of bytes, decoding it from BER-OID format.
+///
+/// For an explanation of BER-OID, see the MISB Motion Imagery Handbook,
+/// Section 7.3.2.
+/// \see
+/// https://gwg.nga.mil/misb/docs/misp/MISP-2020.1_Motion_Imagery_Handbook.pdf
+///
+/// \param[in,out] data Iterator to sequence of \c uint8_t. Set to end of read
+/// bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to read.
+///
+/// \returns Integer decoded from \p data.
+///
+/// \throws metadata_buffer_overflow When decoding would require reading more
+/// than \p max_length bytes.
+/// \throws metadata_type_overflow When the decoded value is too large to fit
+/// in the return type \c T.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+T
+klv_read_ber_oid( Iterator& data, size_t max_length );
+
+// ---------------------------------------------------------------------------
+/// Write an integer to a sequence of bytes, encoding it into BER-OID format.
+///
+/// For an explanation of BER-OID, see the MISB Motion Imagery Handbook,
+/// Section 7.3.2.
+/// \see
+/// https://gwg.nga.mil/misb/docs/misp/MISP-2020.1_Motion_Imagery_Handbook.pdf
+///
+/// \param[in,out] data Writeable iterator to sequence of \c uint8_t. Set to
+/// end of written bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to write.
+///
+/// \throws metadata_buffer_overflow When encoding would require writing more
+/// than \p max_length bytes.
+template < class T, class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+void
+klv_write_ber_oid( T value, Iterator& data, size_t max_length );
+
+// ---------------------------------------------------------------------------
+/// Return the number of bytes required to store the given integer in BER-OID
+/// format.
+///
+/// For an explanation of BER-OID, see the MISB Motion Imagery Handbook,
+/// Section 7.3.2.
+/// \see
+/// https://gwg.nga.mil/misb/docs/misp/MISP-2020.1_Motion_Imagery_Handbook.pdf
+///
+/// \param value Integer whose byte length is being queried.
+///
+/// \returns Bytes required to store \p value in BER format.
+template < class T >
+KWIVER_ALGO_KLV_EXPORT
+size_t
+klv_ber_oid_length( T value );
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/klv/klv_read_write.txx
+++ b/arrows/klv/klv_read_write.txx
@@ -1,0 +1,348 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the templated basic KLV read/write functions.
+
+#include "klv_read_write.h"
+
+#include <vital/exceptions.h>
+
+#include <limits>
+#include <numeric>
+#include <string>
+
+#include <cmath>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ---------------------------------------------------------------------------
+// Macros for verifying type attributes
+// Message-less static_assert not available in C++11
+
+#define KLV_ASSERT_INT( T ) \
+  static_assert( std::is_integral< T >::value, "must be an integer type" )
+
+#define KLV_ASSERT_UINT( T )                                                \
+  KLV_ASSERT_INT( T );                                                      \
+  static_assert( std::is_unsigned< T >::value, "must be an unsigned type" )
+
+#define KLV_ASSERT_SINT( T )                                           \
+  KLV_ASSERT_INT( T );                                                 \
+  static_assert( std::is_signed< T >::value, "must be a signed type" )
+
+#define KLV_ASSERT_UINT8_ITERATOR( ITER )                              \
+  static_assert(                                                       \
+    std::is_same< typename std::decay< decltype( *ITER ) >::type,      \
+                  uint8_t >::value, "iterator must point to uint8_t" )
+
+// ---------------------------------------------------------------------------
+// Return number of bits required to store the given signed or unsigned int.
+template < class T >
+KWIVER_ALGO_KLV_EXPORT
+size_t
+_int_bit_length( T value );
+
+// ---------------------------------------------------------------------------
+// Return whether left-shifting by given amount would overflow type T.
+template < int shift_amount, typename T >
+KWIVER_ALGO_KLV_EXPORT
+bool
+_left_shift_overflow( T value );
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+T
+klv_read_int( Iterator& data, size_t length )
+{
+  // Ensure types are compatible with our assumptions
+  KLV_ASSERT_INT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  if( sizeof( T ) < length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_type_overflow,
+                 "integer will overflow given type" );
+  }
+
+  // Avoid integer underflow in later expressions
+  if( !length )
+  {
+    return 0;
+  }
+
+  // We have to work with unsigned for proper behavior of << >> operators
+  using UnsignedT = typename std::make_unsigned< T >::type;
+
+  // Functor to insert each successive byte into the output value
+  auto const accumulator = []( UnsignedT value, uint8_t byte ){
+                             return ( value << 8 ) | byte;
+                           };
+
+  // Reduce span to final result
+  auto result =
+    std::accumulate( data, data + length, static_cast< UnsignedT >( 0 ),
+                     accumulator );
+
+  // Extend sign bit
+  UnsignedT const result_sign_bit = 1ull << ( 8 * length - 1 );
+  if( std::is_signed< T >::value && sizeof( T ) != length &&
+      ( result_sign_bit & result ) )
+  {
+    result |= ~UnsignedT{ 0 } << ( 8 * length );
+  }
+
+  data += length;
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+void
+klv_write_int( T value, Iterator& data, size_t length )
+{
+  // Ensure types are compatible with our assumptions
+  KLV_ASSERT_INT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  auto const value_length = klv_int_length( value );
+  if( value_length > length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_type_overflow,
+                 "integer not representable using given length" );
+  }
+
+  using UnsignedT = typename std::make_unsigned< T >::type;
+
+  auto const unsigned_value = static_cast< UnsignedT >( value );
+
+  for( size_t i = 0; i < length; ++i, ++data )
+  {
+    auto const shift_amount = ( length - i - 1 ) * 8;
+    *data =
+      static_cast< uint8_t >( 0xFF & ( unsigned_value >> shift_amount ) );
+  }
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+size_t
+klv_int_length( T value )
+{
+  return ( _int_bit_length( value ) + 7 ) / 8;
+}
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+T
+klv_read_ber( Iterator& data, size_t max_length )
+{
+  // Ensure types are compatible with our assumptions
+  KLV_ASSERT_UINT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  if( !max_length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "BER decoding overruns end of data buffer" );
+  }
+
+  // Short form - first bit is 0, remaining bits are the value itself
+  if( !( 0x80 & *data ) )
+  {
+    auto const result = *data;
+    ++data;
+    return result;
+  }
+
+  // Long form - first bit is 1, remaining bits are the length of the
+  // following
+  size_t const total_length = ( 0x7F & *data ) + 1;
+
+  if( total_length > max_length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "BER decoding overruns end of data buffer" );
+  }
+
+  auto const rewind = data;
+  try
+  {
+    return klv_read_int< T >( ++data, total_length - 1 );
+  }
+  catch ( const kwiver::vital::metadata_type_overflow& e )
+  {
+    data = rewind;
+
+    throw e;
+  }
+}
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+void
+klv_write_ber( T value, Iterator& data, size_t max_length )
+{
+  KLV_ASSERT_UINT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  auto const value_length = klv_ber_length( value );
+  if( value_length > max_length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "BER encoding overruns end of data buffer" );
+  }
+
+  if( value < 128 )
+  {
+    *data = static_cast< uint8_t >( value );
+    ++data;
+  }
+  else
+  {
+    *data = static_cast< uint8_t >( ( 0x7F & value_length - 1 ) | 0x80 );
+    klv_write_int( value, ++data, value_length - 1 );
+  }
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+size_t
+klv_ber_length( T value )
+{
+  KLV_ASSERT_UINT( T );
+  return ( value > 127 ) ? klv_int_length( value ) + 1 : 1;
+}
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+T
+klv_read_ber_oid( Iterator& data, size_t max_length )
+{
+  KLV_ASSERT_UINT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  auto const rewind = data;
+
+  // Highest bit set = not final byte
+  T value = 0;
+  for( uint8_t prev_byte = 0x80; prev_byte & 0x80; ++data )
+  {
+    if( !max_length )
+    {
+      data = rewind;
+      VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                   "BER-OID decoding overruns end of data buffer" );
+    }
+    --max_length;
+
+    if( _left_shift_overflow< 7, T >( value ) )
+    {
+      data = rewind;
+      VITAL_THROW( kwiver::vital::metadata_type_overflow,
+                   "BER-OID value will overflow given type" );
+    }
+
+    value <<= 7;
+    value |= 0x7F & ( prev_byte = *data );
+  }
+
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+template < class T, class Iterator >
+void
+klv_write_ber_oid( T value, Iterator& data, size_t max_length )
+{
+  KLV_ASSERT_UINT( T );
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  auto value_length = klv_ber_oid_length( value );
+  if( value_length > max_length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "BER-OID encoding overruns end of data buffer" );
+  }
+
+  if( !value )
+  {
+    *data = 0;
+    ++data;
+    return;
+  }
+
+  while( value_length )
+  {
+    auto const shift_amount = static_cast< uint8_t >( --value_length * 7 );
+    auto const top_bit = static_cast< uint8_t >( value_length ? 0x80 : 0x00 );
+    auto const bottom_bits =
+      static_cast< uint8_t >( ( value >> shift_amount ) & 0x7F );
+    *data = top_bit | bottom_bits;
+    ++data;
+  }
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+size_t
+klv_ber_oid_length( T value )
+{
+  KLV_ASSERT_UINT( T );
+  return ( _int_bit_length( value ) + 6 ) / 7;
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+size_t
+_int_bit_length( T value )
+{
+  KLV_ASSERT_INT( T );
+
+  if( value == 0 )
+  {
+    return 1;
+  }
+
+  // Transform signed number into equivalent-length unsigned number
+  using UnsignedT = typename std::make_unsigned< T >::type;
+
+  auto unsigned_value = static_cast< UnsignedT >( value );
+  if( std::is_signed< T >::value )
+  {
+    unsigned_value = ( ( value < 0 ) ? ~unsigned_value : unsigned_value ) << 1;
+  }
+
+  // Find out number of bits needed
+  size_t i = 0;
+  for(; unsigned_value; ++i )
+  {
+    unsigned_value >>= 1;
+  }
+  return i;
+}
+
+// ---------------------------------------------------------------------------
+template < int shift_amount, typename T >
+bool
+_left_shift_overflow( T value )
+{
+  KLV_ASSERT_UINT( T );
+
+  constexpr auto retained_bits = ( 8 * sizeof( T ) ) - shift_amount;
+  constexpr auto mask = static_cast< T >( ~0ull << retained_bits );
+
+  return ( value & mask ) != 0;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/tests/CMakeLists.txt
+++ b/arrows/klv/tests/CMakeLists.txt
@@ -1,12 +1,13 @@
-project(kwiver_klv_tests)
+project(arrows_test_klv)
+
+set(CMAKE_FOLDER "Arrows/KLV/Tests")
 
 include(kwiver-test-setup)
 
-set( test_libraries vital vital_vpm )
+set( test_libraries kwiver_algo_core vital )
 
 ##############################
 # KLV tests
 ##############################
 
-# TODO implement this test!
-# kwiver_discover_tests(KLV             test_libraries test_klv.cxx)
+kwiver_discover_gtests( klv klv_read_write LIBRARIES ${test_libraries} )

--- a/arrows/klv/tests/test_klv_read_write.cxx
+++ b/arrows/klv/tests/test_klv_read_write.cxx
@@ -1,0 +1,623 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Test basic KLV read / write functions
+
+#include <arrows/klv/klv_read_write.txx>
+
+#include <gtest/gtest.h>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+#define CALL_TEST( func, ... ) \
+  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
+
+using namespace kwiver::arrows::klv;
+namespace kv = kwiver::vital;
+
+using vec_t = std::vector< uint8_t >;
+
+auto const uint8_min  = std::numeric_limits< uint8_t  >::min();
+auto const uint16_min = std::numeric_limits< uint16_t >::min();
+auto const uint32_min = std::numeric_limits< uint32_t >::min();
+auto const uint64_min = std::numeric_limits< uint64_t >::min();
+
+auto const uint8_max  = std::numeric_limits< uint8_t  >::max();
+auto const uint16_max = std::numeric_limits< uint16_t >::max();
+auto const uint32_max = std::numeric_limits< uint32_t >::max();
+auto const uint64_max = std::numeric_limits< uint64_t >::max();
+
+auto const int8_min  = std::numeric_limits< int8_t  >::lowest();
+auto const int16_min = std::numeric_limits< int16_t >::lowest();
+auto const int32_min = std::numeric_limits< int32_t >::lowest();
+auto const int64_min = std::numeric_limits< int64_t >::lowest();
+
+auto const int8_max  = std::numeric_limits< int8_t  >::max();
+auto const int16_max = std::numeric_limits< int16_t >::max();
+auto const int32_max = std::numeric_limits< int32_t >::max();
+auto const int64_max = std::numeric_limits< int64_t >::max();
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_int( vec_t const& data, size_t offset, size_t length, T value )
+{
+  auto it = data.cbegin() + offset;
+  EXPECT_EQ( value, klv_read_int< T >( it, length ) );
+  EXPECT_EQ( it, data.cbegin() + offset + length );
+}
+
+// ----------------------------------------------------------------------------
+template < class T, class E >
+void
+test_read_int_throw( vec_t const& data, size_t offset, size_t length )
+{
+  auto it = data.cbegin() + offset;
+  EXPECT_THROW( klv_read_int< T >( it, length ), E );
+  EXPECT_EQ( it, data.cbegin() + offset );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_int_type_overflow( vec_t const& data, size_t offset, size_t length )
+{
+  test_read_int_throw< T, kv::metadata_type_overflow >( data, offset, length );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, read_int )
+{
+  // Each byte unique to ensure ordering is correct
+  vec_t const data = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                       0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+
+  // Unsigned
+  CALL_TEST( test_read_int< uint8_t >,  data, 0, 1, 0x00 );
+  CALL_TEST( test_read_int< uint16_t >, data, 0, 2, 0x0011 );
+  CALL_TEST( test_read_int< uint32_t >, data, 0, 4, 0x00112233 );
+  CALL_TEST( test_read_int< uint64_t >, data, 0, 8, 0x0011223344556677 );
+
+  // Signed, positive
+  CALL_TEST( test_read_int< int8_t >,  data, 0, 1, 0x00 );
+  CALL_TEST( test_read_int< int16_t >, data, 0, 2, 0x0011 );
+  CALL_TEST( test_read_int< int32_t >, data, 0, 4, 0x00112233 );
+  CALL_TEST( test_read_int< int64_t >, data, 0, 8, 0x0011223344556677 );
+
+  // Signed, negative
+  CALL_TEST( test_read_int< int8_t >,  data, 8, 1, 0x88 );
+  CALL_TEST( test_read_int< int16_t >, data, 8, 2, 0x8899 );
+  CALL_TEST( test_read_int< int32_t >, data, 8, 4, 0x8899aabb );
+  CALL_TEST( test_read_int< int64_t >, data, 8, 8, 0x8899aabbccddeeff );
+
+  // Unsigned - smaller than native size
+  CALL_TEST( test_read_int< uint8_t  >, data, 0, 0, 0 );
+  CALL_TEST( test_read_int< uint16_t >, data, 0, 1, 0x00 );
+  CALL_TEST( test_read_int< uint32_t >, data, 0, 3, 0x001122 );
+  CALL_TEST( test_read_int< uint64_t >, data, 0, 6, 0x001122334455 );
+
+  // Signed, positive - smaller than native size
+  CALL_TEST( test_read_int< int8_t  >, data, 0, 0, 0 );
+  CALL_TEST( test_read_int< int16_t >, data, 0, 1, 0x00 );
+  CALL_TEST( test_read_int< int32_t >, data, 0, 3, 0x001122 );
+  CALL_TEST( test_read_int< int64_t >, data, 0, 6, 0x001122334455 );
+
+  // Signed, negative - smaller than native size
+  CALL_TEST( test_read_int< int8_t  >, data, 8, 0, 0 );
+  CALL_TEST( test_read_int< int16_t >, data, 8, 1, 0xFF88 );
+  CALL_TEST( test_read_int< int32_t >, data, 8, 3, 0xFF8899aa );
+  CALL_TEST( test_read_int< int64_t >, data, 8, 6, 0xFFFF8899aabbccdd );
+
+  // Unsigned - bigger than native size
+  CALL_TEST( test_read_int_type_overflow< uint8_t  >, data, 0, 2 );
+  CALL_TEST( test_read_int_type_overflow< uint16_t >, data, 0, 3 );
+  CALL_TEST( test_read_int_type_overflow< uint32_t >, data, 0, 5 );
+  CALL_TEST( test_read_int_type_overflow< uint32_t >, data, 0, 9 );
+
+  // Signed - bigger than native size
+  CALL_TEST( test_read_int_type_overflow< int8_t  >, data, 0, 2 );
+  CALL_TEST( test_read_int_type_overflow< int16_t >, data, 0, 3 );
+  CALL_TEST( test_read_int_type_overflow< int32_t >, data, 0, 5 );
+  CALL_TEST( test_read_int_type_overflow< int32_t >, data, 0, 9 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_write_int( size_t length, T value )
+{
+  vec_t data( length, 0xba );
+  auto it = data.begin();
+  klv_write_int< T >( value, it, length );
+  EXPECT_EQ( it, data.begin() + length );
+  it = data.begin();
+  EXPECT_EQ( value, klv_read_int< T >( it, length ) );
+}
+
+// ----------------------------------------------------------------------------
+template < class T, class E >
+void
+test_write_int_throw( size_t length, T value )
+{
+  vec_t data( length, 0xba );
+  auto it = data.begin();
+  EXPECT_THROW( klv_write_int< T >( value, it, length ), E );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_write_int_type_overflow( size_t length, T value )
+{
+  test_write_int_throw< T, kv::metadata_type_overflow >( length, value );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, write_int )
+{
+  // Unsigned - arbitrary numbers
+  CALL_TEST( test_write_int< uint8_t >,  1, 0x11 );
+  CALL_TEST( test_write_int< uint16_t >, 2, 0x1122 );
+  CALL_TEST( test_write_int< uint32_t >, 4, 0x11223344 );
+  CALL_TEST( test_write_int< uint64_t >, 8, 0x1122334455667788 );
+
+  // Signed, positive - arbitrary numbers
+  CALL_TEST( test_write_int< int8_t >,   1, 0x11 );
+  CALL_TEST( test_write_int< int16_t >,  2, 0x1122 );
+  CALL_TEST( test_write_int< int32_t >,  4, 0x11223344 );
+  CALL_TEST( test_write_int< int64_t >,  8, 0x1122334455667788 );
+
+  // Signed, negative - arbitrary numbers
+  CALL_TEST( test_write_int< int8_t >,   1, -0x11 );
+  CALL_TEST( test_write_int< int16_t >,  2, -0x1122 );
+  CALL_TEST( test_write_int< int32_t >,  4, -0x11223344 );
+  CALL_TEST( test_write_int< int64_t >,  8, -0x1122334455667788 );
+
+  // Lowest representable value
+  CALL_TEST( test_write_int< uint8_t >,  1, uint8_min );
+  CALL_TEST( test_write_int< uint16_t >, 2, uint16_min );
+  CALL_TEST( test_write_int< uint32_t >, 4, uint32_min );
+  CALL_TEST( test_write_int< uint64_t >, 8, uint64_min );
+  CALL_TEST( test_write_int< int8_t >,   1, int8_min );
+  CALL_TEST( test_write_int< int16_t >,  2, int16_min );
+  CALL_TEST( test_write_int< int32_t >,  4, int32_min );
+  CALL_TEST( test_write_int< int64_t >,  8, int64_min );
+
+  // Highest representable value
+  CALL_TEST( test_write_int< uint8_t >,  1, uint8_max );
+  CALL_TEST( test_write_int< uint16_t >, 2, uint16_max );
+  CALL_TEST( test_write_int< uint32_t >, 4, uint32_max );
+  CALL_TEST( test_write_int< uint64_t >, 8, uint64_max );
+  CALL_TEST( test_write_int< int8_t >,   1, int8_max );
+  CALL_TEST( test_write_int< int16_t >,  2, int16_max );
+  CALL_TEST( test_write_int< int32_t >,  4, int32_max );
+  CALL_TEST( test_write_int< int64_t >,  8, int64_max );
+
+  // Unsigned - smaller than native size
+  CALL_TEST( test_write_int< uint16_t >, 1, 0x00 );
+  CALL_TEST( test_write_int< uint32_t >, 3, 0x001122 );
+  CALL_TEST( test_write_int< uint64_t >, 5, 0x0011223344 );
+
+  // Signed, positive - smaller than native size
+  CALL_TEST( test_write_int< int16_t >,  1, 0x00 );
+  CALL_TEST( test_write_int< int32_t >,  3, 0x001122 );
+  CALL_TEST( test_write_int< int64_t >,  5, 0x0011223344 );
+
+  // Signed, negative - smaller than native size
+  CALL_TEST( test_write_int< int16_t >,  1, -0x11 );
+  CALL_TEST( test_write_int< int32_t >,  3, -0x112233 );
+  CALL_TEST( test_write_int< int64_t >,  5, -0x1122334455 );
+
+  // Unsigned - too few bytes allowed
+  CALL_TEST( test_write_int_type_overflow< uint16_t >, 1, 0x0100 );
+  CALL_TEST( test_write_int_type_overflow< uint32_t >, 3, 0x01000000 );
+  CALL_TEST( test_write_int_type_overflow< uint64_t >, 5, 0x010000000000 );
+
+  // Signed, positive - too few bytes allowed
+  CALL_TEST( test_write_int_type_overflow< int16_t >, 1, 0x80 );
+  CALL_TEST( test_write_int_type_overflow< int32_t >, 3, 0x800000 );
+  CALL_TEST( test_write_int_type_overflow< int64_t >, 5, 0x8000000000 );
+
+  // Signed, negative - too few bytes allowed
+  CALL_TEST( test_write_int_type_overflow< int16_t >, 1, -0x81 );
+  CALL_TEST( test_write_int_type_overflow< int32_t >, 3, -0x800001 );
+  CALL_TEST( test_write_int_type_overflow< int64_t >, 5, -0x8000000001 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_int_length( T value, size_t expected_length )
+{
+  EXPECT_EQ( expected_length, klv_int_length( value ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, int_length )
+{
+  // Unsigned
+  CALL_TEST( test_int_length< uint8_t >,  0x00ull,               1 );
+  CALL_TEST( test_int_length< uint8_t >,  0xFFull,               1 );
+  CALL_TEST( test_int_length< uint16_t >, 0x0100ull,             2 );
+  CALL_TEST( test_int_length< uint16_t >, 0xFFFFull,             2 );
+  CALL_TEST( test_int_length< uint32_t >, 0x010000ull,           3 );
+  CALL_TEST( test_int_length< uint32_t >, 0xFFFFFFull,           3 );
+  CALL_TEST( test_int_length< uint32_t >, 0x01000000ull,         4 );
+  CALL_TEST( test_int_length< uint32_t >, 0xFFFFFFFFull,         4 );
+  CALL_TEST( test_int_length< uint64_t >, 0x0100000000ull,       5 );
+  CALL_TEST( test_int_length< uint64_t >, 0xFFFFFFFFFFull,       5 );
+  CALL_TEST( test_int_length< uint64_t >, 0x010000000000ull,     6 );
+  CALL_TEST( test_int_length< uint64_t >, 0xFFFFFFFFFFFFull,     6 );
+  CALL_TEST( test_int_length< uint64_t >, 0x01000000000000ull,   7 );
+  CALL_TEST( test_int_length< uint64_t >, 0xFFFFFFFFFFFFFFull,   7 );
+  CALL_TEST( test_int_length< uint64_t >, 0x0100000000000000ull, 8 );
+  CALL_TEST( test_int_length< uint64_t >, 0xFFFFFFFFFFFFFFFFull, 8 );
+
+  // Signed - positive
+  CALL_TEST( test_int_length< int8_t >,  0x00ll,               1 );
+  CALL_TEST( test_int_length< int8_t >,  0x7Fll,               1 );
+  CALL_TEST( test_int_length< int16_t >, 0x80ll,               2 );
+  CALL_TEST( test_int_length< int16_t >, 0x7FFFll,             2 );
+  CALL_TEST( test_int_length< int32_t >, 0x8000ll,             3 );
+  CALL_TEST( test_int_length< int32_t >, 0x7FFFFFll,           3 );
+  CALL_TEST( test_int_length< int32_t >, 0x800000ll,           4 );
+  CALL_TEST( test_int_length< int32_t >, 0x7FFFFFFFll,         4 );
+  CALL_TEST( test_int_length< int64_t >, 0x80000000ll,         5 );
+  CALL_TEST( test_int_length< int64_t >, 0x7FFFFFFFFFll,       5 );
+  CALL_TEST( test_int_length< int64_t >, 0x8000000000ll,       6 );
+  CALL_TEST( test_int_length< int64_t >, 0x7FFFFFFFFFFFll,     6 );
+  CALL_TEST( test_int_length< int64_t >, 0x800000000000ll,     7 );
+  CALL_TEST( test_int_length< int64_t >, 0x7FFFFFFFFFFFFFll,   7 );
+  CALL_TEST( test_int_length< int64_t >, 0x80000000000000ll,   8 );
+  CALL_TEST( test_int_length< int64_t >, 0x7FFFFFFFFFFFFFFFll, 8 );
+
+  // Signed - negative
+  CALL_TEST( test_int_length< int16_t >, -0x80ll,               1 );
+  CALL_TEST( test_int_length< int16_t >, -0x81ll,               2 );
+  CALL_TEST( test_int_length< int32_t >, -0x8000ll,             2 );
+  CALL_TEST( test_int_length< int32_t >, -0x8001ll,             3 );
+  CALL_TEST( test_int_length< int32_t >, -0x800000ll,           3 );
+  CALL_TEST( test_int_length< int32_t >, -0x800001ll,           4 );
+  CALL_TEST( test_int_length< int64_t >, -0x80000000ll,         4 );
+  CALL_TEST( test_int_length< int64_t >, -0x80000001ll,         5 );
+  CALL_TEST( test_int_length< int64_t >, -0x8000000000ll,       5 );
+  CALL_TEST( test_int_length< int64_t >, -0x8000000001ll,       6 );
+  CALL_TEST( test_int_length< int64_t >, -0x800000000000ll,     6 );
+  CALL_TEST( test_int_length< int64_t >, -0x800000000001ll,     7 );
+  CALL_TEST( test_int_length< int64_t >, -0x80000000000000ll,   7 );
+  CALL_TEST( test_int_length< int64_t >, -0x80000000000001ll,   8 );
+  CALL_TEST( test_int_length< int64_t >, -0x8000000000000000ll, 8 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber( T value, vec_t const& data )
+{
+  auto it = data.begin();
+  EXPECT_EQ( value, klv_read_ber< T >( it, data.size() ) );
+  EXPECT_EQ( data.end(), it );
+}
+
+// ----------------------------------------------------------------------------
+template < class T, class E >
+void
+test_read_ber_throw( size_t length, vec_t const& data )
+{
+  auto it = data.begin();
+  EXPECT_THROW( klv_read_ber< T >( it, length ), E );
+  EXPECT_EQ( data.begin(), it );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber_buffer_overflow( size_t length, vec_t const& data )
+{
+  test_read_ber_throw< T, kv::metadata_buffer_overflow >( length, data );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber_type_overflow( size_t length, vec_t const& data )
+{
+  test_read_ber_throw< T, kv::metadata_type_overflow >( length, data );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, read_ber )
+{
+  // Short form
+  CALL_TEST( test_read_ber< uint8_t >, 0x00, { 0x00 } );
+  CALL_TEST( test_read_ber< uint8_t >, 0x42, { 0x42 } );
+  CALL_TEST( test_read_ber< uint8_t >, 0x7F, { 0x7F } );
+
+  // Long form
+  CALL_TEST( test_read_ber< uint8_t >,  0xFF,       { 0x81, 0xFF } );
+  CALL_TEST( test_read_ber< uint16_t >, 0x102,      { 0x82, 0x01, 0x02 } );
+  CALL_TEST( test_read_ber< uint32_t >, 0x010203,
+             { 0x83, 0x01, 0x02, 0x03 } );
+  CALL_TEST( test_read_ber< uint32_t >, 0xFF428012,
+             { 0x84, 0xFF, 0x42, 0x80, 0x12 } );
+
+  // Not enough buffer space given
+  CALL_TEST( test_read_ber_buffer_overflow< uint32_t >, 1, { 0x81, 0xFF } );
+  CALL_TEST( test_read_ber_buffer_overflow< uint32_t >, 2,
+             { 0x82, 0xFF, 0x00 } );
+  CALL_TEST( test_read_ber_buffer_overflow< uint32_t >, 0, { 0 } );
+
+  // Specified type too small
+  CALL_TEST( test_read_ber_type_overflow< uint8_t  >, 3,
+             { 0x82, 0x01, 0x00 } );
+  CALL_TEST( test_read_ber_type_overflow< uint16_t >, 4,
+             { 0x83, 0x01, 0x00, 0x00 } );
+  CALL_TEST( test_read_ber_type_overflow< uint32_t >, 6,
+             { 0x85, 0x01, 0x00, 0x00, 0x00, 0x00 } );
+  CALL_TEST( test_read_ber_type_overflow< uint64_t >, 10,
+             { 0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_write_ber( uint64_t value, size_t length )
+{
+  auto data = vec_t( length, 0xba );
+  auto it = data.begin();
+  klv_write_ber( value, it, data.size() );
+  EXPECT_EQ( it, data.end() );
+
+  // Avoid technically correct but bad-form encoding
+  try
+  {
+    // Length should never be zero
+    EXPECT_NE( 0x80, data.at( 0 ) );
+
+    // Avoid leading zero bytes in value
+    EXPECT_NE( 0x00, data.at( 1 ) );
+  }
+  catch ( std::exception const& e )
+  {
+    // data.at() threw - data doesn't have 0 or 1 index
+  }
+
+  it = data.begin();
+  EXPECT_EQ( value, klv_read_ber< uint64_t >( it, data.size() ) );
+}
+
+// ----------------------------------------------------------------------------
+template < class E >
+void
+test_write_ber_throw( uint64_t value, size_t length )
+{
+  auto data = vec_t( length, 0xba );
+  auto it = data.begin();
+  EXPECT_THROW( klv_write_ber( value, it, data.size() ), E );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, write_ber )
+{
+  // Valid values
+  CALL_TEST( test_write_ber, 0X00,              1 );
+  CALL_TEST( test_write_ber, 0X42,              1 );
+  CALL_TEST( test_write_ber, 0x7F,              1 );
+  CALL_TEST( test_write_ber, 0x80,              2 );
+  CALL_TEST( test_write_ber, uint8_max,         2 );
+  CALL_TEST( test_write_ber, uint8_max  + 1ull, 3 );
+  CALL_TEST( test_write_ber, uint16_max,        3 );
+  CALL_TEST( test_write_ber, uint16_max + 1ull, 4 );
+  CALL_TEST( test_write_ber, uint32_max,        5 );
+  CALL_TEST( test_write_ber, uint32_max + 1ull, 6 );
+  CALL_TEST( test_write_ber, uint64_max,        9 );
+
+  // Not enough buffer space given
+  auto test_buffer_overflow =
+    test_write_ber_throw< kv::metadata_buffer_overflow >;
+  CALL_TEST( test_buffer_overflow, 0x00,              0 );
+  CALL_TEST( test_buffer_overflow, 0x42,              0 );
+  CALL_TEST( test_buffer_overflow, 0x7F,              0 );
+  CALL_TEST( test_buffer_overflow, 0x80,              1 );
+  CALL_TEST( test_buffer_overflow, uint8_max,         1 );
+  CALL_TEST( test_buffer_overflow, uint8_max + 1ull,  2 );
+  CALL_TEST( test_buffer_overflow, uint16_max,        2 );
+  CALL_TEST( test_buffer_overflow, uint16_max + 1ull, 3 );
+  CALL_TEST( test_buffer_overflow, uint32_max,        4 );
+  CALL_TEST( test_buffer_overflow, uint32_max + 1ull, 5 );
+  CALL_TEST( test_buffer_overflow, uint64_max,        8 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_ber_length( T value, size_t expected_length )
+{
+  EXPECT_EQ( expected_length, klv_ber_length( value ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, ber_length )
+{
+  CALL_TEST( test_ber_length< uint8_t >,  0x00,               1 );
+  CALL_TEST( test_ber_length< uint8_t >,  0x7F,               1 );
+  CALL_TEST( test_ber_length< uint8_t >,  0x80,               2 );
+  CALL_TEST( test_ber_length< uint8_t >,  0xFF,               2 );
+  CALL_TEST( test_ber_length< uint16_t >, 0x0100,             3 );
+  CALL_TEST( test_ber_length< uint16_t >, 0xFFFF,             3 );
+  CALL_TEST( test_ber_length< uint32_t >, 0x010000,           4 );
+  CALL_TEST( test_ber_length< uint32_t >, 0xFFFFFF,           4 );
+  CALL_TEST( test_ber_length< uint32_t >, 0x01000000,         5 );
+  CALL_TEST( test_ber_length< uint32_t >, 0xFFFFFFFF,         5 );
+  CALL_TEST( test_ber_length< uint64_t >, 0x0100000000,       6 );
+  CALL_TEST( test_ber_length< uint64_t >, 0xFFFFFFFFFF,       6 );
+  CALL_TEST( test_ber_length< uint64_t >, 0x010000000000,     7 );
+  CALL_TEST( test_ber_length< uint64_t >, 0xFFFFFFFFFFFF,     7 );
+  CALL_TEST( test_ber_length< uint64_t >, 0x01000000000000,   8 );
+  CALL_TEST( test_ber_length< uint64_t >, 0xFFFFFFFFFFFFFF,   8 );
+  CALL_TEST( test_ber_length< uint64_t >, 0x0100000000000000, 9 );
+  CALL_TEST( test_ber_length< uint64_t >, 0xFFFFFFFFFFFFFFFF, 9 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber_oid( T value, vec_t const& data )
+{
+  auto it = data.cbegin();
+  EXPECT_EQ( value, klv_read_ber_oid< T >( it, data.size() ) );
+  EXPECT_EQ( data.cend(), it );
+}
+
+// ----------------------------------------------------------------------------
+template < class T, class E >
+void
+test_read_ber_oid_throw( vec_t const& data )
+{
+  auto it = data.cbegin();
+  EXPECT_THROW( klv_read_ber_oid< T >( it, data.size() ), E );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber_oid_buffer_overflow( vec_t const& data )
+{
+  test_read_ber_oid_throw< T, kv::metadata_buffer_overflow >( data );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_read_ber_oid_type_overflow( vec_t const& data )
+{
+  test_read_ber_oid_throw< T, kv::metadata_type_overflow >( data );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, read_ber_oid )
+{
+  // Valid values
+  CALL_TEST( test_read_ber_oid< uint8_t  >, 0x00,        { 0x00 } );
+  CALL_TEST( test_read_ber_oid< uint8_t  >, 0x42,        { 0x42 } );
+  CALL_TEST( test_read_ber_oid< uint8_t  >, 0x7F,        { 0x7F } );
+  CALL_TEST( test_read_ber_oid< uint8_t  >, 0x80,        { 0x81, 0 } );
+  CALL_TEST( test_read_ber_oid< uint8_t  >, 0xFF,        { 0x81, 0x7F } );
+  CALL_TEST( test_read_ber_oid< uint16_t >, 0x3FFF,      { 0xFF, 0x7F } );
+  CALL_TEST( test_read_ber_oid< uint16_t >, 0x4000,
+             { 0x81, 0x80, 0x00 } );
+  CALL_TEST( test_read_ber_oid< uint32_t >, 0x1FFFFF,
+             { 0xFF, 0xFF, 0x7F } );
+  CALL_TEST( test_read_ber_oid< uint32_t >, 0x200000,
+             { 0x81, 0x80, 0x80, 0x00 } );
+  CALL_TEST( test_read_ber_oid< uint64_t >, 0x7FFFFFFFF,
+             { 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } );
+  CALL_TEST( test_read_ber_oid< uint64_t >, 0x800000000,
+             { 0x81, 0x80, 0x80, 0x80, 0x80, 0x00 } );
+  CALL_TEST( test_read_ber_oid< uint64_t >, uint64_max,
+             { 0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } );
+
+  // Truncated values
+  CALL_TEST( test_read_ber_oid_buffer_overflow< uint64_t >, {} );
+  CALL_TEST( test_read_ber_oid_buffer_overflow< uint64_t >, { 0x81 } );
+  CALL_TEST( test_read_ber_oid_buffer_overflow< uint64_t >, { 0xFF, 0x81 } );
+
+  // Values too large for native type
+  CALL_TEST( test_read_ber_oid_type_overflow< uint8_t  >, { 0x82, 0X00 } );
+  CALL_TEST( test_read_ber_oid_type_overflow< uint16_t >,
+             { 0x84, 0x80, 0X00 } );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_write_ber_oid( T value, size_t length )
+{
+  auto data = vec_t( length, 0xba );
+  auto it = data.begin();
+  klv_write_ber_oid< T >( value, it, length );
+  EXPECT_EQ( data.end(), it );
+  // Avoid technically correct but bad-form encoding ( leading zero bytes )
+  EXPECT_NE( data[ 0 ], 0x80 );
+  it = data.begin();
+  EXPECT_EQ( value, klv_read_ber_oid< T >( it, length ) );
+}
+
+// ----------------------------------------------------------------------------
+template < class T, class E >
+void
+test_write_ber_oid_throw( T value, size_t length )
+{
+  auto data = vec_t( length, 0xba );
+  auto it = data.begin();
+  EXPECT_THROW( klv_write_ber_oid( value, it, length ), E );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, write_ber_oid )
+{
+  // Valid values
+  CALL_TEST( test_write_ber_oid< uint8_t >,  0x00,              1 );
+  CALL_TEST( test_write_ber_oid< uint8_t >,  0x42,              1 );
+  CALL_TEST( test_write_ber_oid< uint8_t >,  0x7F,              1 );
+  CALL_TEST( test_write_ber_oid< uint8_t >,  0x80,              2 );
+  CALL_TEST( test_write_ber_oid< uint8_t >,  uint8_max,         2 );
+  CALL_TEST( test_write_ber_oid< uint16_t >, 0x3FFF,            2 );
+  CALL_TEST( test_write_ber_oid< uint16_t >, 0x4000,            3 );
+  CALL_TEST( test_write_ber_oid< uint32_t >, 0x0FFFFFFF,        4 );
+  CALL_TEST( test_write_ber_oid< uint32_t >, 0x10000000,        5 );
+  CALL_TEST( test_write_ber_oid< uint64_t >, 0x0FFFFFFFFFFFFFF, 8 );
+  CALL_TEST( test_write_ber_oid< uint64_t >, 0x100000000000000, 9 );
+  CALL_TEST( test_write_ber_oid< uint64_t >, uint64_max,        10 );
+
+  // Not enough buffer space given
+  auto test_buffer_overflow =
+    test_write_ber_oid_throw< uint64_t, kv::metadata_buffer_overflow >;
+  CALL_TEST( test_buffer_overflow, 0,              0 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 7 ),  1 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 14 ), 2 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 21 ), 3 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 28 ), 4 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 56 ), 8 );
+  CALL_TEST( test_buffer_overflow, ( 1ull << 63 ), 9 );
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+test_ber_oid_length( T value, size_t expected_length )
+{
+  EXPECT_EQ( expected_length, klv_ber_oid_length( value ) );
+}
+
+TEST ( klv, ber_oid_length )
+{
+  CALL_TEST( test_ber_oid_length< uint8_t >,  0,                  1 );
+  CALL_TEST( test_ber_oid_length< uint8_t >,  ( 1ull << 7 ) - 1,  1 );
+  CALL_TEST( test_ber_oid_length< uint8_t >,  ( 1ull << 7 ),      2 );
+  CALL_TEST( test_ber_oid_length< uint16_t >, ( 1ull << 14 ) - 1, 2 );
+  CALL_TEST( test_ber_oid_length< uint16_t >, ( 1ull << 14 ),     3 );
+  CALL_TEST( test_ber_oid_length< uint32_t >, ( 1ull << 21 ) - 1, 3 );
+  CALL_TEST( test_ber_oid_length< uint32_t >, ( 1ull << 21 ),     4 );
+  CALL_TEST( test_ber_oid_length< uint32_t >, ( 1ull << 28 ) - 1, 4 );
+  CALL_TEST( test_ber_oid_length< uint32_t >, ( 1ull << 28 ),     5 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 35 ) - 1, 5 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 35 ),     6 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 42 ) - 1, 6 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 42 ),     7 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 49 ) - 1, 7 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 49 ),     8 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 56 ) - 1, 8 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 56 ),     9 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 63 ) - 1, 9 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, ( 1ull << 63 ),     10 );
+  CALL_TEST( test_ber_oid_length< uint64_t >, uint64_max,         10 );
+}

--- a/vital/exceptions/metadata.cxx
+++ b/vital/exceptions/metadata.cxx
@@ -2,14 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation for metadata exceptions
- */
+/// \file
+/// \brief Implementation for metadata exceptions
 
 #include "metadata.h"
 
 namespace kwiver {
+
 namespace vital {
 
 metadata_exception
@@ -20,6 +19,24 @@ metadata_exception
 
 metadata_exception
 ::~metadata_exception() noexcept
-{ }
+{}
 
-} } // end vital namespace
+metadata_buffer_overflow
+::metadata_buffer_overflow( std::string const& str ) : metadata_exception( str )
+{}
+
+metadata_buffer_overflow
+::~metadata_buffer_overflow() noexcept
+{}
+
+metadata_type_overflow
+::metadata_type_overflow( std::string const& str ) : metadata_exception( str )
+{}
+
+metadata_type_overflow
+::~metadata_type_overflow() noexcept
+{}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/exceptions/metadata.h
+++ b/vital/exceptions/metadata.h
@@ -2,10 +2,9 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief VITAL Exceptions pertaining to metadata operations
- */
+/// \file
+/// \brief VITAL Exceptions pertaining to metadata operations
+///
 
 #ifndef VITAL_CORE_EXCEPTIONS_METADATA_H_
 #define VITAL_CORE_EXCEPTIONS_METADATA_H_
@@ -15,6 +14,7 @@
 #include <vital/exceptions/base.h>
 
 namespace kwiver {
+
 namespace vital {
 
 // ------------------------------------------------------------------
@@ -29,6 +29,30 @@ public:
   virtual ~metadata_exception() noexcept;
 };
 
-} } // end namespace
+// ------------------------------------------------------------------
+/// Data buffer is too small to complete read or write operation.
+class VITAL_EXCEPTIONS_EXPORT metadata_buffer_overflow
+  : public metadata_exception
+{
+public:
+  metadata_buffer_overflow( std::string const& str );
 
-#endif // VITAL_CORE_EXCEPTIONS_METADATA_H_
+  virtual ~metadata_buffer_overflow() noexcept;
+};
+
+// ------------------------------------------------------------------
+/// Size of value is greater than data type or format allows.
+class VITAL_EXCEPTIONS_EXPORT metadata_type_overflow
+  : public metadata_exception
+{
+public:
+  metadata_type_overflow( std::string const& str );
+
+  virtual ~metadata_type_overflow() noexcept;
+};
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Create flexible, robust, and error-checking functions for reading and writing three KLV integer formats. Begin the much-needed process of writing KLV unit tests here. Add two new exception types to differentiate the types of runtime errors one might run across when dealing with low-level KLV reading and writing.

Floating-point and string readers/writers soon to follow.