### PR TITLE
Add KLV universal and local set formats

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -13,6 +13,7 @@ set( sources
   klv_key.cxx
   klv_parse.cxx
   klv_read_write.cxx
+  klv_set.cxx
   klv_tag_traits.cxx
   klv_value.cxx
   klv_0601.cxx

--- a/arrows/klv/klv_set.cxx
+++ b/arrows/klv/klv_set.cxx
@@ -1,0 +1,26 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Instantiations of \c klv_set and \c klv_set_format.
+
+#include "klv_set.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+template class klv_set< klv_lds_key >;
+template class klv_set< klv_uds_key >;
+
+template class klv_set_format< klv_lds_key >;
+template class klv_set_format< klv_uds_key >;
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_set.h
+++ b/arrows/klv/klv_set.h
@@ -8,10 +8,14 @@
 #ifndef KWIVER_VITAL_KLV_KLV_SET_H_
 #define KWIVER_VITAL_KLV_KLV_SET_H_
 
+#include <arrows/klv/klv_data_format.h>
+#include <arrows/klv/klv_tag_traits.h>
 #include <arrows/klv/klv_value.h>
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
 #include <boost/range.hpp>
+
+#include <map>
 
 namespace kwiver {
 
@@ -30,7 +34,7 @@ namespace klv {
 /// Therefore, multimaps { A : 1, A : 2 } and { A : 2, A : 1 } evaluate as not
 /// equal. This class treats those sets as equal.
 template < class Key >
-class klv_set
+class KWIVER_ALGO_KLV_EXPORT klv_set
 {
 public:
   using container = std::multimap< Key, klv_value >;
@@ -213,10 +217,14 @@ public:
   }
 
   /// Returns iterators to all entries, sorted by key, then by value.
-  std::vector< iterator >
+  std::vector< const_iterator >
   fully_sorted() const
   {
-    std::vector< iterator > result{ cbegin(), cend() };
+    std::vector< const_iterator > result;
+    for( auto it = cbegin(); it != cend(); ++it )
+    {
+      result.push_back( it );
+    }
     std::sort( result.begin(), result.end(), value_compare );
     return result;
   }
@@ -234,8 +242,8 @@ public:
 
     return std::equal( lhs_values.cbegin(), lhs_values.cend(),
                        rhs_values.cbegin(),
-                       []( const_iterator lhs, const_iterator rhs ){
-                         return *lhs == *rhs;
+                       []( const_iterator lhs_value, const_iterator rhs_value ){
+                         return *lhs_value == *rhs_value;
                        } );
   }
 
@@ -267,7 +275,7 @@ public:
     for( auto const pair : values )
     {
       first = first ? false : ( os << ", ", false );
-      os << pair.get().first << ": " << pair.get().second;
+      os << pair->first << ": " << pair->second;
     }
     os << " }";
     return os;
@@ -291,6 +299,225 @@ private:
 
   std::multimap< Key, klv_value > m_items;
 };
+
+namespace klv_detail {
+
+// ----------------------------------------------------------------------------
+// Helper class for klv_set_format allowing compile-time lookup of functions
+// pertaining to a KLV key type.
+template < class Key > class KWIVER_ALGO_KLV_EXPORT key_traits;
+
+// ----------------------------------------------------------------------------
+template <>
+class KWIVER_ALGO_KLV_EXPORT key_traits< klv_lds_key >
+{
+public:
+  static klv_lds_key
+  read_key( klv_read_iter_t& data, size_t max_length )
+  {
+    return klv_read_lds_key( data, max_length );
+  }
+
+  static void
+  write_key( klv_lds_key const& key,
+             klv_write_iter_t& data, size_t max_length )
+  {
+    klv_write_lds_key( key, data, max_length );
+  }
+
+  static size_t
+  length_of_key( klv_lds_key const& key )
+  {
+    return klv_lds_key_length( key );
+  }
+
+  static klv_tag_traits const&
+  tag_traits_from_key( klv_tag_traits_lookup const& lookup,
+                       klv_lds_key const& key )
+  {
+    return lookup.by_tag( key );
+  }
+
+  static klv_lds_key
+  key_from_tag_traits( klv_tag_traits const& trait )
+  {
+    return trait.tag();
+  }
+};
+
+// ----------------------------------------------------------------------------
+template <>
+class KWIVER_ALGO_KLV_EXPORT key_traits< klv_uds_key >
+{
+public:
+  static klv_uds_key
+  read_key( klv_read_iter_t& data, size_t max_length )
+  {
+    return klv_read_uds_key( data, max_length );
+  }
+
+  static void
+  write_key( klv_uds_key const& key,
+             klv_write_iter_t& data, size_t max_length )
+  {
+    klv_write_uds_key( key, data, max_length );
+  }
+
+  static size_t
+  length_of_key( klv_uds_key const& key )
+  {
+    return klv_uds_key_length( key );
+  }
+
+  static klv_tag_traits const&
+  tag_traits_from_key( klv_tag_traits_lookup const& lookup,
+                       klv_uds_key const& key )
+  {
+    return lookup.by_uds_key( key );
+  }
+
+  static klv_uds_key
+  key_from_tag_traits( klv_tag_traits const& trait )
+  {
+    return trait.uds_key();
+  }
+};
+
+} // namespace klv_detail
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a local or universal set.
+template < class Key >
+class KWIVER_ALGO_KLV_EXPORT klv_set_format
+  : public klv_data_format_< klv_set< Key > >
+{
+public:
+  explicit
+  klv_set_format( klv_tag_traits_lookup const& traits )
+    : klv_data_format_< klv_set< Key > >{ 0 }, m_traits{ traits } {}
+
+  virtual
+  ~klv_set_format() = default;
+
+protected:
+  using key_traits = klv_detail::key_traits< Key >;
+
+  klv_set< Key >
+  read_typed( klv_read_iter_t& data, size_t length ) const override final
+  {
+    // These help us keep track of how many bytes we have read
+    auto const begin = data;
+    auto const remaining_length =
+      [ & ]() -> size_t {
+        return length - std::distance( begin, data );
+      };
+
+    klv_set< Key > result;
+    while( remaining_length() )
+    {
+      // Key
+      auto const key = key_traits::read_key( data, remaining_length() );
+
+      // Length
+      auto const length_of_value =
+        klv_read_ber< size_t >( data, remaining_length() );
+
+      // Value
+      auto const& traits = key_traits::tag_traits_from_key( m_traits, key );
+      auto value = traits.format().read( data, length_of_value );
+
+      result.add( key, std::move( value ) );
+    }
+    check_tag_counts( result );
+
+    return result;
+  }
+
+  void
+  write_typed( klv_set< Key > const& klv,
+               klv_write_iter_t& data, size_t length ) const override final
+  {
+    // These help us keep track of how many bytes we have written
+    auto const begin = data;
+    auto const remaining_length =
+      [ & ]() -> size_t {
+        return length - std::distance( begin, data );
+      };
+
+    check_tag_counts( klv );
+    for( auto const& entry : klv )
+    {
+      auto const& key = entry.first;
+      auto const& value = entry.second;
+      auto const& traits = key_traits::tag_traits_from_key( m_traits, key );
+
+      // Key
+      key_traits::write_key( key, data, remaining_length() );
+
+      // Length
+      auto const length_of_value = traits.format().length_of( value );
+      klv_write_ber( length_of_value, data, remaining_length() );
+
+      // Value
+      traits.format().write( value, data, remaining_length() );
+    }
+  }
+
+  size_t
+  length_of_typed( klv_set< Key > const& value,
+                   VITAL_UNUSED size_t length_hint ) const override final
+  {
+    constexpr size_t initializer = 0;
+    auto accumulator =
+      [ this ]( size_t total,
+                typename klv_set< Key >::value_type const& entry ){
+        auto const& key = entry.first;
+        auto const& traits = key_traits::tag_traits_from_key( m_traits, key );
+
+        auto const length_of_key = key_traits::length_of_key( key );
+        auto const length_of_value = traits.format().length_of( entry.second );
+        auto const length_of_length = klv_ber_length( length_of_value );
+        return total +
+               length_of_key + length_of_length + length_of_value;
+      };
+    return std::accumulate( value.cbegin(), value.cend(),
+                            initializer, accumulator );
+  }
+
+  // Print warnings if tags appear too few or too many times in the given set.
+  void
+  check_tag_counts( klv_set< Key > const& klv ) const
+  {
+    for( auto const& trait : m_traits )
+    {
+      auto const count = klv.count( key_traits::key_from_tag_traits( trait ) );
+      auto const range = trait.tag_count_range();
+      if( !range.is_count_allowed( count ) )
+      {
+        LOG_WARN( kwiver::vital::get_logger( "klv" ),
+                  range.error_message( count ) );
+      }
+    }
+  }
+
+  klv_tag_traits_lookup const& m_traits;
+};
+
+// ----------------------------------------------------------------------------
+/// KLV local set. Key-value pairs of a format defined by a standard.
+using klv_local_set = klv_set< klv_lds_key >;
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a KLV local set.
+using klv_local_set_format = klv_set_format< klv_lds_key >;
+
+// ----------------------------------------------------------------------------
+/// KLV universal set. Key-value pairs of a format defined by a standard.
+using klv_universal_set = klv_set< klv_uds_key >;
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a KLV universal set.
+using klv_universal_set_format = klv_set_format< klv_uds_key >;
 
 } // namespace klv
 


### PR DESCRIPTION
Add data format classes for KLV universal and local sets. These are very similar formats, differing only in the type of key used. They are actually implemented here as a single template class `klv_set_format`, templated on `Key`. Key-specific functionality is relegated to a helper class, `key_traits`. 

Also included here are a few fixes to `klv_set` which were not detected earlier because I forgot to instantiate the template, so the compiler didn't actually compile it.