### PR TITLE
Add KLV read / write for IMAP format

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -11,6 +11,7 @@ set( sources
   klv_data.cxx
   klv_key.cxx
   klv_parse.cxx
+  klv_read_write.cxx
   klv_0601.cxx
   klv_0104.cxx
   misp_time.cxx

--- a/arrows/klv/klv_read_write.cxx
+++ b/arrows/klv/klv_read_write.cxx
@@ -1,0 +1,153 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the non-templated basic KLV read/write functions.
+
+#include "klv_read_write.txx"
+
+#include <stdexcept>
+
+namespace kv = kwiver::vital;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ---------------------------------------------------------------------------
+uint64_t
+_imap_infinity( bool sign_bit, size_t length )
+{
+  auto const identifier = sign_bit ? 0xE8ull : 0xC8ull;
+  return length ? identifier << ( ( length - 1 ) * 8 ) : 0;
+}
+
+// ---------------------------------------------------------------------------
+uint64_t
+_imap_quiet_nan( bool sign_bit, size_t length )
+{
+  auto const identifier = sign_bit ? 0xF0ull : 0xD0ull;
+  return length ? identifier << ( ( length - 1 ) * 8 ) : 0;
+}
+
+// ---------------------------------------------------------------------------
+uint64_t
+_imap_signal_nan( bool sign_bit, size_t length )
+{
+  auto const identifier = sign_bit ? 0xF8ull : 0xD8ull;
+  return length ? identifier << ( ( length - 1 ) * 8 ) : 0;
+}
+
+// ---------------------------------------------------------------------------
+_imap_terms
+_calculate_imap_terms( double minimum, double maximum, size_t length )
+{
+  // ST1201, Section 8.1.2
+  auto const float_exponent = std::ceil( std::log2( maximum - minimum ) );
+  auto const int_exponent = 8.0 * length - 1.0;
+
+  _imap_terms result = {};
+  result.forward_scale = std::exp2( int_exponent - float_exponent );
+  result.backward_scale = std::exp2( float_exponent - int_exponent );
+  result.zero_offset = ( minimum < 0 && maximum > 0 )
+                       ? result.forward_scale * minimum -
+                       std::floor( result.forward_scale * minimum )
+                       : 0.0;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+size_t
+klv_imap_length( double minimum, double maximum, double precision )
+{
+  // ST1201, Section 8.1.1
+  _check_range_precision( minimum, maximum, precision );
+
+  auto const length_bits = std::ceil( std::log2( maximum - minimum ) ) -
+                           std::floor( std::log2( precision ) ) + 1.0;
+  return static_cast< size_t >( std::ceil( length_bits / 8.0 ) );
+}
+
+// ---------------------------------------------------------------------------
+double
+klv_imap_precision( double minimum, double maximum, size_t length )
+{
+  _check_range_length( minimum, maximum, length );
+
+  auto const length_bits = length * 8.0;
+  return std::exp2( std::log2( maximum - minimum ) - length_bits + 1 );
+}
+
+namespace {
+
+// ---------------------------------------------------------------------------
+void
+_check_range( double minimum, double maximum )
+{
+  if( !std::isfinite( minimum ) )
+  {
+    throw std::logic_error( "minimum must be finite" );
+  }
+
+  if( !std::isfinite( maximum ) )
+  {
+    throw std::logic_error( "maximum must be finite" );
+  }
+
+  if( std::isinf( maximum - minimum ) )
+  {
+    VITAL_THROW( kv::metadata_type_overflow,
+                 "span too large for double type" );
+  }
+
+  if( !( minimum < maximum ) )
+  {
+    throw std::logic_error( "minimum must be less than maximum" );
+  }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+void
+_check_range_precision( double minimum, double maximum, double precision )
+{
+  _check_range( minimum, maximum );
+
+  if( !std::isfinite( precision ) )
+  {
+    throw std::logic_error( "precision must be finite" );
+  }
+
+  if( !( precision < maximum - minimum ) )
+  {
+    throw std::logic_error( "precision must be less than min-max span" );
+  }
+}
+
+// ---------------------------------------------------------------------------
+void
+_check_range_length( double minimum, double maximum, size_t length )
+{
+  _check_range( minimum, maximum );
+
+  if( !length )
+  {
+    throw std::logic_error( "length must not be zero" );
+  }
+
+  if( length > sizeof( uint64_t ) )
+  {
+    VITAL_THROW( kv::metadata_type_overflow,
+                 "value too large for native type" );
+  }
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_read_write.txx
+++ b/arrows/klv/klv_read_write.txx
@@ -56,6 +56,51 @@ bool
 _left_shift_overflow( T value );
 
 // ---------------------------------------------------------------------------
+// Returns the IMAP representation of positive or negative infinity.
+KWIVER_ALGO_KLV_EXPORT
+uint64_t
+_imap_infinity( bool sign_bit, size_t length );
+
+// ---------------------------------------------------------------------------
+// Returns the IMAP representation of positive or negative quiet NaN.
+KWIVER_ALGO_KLV_EXPORT
+uint64_t
+_imap_quiet_nan( bool sign_bit, size_t length );
+
+// ---------------------------------------------------------------------------
+// Returns the IMAP representation of positive or negative signaling NaN.
+KWIVER_ALGO_KLV_EXPORT
+uint64_t
+_imap_signal_nan( bool sign_bit, size_t length );
+
+// ---------------------------------------------------------------------------
+// Helper struct
+struct KWIVER_ALGO_KLV_EXPORT _imap_terms
+{
+  double forward_scale;
+  double backward_scale;
+  double zero_offset;
+};
+
+// ---------------------------------------------------------------------------
+// Calculates the derived terms needed for both IMAP reading and writing.
+KWIVER_ALGO_KLV_EXPORT
+_imap_terms
+_calculate_imap_terms( double minimum, double maximum, size_t length );
+
+// ---------------------------------------------------------------------------
+// Throws invalid_value if arguments don't make sense
+KWIVER_ALGO_KLV_EXPORT
+void
+_check_range_precision( double minimum, double maximum, double precision );
+
+// ---------------------------------------------------------------------------
+// Throws invalid_value if arguments don't make sense
+KWIVER_ALGO_KLV_EXPORT
+void
+_check_range_length( double minimum, double maximum, size_t length );
+
+// ---------------------------------------------------------------------------
 template < class T, class Iterator >
 T
 klv_read_int( Iterator& data, size_t length )
@@ -296,6 +341,103 @@ klv_ber_oid_length( T value )
 {
   KLV_ASSERT_UINT( T );
   return ( _int_bit_length( value ) + 6 ) / 7;
+}
+
+// ---------------------------------------------------------------------------
+template < class Iterator >
+double
+klv_read_imap( double minimum, double maximum, Iterator& data, size_t length )
+{
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  // Section 8.1.2
+  _check_range_length( minimum, maximum, length );
+
+  auto const int_value = klv_read_int< uint64_t >( data, length );
+  auto value = static_cast< double >( int_value );
+
+  // Section 8.2.2
+  // Left-shift required to shift a bit from the least significant place to the
+  // most significant place
+  auto const msb_shift = length * 8 - 1;
+
+  // Most significant bit and any other bit set means this is a special value
+  if( int_value & ( 1ull << msb_shift ) && int_value != ( 1ull << msb_shift ) )
+  {
+    // Third most significant bit = sign bit
+    bool const sign_bit = int_value & 1ull << ( msb_shift - 2 );
+
+    // Second, fourth, and fifth most significant bits = special value
+    // identifiers
+    constexpr uint64_t identifier_mask = 0xB; // 01011
+    auto const identifier =
+      ( int_value >> ( length * 8 - 5 ) ) & identifier_mask;
+
+    switch( identifier )
+    {
+      case 0x9: // 1001
+        value = std::numeric_limits< double >::infinity();
+        break;
+      case 0xA: // 1010
+        value = std::numeric_limits< double >::quiet_NaN();
+        break;
+      case 0xB: // 1011
+        value = std::numeric_limits< double >::signaling_NaN();
+        break;
+      default: // Reserved and user-defined values
+        return std::numeric_limits< double >::quiet_NaN();
+    }
+
+    return sign_bit ? -value : value;
+  }
+
+  // Normal value
+  auto const terms = _calculate_imap_terms( minimum, maximum, length );
+  value = terms.backward_scale * ( value - terms.zero_offset ) + minimum;
+
+  // Return exactly zero if applicable, overriding rounding errors. IMAP
+  // specification considers this important
+  auto const precision = klv_imap_precision( minimum, maximum, length );
+  return ( std::abs( value ) < precision / 2.0 ) ? 0.0 : value;
+}
+
+// ---------------------------------------------------------------------------
+template < class Iterator >
+void
+klv_write_imap( double value, double minimum, double maximum, Iterator& data,
+                size_t length )
+{
+  KLV_ASSERT_UINT8_ITERATOR( data );
+
+  // Section 8.1.2, 8.2.1
+  _check_range_length( minimum, maximum, length );
+
+  uint64_t int_value = 0;
+  if( std::isnan( value ) )
+  {
+    // We can't robustly tell the difference between quiet and signaling NaNs,
+    // so we just assume quiet. Therefore, we will never write signaling NaNs.
+    int_value = _imap_quiet_nan( std::signbit( value ), length );
+  }
+  // Out-of-range values set to infinity
+  else if( value < minimum )
+  {
+    int_value = _imap_infinity( true, length );
+  }
+  else if( value > maximum )
+  {
+    int_value = _imap_infinity( false, length );
+  }
+  // Normal values
+  else
+  {
+    auto const terms = _calculate_imap_terms( minimum, maximum, length );
+    int_value =
+      static_cast< uint64_t >( terms.forward_scale * ( value - minimum ) +
+                               terms.zero_offset );
+  }
+
+  klv_write_int( int_value, data, length );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
IMAP format is a method of encoding a floating-point number between defined upper and lower limits into an integer for concise transmission. Defined by [MISB ST1201](https://gwg.nga.mil/misb/docs/standards/ST1201.4.pdf), IMAP is a standardized series of calculations which map an integer of variable byte length such that each resultant floating-point value is equally spaced in the range, and such that zero, if present in the range, is mapped to exactly by some integer value. It contains additional special bit patterns for NaNs and infinities. It is one of three methods by which MISB encodes floating-point values into KLV streams.