### PR TITLE
Add KLV ST1108 metric set parser

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -18,6 +18,7 @@ set( sources
   klv_value.cxx
   klv_0601.cxx
   klv_0104.cxx
+  klv_1108_metric_set.cxx
   misp_time.cxx
   )
 

--- a/arrows/klv/klv_1108_metric_set.cxx
+++ b/arrows/klv/klv_1108_metric_set.cxx
@@ -1,0 +1,197 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV 1108 Metric Local Set parser.
+
+#include "klv_1108_metric_set.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+namespace {
+
+constexpr auto metric_implementer_separator = '\x1E';
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_1108_metric_set_tag tag )
+{
+  return os << klv_1108_metric_set_traits_lookup().by_tag( tag ).name();
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator==( klv_1108_metric_implementer const& lhs,
+            klv_1108_metric_implementer const& rhs )
+{
+  return lhs.organization == rhs.organization && lhs.subgroup == rhs.subgroup;
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator<( klv_1108_metric_implementer const& lhs,
+           klv_1108_metric_implementer const& rhs )
+{
+  if( lhs.organization < rhs.organization )
+  {
+    return true;
+  }
+  if( lhs.organization > rhs.organization )
+  {
+    return false;
+  }
+  return lhs.subgroup < rhs.subgroup;
+}
+
+// ----------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_1108_metric_implementer const& rhs )
+{
+  return os << "{ Organization: \"" << rhs.organization << "\", "
+            << "Subgroup: \"" << rhs.subgroup << "\" }";
+}
+
+// ----------------------------------------------------------------------------
+klv_1108_metric_implementer_format
+::klv_1108_metric_implementer_format()
+  : klv_data_format_< klv_1108_metric_implementer >{ 0 }
+{}
+
+// ----------------------------------------------------------------------------
+klv_1108_metric_implementer
+klv_1108_metric_implementer_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  // Split by separator character
+  auto const s = klv_read_string( data, length );
+  auto const pos = s.find( metric_implementer_separator );
+  if( pos == s.npos )
+  {
+    LOG_WARN( kwiver::vital::get_logger( "klv" ),
+              "separator character 0x1E not found "
+              "in metric implementer string" );
+    return { s, "" };
+  }
+  return { s.substr( 0, pos ), s.substr( pos + 1 ) };
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_1108_metric_implementer_format
+::write_typed( klv_1108_metric_implementer const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  auto const s = value.organization + metric_implementer_separator +
+                 value.subgroup;
+  klv_write_string( s, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_1108_metric_implementer_format
+::length_of_typed( klv_1108_metric_implementer const& value,
+                   VITAL_UNUSED size_t length_hint ) const
+{
+  // Add one byte for separator character
+  return value.organization.size() + 1 + value.subgroup.size();
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_1108_metric_implementer_format
+::description() const
+{
+  return "metric implementer of " + length_description();
+}
+
+// ----------------------------------------------------------------------------
+klv_1108_metric_local_set_format
+::klv_1108_metric_local_set_format()
+  : klv_local_set_format{ klv_1108_metric_set_traits_lookup() }
+{}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_1108_metric_local_set_format
+::description() const
+{
+  std::stringstream ss;
+  ss << "ST 1108 metric local set";
+  return ss.str();
+}
+
+// ----------------------------------------------------------------------------
+klv_uds_key
+klv_1108_metric_set_key()
+{
+  // From Table 1 of https://gwg.nga.mil/misb/docs/standards/ST1108.3.pdf
+  return { 0x060E2B3402030101, 0x0E01050100000000 };
+}
+
+// ----------------------------------------------------------------------------
+klv_tag_traits_lookup const&
+klv_1108_metric_set_traits_lookup()
+{
+#define ENUM_AND_NAME( X ) X, #X
+  // Constants here are taken from Table 5 of
+  // https://gwg.nga.mil/misb/docs/standards/ST1108.3.pdf
+  // Descriptions are edited for clarity, brevity, consistency, etc.
+  static klv_tag_traits_lookup const lookup = {
+    { {},
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_UNKNOWN ),
+      std::make_shared< klv_blob_format >(),
+      "Unknown Tag",
+      "Unknown tag.",
+      0 },
+    { { 0x060E2B3401010101, 0x0E01050700000000 }, // "Key" column
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_NAME ),  // KWIVER enumeration
+      std::make_shared< klv_string_format >(),    // "Type" column
+      "Metric Name",                              // "Item Name" column
+      "Examples: 'VNIIRS', 'RER', 'GSD'.",        // "Notes" column
+      1 },                                        // "M/O" column (mandatory)
+    { { 0x060E2B3401010101, 0x0E01050800000000 },
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_VERSION ),
+      std::make_shared< klv_string_format >(),
+      "Metric Version",
+      "Alphanumeric denoting calculated values. 'Human' for observed.",
+      1 },
+    { { 0x060E2B3401010101, 0x0E01050900000000 },
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_IMPLEMENTER ),
+      std::make_shared< klv_1108_metric_implementer_format >(),
+      "Metric Implementer",
+      "Identifies organization responsible for how metric is calculated.",
+      1 },
+    { { 0x060E2B3401010101, 0x0E01050A00000000 },
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_PARAMETERS ),
+      std::make_shared< klv_string_format >(),
+      "Metric Parameters",
+      "Additional information needed to replicate the calculation.",
+      { 0, 1 } },
+    { { 0x060E2B3401010103, 0x0702010101050000 },
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_TIME ),
+      std::make_shared< klv_uint_format >( 8 ),
+      "Metric Time",
+      "Time of metric assessment. MISP Precision Timestamp.",
+      1 },
+    { { 0x060E2B3401010101, 0x0E01050B00000000 },
+      ENUM_AND_NAME( KLV_1108_METRIC_SET_VALUE ),
+      std::make_shared< klv_float_format >(),
+      "Metric Value",
+      "Numeric value of calculation.",
+      1 } };
+#undef ENUM_AND_NAME
+  return lookup;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_1108_metric_set.h
+++ b/arrows/klv/klv_1108_metric_set.h
@@ -1,0 +1,118 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Interface to the KLV 1108 Metric Local Set parser.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_1108_METRIC_SET_H_
+#define KWIVER_ARROWS_KLV_KLV_1108_METRIC_SET_H_
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include "klv_key.h"
+#include "klv_set.h"
+
+#include <ostream>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+enum klv_1108_metric_set_tag : klv_lds_key
+{
+  KLV_1108_METRIC_SET_UNKNOWN     = 0,
+  KLV_1108_METRIC_SET_NAME        = 1,
+  KLV_1108_METRIC_SET_VERSION     = 2,
+  KLV_1108_METRIC_SET_IMPLEMENTER = 3,
+  KLV_1108_METRIC_SET_PARAMETERS  = 4,
+  KLV_1108_METRIC_SET_TIME        = 5,
+  KLV_1108_METRIC_SET_VALUE       = 6,
+  KLV_1108_METRIC_SET_ENUM_END,
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_1108_metric_set_tag tag );
+
+// ----------------------------------------------------------------------------
+/// Indicates who implemented the software which calculated the metric.
+struct KWIVER_ALGO_KLV_EXPORT klv_1108_metric_implementer {
+  std::string organization;
+  std::string subgroup;
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator==( klv_1108_metric_implementer const& lhs,
+            klv_1108_metric_implementer const& rhs );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator<( klv_1108_metric_implementer const& lhs,
+           klv_1108_metric_implementer const& rhs );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_1108_metric_implementer const& rhs );
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a KLV 1108 metric local set implementer.
+class KWIVER_ALGO_KLV_EXPORT klv_1108_metric_implementer_format
+  : public klv_data_format_< klv_1108_metric_implementer >
+{
+public:
+  klv_1108_metric_implementer_format();
+
+  std::string
+  description() const override;
+
+private:
+  klv_1108_metric_implementer
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( klv_1108_metric_implementer const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( klv_1108_metric_implementer const& value,
+                   size_t length_hint ) const override;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a KLV 1108 metric local set.
+class KWIVER_ALGO_KLV_EXPORT klv_1108_metric_local_set_format
+  : public klv_local_set_format
+{
+public:
+  klv_1108_metric_local_set_format();
+
+  std::string
+  description() const override;
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+klv_uds_key
+klv_1108_metric_set_key();
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+klv_tag_traits_lookup const&
+klv_1108_metric_set_traits_lookup();
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/klv/klv_blob.cxx
+++ b/arrows/klv/klv_blob.cxx
@@ -8,7 +8,6 @@
 #include "klv_blob.h"
 
 #include <iomanip>
-#include <ostream>
 
 namespace kwiver {
 

--- a/arrows/klv/klv_set.h
+++ b/arrows/klv/klv_set.h
@@ -394,7 +394,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_set_format
 public:
   explicit
   klv_set_format( klv_tag_traits_lookup const& traits )
-    : klv_data_format_< klv_set< Key > >{ 0 }, m_traits{ traits } {}
+    : klv_data_format_< klv_set< Key > >{ 0 }, m_traits( traits ) {}
 
   virtual
   ~klv_set_format() = default;

--- a/arrows/klv/klv_tag_traits.cxx
+++ b/arrows/klv/klv_tag_traits.cxx
@@ -252,7 +252,7 @@ klv_tag_traits_lookup
       throw std::logic_error( ss.str() );
     }
     if( !trait.enum_name().empty() &&
-        !m_name_to_traits.emplace( trait.enum_name(), &trait ).second )
+        !m_enum_name_to_traits.emplace( trait.enum_name(), &trait ).second )
     {
       std::stringstream ss;
       ss << "duplicate enum name in traits: '" << trait.enum_name() << "'";

--- a/arrows/klv/tests/CMakeLists.txt
+++ b/arrows/klv/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set( test_libraries kwiver_algo_core kwiver_algo_klv vital )
 # KLV tests
 ##############################
 
-kwiver_discover_gtests( klv klv_blob       LIBRARIES ${test_libraries} )
-kwiver_discover_gtests( klv klv_checksum   LIBRARIES ${test_libraries} )
-kwiver_discover_gtests( klv klv_read_write LIBRARIES ${test_libraries} )
+kwiver_discover_gtests( klv klv_blob            LIBRARIES ${test_libraries} )
+kwiver_discover_gtests( klv klv_checksum        LIBRARIES ${test_libraries} )
+kwiver_discover_gtests( klv klv_read_write      LIBRARIES ${test_libraries} )
+kwiver_discover_gtests( klv klv_1108_metric_set LIBRARIES ${test_libraries} )

--- a/arrows/klv/tests/data_format.h
+++ b/arrows/klv/tests/data_format.h
@@ -1,0 +1,102 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Utility function templates for testing read/write for KLV data
+/// formats.
+
+#include <arrows/klv/klv_data_format.h>
+
+#include <vital/util/demangle.h>
+
+#include <tests/test_gtest.h>
+
+// ----------------------------------------------------------------------------
+using namespace kwiver::arrows::klv;
+namespace kv = kwiver::vital;
+
+// ----------------------------------------------------------------------------
+template < class Format >
+void
+test_read_format( klv_value const& expected_result, klv_bytes_t const& bytes )
+{
+  Format const format;
+  auto it = bytes.cbegin();
+  auto const result = format.read( it, bytes.size() );
+  ASSERT_EQ( bytes.cend(), it );
+  ASSERT_EQ( expected_result.type(), result.type() )
+        << "\n  --type difference--\n  "
+        << kv::demangle( expected_result.type().name() )
+        << "\n  --versus--\n  "
+        << kv::demangle( result.type().name() );
+  EXPECT_EQ( expected_result, result )
+        << "\n  --value difference--\n  "
+        << format.to_string( expected_result )
+        << "\n  --versus--\n  "
+        << format.to_string( result );
+}
+
+// ----------------------------------------------------------------------------
+template < class Format >
+void
+test_write_format( klv_value const& value )
+{
+  Format const format;
+  klv_bytes_t bytes( format.length_of( value ) );
+  auto write_it = bytes.begin();
+  format.write( value, write_it, bytes.size() );
+  ASSERT_EQ( bytes.end(), write_it );
+
+  auto read_it = bytes.cbegin();
+  auto const result = format.read( read_it, bytes.size() );
+  ASSERT_EQ( value.type(), result.type() )
+        << "\n  --type difference--\n  "
+        << kv::demangle( value.type().name() )
+        << "\n  --versus--\n  "
+        << kv::demangle( result.type().name() );
+  EXPECT_EQ( value, result )
+        << "\n  --value difference--\n  "
+        << format.to_string( value )
+        << format.to_string( result );
+}
+
+// ----------------------------------------------------------------------------
+template < class Format >
+void
+test_read_write_format( klv_value const& expected_result,
+                        klv_bytes_t const& bytes )
+{
+  Format const format;
+  auto it = bytes.cbegin();
+  auto result = format.read( it, bytes.size() );
+  ASSERT_EQ( bytes.cend(), it );
+  ASSERT_EQ( expected_result.type(), result.type() )
+        << "\n  --type difference--\n  "
+        << kv::demangle( expected_result.type().name() )
+        << "\n  --versus--\n  "
+        << kv::demangle( result.type().name() );
+  EXPECT_EQ( expected_result, result )
+        << "\n  --value difference--\n  "
+        << format.to_string( expected_result )
+        << "\n  --versus--\n  "
+        << format.to_string( result );
+
+  klv_bytes_t buffer( format.length_of( result ) );
+  auto write_it = buffer.begin();
+  format.write( result, write_it, buffer.size() );
+  ASSERT_EQ( buffer.end(), write_it );
+
+  auto read_it = buffer.cbegin();
+  result = format.read( read_it, buffer.size() );
+  ASSERT_EQ( expected_result.type(), result.type() )
+        << "\n  --type difference--\n  "
+        << kv::demangle( expected_result.type().name() )
+        << "\n  --versus--\n  "
+        << kv::demangle( result.type().name() );
+  EXPECT_EQ( expected_result, result )
+        << "\n  --value difference--\n  "
+        << format.to_string( expected_result )
+        << "\n  --versus--\n  "
+        << format.to_string( result );
+}

--- a/arrows/klv/tests/test_klv_1108_metric_set.cxx
+++ b/arrows/klv/tests/test_klv_1108_metric_set.cxx
@@ -1,0 +1,76 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Test KLV 1108 metric set read / write.
+
+#include "data_format.h"
+
+#include <arrows/klv/klv_1108_metric_set.h>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+void
+test_read( klv_value const& expected_result, klv_bytes_t const& input_bytes )
+{
+  using format_t = klv_1108_metric_local_set_format;
+  test_read_format< format_t >( expected_result, input_bytes );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, read_1108_metric_set )
+{
+  auto const input_bytes = klv_bytes_t{
+    KLV_1108_METRIC_SET_NAME,        3, 'G', 'S', 'D',
+    KLV_1108_METRIC_SET_VERSION,     5, 'H', 'u', 'm', 'a', 'n',
+    KLV_1108_METRIC_SET_IMPLEMENTER, 5, 'K', 'W', 30, 'C', 'V',
+    KLV_1108_METRIC_SET_PARAMETERS,  3, 'x', '=', '7',
+    KLV_1108_METRIC_SET_TIME,        8,
+    0x00, 0x00, 0x00, 0x00, 0x61, 0x27, 0xD3, 0x80,
+    KLV_1108_METRIC_SET_VALUE,       8,
+    0x3F, 0xF3, 0xC0, 0xC9, 0x53, 0x9B, 0x88, 0x87,
+    // Unknown tag
+    KLV_1108_METRIC_SET_ENUM_END,    2, 0x01, 0x02 };
+  auto const expected_result = klv_local_set{
+    { KLV_1108_METRIC_SET_NAME,        std::string{ "GSD" } },
+    { KLV_1108_METRIC_SET_VERSION,     std::string{ "Human" } },
+    { KLV_1108_METRIC_SET_IMPLEMENTER,
+      klv_1108_metric_implementer{ "KW", "CV" } },
+    { KLV_1108_METRIC_SET_PARAMETERS,  std::string{ "x=7" } },
+    { KLV_1108_METRIC_SET_TIME,        uint64_t{ 1630000000 } },
+    { KLV_1108_METRIC_SET_VALUE,       1.234567 },
+    { KLV_1108_METRIC_SET_ENUM_END,    klv_blob{ { 0x01, 0x02 } } } };
+
+  CALL_TEST( test_read, {}, {} );
+  CALL_TEST( test_read, expected_result, input_bytes );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_write( klv_value const& value )
+{
+  test_write_format< klv_1108_metric_local_set_format >( value );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, write_1108_metric_set )
+{
+  auto const test_data = klv_local_set{
+    { KLV_1108_METRIC_SET_NAME,        std::string{ "METRIC" } },
+    { KLV_1108_METRIC_SET_VERSION,     std::string{ "13 and a half" } },
+    { KLV_1108_METRIC_SET_IMPLEMENTER, klv_1108_metric_implementer{ "", "" } },
+    { KLV_1108_METRIC_SET_PARAMETERS,  klv_value{} },
+    { KLV_1108_METRIC_SET_TIME,        uint64_t{ 1630000001000000 } },
+    { KLV_1108_METRIC_SET_VALUE,
+      klv_value{ std::numeric_limits< double >::infinity(), 4 } }, };
+  CALL_TEST( test_write, {} );
+  CALL_TEST( test_write, test_data );
+}

--- a/arrows/klv/tests/test_klv_blob.cxx
+++ b/arrows/klv/tests/test_klv_blob.cxx
@@ -7,7 +7,7 @@
 
 #include <arrows/klv/klv_blob.txx>
 
-#include <gtest/gtest.h>
+#include <tests/test_gtest.h>
 
 #include <vector>
 
@@ -18,10 +18,6 @@ main( int argc, char** argv )
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
 }
-
-// ----------------------------------------------------------------------------
-#define CALL_TEST( func, ... ) \
-  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
 
 using namespace kwiver::arrows::klv;
 

--- a/arrows/klv/tests/test_klv_checksum.cxx
+++ b/arrows/klv/tests/test_klv_checksum.cxx
@@ -7,7 +7,7 @@
 
 #include <arrows/klv/klv_checksum.h>
 
-#include <gtest/gtest.h>
+#include <tests/test_gtest.h>
 
 #include <vector>
 
@@ -18,10 +18,6 @@ main( int argc, char** argv )
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
 }
-
-// ----------------------------------------------------------------------------
-#define CALL_TEST( func, ... ) \
-  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
 
 using namespace kwiver::arrows::klv;
 

--- a/arrows/klv/tests/test_klv_read_write.cxx
+++ b/arrows/klv/tests/test_klv_read_write.cxx
@@ -7,7 +7,7 @@
 
 #include <arrows/klv/klv_read_write.txx>
 
-#include <gtest/gtest.h>
+#include <tests/test_gtest.h>
 
 // ----------------------------------------------------------------------------
 int
@@ -16,10 +16,6 @@ main( int argc, char** argv )
   ::testing::InitGoogleTest( &argc, argv );
   return RUN_ALL_TESTS();
 }
-
-// ----------------------------------------------------------------------------
-#define CALL_TEST( func, ... ) \
-  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
 
 using namespace kwiver::arrows::klv;
 namespace kv = kwiver::vital;

--- a/tests/test_gtest.h
+++ b/tests/test_gtest.h
@@ -72,6 +72,14 @@
 #define TEST_ARG(var) \
   public: decltype(g_ ## var) const& var = g_ ## var
 
+// ----------------------------------------------------------------------------
+/// Call a test function with the given arguments and print a traceback
+/// on failure.
+///
+/// \param func Test function to call.
+#define CALL_TEST( func, ... ) \
+  do { SCOPED_TRACE( #func ); func( __VA_ARGS__ ); } while( 0 )
+
 namespace kwiver {
 namespace testing {
 


### PR DESCRIPTION
We are finally at the point where we can start pushing MISB standard readers/writers. There will be four in total. This is the simplest one, based on [ST1108](https://gwg.nga.mil/misb/docs/standards/ST1108.3.pdf), section 6.4. The ST1108 metric set is a local set found within the larger ST1108 local set, which is described in the rest of the document. A few custom types need to be defined along with the local set itself.

A test is included here to verify the read/write capabilities of this code.