### PR TITLE
Add support for alternate metadata representations

### DIFF
--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -170,7 +170,7 @@ public:
   metadata();
   metadata( metadata const& other );
   metadata( metadata&& other ) = default;
-  ~metadata() = default;
+  virtual ~metadata() = default;
   metadata& operator=( metadata&& other ) = default;
   metadata& operator=( metadata const& other );
 
@@ -364,6 +364,19 @@ public:
   kwiver::vital::timestamp timestamp() const;
 
   static std::string format_string( std::string const& val );
+
+protected:
+  // These functions can be overridden in a derived class to allow simultaneous
+  // manipulation of an alternate metadata representation using the same
+  // generalized interface.
+
+  // Add the given item to the alternate internal representation. Return false
+  // if the given tag cannot be represented.
+  virtual bool add_internal( metadata_item const& item );
+
+  // Remove the given tag's data from the alternate internal representation, if
+  // such data exists. Fail silently.
+  virtual void erase_internal( vital_metadata_tag tag );
 
 private:
   metadata_map_t m_metadata_map;


### PR DESCRIPTION
This branch was meant to solve the problem of interfacing with data structures for specific metadata formats (e.g. KLV) in a general way. We currently have the `kwiver::vital::metadata` class, but it only maintains an internal lookup table of simple tag-to-value pairs, and can't necessarily hold all the structured information KLV requires to read and write the data back out identically. Thus, we needed a way to both preserve the native KLV data structure while also allowing algorithms to interact with its metadata generically.

Originally, the idea was to make the `metadata` class an abstract interface, with `simple_metadata` and, eventually `klv_metadata` derived classes implementing that interface. However, this ran into a few wrinkles. First, there are many places in the existing codebase where `metadata` is instantiated directly, and we would have to go change all of those to `simple_metadata`, touching lots of code all over KWIVER and hopefully not breaking any of it. Second, functions which were extremely simple for the `map`-based implementation, like `size()`, become a lot more complicated once each tag has to be found and translated from another format. Third, KLV does not support e.g. the `FRAME_NUMBER` vital tag, but we don't want the program to crash or drop tags when an unsupported one is added to an `metadata` object, since that would break the interface. Suffice it to say, it solves many problems to just maintain a `map` of vital tags even in the derived classes, and the alternate representation (e.g. KLV) besides. Any modification of data happens to the two representations in parallel.

All this to justify why the below code is different from the usual KWIVER _modus operandi_ of abstract base classes and concrete implementations. We add two virtual functions `add_internal()` and `erase_internal()`, which serve as an interface between derived and base classes, with the base class implementing all the `map` functionality as before, and the derived class modifying the alternate representation as needed.

Feedback about these design decisions as well as the usual fare would be appreciated.