### PR TITLE
Add KLV blob wrapper class

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -6,6 +6,7 @@ set( sources
   convert_metadata.cxx
   convert_0601_metadata.cxx
   convert_0104_metadata.cxx
+  klv_blob.cxx
   klv_data.cxx
   klv_key.cxx
   klv_parse.cxx

--- a/arrows/klv/klv_blob.cxx
+++ b/arrows/klv/klv_blob.cxx
@@ -1,0 +1,69 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV blob class.
+
+#include "klv_blob.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+klv_blob
+::klv_blob()
+{}
+
+// ----------------------------------------------------------------------------
+klv_blob
+::klv_blob( klv_bytes_t const& bytes ) : bytes{ bytes }
+{}
+
+// ----------------------------------------------------------------------------
+klv_bytes_t&
+klv_blob
+::operator*()
+{
+  return bytes;
+}
+
+// ----------------------------------------------------------------------------
+klv_bytes_t const&
+klv_blob
+::operator*() const
+{
+  return bytes;
+}
+
+// ----------------------------------------------------------------------------
+klv_bytes_t*
+klv_blob
+::operator->()
+{
+  return &bytes;
+}
+
+// ----------------------------------------------------------------------------
+klv_bytes_t const*
+klv_blob
+::operator->() const
+{
+  return &bytes;
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_blob_length( klv_blob const& value )
+{
+  return value->size();
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_blob.h
+++ b/arrows/klv/klv_blob.h
@@ -1,0 +1,98 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Interface to the KLV blob class.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_BLOB_H_
+#define KWIVER_ARROWS_KLV_KLV_BLOB_H_
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vector>
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+using klv_bytes_t = std::vector< uint8_t >;
+
+// ----------------------------------------------------------------------------
+/// Structure to hold explicitly uninterpreted bytes.
+///
+/// This wrapper type is used to signify that the bytes it holds were unable to
+/// be parsed, likely due to an unsupported field or irrecoverably incorrect
+/// formatting. Unparsed bytes are still stored, however, to potentially write
+/// them back out later.
+class KWIVER_ALGO_KLV_EXPORT klv_blob
+{
+public:
+  klv_blob();
+
+  klv_blob( klv_bytes_t const& bytes );
+
+  // Operator overloads to access internal vector-of-bytes
+  klv_bytes_t& operator*();
+  klv_bytes_t const& operator*() const;
+
+  // Operator overloads to access methods of internal vector-of-bytes
+  klv_bytes_t* operator->();
+  klv_bytes_t const* operator->() const;
+
+private:
+  klv_bytes_t bytes;
+};
+
+// While simple in implementation, these utility functions are included for
+// consistency with the rest of the KLV read / write API.
+
+// ----------------------------------------------------------------------------
+/// Load a sequence of bytes into a \c klv_blob structure.
+///
+/// \param[in,out] data Iterator to sequence of \c uint8_t. Set to end of read
+/// bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to read.
+///
+/// \returns A blob of \p length bytes from \p data.
+template < class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+klv_blob
+klv_read_blob( Iterator& data, size_t length );
+
+// ----------------------------------------------------------------------------
+/// Write a \c klv_blob structure to sequence of bytes.
+///
+/// \param[in,out] data Writeable iterator to sequence of \c uint8_t. Set to
+/// end of written bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to write.
+///
+/// \throws metadata_buffer_overflow When encoding would require writing more
+/// than \p max_length bytes.
+template < class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+void
+klv_write_blob( klv_blob const& value, Iterator& data, size_t max_length );
+
+// ---------------------------------------------------------------------------
+/// Return the number of bytes required to write the given blob.
+///
+/// \param value Blob whose byte length is being queried.
+///
+/// \returns Bytes required to write \p value.
+KWIVER_ALGO_KLV_EXPORT
+size_t
+klv_blob_length( klv_blob const& value );
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/klv/klv_blob.txx
+++ b/arrows/klv/klv_blob.txx
@@ -1,0 +1,60 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV blob class's templated functions.
+
+#include "klv_blob.h"
+
+#include <vital/exceptions/metadata.h>
+
+#include <algorithm>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+#define KLV_ASSERT_UINT8_ITERATOR( ITER )                         \
+  static_assert(                                                  \
+    std::is_same< typename std::decay< decltype( *ITER ) >::type, \
+                  uint8_t >::value,                               \
+    "iterator must point to uint8_t" )
+
+// ----------------------------------------------------------------------------
+template < class Iterator >
+klv_blob
+klv_read_blob( Iterator& data, size_t length )
+{
+  KLV_ASSERT_UINT8_ITERATOR( data );
+  auto const begin = data;
+  auto const end = ( data += length );
+  return klv_bytes_t{ begin, end };
+}
+
+// ----------------------------------------------------------------------------
+template < class Iterator >
+void
+klv_write_blob( klv_blob const& value, Iterator& data, size_t max_length )
+{
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  if( max_length < value->size() )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "writing blob overruns end of data buffer" );
+  }
+
+  data = std::copy( value->cbegin(), value->cend(), data );
+}
+
+#undef KLV_ASSERT_UINT8_ITERATOR
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/tests/CMakeLists.txt
+++ b/arrows/klv/tests/CMakeLists.txt
@@ -4,10 +4,11 @@ set(CMAKE_FOLDER "Arrows/KLV/Tests")
 
 include(kwiver-test-setup)
 
-set( test_libraries kwiver_algo_core vital )
+set( test_libraries kwiver_algo_core kwiver_algo_klv vital )
 
 ##############################
 # KLV tests
 ##############################
 
+kwiver_discover_gtests( klv klv_blob       LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_read_write LIBRARIES ${test_libraries} )

--- a/arrows/klv/tests/test_klv_blob.cxx
+++ b/arrows/klv/tests/test_klv_blob.cxx
@@ -1,0 +1,84 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Test KLV blob functions.
+
+#include <arrows/klv/klv_blob.txx>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+#define CALL_TEST( func, ... ) \
+  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
+
+using namespace kwiver::arrows::klv;
+
+// ----------------------------------------------------------------------------
+void
+test_blob_read( klv_bytes_t const& data )
+{
+  auto it = data.cbegin();
+  EXPECT_EQ( data, *klv_read_blob( it, data.size() ) );
+  EXPECT_EQ( data.cend(), it );
+}
+
+// ----------------------------------------------------------------------------
+TEST( klv, blob_read )
+{
+  CALL_TEST( test_blob_read, {} );
+  CALL_TEST( test_blob_read, { 0x00 } );
+  CALL_TEST( test_blob_read, { 0xFF, 0xFF } );
+  CALL_TEST( test_blob_read,
+             { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00 } );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_blob_write( klv_bytes_t const& data )
+{
+  klv_bytes_t buffer( data.size(), 0xba );
+  auto it = buffer.begin();
+  klv_write_blob( data, it, buffer.size() );
+  EXPECT_EQ( buffer.end(), it );
+  it = buffer.begin();
+  EXPECT_EQ( data, *klv_read_blob( it, buffer.size() ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST( klv, blob_write )
+{
+  CALL_TEST( test_blob_read, {} );
+  CALL_TEST( test_blob_read, { 0x00 } );
+  CALL_TEST( test_blob_read, { 0xFF, 0xFF } );
+  CALL_TEST( test_blob_read,
+             { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00 } );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_blob_length( klv_bytes_t const& data )
+{
+  EXPECT_EQ( data.size(), klv_blob_length( data ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST( klv, blob_length )
+{
+  CALL_TEST( test_blob_length, {} );
+  CALL_TEST( test_blob_length, { 0x00 } );
+  CALL_TEST( test_blob_length, { 0xBA, 0xDA } );
+  CALL_TEST( test_blob_length,
+             { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00 } );
+}


### PR DESCRIPTION
Create a class which is just a wrapper around a `std::vector< uint8_t >`. This is meant to mark these bytes as explicitly unparsed, to avoid confusion with some KLV data type which is actually best represented by a sequence of bytes. 

The KLV parser returns a `kwiver::vital::any` for the value of a KLV entry, which usually contains a value of a type deterministic to that entry's tag (e.g. `UNIX_TIME_STAMP` should have type `uint64_t`). There will be two edge cases where the `any` does not hold an object matching the standard tag type:
1. KLV denotes that a value is null / unknown by setting the length to zero. This will be represented in the KLV arrow by an empty `any` object. The emptiness of an `any` can be tested for by its built-in methods.
2. The parser may encounter an unknown field tag, or perhaps an error occurs during parsing. In this case, we cannot return a value of the desired type, but we still want to save the bytes for later to be able to re-write the data unharmed. The purpose of the `klv_blob` is to hold those bytes. One can definitively identify such a failure by checking to see if the type that the `any` contains is `klv_blob`.

If neither of the above are true, then the `any` should hold a valid value of the expected type.