### PR TITLE
Move configure_logging to kwiver tool setup

### DIFF
--- a/python/kwiver/kwiver_tools.py
+++ b/python/kwiver/kwiver_tools.py
@@ -55,6 +55,7 @@ def _setup_environment():
 
 
 def _kwiver_tools(tool_name, args):
+    vital_logging._configure_logging()
     assert tool_name in KWIVER_SUPPORTED_TOOLS, "Unsupported tool {0} specified".format(tool_name)
     tool_environment = _setup_environment()
     tool_path = os.path.join(KWIVER_BIN_DIR, tool_name)

--- a/python/kwiver/vital/__init__.py
+++ b/python/kwiver/vital/__init__.py
@@ -1,9 +1,0 @@
-
-# flake8: noqa
-from __future__ import print_function, unicode_literals, absolute_import
-
-# Configure logging and initialize the root sprokit logger
-from kwiver.vital import vital_logging
-vital_logging._configure_logging()
-
-logger = vital_logging.getLogger(__name__)


### PR DESCRIPTION
This PR moves _configure_logging to kwiver tool setup. This prevents it from running when vital is imported and changing log levels. 