### PR TITLE
Add klv_value

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -12,6 +12,7 @@ set( sources
   klv_key.cxx
   klv_parse.cxx
   klv_read_write.cxx
+  klv_value.cxx
   klv_0601.cxx
   klv_0104.cxx
   misp_time.cxx

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -1,0 +1,185 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief This file contains the implementation of the \c klv_value class.
+
+#include "klv_value.h"
+
+#include "klv_blob.h"
+
+#include <vital/util/demangle.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ---------------------------------------------------------------------------
+klv_bad_value_cast
+::klv_bad_value_cast( std::type_info const& requested_type,
+                      std::type_info const& actual_type )
+{
+  std::stringstream ss;
+  ss    << "klv_value: type "
+        << kwiver::vital::demangle( requested_type.name() )
+        << " was requested, but the object holds type "
+        << kwiver::vital::demangle( actual_type.name() );
+  m_message = ss.str();
+}
+
+// ---------------------------------------------------------------------------
+char const*
+klv_bad_value_cast
+::what() const noexcept
+{
+  return m_message.c_str();
+}
+
+// ---------------------------------------------------------------------------
+klv_value
+::klv_value() : m_length_hint{ 0 } {}
+
+// ---------------------------------------------------------------------------
+klv_value
+::klv_value( klv_value const& other ) : m_length_hint{ other.m_length_hint }
+{
+  m_item.reset( other.m_item ? other.m_item->clone() : nullptr );
+}
+
+// ---------------------------------------------------------------------------
+klv_value
+::klv_value( klv_value&& other )
+{
+  swap( other );
+}
+
+// ---------------------------------------------------------------------------
+kwiver::vital::any
+klv_value
+::to_any() const
+{
+  return m_item ? m_item->to_any() : kwiver::vital::any{};
+}
+
+// ---------------------------------------------------------------------------
+void
+klv_value
+::set_length_hint( size_t length_hint )
+{
+  m_length_hint = length_hint;
+}
+
+// ---------------------------------------------------------------------------
+size_t
+klv_value
+::length_hint() const
+{
+  return m_length_hint;
+}
+
+// ---------------------------------------------------------------------------
+klv_value&
+klv_value
+::swap( klv_value& rhs ) noexcept
+{
+  m_item.swap( rhs.m_item );
+  std::swap( m_length_hint, rhs.m_length_hint );
+  return *this;
+}
+
+// ---------------------------------------------------------------------------
+bool
+klv_value
+::empty() const noexcept
+{
+  return !m_item;
+}
+
+// ---------------------------------------------------------------------------
+bool
+klv_value
+::valid() const noexcept
+{
+  return m_item && type() != typeid( klv_blob );
+}
+
+// ---------------------------------------------------------------------------
+void
+klv_value
+::clear() noexcept
+{
+  m_item.reset();
+}
+
+// ---------------------------------------------------------------------------
+std::type_info const&
+klv_value
+::type() const noexcept
+{
+  return m_item ? m_item->type() : typeid( void );
+}
+
+// ---------------------------------------------------------------------------
+std::string
+klv_value
+::type_name() const noexcept
+{
+  return kwiver::vital::demangle( type().name() );
+}
+
+// ---------------------------------------------------------------------------
+std::string
+klv_value
+::to_string() const
+{
+  std::stringstream ss;
+  ss << *this;
+  return ss.str();
+}
+
+// ---------------------------------------------------------------------------
+bool
+operator<( klv_value const& lhs, klv_value const& rhs )
+{
+  if( rhs.empty() )
+  {
+    return false;
+  }
+  return lhs.empty() ? true : lhs.m_item->less_than( *rhs.m_item );
+}
+
+// ---------------------------------------------------------------------------
+bool
+operator==( klv_value const& lhs, klv_value const& rhs )
+{
+  if( lhs.empty() != rhs.empty() )
+  {
+    return false;
+  }
+  return ( lhs.empty() && rhs.empty() )
+         ? true
+         : lhs.m_item->equal_to( *rhs.m_item );
+}
+
+// ---------------------------------------------------------------------------
+bool
+operator!=( klv_value const& lhs, klv_value const& rhs )
+{
+  return !( lhs == rhs );
+}
+
+// ---------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_value const& rhs )
+{
+  return rhs.empty() ? os << "(empty)" : rhs.m_item->print( os );
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_value.h
+++ b/arrows/klv/klv_value.h
@@ -1,0 +1,314 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief This file contains the interface for the \c klv_value class.
+
+#include <arrows/klv/klv_blob.h>
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vital/any.h>
+
+#include <sstream>
+
+#ifndef KWIVER_ARROWS_KLV_KLV_VALUE_H_
+# define KWIVER_ARROWS_KLV_KLV_VALUE_H_
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Exception indicating a \c klv_value container did not contain the requested
+/// type.
+class klv_bad_value_cast : public std::bad_cast
+{
+public:
+  klv_bad_value_cast( std::type_info const& requested_type,
+                      std::type_info const& actual_type );
+
+  virtual ~klv_bad_value_cast() noexcept = default;
+
+  char const* what() const noexcept override;
+
+private:
+  std::string m_message;
+};
+
+// ----------------------------------------------------------------------------
+/// Type-erased container class for the values of KLV fields.
+///
+/// It is necessary for this class to exist separately from kwiver::vital::any
+/// to enforce that all contained values support comparison and stringstream
+/// operations. It also contains an optional embedded byte count - for some KLV
+/// data formats, the length can vary to reflect the precision of the numerical
+/// value. Knowing this precision may be desirable when performing
+/// calculations or writing the value back to KLV.
+class klv_value
+{
+public:
+  klv_value();
+
+  template < class T, typename std::enable_if<
+               !std::is_same< typename std::decay< T >::type,
+                              kwiver::vital::any >::value &&
+               !std::is_same< typename std::decay< T >::type,
+                              klv_value >::value, bool >::type = true >
+  klv_value( T&& value ) : m_length_hint{ 0 }
+  {
+    m_item.reset( new internal_< typename std::decay< T >::type >{ value } );
+  }
+
+  template < class T > explicit
+  klv_value( T&& value, size_t length_hint )
+  {
+    klv_value{ value }.swap( *this );
+    m_length_hint = length_hint;
+  }
+
+  klv_value( klv_value const& other );
+
+  klv_value( klv_value&& other );
+
+  ~klv_value() = default;
+
+  klv_value&
+  operator=( klv_value const& ) = default;
+
+  template < class T >
+  klv_value&
+  operator=( T&& rhs )
+  {
+    klv_value{ rhs }.swap( *this );
+    return *this;
+  }
+
+  /// Swap the contents of this \c klv_value with another.
+  klv_value&
+  swap( klv_value& rhs ) noexcept;
+
+  /// Create an \c any object with a copy of this value.
+  kwiver::vital::any
+  to_any() const;
+
+  /// Set the number of bytes this value should be written with.
+  void
+  set_length_hint( size_t length_hint );
+
+  /// Get the number of bytes this value should be written with.
+  size_t
+  length_hint() const;
+
+  /// Check if the object contains no value.
+  bool
+  empty() const noexcept;
+
+  /// Check if the object contains a value which is not of type \c klv_blob.
+  bool
+  valid() const noexcept;
+
+  /// Remove any existing value.
+  void
+  clear() noexcept;
+
+  /// Return type information for the contained value.
+  std::type_info const& type() const noexcept;
+
+  /// Return the demangled type name of the contained value.
+  std::string type_name() const noexcept;
+
+  /// Return a string representation of the contained value.
+  std::string
+  to_string() const;
+
+  /// Return a reference to the contained value of type \c T.
+  ///
+  /// \throws klv_bad_value_cast If the object does not contain a value of type
+  /// \c T.
+  template < class T >
+  T&
+  get()
+  {
+    auto const ptr = get_ptr< T >();
+    if( !ptr )
+    {
+      throw klv_bad_value_cast( typeid( T ), type() );
+    }
+    return *ptr;
+  }
+
+  /// Return a reference to the contained value of type \c T.
+  ///
+  /// \throws klv_bad_value_cast If the object does not contain a value of type
+  /// \c T.
+  template < class T >
+  T const&
+  get() const
+  {
+    auto const ptr = get_ptr< T >();
+    if( !ptr )
+    {
+      throw klv_bad_value_cast( typeid( T ), type() );
+    }
+    return *ptr;
+  }
+
+  /// Return a pointer to the contained value of type \c T, or \c nullptr on
+  /// failure.
+  template < class T >
+  T*
+  get_ptr() noexcept
+  {
+    if( !m_item )
+    {
+      return nullptr;
+    }
+
+    auto const ptr = dynamic_cast< internal_< T >* >( m_item.get() );
+    return ptr ? &ptr->m_item : nullptr;
+  }
+
+  /// Return a pointer to the contained value of type \c T, or \c nullptr on
+  /// failure.
+  template < class T >
+  T const*
+  get_ptr() const noexcept
+  {
+    if( !m_item )
+    {
+      return nullptr;
+    }
+
+    auto const ptr = dynamic_cast< internal_< T > const* >( m_item.get() );
+    return ptr ? &ptr->m_item : nullptr;
+  }
+
+  friend bool
+  operator<( klv_value const& lhs, klv_value const& rhs );
+
+  friend bool
+  operator==( klv_value const& lhs, klv_value const& rhs );
+
+  friend std::ostream&
+  operator<<( std::ostream& os, klv_value const& rhs );
+
+private:
+
+  // Abstract base class interfacing with the contained data type.
+  class internal_base
+  {
+  public:
+    virtual ~internal_base() = default;
+
+    virtual std::type_info const& type() const noexcept = 0;
+    virtual bool less_than( internal_base const& rhs ) const = 0;
+    virtual bool equal_to( internal_base const& rhs ) const = 0;
+    virtual std::ostream& print( std::ostream& os ) const = 0;
+    virtual internal_base* clone() const = 0;
+    virtual kwiver::vital::any to_any() const = 0;
+  };
+
+  // Type-specific implementation of the internal_base interface.
+  template < class T >
+  class internal_ : public internal_base
+  {
+  public:
+    explicit
+    internal_( T const& value ) : m_item( value ) {}
+
+    explicit
+    internal_( T&& value ) : m_item( value ) {}
+
+    std::type_info const&
+    type() const noexcept override final
+    {
+      return typeid( T );
+    }
+
+    bool
+    less_than( internal_base const& rhs ) const override final
+    {
+      auto const& lhs = *this;
+      // First, compare types
+      if( lhs.type().before( rhs.type() ) )
+      {
+        return true;
+      }
+      else if( lhs.type() == rhs.type() )
+      {
+        auto const& rhs_item =
+          dynamic_cast< internal_< T > const& >( rhs ).m_item;
+        // Second, compare values
+        return lhs.m_item < rhs_item;
+      }
+      return false;
+    }
+
+    bool
+    equal_to( internal_base const& rhs ) const override final
+    {
+      auto const& lhs = *this;
+
+      // First, compare types
+      if( lhs.type() != rhs.type() )
+      {
+        return false;
+      }
+
+      auto const& rhs_item =
+        dynamic_cast< internal_< T > const& >( rhs ).m_item;
+      // Second, compare values
+      return lhs.m_item == rhs_item;
+    }
+
+    std::ostream&
+    print( std::ostream& os ) const override final
+    {
+      return os << m_item;
+    }
+
+    internal_base*
+    clone() const override final
+    {
+      return new internal_< T >{ m_item };
+    }
+
+    kwiver::vital::any
+    to_any() const override final
+    {
+      return m_item;
+    }
+
+    T m_item;
+  };
+
+  std::unique_ptr< internal_base > m_item;
+  size_t m_length_hint;
+};
+
+// ---------------------------------------------------------------------------
+bool
+operator<( klv_value const& lhs, klv_value const& rhs );
+
+// ---------------------------------------------------------------------------
+bool
+operator==( klv_value const& lhs, klv_value const& rhs );
+
+// ---------------------------------------------------------------------------
+bool
+operator!=( klv_value const& lhs, klv_value const& rhs );
+
+// ---------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_value const& rhs );
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Add the `klv_value` class, which is similar to `kwiver::vital::any`, but with built-in support for the `<`, `<<`, `==` operators. This ensures we can perform certain basic operations even on type-erased values.