### PR TITLE
Add required `klv_value` operators for `klv_blob`

### DIFF
--- a/arrows/klv/klv_blob.cxx
+++ b/arrows/klv/klv_blob.cxx
@@ -7,6 +7,9 @@
 
 #include "klv_blob.h"
 
+#include <iomanip>
+#include <ostream>
+
 namespace kwiver {
 
 namespace arrows {
@@ -53,6 +56,39 @@ klv_blob
 ::operator->() const
 {
   return &bytes;
+}
+
+// ----------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_blob const& blob )
+{
+  auto const flags = os.flags();
+
+  os << std::hex << std::setfill( '0' );
+  os << "< ";
+  for( auto const c : *blob )
+  {
+    os << std::setw( 2 ) << static_cast< unsigned int >( c ) << ' ';
+  }
+  os << ">";
+
+  os.flags( flags );
+  return os;
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator==( klv_blob const& lhs, klv_blob const& rhs )
+{
+  return *lhs == *rhs;
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator<( klv_blob const& lhs, klv_blob const& rhs )
+{
+  return std::lexicographical_compare( lhs->cbegin(), lhs->cend(),
+                                       rhs->cbegin(), rhs->cend() );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_blob.h
+++ b/arrows/klv/klv_blob.h
@@ -10,6 +10,7 @@
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
+#include <ostream>
 #include <vector>
 
 #include <cstdint>
@@ -48,6 +49,21 @@ public:
 private:
   klv_bytes_t bytes;
 };
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_blob const& blob );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator==( klv_blob const& lhs, klv_blob const& rhs );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator<( klv_blob const& lhs, klv_blob const& rhs );
 
 // While simple in implementation, these utility functions are included for
 // consistency with the rest of the KLV read / write API.


### PR DESCRIPTION
In order to be a `klv_value`, `klv_blob` needs to support the `<`, `==`, and `<<` operators. This PR adds them.