### PR TITLE
Add KLV tag traits

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -13,6 +13,7 @@ set( sources
   klv_key.cxx
   klv_parse.cxx
   klv_read_write.cxx
+  klv_tag_traits.cxx
   klv_value.cxx
   klv_0601.cxx
   klv_0104.cxx

--- a/arrows/klv/klv_tag_traits.cxx
+++ b/arrows/klv/klv_tag_traits.cxx
@@ -1,0 +1,150 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV tag traits interface.
+
+#include "klv_tag_traits.h"
+
+#include <algorithm>
+#include <limits>
+#include <sstream>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+klv_tag_count_range
+::klv_tag_count_range( size_t exact ) : m_lower{ exact }, m_upper{ exact } {}
+
+// ----------------------------------------------------------------------------
+klv_tag_count_range
+::klv_tag_count_range( size_t lower, size_t upper )
+  : m_lower{ std::min( lower, upper ) }, m_upper{ std::max( lower, upper ) }
+{}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_tag_count_range
+::lower() const { return m_lower; }
+
+// ----------------------------------------------------------------------------
+size_t
+klv_tag_count_range
+::upper() const { return m_upper; }
+
+// ----------------------------------------------------------------------------
+bool
+klv_tag_count_range
+::is_count_allowed( size_t count ) const
+{
+  return m_lower <= count && count <= m_upper;
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_count_range
+::description() const
+{
+  std::stringstream ss;
+  if( m_lower == m_upper )
+  {
+    ss << "exactly " << m_lower;
+  }
+  else if( m_lower == 0 && m_upper == SIZE_MAX )
+  {
+    ss << "any number";
+  }
+  else if( m_lower == 0 )
+  {
+    ss << "at most " << m_upper;
+  }
+  else if( m_upper == SIZE_MAX )
+  {
+    ss << "at least " << m_lower;
+  }
+  else
+  {
+    ss << "between " << m_lower << " and " << m_upper;
+  }
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_count_range
+::error_message( size_t count ) const
+{
+  std::stringstream ss;
+  ss << "tag appears " << count << " times; expected " << description();
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+klv_tag_traits
+::klv_tag_traits( klv_uds_key uds_key,
+                  klv_lds_key tag,
+                  std::string const& enum_name,
+                  klv_data_format_sptr format,
+                  std::string const& name,
+                  std::string const& description,
+                  klv_tag_count_range const& tag_count_range )
+  : m_name{ name }, m_enum_name{ enum_name }, m_description{ description },
+    m_lds_key{ tag }, m_uds_key{ uds_key }, m_format{ format },
+    m_tag_count_range{ tag_count_range }
+{}
+
+// ----------------------------------------------------------------------------
+klv_lds_key
+klv_tag_traits
+::tag() const { return m_lds_key; }
+
+// ----------------------------------------------------------------------------
+klv_uds_key
+klv_tag_traits
+::uds_key() const { return m_uds_key; }
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_traits
+::name() const { return m_name; }
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_traits
+::enum_name() const { return m_enum_name; }
+
+// ----------------------------------------------------------------------------
+std::type_info const&
+klv_tag_traits
+::type() const { return m_format->type(); }
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_traits
+::type_name() const { return m_format->type_name(); }
+
+// ----------------------------------------------------------------------------
+std::string
+klv_tag_traits
+::description() const { return m_description; }
+
+// ----------------------------------------------------------------------------
+klv_data_format&
+klv_tag_traits
+::format() const { return *m_format; }
+
+// ----------------------------------------------------------------------------
+klv_tag_count_range
+klv_tag_traits
+::tag_count_range() const { return m_tag_count_range; }
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_tag_traits.h
+++ b/arrows/klv/klv_tag_traits.h
@@ -1,0 +1,122 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of the KLV tag traits interface.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_TAG_TRAITS_H_
+#define KWIVER_ARROWS_KLV_KLV_TAG_TRAITS_H_
+
+
+#include <arrows/klv/klv_data_format.h>
+#include <arrows/klv/klv_key.h>
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vital/types/metadata.h>
+
+#include <string>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Inclusive numerical range describing how many times a tag is allowed to
+/// appear in the same metadata set.
+class KWIVER_ALGO_KLV_EXPORT klv_tag_count_range
+{
+public:
+  klv_tag_count_range( size_t exact );
+
+  klv_tag_count_range( size_t lower, size_t upper );
+
+  size_t
+  lower() const;
+
+  size_t
+  upper() const;
+
+  bool
+  is_count_allowed( size_t count ) const;
+
+  std::string
+  description() const;
+
+  std::string
+  error_message( size_t count ) const;
+
+private:
+  size_t m_lower;
+  size_t m_upper;
+};
+
+// ----------------------------------------------------------------------------
+/// Contains the constant attributes of a KLV metadata tag.
+class KWIVER_ALGO_KLV_EXPORT klv_tag_traits
+{
+public:
+  klv_tag_traits( klv_uds_key uds_key,
+                  klv_lds_key tag,
+                  std::string const& enum_name,
+                  klv_data_format_sptr format,
+                  std::string const& name,
+                  std::string const& description,
+                  klv_tag_count_range const& tag_count_range );
+
+  /// Return the LDS tag.
+  klv_lds_key
+  tag() const;
+
+  /// Return the UDS key.
+  klv_uds_key
+  uds_key() const;
+
+  /// Return the tag's name.
+  std::string
+  name() const;
+
+  /// Return a string version of the LDS tag, e.g. "KLV_0601_CHECKSUM".
+  std::string
+  enum_name() const;
+
+  /// Return the normative data type of the tag's value.
+  std::type_info const&
+  type() const;
+
+  /// Return a string representation of the tag's value's data type.
+  std::string
+  type_name() const;
+
+  /// Return a description of what this tag holds.
+  std::string
+  description() const;
+
+  /// Return the data format used to represent this tag's value.
+  klv_data_format&
+  format() const;
+
+  /// Return a range describing how many times this tag can appear in the same
+  /// metadata set.
+  klv_tag_count_range
+  tag_count_range() const;
+
+private:
+  std::string m_name;
+  std::string m_enum_name;
+  std::string m_description;
+  klv_lds_key m_lds_key;
+  klv_uds_key m_uds_key;
+  klv_data_format_sptr m_format;
+  klv_tag_count_range m_tag_count_range;
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Add a tag traits class for the KLV standards to hold static data for each tag - name, description, data format, etc. Similar idea to the traits for the vital tags.