### PR TITLE
Remove dummy terms from VNIIRS equation

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -337,13 +337,23 @@ compute_vniirs( double gsd, double rer, double snr )
   gsd *= meters_to_inches;
 
   double const log10_gsd = std::log10( gsd );
-  double const log10_rer = std::log10( rer );
 
-  auto vniirs = a0 +
-                a1 * log10_gsd +
-                a2 * ( 1.0 - std::exp( a3 / snr ) ) * log10_rer +
-                a4 * std::pow( log10_rer, 4 ) +
-                a5 / snr;
+  // double const log10_rer = std::log10( rer );
+  // auto vniirs = a0 +
+  //               a1 * log10_gsd +
+  //               a2 * ( 1.0 - std::exp( a3 / snr ) ) * log10_rer +
+  //               a4 * std::pow( log10_rer, 4 ) +
+  //               a5 / snr;
+  // Above is full equation; below is partial equation since we don't actually
+  // know RER or SNR
+  (void)rer;
+  (void)snr;
+  (void)a2;
+  (void)a3;
+  (void)a4;
+  (void)a5;
+  auto vniirs = a0 + a1 * log10_gsd;
+
   // 2.0 is defined as the lower bound for VNIIRs
   vniirs = std::max( vniirs, 2.0 );
   return vniirs;

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -102,7 +102,7 @@ TEST_F( derive_metadata, compute_derived )
 
   EXPECT_NEAR( 0.202224, gsd_value.as_double(), 0.000001);
 
-  // This will not actualy be correct due to image terms
-  // EXPECT_DOUBLE_EQ( 6.58, vniirs_value.as_double() );
+  // This only takes into account terms a0 and a1
+  EXPECT_NEAR( 6.578680, vniirs_value.as_double(), 0.000001 );
   EXPECT_DOUBLE_EQ( 13296.55762, slant_range_value.as_double() );
 }


### PR DESCRIPTION
Comments out the dummy placeholder values we previously put in for SNR and RER, opting instead to simply omit their terms from the equation.