### PR TITLE
Add KLV integral formats

### DIFF
--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -53,6 +53,173 @@ klv_data_format
   return ss.str();
 }
 
+// ----------------------------------------------------------------------------
+klv_uint_format
+::klv_uint_format( size_t fixed_length )
+  : klv_data_format_< data_type >{ fixed_length }
+{}
+
+// ----------------------------------------------------------------------------
+uint64_t
+klv_uint_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  return klv_read_int< uint64_t >( data, length );
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_uint_format
+::write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  klv_write_int( value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_uint_format
+::length_of_typed( uint64_t const& value,
+                   VITAL_UNUSED size_t length_hint ) const
+{
+  return klv_int_length( value );
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_uint_format
+::description() const
+{
+  std::stringstream ss;
+  ss << "unsigned integer of " << length_description();
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+klv_sint_format
+::klv_sint_format( size_t fixed_length )
+  : klv_data_format_< data_type >{ fixed_length }
+{}
+
+// ----------------------------------------------------------------------------
+int64_t
+klv_sint_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  return klv_read_int< int64_t >( data, length );
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_sint_format
+::write_typed( int64_t const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  klv_write_int( value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_sint_format
+::length_of_typed( int64_t const& value,
+                   VITAL_UNUSED size_t length_hint ) const
+{
+  return klv_int_length( value );
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_sint_format
+::description() const
+{
+  std::stringstream ss;
+  ss << "signed integer of " << length_description();
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+klv_ber_format
+::klv_ber_format() : klv_data_format_< data_type >{ 0 }
+{}
+
+// ----------------------------------------------------------------------------
+uint64_t
+klv_ber_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  return klv_read_ber< uint64_t >( data, length );
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_ber_format
+::write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  klv_write_ber( value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_ber_format
+::length_of_typed( uint64_t const& value,
+                   VITAL_UNUSED size_t length_hint ) const
+{
+  return klv_ber_length( value );
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_ber_format
+::description() const
+{
+  std::stringstream ss;
+  ss << "BER-encoded unsigned integer of " << length_description();
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+klv_ber_oid_format
+::klv_ber_oid_format()
+  : klv_data_format_< data_type >{ 0 }
+{}
+
+// ----------------------------------------------------------------------------
+uint64_t
+klv_ber_oid_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  return klv_read_ber_oid< uint64_t >( data, length );
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_ber_oid_format
+::write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  klv_write_ber_oid< uint64_t >( value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_ber_oid_format
+::length_of_typed( uint64_t const& value,
+                   VITAL_UNUSED size_t length_hint ) const
+{
+  return klv_ber_oid_length( value );
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_ber_oid_format
+::description() const
+{
+  std::stringstream ss;
+  ss << "BER-OID-encoded unsigned integer of " << length_description();
+  return ss.str();
+}
+
 } // namespace klv
 
 } // namespace arrows

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -260,6 +260,156 @@ protected:
   }
 };
 
+// ----------------------------------------------------------------------------
+/// Interprets data as an unsigned integer.
+class KWIVER_ALGO_KLV_EXPORT klv_uint_format
+  : public klv_data_format_< uint64_t >
+{
+public:
+  klv_uint_format( size_t fixed_length = 0 );
+
+  virtual
+  ~klv_uint_format() = default;
+
+  std::string
+  description() const override;
+
+protected:
+  uint64_t
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( uint64_t const& value, size_t length_hint ) const override;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a signed integer.
+class KWIVER_ALGO_KLV_EXPORT klv_sint_format
+  : public klv_data_format_< int64_t >
+{
+public:
+  klv_sint_format( size_t fixed_length = 0 );
+
+  virtual
+  ~klv_sint_format() = default;
+
+  std::string
+  description() const override;
+
+protected:
+  int64_t
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( int64_t const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( int64_t const& value, size_t length_hint ) const override;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as an enum type.
+template < class T >
+class KWIVER_ALGO_KLV_EXPORT klv_enum_format : public klv_data_format_< T >
+{
+public:
+  klv_enum_format( size_t fixed_length = 1 )
+    : klv_data_format_< T >{ fixed_length }
+  {}
+
+  virtual
+  ~klv_enum_format() = default;
+
+  std::string
+  description() const override
+  {
+    std::stringstream ss;
+    ss << this->type_name() << " enumeration of "
+       << this->length_description();
+    return ss.str();
+  }
+
+protected:
+  T
+  read_typed( klv_read_iter_t& data, size_t length ) const override
+  {
+    return static_cast< T >( klv_read_int< uint64_t >( data, length ) );
+  }
+
+  void
+  write_typed( T const& value,
+               klv_write_iter_t& data, size_t length ) const override
+  {
+    klv_write_int( static_cast< uint64_t >( value ), data, length );
+  }
+
+  size_t
+  length_of_typed( T const& value,
+                   VITAL_UNUSED size_t length_hint ) const override
+  {
+    return klv_int_length( static_cast< uint64_t >( value ) );
+  }
+
+  size_t m_length;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as an unsigned integer encoded in BER format.
+class KWIVER_ALGO_KLV_EXPORT klv_ber_format
+  : public klv_data_format_< uint64_t >
+{
+public:
+  klv_ber_format();
+
+  virtual
+  ~klv_ber_format() = default;
+
+  std::string
+  description() const override;
+
+protected:
+  uint64_t
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( uint64_t const& value, size_t length_hint ) const override;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as an unsigned integer encoded in BER-OID format.
+class KWIVER_ALGO_KLV_EXPORT klv_ber_oid_format
+  : public klv_data_format_< uint64_t >
+{
+public:
+  klv_ber_oid_format();
+
+  virtual
+  ~klv_ber_oid_format() = default;
+
+  std::string
+  description() const override;
+
+protected:
+  uint64_t
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( uint64_t const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( uint64_t const& value, size_t length_hint ) const override;
+};
+
 } // namespace klv
 
 } // namespace arrows


### PR DESCRIPTION
Add the `klv_data_format` classes for the `unsigned int`, `signed int`, `BER`, `BER-OID`, and `enum` formats. These are mostly just wrappers around existing functions.