### PR TITLE
Fix a bug typo in a cmake file that was missing a closing bracket

### DIFF
--- a/CMake/utils/kwiver-utils-python.cmake
+++ b/CMake/utils/kwiver-utils-python.cmake
@@ -149,7 +149,7 @@ function (kwiver_add_python_module path     modpath    module)
   # in source build this would be kwiver_python_install_path/project_name
   if(SKBUILD)
     set(pyfile_dst "${CMAKE_BINARY_DIR}/${modpath}/${module}.py")
-    set(mod_dst "${CMAKE_BINARY_DIR/${modpath}/" PARENT_SCOPE)
+    set(mod_dst "${CMAKE_BINARY_DIR}/${modpath}/" PARENT_SCOPE)
     # installation path for this module
     set(pypkg_install_path "${CMAKE_INSTALL_PREFIX}/${modpath}")
   else()

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -6,3 +6,7 @@ v1.6.0 release.
 
 Bug Fixes since v1.6.0
 ----------------------
+
+Build System
+
+* Fix missing-closing-bracket typo in `CMake/utils/kwiver-utils-python.cmake`.


### PR DESCRIPTION
This came up as an issue trying to locally build the python wheel.