### PR TITLE
Add KLV packet

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -11,6 +11,7 @@ set( sources
   klv_data.cxx
   klv_data_format.cxx
   klv_key.cxx
+  klv_packet.cxx
   klv_parse.cxx
   klv_read_write.cxx
   klv_set.cxx

--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -1,0 +1,151 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV packet.
+
+#include "klv_packet.h"
+
+namespace kv = kwiver::vital;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+std::ostream&
+operator<<( std::ostream& os, klv_packet const& packet )
+{
+  auto const& traits = klv_lookup_packet_traits().by_uds_key( packet.key );
+  os << "{ " << traits.name() << ": ";
+  return traits.format().print( os, packet.value ) << " }";
+}
+
+// ----------------------------------------------------------------------------
+klv_packet
+klv_read_packet( klv_read_iter_t& data, size_t max_length )
+{
+  auto const begin = data;
+  auto const remaining_length =
+    [ & ]() -> size_t {
+      return max_length - std::distance( begin, data );
+    };
+
+  // Find the prefix which begins all UDS keys
+  auto const search_result =
+    std::search( data, data + max_length,
+                 klv_uds_key::prefix, klv_uds_key::prefix + 4 );
+  if( search_result == data + max_length )
+  {
+    VITAL_THROW( kv::metadata_buffer_overflow,
+                 "universal key not found in data buffer" );
+  }
+
+  // Sometimes encoders will put other data between KLV packets, so we may have
+  // to skip some bytes
+  if( search_result != data )
+  {
+    LOG_DEBUG( kv::get_logger( "klv" ), "skipped "
+                << std::distance( data, search_result )
+                << " bytes in klv stream" );
+    data = search_result;
+  }
+
+  // Read key
+  auto const key = klv_read_uds_key( data, remaining_length() );
+  if( !key.is_valid() )
+  {
+    // This might be an encoding error, or maybe we falsely detected a prefix
+    // in the data between the packets
+    VITAL_THROW( kwiver::vital::metadata_exception, "invalid universal key" );
+  }
+
+  // Read length
+  auto const length_of_value =
+    klv_read_ber< size_t >( data, remaining_length() );
+  if( max_length < remaining_length() )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "reading klv packet value overflows buffer" );
+  }
+
+  // Read value
+  auto const value =
+    klv_lookup_packet_traits().by_uds_key( key )
+    .format().read( data, length_of_value );
+
+  return { key, value };
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_write_packet( klv_packet const& packet, klv_write_iter_t& data,
+                  size_t max_length )
+{
+  auto const& format =
+    klv_lookup_packet_traits().by_uds_key( packet.key ).format();
+  auto const length = format.length_of( packet.value );
+  if( max_length < length )
+  {
+    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
+                 "writing klv packet overflows buffer" );
+  }
+  format.write( packet.value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_packet_length( klv_packet const& packet )
+{
+  return klv_lookup_packet_traits().by_uds_key( packet.key )
+    .format().length_of( packet.value );
+}
+
+// ----------------------------------------------------------------------------
+klv_tag_traits_lookup const&
+klv_lookup_packet_traits()
+{
+  // TODO: Edit these once parsers are finalized
+#define ENUM_AND_NAME( X ) X, #X
+  static klv_tag_traits_lookup const lookup = {
+    { {},
+      ENUM_AND_NAME( KLV_PACKET_UNKNOWN ),
+      std::make_shared< klv_blob_format >(),
+      "Unknown Packet",
+      "Packet of unknown type.",
+      0 },
+    { {},
+      ENUM_AND_NAME( KLV_PACKET_MISB_1108_LOCAL_SET ),
+      std::make_shared< klv_blob_format >(),
+      "MISB ST 1108 Local Set",
+      "Interpretability and Quality Local Set. Contains image quality metrics "
+      "and compression characteristics for a video stream or file.",
+      0 },
+    { {},
+      ENUM_AND_NAME( KLV_PACKET_MISB_0601_LOCAL_SET ),
+      std::make_shared< klv_blob_format >(),
+      "MISB ST 0601 Local Set",
+      "UAS Datalink Local Set. Contains a wide variety of metadata describing "
+      "an unmanned aerial system producing FMV footage.",
+      0 },
+    { {},
+      ENUM_AND_NAME( KLV_PACKET_MISB_0104_UNIVERSAL_SET ),
+      std::make_shared< klv_blob_format >(),
+      "MISB ST 0104 Universal Set",
+      "Predator UAV Basic Universal Set. Contains basic metadata describing a "
+      "Predator unmanned aerial system producing FMV footage. Predecessor to "
+      "MISB ST 0601. Deprecated as of 2008.",
+      0 } };
+#undef ENUM_AND_NAME
+
+  return lookup;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_packet.h
+++ b/arrows/klv/klv_packet.h
@@ -1,0 +1,108 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of the KLV packet.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_PARSER_H_
+#define KWIVER_ARROWS_KLV_KLV_PARSER_H_
+
+#include <arrows/klv/klv_data_format.h>
+#include <arrows/klv/klv_key.h>
+#include <arrows/klv/klv_tag_traits.h>
+#include <arrows/klv/klv_value.h>
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+// Does not appear anywhere in KLV standards, just a way to consistently access
+// traits of a specific standard
+enum klv_top_level_tag : klv_lds_key
+{
+  KLV_PACKET_UNKNOWN,
+  KLV_PACKET_MISB_0601_LOCAL_SET,
+  KLV_PACKET_MISB_1108_LOCAL_SET,
+  KLV_PACKET_MISB_0104_UNIVERSAL_SET,
+  KLV_PACKET_ENUM_END,
+};
+
+// ----------------------------------------------------------------------------
+/// Top-level KLV packet.
+///
+/// A KLV metadata stream consists of a sequence of these.
+struct KWIVER_ALGO_KLV_EXPORT klv_packet
+{
+  klv_uds_key key;
+  klv_value value;
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_packet const& packet );
+
+// ----------------------------------------------------------------------------
+/// Find and read a KLV packet from a sequence of bytes.
+///
+/// This function will search for a valid UDS key in the given bytes,
+/// indicating the beginning of a packet. It will skip any number of non-packet
+/// bytes to find the next packet. The value
+///
+/// \param[in,out] data Iterator to sequence of \c uint8_t. Set to end of read
+/// bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to read.
+///
+/// \returns Packet read in from \p data.
+///
+/// \throws metadata_buffer_overflow If more bytes are needed to find or read
+/// the next packet.
+/// \throws metadata_exception If the UDS key prefix is found, but it is
+/// attached to an invalid key.
+KWIVER_ALGO_KLV_EXPORT
+klv_packet
+klv_read_packet( klv_read_iter_t& data, size_t max_length );
+
+// ----------------------------------------------------------------------------
+/// Write a KLV packet to a sequence of bytes.
+///
+/// \param packet KLV packet to write.
+/// \param[in,out] data Writeable iterator to sequence of \c uint8_t. Set to
+/// end of written bytes on success, left as is on error.
+/// \param max_length Maximum number of bytes to write.
+///
+/// \throws metadata_buffer_overflow When \p packet is too large to fit in \p
+/// length bytes.
+KWIVER_ALGO_KLV_EXPORT
+void
+klv_write_packet( klv_packet const& packet,
+                  klv_write_iter_t& data, size_t max_length );
+
+// ----------------------------------------------------------------------------
+/// Return the number of bytes required to store the given \p packet.
+///
+/// \param packet KLV packet whose byte length is being queried.
+///
+/// \returns Bytes required to store \p packet.
+KWIVER_ALGO_KLV_EXPORT
+size_t
+klv_packet_length( klv_packet const& packet );
+
+// ----------------------------------------------------------------------------
+/// Return a traits lookup object for top-level keys.
+KWIVER_ALGO_KLV_EXPORT
+klv_tag_traits_lookup const&
+klv_lookup_packet_traits();
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
Add a `struct` to represent a KLV packet, which is the highest-level self-contained KLV entity. It consists of a UDS key and a value, which are directly exposed because they are purely data. The values here are going to be one of the ST0104, ST0601, or ST1108 sets, which are being PR'd in parallel to this. `klv_{read,write,length}` functions are provided, consistent with the rest of the API.