### PR TITLE
Use new vital iterator_range instead of boost

### DIFF
--- a/arrows/klv/klv_set.h
+++ b/arrows/klv/klv_set.h
@@ -13,7 +13,7 @@
 #include <arrows/klv/klv_value.h>
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
-#include <boost/range.hpp>
+#include <vital/range/iterator_range.h>
 
 #include <map>
 
@@ -41,8 +41,8 @@ public:
   using iterator = typename container::iterator;
   using const_iterator = typename container::const_iterator;
   using value_type = typename container::value_type;
-  using range = boost::iterator_range< iterator >;
-  using const_range = boost::iterator_range< const_iterator >;
+  using range = kwiver::vital::range::iterator_range< iterator >;
+  using const_range = kwiver::vital::range::iterator_range< const_iterator >;
 
   klv_set() {}
 

--- a/vital/range/iterator_range.h
+++ b/vital/range/iterator_range.h
@@ -1,0 +1,43 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef VITAL_ITERATOR_RANGE_H
+#define VITAL_ITERATOR_RANGE_H
+
+/// \file Class to wrap two iterators in a range-friendly way.
+
+#include <utility>
+
+namespace kwiver {
+
+namespace vital {
+
+namespace range {
+
+// ----------------------------------------------------------------------------
+/// Wraps two iterators into a range.
+template < class Iterator >
+class iterator_range
+{
+public:
+  iterator_range( Iterator const& begin, Iterator const& end )
+    : m_begin{ begin }, m_end{ end } {}
+  iterator_range( Iterator&& begin, Iterator&& end )
+    : m_begin{ std::move( begin ) }, m_end{ std::move( end ) } {}
+
+  Iterator begin() const { return m_begin; }
+  Iterator end() const { return m_end; }
+
+protected:
+  Iterator m_begin;
+  Iterator m_end;
+};
+
+} // namespace range
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif

--- a/vital/range/tests/CMakeLists.txt
+++ b/vital/range/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set( test_libraries )
 # Range tests
 ##############################
 
+kwiver_discover_gtests(vital iterator_range     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital range_filter       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital range_indirect     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital range_iota         LIBRARIES ${test_libraries})

--- a/vital/range/tests/test_iterator_range.cxx
+++ b/vital/range/tests/test_iterator_range.cxx
@@ -1,0 +1,38 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test iterator range.
+
+#include "test_values.h"
+
+#include <vital/range/iterator_range.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST ( iterator_range, equal )
+{
+  auto const begin = test_values;
+  auto const end = test_values + sizeof( test_values ) / sizeof( int );
+  auto const test_range = range::iterator_range< int const* >{ begin, end };
+
+  auto it = begin;
+  for( auto const x : test_range )
+  {
+    EXPECT_EQ( *it, x );
+    ++it;
+  }
+  EXPECT_EQ( end, it );
+}


### PR DESCRIPTION
Create a custom range wrapper class that allows use of e.g. range-based for loops on an arbitrary pair of iterators. A very simple implementation for now, but helps clean up syntax a bit. Motivated by the desire to replace the boost version of this class in `klv_set`, which is done here also.