### PR TITLE
Add config options to limit metadata export frequency

### DIFF
--- a/arrows/core/metadata_map_io_csv.h
+++ b/arrows/core/metadata_map_io_csv.h
@@ -52,7 +52,10 @@ public:
   ///  Set configuration values
   void set_configuration( vital::config_block_sptr config ) override;
 
-  /// Check supplied configuration
+  /// Check supplied configuration.
+  ///
+  /// The options \c every_n_microseconds and \c every_n_frames cannot appear
+  /// in the same configuration.
   bool check_configuration( vital::config_block_sptr config ) const override;
 
   /// Get current configuration


### PR DESCRIPTION
Add `every_n_microseconds` and `every_n_frames` configuration options to the metadata CSV exporter, which allow the user to choose how often to add a new line to the CSV file, in terms of time or frames elapsed. A video may have one or more metadata packets per frame, which results in exported CSV files of significant size when given long videos or very detailed metadata. In use cases where large output files are undesirable, users may choose to export only sparse metadata using these new options.