### PR TITLE
Automated conversion of comment format.

### DIFF
--- a/vital/algo/activity_detector.cxx
+++ b/vital/algo/activity_detector.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief activity_detector algorithm instantiation
- */
+///
+/// \file
+/// \brief activity_detector algorithm instantiation
+///
 
 #include <vital/algo/activity_detector.h>
 #include <vital/algo/algorithm.txx>

--- a/vital/algo/activity_detector.h
+++ b/vital/algo/activity_detector.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract activity detector
- */
+///
+/// \file
+/// \brief Header defining abstract activity detector
+///
 
 #ifndef VITAL_ALGO_ACTIVITY_DETECTOR_H_
 #define VITAL_ALGO_ACTIVITY_DETECTOR_H_
@@ -24,10 +24,10 @@ namespace algo {
 
 // ----------------------------------------------------------------
 
-/**
- * @brief activity detector base class/
- *
- */
+///
+/// @brief activity detector base class/
+///
+///
 class VITAL_ALGO_EXPORT activity_detector
   : public algorithm_def< activity_detector >
 {

--- a/vital/algo/algo_explorer_plugin.cxx
+++ b/vital/algo/algo_explorer_plugin.cxx
@@ -14,12 +14,12 @@ namespace vital {
 
 // ----------------------------------------------------------------
 
-/**
- * @brief Plugin to provide detailed dsplay of algorithm plugins.
- *
- * This class implements a plugin category formatter for the plugin_explorer
- * tool.
- */
+///
+/// @brief Plugin to provide detailed dsplay of algorithm plugins.
+///
+/// This class implements a plugin category formatter for the plugin_explorer
+/// tool.
+///
 class algo_explorer
   : public category_explorer
 {
@@ -147,12 +147,12 @@ algo_explorer
 
 // ==================================================================
 
-/**
- * @brief Plugin to provide detailed dsplay of algorithm plugins.
- *
- * This class implements a plugin category formatter for the plugin_explorer
- * tool generating output in pipeline file format.
- */
+///
+/// @brief Plugin to provide detailed dsplay of algorithm plugins.
+///
+/// This class implements a plugin category formatter for the plugin_explorer
+/// tool generating output in pipeline file format.
+///
 class algo_explorer_pipe
   : public category_explorer
 {

--- a/vital/algo/algorithm.cxx
+++ b/vital/algo/algorithm.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief base algorithm function implementations
- */
+///
+/// \file
+/// \brief base algorithm function implementations
+///
 
 #include "algorithm.h"
 

--- a/vital/algo/algorithm.h
+++ b/vital/algo/algorithm.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief base algorithm/_def/_impl class interfaces
- */
+///
+/// \file
+/// \brief base algorithm/_def/_impl class interfaces
+///
 
 #ifndef VITAL_ALGO_ALGORITHM_H_
 #define VITAL_ALGO_ALGORITHM_H_
@@ -33,12 +33,12 @@ typedef std::shared_ptr< algorithm > algorithm_sptr;
 
 // ----------------------------------------------------------------
 
-/**
- * @brief An abstract base class for all algorithms
- *
- * This class is an abstract base class for all algorithm
- * implementations.
- */
+///
+/// @brief An abstract base class for all algorithms
+///
+/// This class is an abstract base class for all algorithm
+/// implementations.
+///
 class VITAL_ALGO_EXPORT algorithm
 {
 public:
@@ -52,96 +52,91 @@ public:
 
   /// Get this algorithm's \link kwiver::vital::config_block configuration
   /// block \endlink
-
-  /**
-   * This method returns the required configuration for the
-   * algorithm. The implementation of this method should be
-   * light-weight and only create and fill in the config
-   * block.
-   *
-   * This base virtual function implementation returns an empty configuration.
-   *
-   * \returns \c config_block containing the configuration for this algorithm
-   *          and any nested components.
-   */
+  ///
+  /// This method returns the required configuration for the
+  /// algorithm. The implementation of this method should be
+  /// light-weight and only create and fill in the config
+  /// block.
+  ///
+  /// This base virtual function implementation returns an empty configuration.
+  ///
+  /// \returns \c config_block containing the configuration for this algorithm
+  ///         and any nested components.
+  ///
   virtual config_block_sptr get_configuration() const;
 
   /// Set this algorithm's properties via a config block
-
-  /**
-   * This method is called to pass a configuration to the
-   * algorithm. The implementation of this method should be
-   * light-weight and only save the necessary config values. Defer
-   * any substantial processing in another method.
-   *
-   * \throws no_such_configuration_value_exception
-   *    Thrown if an expected configuration value is not present.
-   *
-   * \throws algorithm_configuration_exception
-   *    Thrown when the algorithm is given an invalid \c config_block or is
-   *    otherwise unable to configure itself.
-   *
-   * \param config  The \c config_block instance containing the configuration
-   *                parameters for this algorithm
-   */
+  ///
+  /// This method is called to pass a configuration to the
+  /// algorithm. The implementation of this method should be
+  /// light-weight and only save the necessary config values. Defer
+  /// any substantial processing in another method.
+  ///
+  /// \throws no_such_configuration_value_exception
+  ///   Thrown if an expected configuration value is not present.
+  ///
+  /// \throws algorithm_configuration_exception
+  ///   Thrown when the algorithm is given an invalid \c config_block or is
+  ///   otherwise unable to configure itself.
+  ///
+  /// \param config  The \c config_block instance containing the configuration
+  ///               parameters for this algorithm
+  ///
   virtual void set_configuration( config_block_sptr config ) = 0;
 
   /// Check that the algorithm's configuration config_block is valid
-
-  /**
-   * This checks solely within the provided \c config_block and not against
-   * the current state of the instance. This isn't static for inheritance
-   * reasons.
-   *
-   * \param config  The config block to check configuration of.
-   *
-   * \returns true if the configuration check passed and false if it didn't.
-   */
+  ///
+  /// This checks solely within the provided \c config_block and not against
+  /// the current state of the instance. This isn't static for inheritance
+  /// reasons.
+  ///
+  /// \param config  The config block to check configuration of.
+  ///
+  /// \returns true if the configuration check passed and false if it didn't.
+  ///
   virtual bool check_configuration( config_block_sptr config ) const = 0;
 
   /// Helper function for properly getting a nested algorithm's configuration
-
-  /**
-   * Adds a configurable algorithm implementation switch for this algorithm.
-   * If the variable pointed to by \c nested_algo is a defined sptr to an
-   * implementation, its \link kwiver::vital::config_block configuration
-   * \endlink
-   * parameters are merged with the given
-   * \link kwiver::vital::config_block config_block \endlink.
-   *
-   * \param[in]       type_name   The type name of the nested algorithm.
-   * \param[in]       name        An identifying name for the nested algorithm
-   * \param[in,out]   config      The \c config_block instance in which to put
-   * the
-   *                              nested algorithm's configuration.
-   * \param[in]       nested_algo The nested algorithm's sptr variable.
-   */
+  ///
+  /// Adds a configurable algorithm implementation switch for this algorithm.
+  /// If the variable pointed to by \c nested_algo is a defined sptr to an
+  /// implementation, its \link kwiver::vital::config_block configuration
+  /// \endlink
+  /// parameters are merged with the given
+  /// \link kwiver::vital::config_block config_block \endlink.
+  ///
+  /// \param[in]       type_name   The type name of the nested algorithm.
+  /// \param[in]       name        An identifying name for the nested algorithm
+  /// \param[in,out]   config      The \c config_block instance in which to put
+  /// the
+  ///                             nested algorithm's configuration.
+  /// \param[in]       nested_algo The nested algorithm's sptr variable.
+  ///
   static void get_nested_algo_configuration( std::string const& type_name,
                                              std::string const& name,
                                              config_block_sptr config,
                                              algorithm_sptr nested_algo );
 
   /// Helper function for properly setting a nested algorithm's configuration
-
-  /**
-   * If the value for the config parameter "type" is supported by the
-   * concrete algorithm class, then a new algorithm object is created,
-   * configured using the set_configuration() method and returned via
-   * the \c nested_algo pointer.
-   *
-   * The nested algorithm will not be set if the implementation type (as
-   * defined in the \c get_nested_algo_configuration) is not present or set to
-   * an invalid value relative to the registered names for this
-   * \c type_name
-   *
-   * \param[in] type_name           The type name of the nested algorithm.
-   * \param[in] name                Config block name for the nested algorithm.
-   * \param[in] config              The \c config_block instance from which we
-   * will
-   *                                draw configuration needed for the nested
-   *                                algorithm instance.
-   * \param[out] nested_algo The nested algorithm's sptr variable.
-   */
+  ///
+  /// If the value for the config parameter "type" is supported by the
+  /// concrete algorithm class, then a new algorithm object is created,
+  /// configured using the set_configuration() method and returned via
+  /// the \c nested_algo pointer.
+  ///
+  /// The nested algorithm will not be set if the implementation type (as
+  /// defined in the \c get_nested_algo_configuration) is not present or set to
+  /// an invalid value relative to the registered names for this
+  /// \c type_name
+  ///
+  /// \param[in] type_name           The type name of the nested algorithm.
+  /// \param[in] name                Config block name for the nested algorithm.
+  /// \param[in] config              The \c config_block instance from which we
+  /// will
+  ///                               draw configuration needed for the nested
+  ///                               algorithm instance.
+  /// \param[out] nested_algo The nested algorithm's sptr variable.
+  ///
   static void set_nested_algo_configuration( std::string const& type_name,
                                              std::string const& name,
                                              config_block_sptr config,
@@ -149,20 +144,19 @@ public:
 
   /// Helper function for checking that basic nested algorithm configuration is
   /// valid
-
-  /**
-   * Check that the expected implementation switch exists and that its value is
-   * registered implementation name.
-   *
-   * If the name is valid, we also recursively call check_configuration() on
-   * theset implementation. This is done with a fresh create so we don't have
-   * to rely on the implementation being defined in the instance this is
-   * called from.
-   *
-   * \param     type_name   The type name of the nested algorithm.
-   * \param     name        An identifying name for the nested algorithm.
-   * \param     config  The \c config_block to check.
-   */
+  ///
+  /// Check that the expected implementation switch exists and that its value is
+  /// registered implementation name.
+  ///
+  /// If the name is valid, we also recursively call check_configuration() on
+  /// theset implementation. This is done with a fresh create so we don't have
+  /// to rely on the implementation being defined in the instance this is
+  /// called from.
+  ///
+  /// \param     type_name   The type name of the nested algorithm.
+  /// \param     name        An identifying name for the nested algorithm.
+  /// \param     config  The \c config_block to check.
+  ///
   static bool check_nested_algo_configuration( std::string const& type_name,
                                                std::string const& name,
                                                config_block_sptr config );
@@ -173,27 +167,27 @@ public:
 protected:
   algorithm(); // CTOR
 
-  /**
-   * \brief Attach logger to this object.
-   *
-   * This method attaches a logger to this object. The name supplied
-   * is used to name the logger. Since this is a fundamental base
-   * class, derived classes will want to have the logger named
-   * something relevant to the concrete algorithm.
-   *
-   * A logger is attached by the base class, but it is expected that
-   * one of the derived classes will attach a more meaningful logger.
-   *
-   * \param name Name of the logger to attach.
-   */
+  ///
+  /// \brief Attach logger to this object.
+  ///
+  /// This method attaches a logger to this object. The name supplied
+  /// is used to name the logger. Since this is a fundamental base
+  /// class, derived classes will want to have the logger named
+  /// something relevant to the concrete algorithm.
+  ///
+  /// A logger is attached by the base class, but it is expected that
+  /// one of the derived classes will attach a more meaningful logger.
+  ///
+  /// \param name Name of the logger to attach.
+  ///
   void attach_logger( std::string const& name );
 
 private:
-  /**
-   * \brief Logger handle.
-   *
-   * This handle supplies a logger for all derived classes.
-   */
+  ///
+  /// \brief Logger handle.
+  ///
+  /// This handle supplies a logger for all derived classes.
+  ///
   kwiver::vital::logger_handle_t m_logger;
 
   std::string m_impl_name;
@@ -201,21 +195,20 @@ private:
 
 // ------------------------------------------------------------------
 /// An intermediate templated base class for algorithm definition
-
-/**
- *  Uses the curiously recurring template pattern (CRTP) to declare the
- *  clone function and automatically provide functions to register
- *  algorithm, and create new instance by name.
- *  Each algorithm definition should be declared as shown below
- *  \code
-    class my_algo_def
-    : public algorithm_def<my_algo_def>
-    {
-      ...
-    };
-    \endcode
- *  \sa algorithm_impl
- */
+///
+/// Uses the curiously recurring template pattern (CRTP) to declare the
+/// clone function and automatically provide functions to register
+/// algorithm, and create new instance by name.
+/// Each algorithm definition should be declared as shown below
+/// \code
+/// class my_algo_def
+/// : public algorithm_def<my_algo_def>
+/// {
+///   ...
+/// };
+/// \endcode
+/// \sa algorithm_impl
+///
 template < typename Self >
 class VITAL_ALGO_EXPORT algorithm_def
   : public algorithm
@@ -237,63 +230,60 @@ public:
   type_name() const { return Self::static_type_name(); }
 
   /// Helper function for properly getting a nested algorithm's configuration
-
-  /**
-   * Adds a configurable algorithm implementation switch for this
-   * algorithm_def.
-   * If the variable pointed to by \c nested_algo is a defined sptr to an
-   * implementation, its \link kwiver::vital::config_block configuration
-   * \endlink parameters are merged with the given
-   * \link kwiver::vital::config_block config_block \endlink.
-   *
-   * \param     name        An identifying name for the nested algorithm
-   * \param     config      The \c config_block instance in which to put the
-   *                          nested algorithm's configuration.
-   * \param     nested_algo The nested algorithm's sptr variable.
-   */
+  ///
+  /// Adds a configurable algorithm implementation switch for this
+  /// algorithm_def.
+  /// If the variable pointed to by \c nested_algo is a defined sptr to an
+  /// implementation, its \link kwiver::vital::config_block configuration
+  /// \endlink parameters are merged with the given
+  /// \link kwiver::vital::config_block config_block \endlink.
+  ///
+  /// \param     name        An identifying name for the nested algorithm
+  /// \param     config      The \c config_block instance in which to put the
+  ///                         nested algorithm's configuration.
+  /// \param     nested_algo The nested algorithm's sptr variable.
+  ///
   static void get_nested_algo_configuration( std::string const& name,
                                              config_block_sptr config,
                                              base_sptr nested_algo );
 
   /// Instantiate nested algorithm.
-
-  /**
-   * A new concrete algorithm object is created if the value for the
-   * config parameter "type" is supported. The new object is returned
-   * through the nested_algo parameter.
-   *
-   * The nested algorithm will not be set if the implementation switch (as
-   * defined in the \c get_nested_algo_configuration) is not present or set to
-   * an invalid value relative to the registered names for this
-   * \c algorithm_def.
-   *
-   * \param[in] name              Config block name for the nested algorithm.
-   * \param[in] config            The \c config_block instance from which we
-   * will
-   *                              draw configuration needed for the nested
-   *                              algorithm instance.
-   * \param[out] nested_algo      Pointer to the algorithm object is returned
-   * here.
-   */
+  ///
+  /// A new concrete algorithm object is created if the value for the
+  /// config parameter "type" is supported. The new object is returned
+  /// through the nested_algo parameter.
+  ///
+  /// The nested algorithm will not be set if the implementation switch (as
+  /// defined in the \c get_nested_algo_configuration) is not present or set to
+  /// an invalid value relative to the registered names for this
+  /// \c algorithm_def.
+  ///
+  /// \param[in] name              Config block name for the nested algorithm.
+  /// \param[in] config            The \c config_block instance from which we
+  /// will
+  ///                             draw configuration needed for the nested
+  ///                             algorithm instance.
+  /// \param[out] nested_algo      Pointer to the algorithm object is returned
+  /// here.
+  ///
   static void set_nested_algo_configuration( std::string const& name,
                                              config_block_sptr config,
                                              base_sptr& nested_algo );
 
   /// Helper function for checking that basic nested algorithm configuration is
   /// valid
-
-  /**
-   * Check that the expected implementation switch exists and that its value is
-   * registered implementation name.
-   *
-   * If the name is valid, we also recursively call check_configuration() on
-   * the set implementation. This is done with a fresh create so we don't
-   * have to rely on the implementation being defined in the instance this
-   * is called from.
-   *
-   * \param     name        An identifying name for the nested algorithm.
-   * \param     config      The \c config_block to check.
-   */
+  ///
+  /// Check that the expected implementation switch exists and that its value is
+  /// registered implementation name.
+  ///
+  /// If the name is valid, we also recursively call check_configuration() on
+  /// the set implementation. This is done with a fresh create so we don't
+  /// have to rely on the implementation being defined in the instance this
+  /// is called from.
+  ///
+  /// \param     name        An identifying name for the nested algorithm.
+  /// \param     config      The \c config_block to check.
+  ///
   static bool check_nested_algo_configuration( std::string const& name,
                                                config_block_sptr config );
 };

--- a/vital/algo/algorithm.h
+++ b/vital/algo/algorithm.h
@@ -201,11 +201,11 @@ private:
 /// algorithm, and create new instance by name.
 /// Each algorithm definition should be declared as shown below
 /// \code
-/// class my_algo_def
-/// : public algorithm_def<my_algo_def>
-/// {
-///   ...
-/// };
+    class my_algo_def
+    : public algorithm_def<my_algo_def>
+    {
+      ...
+    };
 /// \endcode
 /// \sa algorithm_impl
 ///

--- a/vital/algo/algorithm.txx
+++ b/vital/algo/algorithm.txx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief implementation of algorithm/_def/_impl templated methods
- */
+///
+/// \file
+/// \brief implementation of algorithm/_def/_impl templated methods
+///
 
 #ifndef VITAL_ALGO_ALGORITHM_TXX_
 #define VITAL_ALGO_ALGORITHM_TXX_

--- a/vital/algo/algorithm_factory.h
+++ b/vital/algo/algorithm_factory.h
@@ -17,25 +17,25 @@ namespace kwiver {
 
 namespace vital {
 
-/**
- * \brief Factory class for algorithms.
- *
- * \tparam T Type of the object to be created.
- */
+///
+/// \brief Factory class for algorithms.
+///
+/// \tparam T Type of the object to be created.
+///
 class VITAL_ALGO_EXPORT algorithm_factory
   : public kwiver::vital::plugin_factory
 {
 public:
 
-  /**
-   * \brief CTOR for factory object
-   *
-   * This CTOR also takes a factory function so it can support
-   * creating processes and clusters.
-   *
-   * \param algo Name of the algorithm
-   * \param impl Name of the implementation
-   */
+  ///
+  /// \brief CTOR for factory object
+  ///
+  /// This CTOR also takes a factory function so it can support
+  /// creating processes and clusters.
+  ///
+  /// \param algo Name of the algorithm
+  /// \param impl Name of the implementation
+  ///
   algorithm_factory( const std::string& algo,
                      const std::string& impl )
     : plugin_factory( algo ) // interface type
@@ -89,40 +89,40 @@ protected:
 
 // ------------------------------------------------------------------
 
-/**
- * \brief Create algorithm from interface name and implementation name.
- *
- * \param algo_name Name of the interface
- * \param impl_name Name if the implementation
- *
- * \return New algorithm object or
- */
+///
+/// \brief Create algorithm from interface name and implementation name.
+///
+/// \param algo_name Name of the interface
+/// \param impl_name Name if the implementation
+///
+/// \return New algorithm object or
+///
 VITAL_ALGO_EXPORT
 algorithm_sptr  create_algorithm( std::string const& algo_name,
                                   std::string const& impl_name );
 
-/**
- * \brief Check the given type and implementation names against registered
- * algorithms.
- *
- * \param type_name Type name of algorithm to validate
- * \param impl_name Implementation name of algorithm to validate
- * \returns true if the given \c type_name and \c impl_name describe a valid
- *          registered algorithm, or false if not.
- */
+///
+/// \brief Check the given type and implementation names against registered
+/// algorithms.
+///
+/// \param type_name Type name of algorithm to validate
+/// \param impl_name Implementation name of algorithm to validate
+/// \returns true if the given \c type_name and \c impl_name describe a valid
+///         registered algorithm, or false if not.
+///
 VITAL_ALGO_EXPORT
 bool has_algorithm_impl_name( std::string const& type_name,
                               std::string const& impl_name );
 
-/**
- * \brief Add an algorithm factory
- *
- * \param algo_name Algorithm name or interface type name
- * \param impl_name Implementation name or just name of plugin
- * \param conc_T Type of object to create
- *
- * \return
- */
+///
+/// \brief Add an algorithm factory
+///
+/// \param algo_name Algorithm name or interface type name
+/// \param impl_name Implementation name or just name of plugin
+/// \param conc_T Type of object to create
+///
+/// \return
+///
 #define ADD_ALGORITHM( impl_name, conc_T )                    \
   add_factory( new ::kwiver::vital::algorithm_factory_0< conc_T >( conc_T:: \
                                                                    static_type_name(), \
@@ -130,11 +130,10 @@ bool has_algorithm_impl_name( std::string const& type_name,
 
 // ============================================================================
 /// Derived class to register algorithms.
-
-/**
- * This class contains the specific procedure for registering
- * algorithms with the plugin loader.
- */
+///
+/// This class contains the specific procedure for registering
+/// algorithms with the plugin loader.
+///
 class algorithm_registrar
   : public kwiver::plugin_registrar
 {
@@ -149,15 +148,14 @@ public:
   // ----------------------------------------------------------------------------
 
   /// Register an algorithm plugin.
-
-  /**
-   * An algorithm of the specified type is registered with the plugin
-   * manager.
-   *
-   * \tparam tool_t Type of the algorithm being registered.
-   *
-   * \return The plugin loader reference is returned.
-   */
+  ///
+  /// An algorithm of the specified type is registered with the plugin
+  /// manager.
+  ///
+  /// \tparam tool_t Type of the algorithm being registered.
+  ///
+  /// \return The plugin loader reference is returned.
+  ///
   template < typename algorithm_t >
   kwiver::vital::plugin_factory_handle_t
   register_algorithm()
@@ -180,26 +178,25 @@ public:
 
 // ============================================================================
 /// Derived class to register serializer algorithms.
-
-/**
- * This class contains the specific procedure for registering
- * serializer algorithms with the plugin loader. Serializers are
- * different in that they use the interface name to specify the
- * serialization method.
- */
+///
+/// This class contains the specific procedure for registering
+/// serializer algorithms with the plugin loader. Serializers are
+/// different in that they use the interface name to specify the
+/// serialization method.
+///
 class serializer_registrar
   : public kwiver::plugin_registrar
 {
 public:
-  /**
-   * \brief Constructor for serializer registrar
-   *
-   * \param vpl Plugin loader reference.
-   * \param module_name  name of module to register.
-   * \param ser_method short serialization method. This specifies the
-   * string that is used in the pipe config file to select the
-   * serializer method. Typical entries could be "protobuf" or "json".
-   */
+  ///
+  /// \brief Constructor for serializer registrar
+  ///
+  /// \param vpl Plugin loader reference.
+  /// \param module_name  name of module to register.
+  /// \param ser_method short serialization method. This specifies the
+  /// string that is used in the pipe config file to select the
+  /// serializer method. Typical entries could be "protobuf" or "json".
+  ///
   serializer_registrar( kwiver::vital::plugin_loader& vpl,
                         const std::string& module_name,
                         const std::string& ser_method )
@@ -214,16 +211,15 @@ public:
   // ----------------------------------------------------------------------------
 
   /// Register a serializer algorithm plugin.
-
-  /**
-   * An algorithm of the specified type is registered with the plugin
-   * manager.
-   *
-   * \tparam tool_t Type of the algorithm being registered.
-   * \param name Override type static name with this name if specified.
-   *
-   * \return The plugin loader reference is returned.
-   */
+  ///
+  /// An algorithm of the specified type is registered with the plugin
+  /// manager.
+  ///
+  /// \tparam tool_t Type of the algorithm being registered.
+  /// \param name Override type static name with this name if specified.
+  ///
+  /// \return The plugin loader reference is returned.
+  ///
   template < typename algorithm_t >
   kwiver::vital::plugin_factory_handle_t
   register_algorithm( const std::string& name )
@@ -258,15 +254,14 @@ public:
   // ----------------------------------------------------------------------------
 
   /// Register an algorithm plugin.
-
-  /**
-   * An algorithm of the specified type is registered with the plugin
-   * manager.
-   *
-   * \tparam tool_t Type of the algorithm being registered.
-   *
-   * \return The plugin loader reference is returned.
-   */
+  ///
+  /// An algorithm of the specified type is registered with the plugin
+  /// manager.
+  ///
+  /// \tparam tool_t Type of the algorithm being registered.
+  ///
+  /// \return The plugin loader reference is returned.
+  ///
   template < typename algorithm_t >
   kwiver::vital::plugin_factory_handle_t
   register_algorithm()

--- a/vital/algo/analyze_tracks.h
+++ b/vital/algo/analyze_tracks.h
@@ -14,12 +14,12 @@
 #include <memory>
 #include <ostream>
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::analyze_tracks
- * track
- *        analyzer \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::analyze_tracks
+/// track
+///       analyzer \endlink algorithm
+///
 
 namespace kwiver {
 
@@ -38,11 +38,10 @@ public:
   static std::string static_type_name() { return "analyze_tracks"; }
 
   /// Output various information about the tracks stored in the input set.
-
-  /**
-   * \param [in] track_set the tracks to analyze
-   * \param [in] stream an output stream to write data onto
-   */
+  ///
+  /// \param [in] track_set the tracks to analyze
+  /// \param [in] stream an output stream to write data onto
+  ///
   virtual void
   print_info( kwiver::vital::track_set_sptr track_set,
               stream_t& stream = std::cout ) const = 0;

--- a/vital/algo/associate_detections_to_tracks.h
+++ b/vital/algo/associate_detections_to_tracks.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief associate_detections_to_tracks algorithm definition
- */
+///
+/// \file
+/// \brief associate_detections_to_tracks algorithm definition
+///
 
 #ifndef VITAL_ALGO_ASSOCIATE_DETECTIONS_TO_TRACKS_H_
 #define VITAL_ALGO_ASSOCIATE_DETECTIONS_TO_TRACKS_H_
@@ -36,17 +36,16 @@ public:
   static_type_name() { return "associate_detections_to_tracks"; }
 
   /// Use cost matrices to assign detections to existing tracks
-
-  /**
-   * \param ts frame ID
-   * \param image contains the input image for the current frame
-   * \param tracks active track set from the last frame
-   * \param detections detected object sets from the current frame
-   * \param matrix matrix containing detection to track association scores
-   * \param output the output updated detection set
-   * \param unused output detection set for any detections not associated
-   * \returns whether or not any tracks were updated
-   */
+  ///
+  /// \param ts frame ID
+  /// \param image contains the input image for the current frame
+  /// \param tracks active track set from the last frame
+  /// \param detections detected object sets from the current frame
+  /// \param matrix matrix containing detection to track association scores
+  /// \param output the output updated detection set
+  /// \param unused output detection set for any detections not associated
+  /// \returns whether or not any tracks were updated
+  ///
   virtual bool
   associate( kwiver::vital::timestamp ts,
              kwiver::vital::image_container_sptr image,

--- a/vital/algo/bundle_adjust.cxx
+++ b/vital/algo/bundle_adjust.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- * algorithm_def<T>
- *        \endlink for \link kwiver::vital::algo::bundle_adjust bundle_adjust
- * \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+/// algorithm_def<T>
+///       \endlink for \link kwiver::vital::algo::bundle_adjust bundle_adjust
+/// \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/bundle_adjust.h>

--- a/vital/algo/bundle_adjust.h
+++ b/vital/algo/bundle_adjust.h
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::bundle_adjust
- *        bundle adjustment \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::bundle_adjust
+///       bundle adjustment \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_BUNDLE_ADJUST_H_
 #define VITAL_ALGO_BUNDLE_ADJUST_H_
@@ -37,17 +37,16 @@ public:
   static std::string static_type_name() { return "bundle_adjust"; }
 
   /// Optimize the camera and landmark parameters given a set of feature tracks
-
-  /**
-   * Implementations of this function should not modify the underlying objects
-   * contained in the input structures. Output references should either be new
-   * instances or the same as input.
-   *
-   * \param [in,out] cameras the cameras to optimize
-   * \param [in,out] landmarks the landmarks to optimize
-   * \param [in] tracks the feature tracks to use as constraints
-   * \param [in] metadata the frame metadata to use as constraints
-   */
+  ///
+  /// Implementations of this function should not modify the underlying objects
+  /// contained in the input structures. Output references should either be new
+  /// instances or the same as input.
+  ///
+  /// \param [in,out] cameras the cameras to optimize
+  /// \param [in,out] landmarks the landmarks to optimize
+  /// \param [in] tracks the feature tracks to use as constraints
+  /// \param [in] metadata the frame metadata to use as constraints
+  ///
   virtual void
   optimize( kwiver::vital::camera_map_sptr& cameras,
             kwiver::vital::landmark_map_sptr& landmarks,
@@ -55,17 +54,16 @@ public:
             kwiver::vital::sfm_constraints_sptr constraints = nullptr ) const = 0;
 
   /// Optimize the camera and landmark parameters given a set of feature tracks
-
-  /**
-   * \param [in,out] cameras the cameras to optimize
-   * \param [in,out] landmarks the landmarks to optimize
-   * \param [in] tracks the feature tracks to use as constraints
-   * \param [in] fixed_cameras frame ids for cameras to be fixed in the
-   * optimization
-   * \param [in] fixed_landmarks landmark ids for landmarks to be fixed in the
-   * optimization
-   * \param [in] metadata the frame metadata to use as constraints
-   */
+  ///
+  /// \param [in,out] cameras the cameras to optimize
+  /// \param [in,out] landmarks the landmarks to optimize
+  /// \param [in] tracks the feature tracks to use as constraints
+  /// \param [in] fixed_cameras frame ids for cameras to be fixed in the
+  /// optimization
+  /// \param [in] fixed_landmarks landmark ids for landmarks to be fixed in the
+  /// optimization
+  /// \param [in] metadata the frame metadata to use as constraints
+  ///
   virtual void
   optimize( kwiver::vital::simple_camera_perspective_map& cameras,
             kwiver::vital::landmark_map::map_landmark_t& landmarks,

--- a/vital/algo/close_loops.h
+++ b/vital/algo/close_loops.h
@@ -13,11 +13,11 @@
 
 #include <ostream>
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::close_loops
- *        close_loops \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::close_loops
+///       close_loops \endlink algorithm
+///
 
 namespace kwiver {
 
@@ -26,12 +26,11 @@ namespace vital {
 namespace algo {
 
 /// \brief Abstract base class for loop closure algorithms.
-
-/**
- * Different algorithms can perform loop closure in a variety of ways, either
- * in attempt to make either short or long term closures. Similarly to
- * track_features, this class is designed to be called in an online fashion.
- */
+///
+/// Different algorithms can perform loop closure in a variety of ways, either
+/// in attempt to make either short or long term closures. Similarly to
+/// track_features, this class is designed to be called in an online fashion.
+///
 class VITAL_ALGO_EXPORT close_loops
   : public kwiver::vital::algorithm_def< close_loops >
 {
@@ -40,15 +39,14 @@ public:
   static std::string static_type_name() { return "close_loops"; }
 
   /// Attempt to perform closure operation and stitch tracks together.
-
-  /**
-   * \param frame_number the frame number of the current frame
-   * \param input the input feature track set to stitch
-   * \param image image data for the current frame
-   * \param mask Optional mask image where positive values indicate
-   *                  regions to consider in the input image.
-   * \returns an updated set of feature tracks after the stitching operation
-   */
+  ///
+  /// \param frame_number the frame number of the current frame
+  /// \param input the input feature track set to stitch
+  /// \param image image data for the current frame
+  /// \param mask Optional mask image where positive values indicate
+  ///                 regions to consider in the input image.
+  /// \returns an updated set of feature tracks after the stitching operation
+  ///
   virtual kwiver::vital::feature_track_set_sptr
   stitch( kwiver::vital::frame_id_t frame_number,
           kwiver::vital::feature_track_set_sptr input,

--- a/vital/algo/compute_association_matrix.h
+++ b/vital/algo/compute_association_matrix.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_association_matrix algorithm definition
- */
+///
+/// \file
+/// \brief compute_association_matrix algorithm definition
+///
 
 #ifndef VITAL_ALGO_COMPUTE_ASSOCIATION_MATRIX_H_
 #define VITAL_ALGO_COMPUTE_ASSOCIATION_MATRIX_H_
@@ -39,16 +39,15 @@ public:
   }
 
   /// Compute an association matrix given detections and tracks
-
-  /**
-   * \param ts frame ID
-   * \param image contains the input image for the current frame
-   * \param tracks active track set from the last frame
-   * \param detections input detected object sets from the current frame
-   * \param matrix output matrix
-   * \param considered output detections used in matrix
-   * \return returns whether a matrix was successfully computed
-   */
+  ///
+  /// \param ts frame ID
+  /// \param image contains the input image for the current frame
+  /// \param tracks active track set from the last frame
+  /// \param detections input detected object sets from the current frame
+  /// \param matrix output matrix
+  /// \param considered output detections used in matrix
+  /// \return returns whether a matrix was successfully computed
+  ///
   virtual bool
   compute( kwiver::vital::timestamp ts,
            kwiver::vital::image_container_sptr image,

--- a/vital/algo/compute_depth.h
+++ b/vital/algo/compute_depth.h
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::compute_depth
- *        compute depth \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::compute_depth
+///       compute depth \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_COMPUTE_DEPTH_H_
 #define VITAL_ALGO_COMPUTE_DEPTH_H_
@@ -35,22 +35,21 @@ public:
   static std::string static_type_name() { return "compute_depth"; }
 
   /// Compute a depth map from an image sequence
-
-  /**
-   * Implementations of this function should not modify the underlying objects
-   * contained in the input structures. Output references should either be new
-   * instances or the same as input.
-   *
-   * \param [in] frames image sequence to compute depth with
-   * \param [in] cameras corresponding to the image sequence
-   * \param [in] depth_min minimum depth expected
-   * \param [in] depth_max maximum depth expected
-   * \param [in] reference_frame index into image sequence denoting the frame
-   * that depth is computed on
-   * \param [in] roi region of interest within reference image (can be entire
-   * image)
-   * \param [in] masks optional masks corresponding to the image sequence
-   */
+  ///
+  /// Implementations of this function should not modify the underlying objects
+  /// contained in the input structures. Output references should either be new
+  /// instances or the same as input.
+  ///
+  /// \param [in] frames image sequence to compute depth with
+  /// \param [in] cameras corresponding to the image sequence
+  /// \param [in] depth_min minimum depth expected
+  /// \param [in] depth_max maximum depth expected
+  /// \param [in] reference_frame index into image sequence denoting the frame
+  /// that depth is computed on
+  /// \param [in] roi region of interest within reference image (can be entire
+  /// image)
+  /// \param [in] masks optional masks corresponding to the image sequence
+  ///
   virtual kwiver::vital::image_container_sptr
   compute( std::vector< kwiver::vital::image_container_sptr > const& frames,
            std::vector< kwiver::vital::camera_perspective_sptr > const& cameras,
@@ -61,23 +60,22 @@ public:
            std::vector< kwiver::vital::image_container_sptr >( ) ) const;
 
   /// Compute a depth map and depth uncertainty from an image sequence
-
-  /**
-   * Implementations of this function should not modify the underlying objects
-   * contained in the input structures. Output references should either be new
-   * instances or the same as input.
-   *
-   * \param [in] frames image sequence to compute depth with
-   * \param [in] cameras corresponding to the image sequence
-   * \param [in] depth_min minimum depth expected
-   * \param [in] depth_max maximum depth expected
-   * \param [in] reference_frame index into image sequence denoting the frame
-   * that depth is computed on
-   * \param [in] roi region of interest within reference image (can be entire
-   * image)
-   * \param [out] depth_uncertainty returns pixel-wise uncertainty
-   * \param [in] masks optional masks corresponding to the image sequence
-   */
+  ///
+  /// Implementations of this function should not modify the underlying objects
+  /// contained in the input structures. Output references should either be new
+  /// instances or the same as input.
+  ///
+  /// \param [in] frames image sequence to compute depth with
+  /// \param [in] cameras corresponding to the image sequence
+  /// \param [in] depth_min minimum depth expected
+  /// \param [in] depth_max maximum depth expected
+  /// \param [in] reference_frame index into image sequence denoting the frame
+  /// that depth is computed on
+  /// \param [in] roi region of interest within reference image (can be entire
+  /// image)
+  /// \param [out] depth_uncertainty returns pixel-wise uncertainty
+  /// \param [in] masks optional masks corresponding to the image sequence
+  ///
   virtual kwiver::vital::image_container_sptr
   compute( std::vector< kwiver::vital::image_container_sptr > const& frames,
            std::vector< kwiver::vital::camera_perspective_sptr > const& cameras,

--- a/vital/algo/compute_ref_homography.h
+++ b/vital/algo/compute_ref_homography.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_ref_homography algorithm definition
- */
+///
+/// \file
+/// \brief compute_ref_homography algorithm definition
+///
 
 #ifndef VITAL_ALGO_COMPUTE_REF_HOMOGRAPHY_H_
 #define VITAL_ALGO_COMPUTE_REF_HOMOGRAPHY_H_
@@ -26,14 +26,13 @@ namespace vital {
 namespace algo {
 
 /// Abstract base class for mapping each image to some reference image.
-
-/**
- * This class differs from estimate_homographies in that estimate_homographies
- * simply performs a homography regression from matching feature points. This
- * class is designed to generate different types of homographies from input
- * feature tracks, which can transform each image back to the same coordinate
- * space derived from some initial refrerence image.
- */
+///
+/// This class differs from estimate_homographies in that estimate_homographies
+/// simply performs a homography regression from matching feature points. This
+/// class is designed to generate different types of homographies from input
+/// feature tracks, which can transform each image back to the same coordinate
+/// space derived from some initial refrerence image.
+///
 class VITAL_ALGO_EXPORT compute_ref_homography
   : public kwiver::vital::algorithm_def< compute_ref_homography >
 {
@@ -42,23 +41,22 @@ public:
   static std::string static_type_name() { return "compute_ref_homography"; }
 
   /// Estimate the transformation which maps some frame to a reference frame
-
-  /**
-   * Similarly to track_features, this class was designed to be called in
-   * an online fashion for each sequential frame. The output homography
-   * will contain a transformation mapping points from the current frame
-   * (with frame_id frame_number) to the earliest possible reference frame
-   * via post multiplying points on the current frame with the computed
-   * homography.
-   *
-   * The returned homography is internally allocated and passed back
-   * through a smart pointer transferring ownership of the memory to
-   * the caller.
-   *
-   * \param [in]   frame_number frame identifier for the current frame
-   * \param [in]   tracks the set of all tracked features from the image
-   * \return estimated homography
-   */
+  ///
+  /// Similarly to track_features, this class was designed to be called in
+  /// an online fashion for each sequential frame. The output homography
+  /// will contain a transformation mapping points from the current frame
+  /// (with frame_id frame_number) to the earliest possible reference frame
+  /// via post multiplying points on the current frame with the computed
+  /// homography.
+  ///
+  /// The returned homography is internally allocated and passed back
+  /// through a smart pointer transferring ownership of the memory to
+  /// the caller.
+  ///
+  /// \param [in]   frame_number frame identifier for the current frame
+  /// \param [in]   tracks the set of all tracked features from the image
+  /// \return estimated homography
+  ///
   virtual kwiver::vital::f2f_homography_sptr
   estimate( kwiver::vital::frame_id_t frame_number,
             kwiver::vital::feature_track_set_sptr tracks ) const = 0;

--- a/vital/algo/compute_stereo_depth_map.cxx
+++ b/vital/algo/compute_stereo_depth_map.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_stereo_depth_map algorithm definition instantiation
- */
+///
+/// \file
+/// \brief compute_stereo_depth_map algorithm definition instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/compute_stereo_depth_map.h>

--- a/vital/algo/compute_stereo_depth_map.h
+++ b/vital/algo/compute_stereo_depth_map.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_stereo_depth_map algorithm definition
- */
+///
+/// \file
+/// \brief compute_stereo_depth_map algorithm definition
+///
 
 #ifndef VITAL_ALGO_COMPUTE_STEREO_DEPTH_MAP_H_
 #define VITAL_ALGO_COMPUTE_STEREO_DEPTH_MAP_H_
@@ -29,15 +29,14 @@ public:
   static std::string static_type_name() { return "compute_stereo_depth_map"; }
 
   /// Compute a stereo depth map given two images
-
-  /**
-   * \throws image_size_mismatch_exception
-   *    When the given input image sizes do not match.
-   *
-   * \param left_image contains the first image to process
-   * \param right_image contains the second image to process
-   * \returns a depth map image
-   */
+  ///
+  /// \throws image_size_mismatch_exception
+  ///   When the given input image sizes do not match.
+  ///
+  /// \param left_image contains the first image to process
+  /// \param right_image contains the second image to process
+  /// \returns a depth map image
+  ///
   virtual kwiver::vital::image_container_sptr
   compute( kwiver::vital::image_container_sptr left_image,
            kwiver::vital::image_container_sptr right_image ) const = 0;

--- a/vital/algo/compute_track_descriptors.cxx
+++ b/vital/algo/compute_track_descriptors.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_track_descriptors algorithm instantiation
- */
+///
+/// \file
+/// \brief compute_track_descriptors algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/compute_track_descriptors.h>

--- a/vital/algo/compute_track_descriptors.h
+++ b/vital/algo/compute_track_descriptors.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief compute_track_descriptors algorithm definition
- */
+///
+/// \file
+/// \brief compute_track_descriptors algorithm definition
+///
 
 #ifndef VITAL_ALGO_COMPUTE_TRACK_DESCRIPTORS_H_
 #define VITAL_ALGO_COMPUTE_TRACK_DESCRIPTORS_H_
@@ -34,28 +34,26 @@ public:
   static std::string static_type_name() { return "compute_track_descriptors"; }
 
   /// Compute track descriptors given an image and tracks
-
-  /**
-   * \param ts timestamp for the current frame
-   * \param image_data contains the image data to process
-   * \param tracks the tracks to extract descriptors around
-   *
-   * \returns a set of track descriptors
-   */
+  ///
+  /// \param ts timestamp for the current frame
+  /// \param image_data contains the image data to process
+  /// \param tracks the tracks to extract descriptors around
+  ///
+  /// \returns a set of track descriptors
+  ///
   virtual kwiver::vital::track_descriptor_set_sptr
   compute( kwiver::vital::timestamp ts,
            kwiver::vital::image_container_sptr image_data,
            kwiver::vital::object_track_set_sptr tracks ) = 0;
 
   /// Flush any remaining in-progress descriptors
-
-  /**
-   * This is typically called at the end of a video, in case
-   * any temporal descriptors and currently in progress and
-   * still need to be output.
-   *
-   * \returns a set of track descriptors
-   */
+  ///
+  /// This is typically called at the end of a video, in case
+  /// any temporal descriptors and currently in progress and
+  /// still need to be output.
+  ///
+  /// \returns a set of track descriptors
+  ///
   virtual kwiver::vital::track_descriptor_set_sptr flush() = 0;
 
 protected:

--- a/vital/algo/convert_image.h
+++ b/vital/algo/convert_image.h
@@ -20,17 +20,16 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for converting base image type.
-
-/**
- * Arrows that implement this interface convert the input image type
- * (e.g. BGR 16) to a different type (e.g. RGB 8). Concrete
- * implementations usually work with a single image representation,
- * such as VXL or OCV.
- *
- * If you are lookling for an interface for an image transform that
- * will change the value of a pixel, then use the image_filter
- * interface.
- */
+///
+/// Arrows that implement this interface convert the input image type
+/// (e.g. BGR 16) to a different type (e.g. RGB 8). Concrete
+/// implementations usually work with a single image representation,
+/// such as VXL or OCV.
+///
+/// If you are lookling for an interface for an image transform that
+/// will change the value of a pixel, then use the image_filter
+/// interface.
+///
 class VITAL_ALGO_EXPORT convert_image
   : public kwiver::vital::algorithm_def< convert_image >
 {

--- a/vital/algo/data_serializer.cxx
+++ b/vital/algo/data_serializer.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief data_serializer algorithm definition instantiation
- */
+///
+/// \file
+/// \brief data_serializer algorithm definition instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/data_serializer.h>

--- a/vital/algo/data_serializer.h
+++ b/vital/algo/data_serializer.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief data_serializer algorithm definition
- */
+///
+/// \file
+/// \brief data_serializer algorithm definition
+///
 
 #ifndef VITAL_ALGO_SERIALIZE_H
 #define VITAL_ALGO_SERIALIZE_H
@@ -26,25 +26,24 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class serializing and deserializing.
-
-/**
- * This class represents a pair of methods that serialize and
- * deserialize concrete data types. These methods are guaranteed to
- * work together. A data type serialized and deserialized by this
- * algorithm are semantically equivalent. The format and process of
- * actually doing the serialization depends on the concrete
- * implementation.
- *
- * It is expected that implementations of this interface will not
- * require any implementation specific configuration parameters. This
- * is because the implementation is selected at run time based on the
- * data type of the port connections.
- *
- * The serializer is stateless and idempotent.
- *
- * The main application for this algorithm is to serialize data
- * objects for inter-process communications.
- */
+///
+/// This class represents a pair of methods that serialize and
+/// deserialize concrete data types. These methods are guaranteed to
+/// work together. A data type serialized and deserialized by this
+/// algorithm are semantically equivalent. The format and process of
+/// actually doing the serialization depends on the concrete
+/// implementation.
+///
+/// It is expected that implementations of this interface will not
+/// require any implementation specific configuration parameters. This
+/// is because the implementation is selected at run time based on the
+/// data type of the port connections.
+///
+/// The serializer is stateless and idempotent.
+///
+/// The main application for this algorithm is to serialize data
+/// objects for inter-process communications.
+///
 class VITAL_ALGO_EXPORT data_serializer
   : public kwiver::vital::algorithm_def< data_serializer >
 {
@@ -53,61 +52,59 @@ public:
   static std::string static_type_name() { return "data_serializer"; }
 
   /// Serialize the item into a byte string.
-
-  /**
-   * This method serializes the supplied data item(s) and returns a
-   * byte string.
-   *
-   * All implementations must define the set of expected element
-   * names. An exception is thrown if a names is supplied and is not
-   * known to the implementation. An implementation can elect to
-   * accept an input map that does not contain all supported element
-   * names.
-   *
-   * If the implementation only supports a single data element, then
-   * the name associated with that element will be "datum".
-   *
-   * The type of the data represented by the datum must match the type
-   * expected by the serializer implementation or an exception will be
-   * thrown.
-   *
-   * @param elements Data items to be serialized.
-   *
-   * @return Byte string of serialized data item.
-   *
-   * @throws kwiver::vital::bad_any_cast
-   * @throws kwiver::vital::serialization - for unexpected element name
-   */
+  ///
+  /// This method serializes the supplied data item(s) and returns a
+  /// byte string.
+  ///
+  /// All implementations must define the set of expected element
+  /// names. An exception is thrown if a names is supplied and is not
+  /// known to the implementation. An implementation can elect to
+  /// accept an input map that does not contain all supported element
+  /// names.
+  ///
+  /// If the implementation only supports a single data element, then
+  /// the name associated with that element will be "datum".
+  ///
+  /// The type of the data represented by the datum must match the type
+  /// expected by the serializer implementation or an exception will be
+  /// thrown.
+  ///
+  /// @param elements Data items to be serialized.
+  ///
+  /// @return Byte string of serialized data item.
+  ///
+  /// @throws kwiver::vital::bad_any_cast
+  /// @throws kwiver::vital::serialization - for unexpected element name
+  ///
   virtual std::shared_ptr< std::string > serialize( const vital::any& element ) = 0;
 
   /// Deserialize byte string into data type.
-
-  /**
-   * Deserialize the supplied string of bytes into new data
-   * item(s). This method must handle an input byte string created by the
-   * \c serialize() method and convert it to the concrete type(s). The
-   * actual type used for the conversion is based on the concrete
-   * implementation of this algorithm. If the input byte string does
-   * not represent the expected data type, then an exception will be
-   * thrown.
-   *
-   * All implementations must define the set of expected element
-   * names. An exception is thrown if a names is supplied and is not
-   * known to the implementation. An implementation can elect to
-   * accept an input map that does not contain all supported element
-   * names.
-   *
-   * If the implementation only supports a single data element, then
-   * the name associated with that element will be "datum".
-   *
-   * @param message Serialized data item that is to be processed.
-   *
-   * @return Concrete data type, represented as an any, created from
-   * the input.
-   *
-   * @throws kwiver::vital::bad_any_cast
-   * @throws kwiver::vital::serialization - for unexpected element name
-   */
+  ///
+  /// Deserialize the supplied string of bytes into new data
+  /// item(s). This method must handle an input byte string created by the
+  /// \c serialize() method and convert it to the concrete type(s). The
+  /// actual type used for the conversion is based on the concrete
+  /// implementation of this algorithm. If the input byte string does
+  /// not represent the expected data type, then an exception will be
+  /// thrown.
+  ///
+  /// All implementations must define the set of expected element
+  /// names. An exception is thrown if a names is supplied and is not
+  /// known to the implementation. An implementation can elect to
+  /// accept an input map that does not contain all supported element
+  /// names.
+  ///
+  /// If the implementation only supports a single data element, then
+  /// the name associated with that element will be "datum".
+  ///
+  /// @param message Serialized data item that is to be processed.
+  ///
+  /// @return Concrete data type, represented as an any, created from
+  /// the input.
+  ///
+  /// @throws kwiver::vital::bad_any_cast
+  /// @throws kwiver::vital::serialization - for unexpected element name
+  ///
   virtual vital::any deserialize( const std::string& message ) = 0;
 
   virtual void set_configuration( kwiver::vital::config_block_sptr config ) {}

--- a/vital/algo/detect_features.cxx
+++ b/vital/algo/detect_features.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief detect_features algorithm definition instantiation
- */
+///
+/// \file
+/// \brief detect_features algorithm definition instantiation
+///
 
 #include <vital/algo/detect_features.h>
 

--- a/vital/algo/detect_features.h
+++ b/vital/algo/detect_features.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief detect_features algorithm definition
- */
+///
+/// \file
+/// \brief detect_features algorithm definition
+///
 
 #ifndef VITAL_ALGO_DETECT_FEATURES_H_
 #define VITAL_ALGO_DETECT_FEATURES_H_
@@ -30,22 +30,21 @@ public:
   static std::string static_type_name() { return "detect_features"; }
 
   /// Extract a set of image features from the provided image
-
-  /**
-   * A given mask image should be one-channel (mask->depth() == 1). If the
-   * given mask image has more than one channel, only the first will be
-   * considered.
-   *
-   * \throws image_size_mismatch_exception
-   *    When the given non-zero mask image does not match the size of the
-   *    dimensions of the given image data.
-   *
-   * \param image_data contains the image data to process
-   * \param mask Mask image where regions of positive values (boolean true)
-   *             indicate regions to consider. Only the first channel will be
-   *             considered.
-   * \returns a set of image features
-   */
+  ///
+  /// A given mask image should be one-channel (mask->depth() == 1). If the
+  /// given mask image has more than one channel, only the first will be
+  /// considered.
+  ///
+  /// \throws image_size_mismatch_exception
+  ///   When the given non-zero mask image does not match the size of the
+  ///   dimensions of the given image data.
+  ///
+  /// \param image_data contains the image data to process
+  /// \param mask Mask image where regions of positive values (boolean true)
+  ///            indicate regions to consider. Only the first channel will be
+  ///            considered.
+  /// \returns a set of image features
+  ///
   virtual kwiver::vital::feature_set_sptr
   detect( kwiver::vital::image_container_sptr image_data,
           kwiver::vital::image_container_sptr mask = kwiver::vital::image_container_sptr() )

--- a/vital/algo/detect_motion.cxx
+++ b/vital/algo/detect_motion.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief detect_motion algorithm instantiation
- */
+///
+/// \file
+/// \brief detect_motion algorithm instantiation
+///
 
 #include <vital/algo/detect_motion.h>
 

--- a/vital/algo/detect_motion.h
+++ b/vital/algo/detect_motion.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface to algorithms for motion detection
- */
+///
+/// \file
+/// \brief Interface to algorithms for motion detection
+///
 
 #ifndef VITAL_ALGO_DETECT_MOTION_H
 #define VITAL_ALGO_DETECT_MOTION_H
@@ -30,24 +30,23 @@ public:
   static std::string static_type_name() { return "detect_motion"; }
 
   /// Detect motion from a sequence of images
-
-  /**
-   * This method detects motion of foreground objects within a
-   * sequence of images in which the background remains stationary.
-   * Sequential images are passed one at a time. Motion estimates
-   * are returned for each image as a heat map with higher values
-   * indicating greater confidence.
-   *
-   * \param ts Timestamp for the input image
-   * \param image Image from a sequence
-   * \param reset_model Indicates that the background model should
-   * be reset, for example, due to changes in lighting condition or
-   * camera pose
-   *
-   * \returns A heat map image is returned indicating the confidence
-   * that motion occurred at each pixel. Heat map image is single channel
-   * and has the same width and height dimensions as the input image.
-   */
+  ///
+  /// This method detects motion of foreground objects within a
+  /// sequence of images in which the background remains stationary.
+  /// Sequential images are passed one at a time. Motion estimates
+  /// are returned for each image as a heat map with higher values
+  /// indicating greater confidence.
+  ///
+  /// \param ts Timestamp for the input image
+  /// \param image Image from a sequence
+  /// \param reset_model Indicates that the background model should
+  /// be reset, for example, due to changes in lighting condition or
+  /// camera pose
+  ///
+  /// \returns A heat map image is returned indicating the confidence
+  /// that motion occurred at each pixel. Heat map image is single channel
+  /// and has the same width and height dimensions as the input image.
+  ///
   virtual image_container_sptr
   process_image( const timestamp& ts,
                  const image_container_sptr image,

--- a/vital/algo/detected_object_filter.cxx
+++ b/vital/algo/detected_object_filter.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief detected_object_filter algorithm instantiation
- */
+///
+/// \file
+/// \brief detected_object_filter algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/detected_object_filter.h>

--- a/vital/algo/detected_object_filter.h
+++ b/vital/algo/detected_object_filter.h
@@ -2,9 +2,9 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- */
+///
+/// \file
+///
 
 #ifndef VITAL_ALGO_DETECTED_OBJECT_FILTER_H_
 #define VITAL_ALGO_DETECTED_OBJECT_FILTER_H_
@@ -25,12 +25,12 @@ namespace algo {
 /// An abstract base class for filtering sets of detected objects
 // ----------------------------------------------------------------
 
-/**
- * A detected object filter accepts a set of detections and produces
- * another set of detections. The output set may be different from the
- * input set. It all depends on the actual implementation. In any
- * case, the input detection set shall be unmodified.
- */
+///
+/// A detected object filter accepts a set of detections and produces
+/// another set of detections. The output set may be different from the
+/// input set. It all depends on the actual implementation. In any
+/// case, the input detection set shall be unmodified.
+///
 class VITAL_ALGO_EXPORT detected_object_filter
   : public algorithm_def< detected_object_filter >
 {
@@ -39,14 +39,13 @@ public:
   static std::string static_type_name() { return "detected_object_filter"; }
 
   /// Filter set of detected objects.
-
-  /**
-   * This method applies a filter to the input set to create an output
-   * set. The input set of detections is unmodified.
-   *
-   * \param input_set Set of detections to be filtered.
-   * \returns Filtered set of detections.
-   */
+  ///
+  /// This method applies a filter to the input set to create an output
+  /// set. The input set of detections is unmodified.
+  ///
+  /// \param input_set Set of detections to be filtered.
+  /// \returns Filtered set of detections.
+  ///
   virtual detected_object_set_sptr
   filter( const detected_object_set_sptr input_set ) const = 0;
 

--- a/vital/algo/detected_object_set_input.cxx
+++ b/vital/algo/detected_object_set_input.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "detected_object_set_input.h"
 

--- a/vital/algo/detected_object_set_input.h
+++ b/vital/algo/detected_object_set_input.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for detected_object_set input
- */
+///
+/// \file
+/// \brief Interface for detected_object_set input
+///
 
 #ifndef _VITAL_DETECTED_OBJECT_SET_INPUT_H
 #define _VITAL_DETECTED_OBJECT_SET_INPUT_H
@@ -23,16 +23,16 @@ namespace vital {
 namespace algo {
 
 // ----------------------------------------------------------------
-/**
- * @brief Read detected object sets
- *
- * This class is the abstract base class for the detected object set
- * writer.
- *
- * Detection sets from multiple images are stored in a single file
- * with enough information to recreate a unique image identifier,
- * usually the file name, and an associated set of detections.
- */
+///
+/// @brief Read detected object sets
+///
+/// This class is the abstract base class for the detected object set
+/// writer.
+///
+/// Detection sets from multiple images are stored in a single file
+/// with enough information to recreate a unique image identifier,
+/// usually the file name, and an associated set of detections.
+///
 class VITAL_ALGO_EXPORT detected_object_set_input
   : public kwiver::vital::algorithm_def<detected_object_set_input>
 {
@@ -43,59 +43,59 @@ public:
   static std::string static_type_name() { return "detected_object_set_input"; }
 
   /// Open a file of detection sets.
-  /**
-   * This method opens a detection set file for reading.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \throws kwiver::vital::file_not_found_exception
-   */
+  ///
+  /// This method opens a detection set file for reading.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \throws kwiver::vital::file_not_found_exception
+  ///
   virtual void open( std::string const& filename );
 
   /// Read detections from an existing stream
-  /**
-   * This method specifies the input stream to use for reading
-   * detections. Using a stream is handy when the detections are
-   * available in a stream format.
-   *
-   * @param strm input stream to use
-   */
+  ///
+  /// This method specifies the input stream to use for reading
+  /// detections. Using a stream is handy when the detections are
+  /// available in a stream format.
+  ///
+  /// @param strm input stream to use
+  ///
   void use_stream( std::istream* strm );
 
   /// Close detection set file.
-  /**
-   * The currently open detection set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open detection set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Read next detected object set
-  /**
-   * This method reads the next set of detected objects from the
-   * file. \b False is returned when the end of file is reached.
-   *
-   * \param[out] set Pointer to the new set of detections. Set may be
-   * empty if there are no detections on an image.
-   *
-   * \param[out] image_name Name of the image that goes with the
-   * detections. This string may be empty depending on the source
-   * format.
-   *
-   * @return \b true if detections are returned, \b false if end of file.
-   */
+  ///
+  /// This method reads the next set of detected objects from the
+  /// file. \b False is returned when the end of file is reached.
+  ///
+  /// \param[out] set Pointer to the new set of detections. Set may be
+  /// empty if there are no detections on an image.
+  ///
+  /// \param[out] image_name Name of the image that goes with the
+  /// detections. This string may be empty depending on the source
+  /// format.
+  ///
+  /// @return \b true if detections are returned, \b false if end of file.
+  ///
   virtual bool read_set( kwiver::vital::detected_object_set_sptr & set, std::string& image_name ) = 0;
 
   /// Determine if input file is at end of file.
-  /**
-   * This method reports the end of file status for a file open for reading.
-   *
-   * @return \b true if file is at end.
-   */
+  ///
+  /// This method reports the end of file status for a file open for reading.
+  ///
+  /// @return \b true if file is at end.
+  ///
   bool at_eof() const;
 
 protected:

--- a/vital/algo/detected_object_set_output.cxx
+++ b/vital/algo/detected_object_set_output.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "detected_object_set_output.h"
 

--- a/vital/algo/detected_object_set_output.h
+++ b/vital/algo/detected_object_set_output.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for detected_object_set output
- */
+///
+/// \file
+/// \brief Interface for detected_object_set output
+///
 
 #ifndef _VITAL_DETECTED_OBJECT_SET_OUTPUT_H
 #define _VITAL_DETECTED_OBJECT_SET_OUTPUT_H
@@ -23,17 +23,17 @@ namespace vital {
 namespace algo {
 
 // ----------------------------------------------------------------
-/**
- * @brief Read and write detected object sets
- *
- * This class is the abstract base class for the detected object set
- * reader and writer.
- *
- * Detection sets from multiple images are stored in a single file
- * with enough information to recreate a unique image identifier,
- * usually the file name, and an associated wet of detections.
- *
- */
+///
+/// @brief Read and write detected object sets
+///
+/// This class is the abstract base class for the detected object set
+/// reader and writer.
+///
+/// Detection sets from multiple images are stored in a single file
+/// with enough information to recreate a unique image identifier,
+/// usually the file name, and an associated wet of detections.
+///
+///
 class VITAL_ALGO_EXPORT detected_object_set_output
   : public kwiver::vital::algorithm_def<detected_object_set_output>
 {
@@ -44,50 +44,50 @@ public:
   static std::string static_type_name() { return "detected_object_set_output"; }
 
   /// Open a file of detection sets.
-  /**
-   * This method opens a detection set file for writing.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   */
+  ///
+  /// This method opens a detection set file for writing.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
   virtual void open( std::string const& filename );
 
   /// Write detections to an existing stream
-  /**
-   * This method specifies the output stream to use for writing
-   * detections. Using a stream is handy when the detections output is
-   * available in a stream format.
-   *
-   * @param strm output stream to use
-   */
+  ///
+  /// This method specifies the output stream to use for writing
+  /// detections. Using a stream is handy when the detections output is
+  /// available in a stream format.
+  ///
+  /// @param strm output stream to use
+  ///
   void use_stream( std::ostream* strm );
 
   /// Close detection set file.
-  /**
-   * The currently open detection set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open detection set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Write detected object set.
-  /**
-   * This method writes the specified detected object set and image
-   * name to the currently open file.
-   *
-   * \param set Detected object set
-   * \param image_path File path to image associated with the detections.
-   */
+  ///
+  /// This method writes the specified detected object set and image
+  /// name to the currently open file.
+  ///
+  /// \param set Detected object set
+  /// \param image_path File path to image associated with the detections.
+  ///
   virtual void write_set( const kwiver::vital::detected_object_set_sptr set,
                           std::string const& image_path ) = 0;
 
   /// Perform end-of-stream actions.
-  /**
-   * This method writes any necessary final data to the currently open file.
-   */
+  ///
+  /// This method writes any necessary final data to the currently open file.
+  ///
   virtual void complete() {}
 
 protected:

--- a/vital/algo/draw_detected_object_set.h
+++ b/vital/algo/draw_detected_object_set.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header for draw_detected_object_set
- */
+///
+/// \file
+/// \brief Header for draw_detected_object_set
+///
 
 #ifndef VITAL_ALGO_DRAW_DETECTED_OBJECT_SET_H
 #define VITAL_ALGO_DRAW_DETECTED_OBJECT_SET_H
@@ -32,17 +32,16 @@ public:
   static std::string static_type_name() { return "draw_detected_object_set"; }
 
   /// Draw detected object boxes on Image.
-
-  /**
-   * This method draws the detections on a copy of the image. The
-   * input image is unmodified. The actual boxes that are drawn are
-   * controlled by the configuration for the implementation.
-   *
-   * @param detected_set Set of detected objects
-   * @param image Boxes are drawn in this image
-   *
-   * @return Image with boxes and other annotations added.
-   */
+  ///
+  /// This method draws the detections on a copy of the image. The
+  /// input image is unmodified. The actual boxes that are drawn are
+  /// controlled by the configuration for the implementation.
+  ///
+  /// @param detected_set Set of detected objects
+  /// @param image Boxes are drawn in this image
+  ///
+  /// @return Image with boxes and other annotations added.
+  ///
   virtual kwiver::vital::image_container_sptr
   draw( kwiver::vital::detected_object_set_sptr detected_set,
         kwiver::vital::image_container_sptr image ) = 0;

--- a/vital/algo/draw_tracks.h
+++ b/vital/algo/draw_tracks.h
@@ -13,12 +13,12 @@
 
 #include <ostream>
 
-/**
- * \file
- * \brief Header defining an abstract \link kwiver::vital::algo::draw_tracks
- * track
- *        drawing \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining an abstract \link kwiver::vital::algo::draw_tracks
+/// track
+///       drawing \endlink algorithm
+///
 
 namespace kwiver {
 
@@ -36,20 +36,19 @@ public:
   static std::string static_type_name() { return "draw_tracks"; }
 
   /// Draw features tracks on top of the input images.
-
-  /**
-   * This process can either be called in an offline fashion, where all
-   * tracks and images are provided to the function on the first call,
-   * or in an online fashion where only new images are provided on
-   * sequential calls. This function can additionally consume a second
-   * track set, which can optionally be used to display additional
-   * information to provide a comparison between the two track sets.
-   *
-   * \param display_set the main track set to draw
-   * \param image_data a list of images the tracks were computed over
-   * \param comparison_set optional comparison track set
-   * \returns a pointer to the last image generated
-   */
+  ///
+  /// This process can either be called in an offline fashion, where all
+  /// tracks and images are provided to the function on the first call,
+  /// or in an online fashion where only new images are provided on
+  /// sequential calls. This function can additionally consume a second
+  /// track set, which can optionally be used to display additional
+  /// information to provide a comparison between the two track sets.
+  ///
+  /// \param display_set the main track set to draw
+  /// \param image_data a list of images the tracks were computed over
+  /// \param comparison_set optional comparison track set
+  /// \returns a pointer to the last image generated
+  ///
   virtual kwiver::vital::image_container_sptr
   draw( kwiver::vital::track_set_sptr display_set,
         kwiver::vital::image_container_sptr_list image_data,

--- a/vital/algo/dynamic_configuration.h
+++ b/vital/algo/dynamic_configuration.h
@@ -15,13 +15,12 @@ namespace algo {
 
 /// Abstract algorithm for getting dynamic configuration values from
 /// an external source.
-
-/**
- * \brief This class represents an interface to an external source of
- *        configuration values. A typical application would be an external
- *        U.I. control that is desired to control the performance of an
- *        algorithm by varying some of its configuration values.
- */
+///
+/// \brief This class represents an interface to an external source of
+///       configuration values. A typical application would be an external
+///       U.I. control that is desired to control the performance of an
+///       algorithm by varying some of its configuration values.
+///
 class VITAL_ALGO_EXPORT dynamic_configuration
   : public kwiver::vital::algorithm_def< dynamic_configuration >
 {
@@ -32,11 +31,10 @@ public:
   virtual bool check_configuration( config_block_sptr config ) const = 0;
 
   /// Return dynamic configuration values
-
-  /**
-   * \brief This method returns dynamic configuration values. a valid config
-   *        block is returned even if there are not values being returned.
-   */
+  ///
+  /// \brief This method returns dynamic configuration values. a valid config
+  ///       block is returned even if there are not values being returned.
+  ///
   virtual config_block_sptr get_dynamic_configuration() = 0;
 
 protected:

--- a/vital/algo/estimate_canonical_transform.cxx
+++ b/vital/algo/estimate_canonical_transform.cxx
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of canonical similarity transform
- *        estimation algorithm definition.
- */
+///
+/// \file
+/// \brief Implementation of canonical similarity transform
+///       estimation algorithm definition.
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_canonical_transform.h>

--- a/vital/algo/estimate_canonical_transform.h
+++ b/vital/algo/estimate_canonical_transform.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Definition for canonical transform estimation algorithm
- */
+///
+/// \file
+/// \brief Definition for canonical transform estimation algorithm
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_CANONICAL_TRANSFORM_H_
 #define VITAL_ALGO_ESTIMATE_CANONICAL_TRANSFORM_H_
@@ -30,14 +30,13 @@ namespace vital {
 namespace algo {
 
 /// Algorithm for estimating a canonical transform for cameras and landmarks
-
-/**
- *  A canonical transform is a repeatable transformation that can be recovered
- *  from data.  In this case we assume at most a similarity transformation.
- *  If data sets P1 and P2 are equivalent up to a similarity transformation,
- *  then applying a canonical transform to P1 and separately a
- *  canonical transform to P2 should bring the data into the same coordinates.
- */
+///
+/// A canonical transform is a repeatable transformation that can be recovered
+/// from data.  In this case we assume at most a similarity transformation.
+/// If data sets P1 and P2 are equivalent up to a similarity transformation,
+/// then applying a canonical transform to P1 and separately a
+/// canonical transform to P2 should bring the data into the same coordinates.
+///
 class VITAL_ALGO_EXPORT estimate_canonical_transform
   : public kwiver::vital::algorithm_def< estimate_canonical_transform >
 {
@@ -47,16 +46,15 @@ public:
   static std::string static_type_name() { return "estimate_canonical_transform"; }
 
   /// Estimate a canonical similarity transform for cameras and points
-
-  /**
-   * \param cameras The camera map containing all the cameras
-   * \param landmarks The landmark map containing all the 3D landmarks
-   * \throws algorithm_exception When the data is insufficient or degenerate.
-   * \returns An estimated similarity transform mapping the data to the
-   *          canonical space.
-   * \note This algorithm does not apply the transformation, it only estimates
-   * it.
-   */
+  ///
+  /// \param cameras The camera map containing all the cameras
+  /// \param landmarks The landmark map containing all the 3D landmarks
+  /// \throws algorithm_exception When the data is insufficient or degenerate.
+  /// \returns An estimated similarity transform mapping the data to the
+  ///         canonical space.
+  /// \note This algorithm does not apply the transformation, it only estimates
+  /// it.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform( kwiver::vital::camera_map_sptr const cameras,
                       kwiver::vital::landmark_map_sptr const landmarks ) const = 0;

--- a/vital/algo/estimate_essential_matrix.cxx
+++ b/vital/algo/estimate_essential_matrix.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate essential matrix instantiation
- */
+///
+/// \file
+/// \brief estimate essential matrix instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_essential_matrix.h>

--- a/vital/algo/estimate_essential_matrix.h
+++ b/vital/algo/estimate_essential_matrix.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_essential_matrix algorithm definition
- */
+///
+/// \file
+/// \brief estimate_essential_matrix algorithm definition
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_ESSENTIAL_MATRIX_H_
 #define VITAL_ALGO_ESTIMATE_ESSENTIAL_MATRIX_H_
@@ -37,19 +37,18 @@ public:
   static std::string static_type_name() { return "estimate_essential_matrix"; }
 
   /// Estimate an essential matrix from corresponding features
-
-  /**
-   * \param [in]  feat1 the set of all features from the first image
-   * \param [in]  feat2 the set of all features from the second image
-   * \param [in]  matches the set of correspondences between \a feat1 and \a
-   * feat2
-   * \param [in]  cal1 the intrinsic parameters of the first camera
-   * \param [in]  cal2 the intrinsic parameters of the second camera
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// \param [in]  feat1 the set of all features from the first image
+  /// \param [in]  feat2 the set of all features from the second image
+  /// \param [in]  matches the set of correspondences between \a feat1 and \a
+  /// feat2
+  /// \param [in]  cal1 the intrinsic parameters of the first camera
+  /// \param [in]  cal2 the intrinsic parameters of the second camera
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual
   kwiver::vital::essential_matrix_sptr
   estimate( const kwiver::vital::feature_set_sptr feat1,
@@ -61,18 +60,17 @@ public:
             double inlier_scale = 1.0 ) const;
 
   /// Estimate an essential matrix from corresponding features
-
-  /**
-   * \param [in]  feat1 the set of all features from the first image
-   * \param [in]  feat2 the set of all features from the second image
-   * \param [in]  matches the set of correspondences between \a feat1 and \a
-   * feat2
-   * \param [in]  cal the intrinsic parameters, same for both cameras
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// \param [in]  feat1 the set of all features from the first image
+  /// \param [in]  feat2 the set of all features from the second image
+  /// \param [in]  matches the set of correspondences between \a feat1 and \a
+  /// feat2
+  /// \param [in]  cal the intrinsic parameters, same for both cameras
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual
   kwiver::vital::essential_matrix_sptr
   estimate( const kwiver::vital::feature_set_sptr feat1,
@@ -83,16 +81,15 @@ public:
             double inlier_scale = 1.0 ) const;
 
   /// Estimate an essential matrix from corresponding points
-
-  /**
-   * \param [in]  pts1 the vector or corresponding points from the first image
-   * \param [in]  pts2 the vector of corresponding points from the second image
-   * \param [in]  cal the intrinsic parameters, same for both cameras
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// \param [in]  pts1 the vector or corresponding points from the first image
+  /// \param [in]  pts2 the vector of corresponding points from the second image
+  /// \param [in]  cal the intrinsic parameters, same for both cameras
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual
   kwiver::vital::essential_matrix_sptr
   estimate( const std::vector< kwiver::vital::vector_2d >& pts1,
@@ -102,17 +99,16 @@ public:
             double inlier_scale = 1.0 ) const;
 
   /// Estimate an essential matrix from corresponding points
-
-  /**
-   * \param [in]  pts1 the vector or corresponding points from the first image
-   * \param [in]  pts2 the vector of corresponding points from the second image
-   * \param [in]  cal1 the intrinsic parameters of the first camera
-   * \param [in]  cal2 the intrinsic parameters of the second camera
-   * \param [out] inliers for each point pa:wir, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// \param [in]  pts1 the vector or corresponding points from the first image
+  /// \param [in]  pts2 the vector of corresponding points from the second image
+  /// \param [in]  cal1 the intrinsic parameters of the first camera
+  /// \param [in]  cal2 the intrinsic parameters of the second camera
+  /// \param [out] inliers for each point pa:wir, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual
   kwiver::vital::essential_matrix_sptr
   estimate( const std::vector< kwiver::vital::vector_2d >& pts1,

--- a/vital/algo/estimate_fundamental_matrix.cxx
+++ b/vital/algo/estimate_fundamental_matrix.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate fundamental matrix instantiation
- */
+///
+/// \file
+/// \brief estimate fundamental matrix instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_fundamental_matrix.h>

--- a/vital/algo/estimate_fundamental_matrix.h
+++ b/vital/algo/estimate_fundamental_matrix.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_fundamental_matrix algorithm definition
- */
+///
+/// \file
+/// \brief estimate_fundamental_matrix algorithm definition
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_FUNDAMENTAL_MATRIX_H_
 #define VITAL_ALGO_ESTIMATE_FUNDAMENTAL_MATRIX_H_
@@ -35,14 +35,14 @@ public:
   static std::string static_type_name() { return "estimate_fundamental_matrix"; }
 
   /// Estimate an fundamental matrix from corresponding features
-  /**
-   * \param [in]  feat1 the set of all features from the first image
-   * \param [in]  feat2 the set of all features from the second image
-   * \param [in]  matches the set of correspondences between \a feat1 and \a feat2
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be inliers
-   */
+  ///
+  /// \param [in]  feat1 the set of all features from the first image
+  /// \param [in]  feat2 the set of all features from the second image
+  /// \param [in]  matches the set of correspondences between \a feat1 and \a feat2
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be inliers
+  ///
   virtual
   kwiver::vital::fundamental_matrix_sptr
   estimate(const kwiver::vital::feature_set_sptr feat1,
@@ -52,13 +52,13 @@ public:
            double inlier_scale = 1.0) const;
 
   /// Estimate an fundamental matrix from corresponding points
-  /**
-   * \param [in]  pts1 the vector or corresponding points from the first image
-   * \param [in]  pts2 the vector of corresponding points from the second image
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be inliers
-   */
+  ///
+  /// \param [in]  pts1 the vector or corresponding points from the first image
+  /// \param [in]  pts2 the vector of corresponding points from the second image
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be inliers
+  ///
   virtual
   kwiver::vital::fundamental_matrix_sptr
   estimate(const std::vector<kwiver::vital::vector_2d>& pts1,

--- a/vital/algo/estimate_homography.cxx
+++ b/vital/algo/estimate_homography.cxx
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_homography algorithm definition instantiation +
- * implementation
- */
+///
+/// \file
+/// \brief estimate_homography algorithm definition instantiation +
+/// implementation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_homography.h>

--- a/vital/algo/estimate_homography.h
+++ b/vital/algo/estimate_homography.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_homography algorithm definition
- */
+///
+/// \file
+/// \brief estimate_homography algorithm definition
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_HOMOGRAPHY_H_
 #define VITAL_ALGO_ESTIMATE_HOMOGRAPHY_H_
@@ -35,19 +35,18 @@ public:
   static std::string static_type_name() { return "estimate_homography"; }
 
   /// Estimate a homography matrix from corresponding features
-
-  /**
-   * If estimation fails, a NULL-containing sptr is returned
-   *
-   * \param [in]  feat1 the set of all features from the source image
-   * \param [in]  feat2 the set of all features from the destination image
-   * \param [in]  matches the set of correspondences between \a feat1 and \a
-   * feat2
-   * \param [out] inliers for each match in \a matcher, the value is true if
-   *                      this pair is an inlier to the homography estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// If estimation fails, a NULL-containing sptr is returned
+  ///
+  /// \param [in]  feat1 the set of all features from the source image
+  /// \param [in]  feat2 the set of all features from the destination image
+  /// \param [in]  matches the set of correspondences between \a feat1 and \a
+  /// feat2
+  /// \param [out] inliers for each match in \a matcher, the value is true if
+  ///                     this pair is an inlier to the homography estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual kwiver::vital::homography_sptr
   estimate( kwiver::vital::feature_set_sptr feat1,
             kwiver::vital::feature_set_sptr feat2,
@@ -56,18 +55,17 @@ public:
             double inlier_scale = 1.0 ) const;
 
   /// Estimate a homography matrix from corresponding points
-
-  /**
-   * If estimation fails, a NULL-containing sptr is returned
-   *
-   * \param [in]  pts1 the vector or corresponding points from the source image
-   * \param [in]  pts2 the vector of corresponding points from the destination
-   * image
-   * \param [out] inliers for each point pair, the value is true if
-   *                      this pair is an inlier to the homography estimate
-   * \param [in]  inlier_scale error distance tolerated for matches to be
-   * inliers
-   */
+  ///
+  /// If estimation fails, a NULL-containing sptr is returned
+  ///
+  /// \param [in]  pts1 the vector or corresponding points from the source image
+  /// \param [in]  pts2 the vector of corresponding points from the destination
+  /// image
+  /// \param [out] inliers for each point pair, the value is true if
+  ///                     this pair is an inlier to the homography estimate
+  /// \param [in]  inlier_scale error distance tolerated for matches to be
+  /// inliers
+  ///
   virtual kwiver::vital::homography_sptr
   estimate( const std::vector< kwiver::vital::vector_2d >& pts1,
             const std::vector< kwiver::vital::vector_2d >& pts2,

--- a/vital/algo/estimate_pnp.cxx
+++ b/vital/algo/estimate_pnp.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_pnp instantiation
- */
+///
+/// \file
+/// \brief estimate_pnp instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_pnp.h>

--- a/vital/algo/estimate_pnp.h
+++ b/vital/algo/estimate_pnp.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief estimate_pnp algorithm definition
- */
+///
+/// \file
+/// \brief estimate_pnp algorithm definition
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_PNP_H_
 #define VITAL_ALGO_ESTIMATE_PNP_H_
@@ -38,15 +38,14 @@ public:
 
   /// Estimate the camera's pose from the 3D points and their corresponding
   /// projections
-
-  /**
-   * \param [in]  pts2d 2d projections of pts3d in the same order as pts3d
-   * \param [in]  pts3d 3d landmarks in the same order as pts2d.  Both must be
-   * same size.
-   * \param [in]  cal the intrinsic parameters of the camera
-   * \param [out] inliers for each point, the value is true if
-   *                      this pair is an inlier to the estimate
-   */
+  ///
+  /// \param [in]  pts2d 2d projections of pts3d in the same order as pts3d
+  /// \param [in]  pts3d 3d landmarks in the same order as pts2d.  Both must be
+  /// same size.
+  /// \param [in]  cal the intrinsic parameters of the camera
+  /// \param [out] inliers for each point, the value is true if
+  ///                     this pair is an inlier to the estimate
+  ///
   virtual
   kwiver::vital::camera_perspective_sptr
   estimate( const std::vector< vector_2d >& pts2d,

--- a/vital/algo/estimate_similarity_transform.cxx
+++ b/vital/algo/estimate_similarity_transform.cxx
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of wrapper functions in similarity transform
- *        estimation algorithm definition.
- */
+///
+/// \file
+/// \brief Implementation of wrapper functions in similarity transform
+///       estimation algorithm definition.
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/estimate_similarity_transform.h>
@@ -70,18 +70,18 @@ namespace
 
 // ------------------------------------------------------------------
 /// Helper function for assigning camera/landmark map contents to point vectors
-/**
- * \tparam M      Map type whose value_type::second_type is a std::shared_ptr
- * \tparam afunc  Pointer to the accessor function in the object that is
- *                contained in the std::shared_ptr.
- *
- * \param from_map      map of type M of objects at \c from position
- * \param to_map        map of type M of objects at \c to position
- * \param from_pts      vector in which to store \c from points that have
- *                      a corresponding \c to point.
- * \param to_pts        vector in which to store \c to points that have
- *                      a corresponding \c from point.
- */
+///
+/// \tparam M      Map type whose value_type::second_type is a std::shared_ptr
+/// \tparam afunc  Pointer to the accessor function in the object that is
+///               contained in the std::shared_ptr.
+///
+/// \param from_map      map of type M of objects at \c from position
+/// \param to_map        map of type M of objects at \c to position
+/// \param from_pts      vector in which to store \c from points that have
+///                     a corresponding \c to point.
+/// \param to_pts        vector in which to store \c to points that have
+///                     a corresponding \c from point.
+///
 template< typename M,
           vector_3d (M::value_type::second_type::element_type::*afunc)() const >
 void map_to_pts(M const& from_map, M const& to_map,

--- a/vital/algo/estimate_similarity_transform.h
+++ b/vital/algo/estimate_similarity_transform.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Definition for similarity transform estimation algorithm
- */
+///
+/// \file
+/// \brief Definition for similarity transform estimation algorithm
+///
 
 #ifndef VITAL_ALGO_ESTIMATE_SIMILARITY_TRANSFORM_H_
 #define VITAL_ALGO_ESTIMATE_SIMILARITY_TRANSFORM_H_
@@ -45,30 +45,28 @@ public:
   }
 
   /// Estimate the similarity transform between two corresponding point sets
-
-  /**
-   * \param from List of length N of 3D points in the from space.
-   * \param to   List of length N of 3D points in the to space.
-   * \throws algorithm_exception When the from and to point sets are
-   *                             misaligned, insufficient or degenerate.
-   * \returns An estimated similarity transform mapping 3D points in the
-   *          \c from space to points in the \c to space.
-   */
+  ///
+  /// \param from List of length N of 3D points in the from space.
+  /// \param to   List of length N of 3D points in the to space.
+  /// \throws algorithm_exception When the from and to point sets are
+  ///                            misaligned, insufficient or degenerate.
+  /// \returns An estimated similarity transform mapping 3D points in the
+  ///         \c from space to points in the \c to space.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform( std::vector< kwiver::vital::vector_3d > const& from,
                       std::vector< kwiver::vital::vector_3d > const& to ) const = 0;
 
   /// Estimate the similarity transform between two corresponding sets of
   /// cameras
-
-  /**
-   * \param from List of length N of cameras in the from space.
-   * \param to   List of length N of cameras in the to space.
-   * \throws algorithm_exception When the from and to point sets are
-   *                             misaligned, insufficient or degenerate.
-   * \returns An estimated similarity transform mapping camera centers in the
-   *          \c from space to camera centers in the \c to space.
-   */
+  ///
+  /// \param from List of length N of cameras in the from space.
+  /// \param to   List of length N of cameras in the to space.
+  /// \throws algorithm_exception When the from and to point sets are
+  ///                            misaligned, insufficient or degenerate.
+  /// \returns An estimated similarity transform mapping camera centers in the
+  ///         \c from space to camera centers in the \c to space.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform(
     std::vector< kwiver::vital::camera_perspective_sptr > const& from,
@@ -76,58 +74,55 @@ public:
 
   /// Estimate the similarity transform between two corresponding sets of
   /// landmarks.
-
-  /**
-   * \param from List of length N of landmarks in the from space.
-   * \param to   List of length N of landmarks in the to space.
-   * \throws algorithm_exception When the from and to point sets are
-   *                             misaligned, insufficient or degenerate.
-   * \returns An estinated similarity transform mapping landmark locations in
-   *          the \c from space to located in the \c to space.
-   */
+  ///
+  /// \param from List of length N of landmarks in the from space.
+  /// \param to   List of length N of landmarks in the to space.
+  /// \throws algorithm_exception When the from and to point sets are
+  ///                            misaligned, insufficient or degenerate.
+  /// \returns An estinated similarity transform mapping landmark locations in
+  ///         the \c from space to located in the \c to space.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform( std::vector< kwiver::vital::landmark_sptr > const& from,
                       std::vector< kwiver::vital::landmark_sptr > const& to )
   const;
 
   /// Estimate the similarity transform between two corresponding camera maps
-
-  /**
-   * Cameras with corresponding frame IDs in the two maps are paired for
-   * transform estimation. Cameras with no corresponding frame ID in the other
-   * map are ignored. An algorithm_exception is thrown if there are no shared
-   * frame IDs between the two provided maps (nothing to pair).
-   *
-   * \throws algorithm_exception When the from and to point sets are
-   *                             misaligned, insufficient or degenerate.
-   * \param from Map of original cameras, sharing N frames with the transformed
-   *             cameras, where N > 0.
-   * \param to   Map of transformed cameras, sharing N frames with the original
-   *             cameras, where N > 0.
-   * \returns An estimated similarity transform mapping camera centers in the
-   *          \c from space to camera centers in the \c to space.
-   */
+  ///
+  /// Cameras with corresponding frame IDs in the two maps are paired for
+  /// transform estimation. Cameras with no corresponding frame ID in the other
+  /// map are ignored. An algorithm_exception is thrown if there are no shared
+  /// frame IDs between the two provided maps (nothing to pair).
+  ///
+  /// \throws algorithm_exception When the from and to point sets are
+  ///                            misaligned, insufficient or degenerate.
+  /// \param from Map of original cameras, sharing N frames with the transformed
+  ///            cameras, where N > 0.
+  /// \param to   Map of transformed cameras, sharing N frames with the original
+  ///            cameras, where N > 0.
+  /// \returns An estimated similarity transform mapping camera centers in the
+  ///         \c from space to camera centers in the \c to space.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform( kwiver::vital::camera_map_sptr const from,
                       kwiver::vital::camera_map_sptr const to ) const;
 
   /// Estimate the similarity transform between two corresponding landmark maps
-
-  /**
-   * Landmarks with corresponding frame IDs in the two maps are paired for
-   * transform estimation. Landmarks with no corresponding frame ID in the
-   * other map are ignored. An algoirithm_exception is thrown if there are no
-   * shared frame IDs between the two provided maps (nothing to pair).
-   *
-   * \throws algorithm_exception When the from and to point sets are
-   *                             misaligned, insufficient or degenerate.
-   * \param from Map of original landmarks, sharing N frames with the
-   *             transformed landmarks, where N > 0.
-   * \param to   Map of transformed landmarks, sharing N frames with the
-   *             original landmarks, where N > 0.
-   * \returns An estimated similarity transform mapping landmark centers in the
-   *          \c from space to camera centers in the \c to space.
-   */
+  ///
+  /// Landmarks with corresponding frame IDs in the two maps are paired for
+  /// transform estimation. Landmarks with no corresponding frame ID in the
+  /// other map are ignored. An algoirithm_exception is thrown if there are no
+  /// shared frame IDs between the two provided maps (nothing to pair).
+  ///
+  /// \throws algorithm_exception When the from and to point sets are
+  ///                            misaligned, insufficient or degenerate.
+  /// \param from Map of original landmarks, sharing N frames with the
+  ///            transformed landmarks, where N > 0.
+  /// \param to   Map of transformed landmarks, sharing N frames with the
+  ///            original landmarks, where N > 0.
+  /// \returns An estimated similarity transform mapping landmark centers in the
+  ///         \c from space to camera centers in the \c to space.
+  ///
   virtual kwiver::vital::similarity_d
   estimate_transform( kwiver::vital::landmark_map_sptr const from,
                       kwiver::vital::landmark_map_sptr const to ) const;

--- a/vital/algo/extract_descriptors.cxx
+++ b/vital/algo/extract_descriptors.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief extract_descriptors algorithm instantiation
- */
+///
+/// \file
+/// \brief extract_descriptors algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/extract_descriptors.h>

--- a/vital/algo/extract_descriptors.h
+++ b/vital/algo/extract_descriptors.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief extract_descriptors algorithm definition
- */
+///
+/// \file
+/// \brief extract_descriptors algorithm definition
+///
 
 #ifndef VITAL_ALGO_EXTRACT_DESCRIPTORS_H_
 #define VITAL_ALGO_EXTRACT_DESCRIPTORS_H_
@@ -32,21 +32,20 @@ public:
   static std::string static_type_name() { return "extract_descriptors"; }
 
   /// Extract from the image a descriptor corresoponding to each feature
-
-  /**
-   * \param [in]     image_data contains the image data to process
-   * \param [in,out] features the feature locations at which descriptors
-   *                 are extracted (may be modified).
-   * \param [in]     image_mask Mask image of the same dimensions as
-   *                            \p image_data where positive values indicate
-   *                            regions of \p image_data to consider.
-   * \returns a set of feature descriptors
-   *
-   * \note The feature_set passed into this function may modified to
-   *       reorder, remove, or duplicate some features to align with the
-   *       set of descriptors detected.  If the feature_set needs to change,
-   *       a new feature_set is created and returned by reference.
-   */
+  ///
+  /// \param [in]     image_data contains the image data to process
+  /// \param [in,out] features the feature locations at which descriptors
+  ///                are extracted (may be modified).
+  /// \param [in]     image_mask Mask image of the same dimensions as
+  ///                           \p image_data where positive values indicate
+  ///                           regions of \p image_data to consider.
+  /// \returns a set of feature descriptors
+  ///
+  /// \note The feature_set passed into this function may modified to
+  ///      reorder, remove, or duplicate some features to align with the
+  ///      set of descriptors detected.  If the feature_set needs to change,
+  ///      a new feature_set is created and returned by reference.
+  ///
 
   virtual kwiver::vital::descriptor_set_sptr
   extract( kwiver::vital::image_container_sptr image_data,

--- a/vital/algo/feature_descriptor_io.cxx
+++ b/vital/algo/feature_descriptor_io.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "feature_descriptor_io.h"
 

--- a/vital/algo/feature_descriptor_io.h
+++ b/vital/algo/feature_descriptor_io.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for feature_descriptor_io \link
- * kwiver::vital::algo::algorithm_def algorithm
- *        definition \endlink.
- */
+///
+/// \file
+/// \brief Interface for feature_descriptor_io \link
+/// kwiver::vital::algo::algorithm_def algorithm
+///       definition \endlink.
+///
 
 #ifndef VITAL_ALGO_FEATURE_DESCRIPTOR_IO_H_
 #define VITAL_ALGO_FEATURE_DESCRIPTOR_IO_H_
@@ -27,11 +27,10 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for reading and writing feature and desriptor sets
-
-/**
- * This class represents an abstract interface for reading and writing
- * feature and descriptor sets
- */
+///
+/// This class represents an abstract interface for reading and writing
+/// feature and descriptor sets
+///
 class VITAL_ALGO_EXPORT feature_descriptor_io
   : public kwiver::vital::algorithm_def< feature_descriptor_io >
 {
@@ -42,40 +41,38 @@ public:
   static std::string static_type_name() { return "feature_descriptor_io"; }
 
   /// Load features and descriptors from a file
-
-  /**
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   * exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \param filename the path to the file the load
-   * \param feat the set of features to load from the file
-   * \param desc the set of descriptors to load from the file
-   */
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  /// exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \param filename the path to the file the load
+  /// \param feat the set of features to load from the file
+  /// \param desc the set of descriptors to load from the file
+  ///
   void load( std::string const& filename,
              feature_set_sptr& feat,
              descriptor_set_sptr& desc ) const;
 
   /// Save features and descriptors to a file
-
-  /**
-   * Saves features and/or descriptors to a file.  Either \p feat or \p desc
-   * may be Null, but not both.  If both \p feat and \p desc are provided then
-   * the must be of the same size.
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the expected
-   *    containing directory of the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_directory Thrown when the expected
-   *    containing directory of the given path is not actually a
-   *    directory.
-   *
-   * \param filename the path to the file to save
-   * \param feat the set of features to write to the file
-   * \param desc the set of descriptors to write to the file
-   */
+  ///
+  /// Saves features and/or descriptors to a file.  Either \p feat or \p desc
+  /// may be Null, but not both.  If both \p feat and \p desc are provided then
+  /// the must be of the same size.
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the expected
+  ///   containing directory of the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_directory Thrown when the expected
+  ///   containing directory of the given path is not actually a
+  ///   directory.
+  ///
+  /// \param filename the path to the file to save
+  /// \param feat the set of features to write to the file
+  /// \param desc the set of descriptors to write to the file
+  ///
   void save( std::string const& filename,
              feature_set_sptr feat,
              descriptor_set_sptr desc ) const;
@@ -85,29 +82,27 @@ protected:
 
 private:
   /// Implementation specific load functionality.
-
-  /**
-   * Concrete implementations of feature_descriptor_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file the load
-   * \param feat the set of features to load from the file
-   * \param desc the set of descriptors to load from the file
-   */
+  ///
+  /// Concrete implementations of feature_descriptor_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file the load
+  /// \param feat the set of features to load from the file
+  /// \param desc the set of descriptors to load from the file
+  ///
   virtual void load_( std::string const& filename,
                       feature_set_sptr& feat,
                       descriptor_set_sptr& desc ) const = 0;
 
   /// Implementation specific save functionality.
-
-  /**
-   * Concrete implementations of feature_descriptor_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file to save
-   * \param feat the set of features to write to the file
-   * \param desc the set of descriptors to write to the file
-   */
+  ///
+  /// Concrete implementations of feature_descriptor_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file to save
+  /// \param feat the set of features to write to the file
+  /// \param desc the set of descriptors to write to the file
+  ///
   virtual void save_( std::string const& filename,
                       feature_set_sptr feat,
                       descriptor_set_sptr desc ) const = 0;

--- a/vital/algo/filter_features.cxx
+++ b/vital/algo/filter_features.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- * algorithm_def<T>
- *        \endlink for \link kwiver::vital::algo::filter_features
- *        filter_features \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+/// algorithm_def<T>
+///       \endlink for \link kwiver::vital::algo::filter_features
+///       filter_features \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/filter_features.h>

--- a/vital/algo/filter_features.h
+++ b/vital/algo/filter_features.h
@@ -15,11 +15,11 @@
 #include <vital/types/feature_set.h>
 #include <vital/types/descriptor_set.h>
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::filter_features
- *        filter features \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::filter_features
+///       filter features \endlink algorithm
+///
 
 namespace kwiver {
 namespace vital {
@@ -35,25 +35,25 @@ public:
   static std::string static_type_name() { return "filter_features"; }
 
   /// Filter a feature set and return a subset of the features
-  /**
-   * The default implementation call the pure virtual function
-   * filter(feature_set_sptr feat, std::vector<unsigned int> &indices) const
-   * \param [in] input The feature set to filter
-   * \returns a filtered version of the feature set (simple_feature_set)
-   */
+  ///
+  /// The default implementation call the pure virtual function
+  /// filter(feature_set_sptr feat, std::vector<unsigned int> &indices) const
+  /// \param [in] input The feature set to filter
+  /// \returns a filtered version of the feature set (simple_feature_set)
+  ///
   virtual kwiver::vital::feature_set_sptr
   filter( kwiver::vital::feature_set_sptr input ) const;
 
   /// Filter a feature_set and its coresponding descriptor_set
-  /**
-   * The default implementation calls
-   * filter(feature_set_sptr feat, std::vector<unsigned int> &indices) const
-   * using with \p feat and then uses the resulting \p indices to construct
-   * a simple_descriptor_set with the corresponding descriptors.
-   * \param [in] feat The feature set to filter
-   * \param [in] descr The parallel descriptor set to filter
-   * \returns a pair of the filtered features and descriptors
-   */
+  ///
+  /// The default implementation calls
+  /// filter(feature_set_sptr feat, std::vector<unsigned int> &indices) const
+  /// using with \p feat and then uses the resulting \p indices to construct
+  /// a simple_descriptor_set with the corresponding descriptors.
+  /// \param [in] feat The feature set to filter
+  /// \param [in] descr The parallel descriptor set to filter
+  /// \returns a pair of the filtered features and descriptors
+  ///
   virtual std::pair<kwiver::vital::feature_set_sptr, kwiver::vital::descriptor_set_sptr>
   filter( kwiver::vital::feature_set_sptr feat, kwiver::vital::descriptor_set_sptr descr) const;
 
@@ -61,11 +61,11 @@ protected:
   filter_features();
 
   /// Filter a feature set and return a new feature set with a subset of features
-  /**
-   * \param [in] feat The input feature set
-   * \param [in,out] indices The indices into \p feat of the features retained
-   * \return a new feature set containing the subset of features noted by \p indices
-   */
+  ///
+  /// \param [in] feat The input feature set
+  /// \param [in,out] indices The indices into \p feat of the features retained
+  /// \return a new feature set containing the subset of features noted by \p indices
+  ///
   virtual kwiver::vital::feature_set_sptr
   filter(kwiver::vital::feature_set_sptr feat, std::vector<unsigned int> &indices) const = 0;
 

--- a/vital/algo/filter_tracks.cxx
+++ b/vital/algo/filter_tracks.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- *        algorithm_def<T> \endlink for
- *        \link kwiver::vital::algo::filter_tracks filter_tracks
- *        \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+///       algorithm_def<T> \endlink for
+///       \link kwiver::vital::algo::filter_tracks filter_tracks
+///       \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/filter_tracks.h>

--- a/vital/algo/filter_tracks.h
+++ b/vital/algo/filter_tracks.h
@@ -14,11 +14,11 @@
 #include <vital/algo/algorithm.h>
 #include <vital/types/track_set.h>
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::filter_tracks
- *        filter tracks \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::filter_tracks
+///       filter tracks \endlink algorithm
+///
 
 namespace kwiver {
 
@@ -35,11 +35,10 @@ public:
   static std::string static_type_name() { return "filter_tracks"; }
 
   /// Filter a track set and return a subset of the tracks
-
-  /**
-   * \param [in] input The track set to filter
-   * \returns a filtered version of the track set (simple_track_set)
-   */
+  ///
+  /// \param [in] input The track set to filter
+  /// \returns a filtered version of the track set (simple_track_set)
+  ///
   virtual kwiver::vital::track_set_sptr
   filter( kwiver::vital::track_set_sptr input ) const = 0;
 

--- a/vital/algo/image_filter.cxx
+++ b/vital/algo/image_filter.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief image_filter algorithm instantiation
- */
+///
+/// \file
+/// \brief image_filter algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/image_filter.h>

--- a/vital/algo/image_filter.h
+++ b/vital/algo/image_filter.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface to abstract filter image algorithm
- */
+///
+/// \file
+/// \brief Interface to abstract filter image algorithm
+///
 
 #ifndef VITAL_ALGO_IMAGE_FILTER_H
 #define VITAL_ALGO_IMAGE_FILTER_H
@@ -21,12 +21,11 @@ namespace vital {
 namespace algo {
 
 /// \brief Abstract base class for image set filter algorithms.
-
-/**
- * This interface supports arrows/algorithms that do a pixel by pixel
- * image modification, such as image enhancement. The resultant image
- * must be the same size as the input image.
- */
+///
+/// This interface supports arrows/algorithms that do a pixel by pixel
+/// image modification, such as image enhancement. The resultant image
+/// must be the same size as the input image.
+///
 class VITAL_ALGO_EXPORT image_filter
   : public kwiver::vital::algorithm_def< image_filter >
 {
@@ -35,15 +34,14 @@ public:
   static std::string static_type_name() { return "image_filter"; }
 
   /// Filter a  input image and return resulting image
-
-  /**
-   * This method implements the filtering operation. The method does
-   * not modify the image in place. The resulting image must be a
-   * newly allocated image which is the same size as the input image.
-   *
-   * \param image_data Image to filter.
-   * \returns a filtered version of the input image
-   */
+  ///
+  /// This method implements the filtering operation. The method does
+  /// not modify the image in place. The resulting image must be a
+  /// newly allocated image which is the same size as the input image.
+  ///
+  /// \param image_data Image to filter.
+  /// \returns a filtered version of the input image
+  ///
   virtual kwiver::vital::image_container_sptr filter(
     kwiver::vital::image_container_sptr image_data ) = 0;
 
@@ -60,4 +58,4 @@ typedef std::shared_ptr< image_filter > image_filter_sptr;
 
 } // namespace kwiver
 
-#endif /* VITAL_ALGO_IMAGE_FILTER_H */
+#endif // VITAL_ALGO_IMAGE_FILTER_H

--- a/vital/algo/image_io.cxx
+++ b/vital/algo/image_io.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "image_io.h"
 

--- a/vital/algo/image_io.h
+++ b/vital/algo/image_io.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for image_io \link kwiver::vital::algo::algorithm_def
- * algorithm
- *        definition \endlink.
- */
+///
+/// \file
+/// \brief Interface for image_io \link kwiver::vital::algo::algorithm_def
+/// algorithm
+///       definition \endlink.
+///
 
 #ifndef VITAL_ALGO_IMAGE_IO_H_
 #define VITAL_ALGO_IMAGE_IO_H_
@@ -28,18 +28,17 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for reading and writing images
-
-/**
- * This class represents an abstract interface for reading and writing
- * images.
- *
- * A note about the basic capabilities:
- *
- * HAS_TIME - This capability is set to true if the image metadata
- *     supplies a timestamp. If a timestamp is supplied, it is made
- *     available in the metadata for the image. If the timestamp
- *     is not supplied, then the metadata will not have the timestamp set.
- */
+///
+/// This class represents an abstract interface for reading and writing
+/// images.
+///
+/// A note about the basic capabilities:
+///
+/// HAS_TIME - This capability is set to true if the image metadata
+///    supplies a timestamp. If a timestamp is supplied, it is made
+///    available in the metadata for the image. If the timestamp
+///    is not supplied, then the metadata will not have the timestamp set.
+///
 class VITAL_ALGO_EXPORT image_io
   : public kwiver::vital::algorithm_def< image_io >
 {
@@ -54,60 +53,57 @@ public:
   static std::string static_type_name() { return "image_io"; }
 
   /// Load image from the file
-
-  /**
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   * exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \param filename the path to the file to load
-   * \returns an image container refering to the loaded image
-   */
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  /// exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \param filename the path to the file to load
+  /// \returns an image container refering to the loaded image
+  ///
   kwiver::vital::image_container_sptr load(
     std::string const& filename ) const;
 
   /// Save image to a file
-
-  /**
-   * Image file format is based on file extension.
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the expected
-   *    containing directory of the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_directory Thrown when the expected
-   *    containing directory of the given path is not actually a
-   *    directory.
-   *
-   * \param filename the path to the file to save
-   * \param data the image container refering to the image to write
-   */
+  ///
+  /// Image file format is based on file extension.
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the expected
+  ///   containing directory of the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_directory Thrown when the expected
+  ///   containing directory of the given path is not actually a
+  ///   directory.
+  ///
+  /// \param filename the path to the file to save
+  /// \param data the image container refering to the image to write
+  ///
   void save( std::string const& filename,
              kwiver::vital::image_container_sptr data ) const;
 
   /// Get the image metadata
-
-  /**
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   * exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \param filename the path to the file to read
-   * \returns pointer to the loaded metadata
-   */
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  /// exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \param filename the path to the file to read
+  /// \returns pointer to the loaded metadata
+  ///
   kwiver::vital::metadata_sptr load_metadata( std::string const& filename )
   const;
 
-  /**
-   * \brief Return capabilities of concrete implementation.
-   *
-   * This method returns the capabilities for the current image reader/writer.
-   *
-   * \return Reference to supported image capabilities.
-   */
+  ///
+  /// \brief Return capabilities of concrete implementation.
+  ///
+  /// This method returns the capabilities for the current image reader/writer.
+  ///
+  /// \return Reference to supported image capabilities.
+  ///
   algorithm_capabilities const& get_implementation_capabilities() const;
 
 protected:
@@ -118,40 +114,37 @@ protected:
 
 private:
   /// Implementation specific load functionality.
-
-  /**
-   * Concrete implementations of image_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file the load
-   * \returns an image container refering to the loaded image
-   */
+  ///
+  /// Concrete implementations of image_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file the load
+  /// \returns an image container refering to the loaded image
+  ///
   virtual kwiver::vital::image_container_sptr load_(
     std::string const& filename ) const = 0;
 
   /// Implementation specific save functionality.
-
-  /**
-   * Concrete implementations of image_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file to save
-   * \param data the image container refering to the image to write
-   */
+  ///
+  /// Concrete implementations of image_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file to save
+  /// \param data the image container refering to the image to write
+  ///
   virtual void save_( std::string const& filename,
                       kwiver::vital::image_container_sptr data ) const = 0;
 
   /// Implementation specific metadata functionality.
-
-  /**
-   * If a concrete implementation provides metadata, it must be provided
-   * in both load() and load_metadata(), and it must be the same metadata.
-   * To provide it in one but not the other, or to provide different metadata
-   * in each, is an error.
-   *
-   * \param filename the path to the file to read
-   * \returns pointer to the loaded metadata
-   */
+  ///
+  /// If a concrete implementation provides metadata, it must be provided
+  /// in both load() and load_metadata(), and it must be the same metadata.
+  /// To provide it in one but not the other, or to provide different metadata
+  /// in each, is an error.
+  ///
+  /// \param filename the path to the file to read
+  /// \returns pointer to the loaded metadata
+  ///
   virtual kwiver::vital::metadata_sptr load_metadata_(
     std::string const& filename ) const;
 

--- a/vital/algo/image_object_detector.cxx
+++ b/vital/algo/image_object_detector.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief image_object_detector algorithm instantiation
- */
+///
+/// \file
+/// \brief image_object_detector algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/image_object_detector.h>

--- a/vital/algo/image_object_detector.h
+++ b/vital/algo/image_object_detector.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract image object detector
- */
+///
+/// \file
+/// \brief Header defining abstract image object detector
+///
 
 #ifndef VITAL_ALGO_IMAGE_OBJECT_DETECTOR_H_
 #define VITAL_ALGO_IMAGE_OBJECT_DETECTOR_H_
@@ -24,10 +24,10 @@ namespace algo {
 
 // ----------------------------------------------------------------
 
-/**
- * @brief Image object detector base class/
- *
- */
+///
+/// @brief Image object detector base class/
+///
+///
 class VITAL_ALGO_EXPORT image_object_detector
   : public algorithm_def< image_object_detector >
 {
@@ -36,14 +36,13 @@ public:
   static std::string static_type_name() { return "image_object_detector"; }
 
   /// Find all objects on the provided image
-
-  /**
-   * This method analyzes the supplied image and along with any saved
-   * context, returns a vector of detected image objects.
-   *
-   * \param image_data the image pixels
-   * \returns vector of image objects found
-   */
+  ///
+  /// This method analyzes the supplied image and along with any saved
+  /// context, returns a vector of detected image objects.
+  ///
+  /// \param image_data the image pixels
+  /// \returns vector of image objects found
+  ///
   virtual detected_object_set_sptr
   detect( image_container_sptr image_data ) const = 0;
 

--- a/vital/algo/initialize_cameras_landmarks.cxx
+++ b/vital/algo/initialize_cameras_landmarks.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- *        algorithm_def<T> \endlink for
- *        \link kwiver::vital::algo::initialize_cameras_landmarks
- *        initialize_cameras_landmarks \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+///       algorithm_def<T> \endlink for
+///       \link kwiver::vital::algo::initialize_cameras_landmarks
+///       initialize_cameras_landmarks \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/initialize_cameras_landmarks.h>

--- a/vital/algo/initialize_cameras_landmarks.h
+++ b/vital/algo/initialize_cameras_landmarks.h
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::initialize_cameras_landmarks
- *        bundle adjustment \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::initialize_cameras_landmarks
+///       bundle adjustment \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_INITIALIZE_CAMERAS_LANDMARKS_H_
 #define VITAL_ALGO_INITIALIZE_CAMERAS_LANDMARKS_H_
@@ -34,26 +34,26 @@ public:
   static std::string static_type_name() { return "initialize_cameras_landmarks"; }
 
   /// Initialize the camera and landmark parameters given a set of feature tracks
-  /**
-   * The algorithm creates an initial estimate of any missing cameras and
-   * landmarks using the available cameras, landmarks, and feature tracks.
-   * If the input cameras map is a NULL pointer then the algorithm should try
-   * to initialize all cameras covered by the track set.  If the input camera
-   * map exists then the algorithm should only initialize cameras on frames for
-   * which the camera is set to NULL.  Frames not in the map will not be
-   * initialized.  This allows the caller to control which subset of cameras to
-   * initialize without needing to manipulate the feature tracks.
-   * The analogous behavior is also applied to the input landmarks map to
-   * select which track IDs should be used to initialize landmarks.
-   *
-   * \note This algorithm may optionally revise the estimates of existing
-   * cameras and landmarks passed as input.
-   *
-   * \param [in,out] cameras the cameras to initialize
-   * \param [in,out] landmarks the landmarks to initialize
-   * \param [in] tracks the feature tracks to use as constraints
-   * \param [in] metadata the frame metadata to use as constraints
-   */
+  ///
+  /// The algorithm creates an initial estimate of any missing cameras and
+  /// landmarks using the available cameras, landmarks, and feature tracks.
+  /// If the input cameras map is a NULL pointer then the algorithm should try
+  /// to initialize all cameras covered by the track set.  If the input camera
+  /// map exists then the algorithm should only initialize cameras on frames for
+  /// which the camera is set to NULL.  Frames not in the map will not be
+  /// initialized.  This allows the caller to control which subset of cameras to
+  /// initialize without needing to manipulate the feature tracks.
+  /// The analogous behavior is also applied to the input landmarks map to
+  /// select which track IDs should be used to initialize landmarks.
+  ///
+  /// \note This algorithm may optionally revise the estimates of existing
+  /// cameras and landmarks passed as input.
+  ///
+  /// \param [in,out] cameras the cameras to initialize
+  /// \param [in,out] landmarks the landmarks to initialize
+  /// \param [in] tracks the feature tracks to use as constraints
+  /// \param [in] metadata the frame metadata to use as constraints
+  ///
   virtual void
   initialize(kwiver::vital::camera_map_sptr& cameras,
              kwiver::vital::landmark_map_sptr& landmarks,

--- a/vital/algo/initialize_object_tracks.h
+++ b/vital/algo/initialize_object_tracks.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief initialize_object_tracks algorithm definition
- */
+///
+/// \file
+/// \brief initialize_object_tracks algorithm definition
+///
 
 #ifndef VITAL_ALGO_INITIALIZE_OBJECT_TRACKS_MATRIX_H_
 #define VITAL_ALGO_INITIALIZE_OBJECT_TRACKS_MATRIX_H_
@@ -33,13 +33,12 @@ public:
   static std::string static_type_name() { return "initialize_object_tracks"; }
 
   /// Initialize new object tracks given detections.
-
-  /**
-   * \param ts frame ID
-   * \param image contains the input image for the current frame
-   * \param detections detected object sets from the current frame
-   * \returns newly initialized tracks
-   */
+  ///
+  /// \param ts frame ID
+  /// \param image contains the input image for the current frame
+  /// \param detections detected object sets from the current frame
+  /// \returns newly initialized tracks
+  ///
   virtual kwiver::vital::object_track_set_sptr
   initialize( kwiver::vital::timestamp ts,
               kwiver::vital::image_container_sptr image,

--- a/vital/algo/integrate_depth_maps.cxx
+++ b/vital/algo/integrate_depth_maps.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link
- *        kwiver::vital::algo::algorithm_def algorithm_def<T> \endlink for
- *        \link kwiver::vital::algo::integrate_depth_maps
- *        integrate_depth_maps \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link
+///       kwiver::vital::algo::algorithm_def algorithm_def<T> \endlink for
+///       \link kwiver::vital::algo::integrate_depth_maps
+///       integrate_depth_maps \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/integrate_depth_maps.h>
@@ -26,16 +26,15 @@ integrate_depth_maps
 }
 
 /// Integrate multiple depth maps into a common volume
-
-/**
- *
- * \param [in]     minpt_bound the min point of the bounding region
- * \param [in]     maxpt_bound the max point of the bounding region
- * \param [in]     depth_maps  the set of floating point depth map images
- * \param [in]     cameras     the set of cameras, one for each depth map
- * \param [in,out] volume      the fused volumetric data
- * \param [out]    spacing     the spacing between voxels in each dimension
- */
+///
+///
+/// \param [in]     minpt_bound the min point of the bounding region
+/// \param [in]     maxpt_bound the max point of the bounding region
+/// \param [in]     depth_maps  the set of floating point depth map images
+/// \param [in]     cameras     the set of cameras, one for each depth map
+/// \param [in,out] volume      the fused volumetric data
+/// \param [out]    spacing     the spacing between voxels in each dimension
+///
 void
 integrate_depth_maps
 ::integrate( vector_3d const& minpt_bound,

--- a/vital/algo/integrate_depth_maps.h
+++ b/vital/algo/integrate_depth_maps.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link
- *        kwiver::vital::algo::integrate_depth_maps
- *        integrate_depth_maps \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link
+///       kwiver::vital::algo::integrate_depth_maps
+///       integrate_depth_maps \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_INTEGRATE_DEPTH_MAPS_H_
 #define VITAL_ALGO_INTEGRATE_DEPTH_MAPS_H_
@@ -27,17 +27,16 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for integration of depth maps into a volume
-
-/**
- *  This algorithm takes a set of depth map images and a corresponding
- *  set of cameras and integrates the depth maps into a 3D voxel grid such
- *  that a level set (zero crossing) of the volumetric data is represents
- *  the fused 3D model surface.
- *
- *  A common implementation of this algorithm is to integrate a truncated
- *  signed distance function (TSDF) along a ray for each pixel of each
- *  depth map.  However, this API is not restricted to TSDF.
- */
+///
+/// This algorithm takes a set of depth map images and a corresponding
+/// set of cameras and integrates the depth maps into a 3D voxel grid such
+/// that a level set (zero crossing) of the volumetric data is represents
+/// the fused 3D model surface.
+///
+/// A common implementation of this algorithm is to integrate a truncated
+/// signed distance function (TSDF) along a ray for each pixel of each
+/// depth map.  However, this API is not restricted to TSDF.
+///
 class VITAL_ALGO_EXPORT integrate_depth_maps
   : public kwiver::vital::algorithm_def< integrate_depth_maps >
 {
@@ -46,16 +45,15 @@ public:
   static std::string static_type_name() { return "integrate_depth_maps"; }
 
   /// Integrate multiple depth maps into a common volume
-
-  /**
-   *
-   * \param [in]     minpt_bound the min point of the bounding region
-   * \param [in]     maxpt_bound the max point of the bounding region
-   * \param [in]     depth_maps  the set of floating point depth map images
-   * \param [in]     cameras     the set of cameras, one for each depth map
-   * \param [in,out] volume      the fused volumetric data
-   * \param [out]    spacing     the spacing between voxels in each dimension
-   */
+  ///
+  ///
+  /// \param [in]     minpt_bound the min point of the bounding region
+  /// \param [in]     maxpt_bound the max point of the bounding region
+  /// \param [in]     depth_maps  the set of floating point depth map images
+  /// \param [in]     cameras     the set of cameras, one for each depth map
+  /// \param [in,out] volume      the fused volumetric data
+  /// \param [out]    spacing     the spacing between voxels in each dimension
+  ///
   virtual void
   integrate( kwiver::vital::vector_3d const& minpt_bound,
              kwiver::vital::vector_3d const& maxpt_bound,
@@ -65,20 +63,19 @@ public:
              kwiver::vital::vector_3d& spacing ) const;
 
   /// Integrate multiple depth maps with per-pixel weights into a common volume
-
-  /**
-   * The weight maps in this variant encode how much weight to give each depth
-   * pixel in the integration sum.  If the vector of weight_maps is empty then
-   * all depths are given full weight.
-   *
-   * \param [in]     minpt_bound the min point of the bounding region
-   * \param [in]     maxpt_bound the max point of the bounding region
-   * \param [in]     depth_maps  the set of floating point depth map images
-   * \param [in]     weight_maps the set of floating point [0,1] weight maps
-   * \param [in]     cameras     the set of cameras, one for each depth map
-   * \param [in,out] volume      the fused volumetric data
-   * \param [out]    spacing     the spacing between voxels in each dimension
-   */
+  ///
+  /// The weight maps in this variant encode how much weight to give each depth
+  /// pixel in the integration sum.  If the vector of weight_maps is empty then
+  /// all depths are given full weight.
+  ///
+  /// \param [in]     minpt_bound the min point of the bounding region
+  /// \param [in]     maxpt_bound the max point of the bounding region
+  /// \param [in]     depth_maps  the set of floating point depth map images
+  /// \param [in]     weight_maps the set of floating point [0,1] weight maps
+  /// \param [in]     cameras     the set of cameras, one for each depth map
+  /// \param [in,out] volume      the fused volumetric data
+  /// \param [out]    spacing     the spacing between voxels in each dimension
+  ///
   virtual void
   integrate( kwiver::vital::vector_3d const& minpt_bound,
              kwiver::vital::vector_3d const& maxpt_bound,

--- a/vital/algo/interpolate_track.h
+++ b/vital/algo/interpolate_track.h
@@ -15,10 +15,10 @@ namespace vital {
 namespace algo {
 
 /// Abstract base class for interpolating track states.
-/**
- * This class represents the abstract interface for algorithms that
- * interpolate track states.
- */
+///
+/// This class represents the abstract interface for algorithms that
+/// interpolate track states.
+///
 class VITAL_ALGO_EXPORT interpolate_track
   : public kwiver::vital::algorithm_def<interpolate_track>
 {
@@ -27,58 +27,58 @@ public:
   static std::string static_type_name() { return "interpolate_track"; }
 
   /// Supply video input algorithm
-  /**
-   * This method supplies the video input algorithm to use for getting
-   * the frames needed to interpolate track states.
-   *
-   * @param input Pointer to the video input algorithm
-   */
+  ///
+  /// This method supplies the video input algorithm to use for getting
+  /// the frames needed to interpolate track states.
+  ///
+  /// @param input Pointer to the video input algorithm
+  ///
   void set_video_input( video_input_sptr input );
 
   /// This method interpolates the states between track states.
-  /**
-   * This method interpolates track states to fill in missing states
-   * between the states supplied in the input parameter. An output
-   * track is created that contains all states between the first and
-   * last state in the intpu track.
-   *
-   * @param init_states List of states to interpolate between.
-   *
-   * @return Output track with missing states filled in.
-   */
+  ///
+  /// This method interpolates track states to fill in missing states
+  /// between the states supplied in the input parameter. An output
+  /// track is created that contains all states between the first and
+  /// last state in the intpu track.
+  ///
+  /// @param init_states List of states to interpolate between.
+  ///
+  /// @return Output track with missing states filled in.
+  ///
   virtual track_sptr interpolate( track_sptr init_states ) = 0;
 
   /// Typedef for the callback function signature
   typedef std::function<void(int, int)> progress_callback_t;
 
   /// Set a callback function to report intermediate progress
-  /**
-   * This method establishes the callback function that will be called
-   * occasionally to report the progress of the interpolation
-   * operation.
-   *
-   * @param cb The callback function.
-   */
+  ///
+  /// This method establishes the callback function that will be called
+  /// occasionally to report the progress of the interpolation
+  /// operation.
+  ///
+  /// @param cb The callback function.
+  ///
   void set_progress_callback( progress_callback_t cb );
 
 protected:
   interpolate_track();
 
-  /**
-   * Call the supplied progress callback function if there is one
-   * currently active.
-   *
-   * @param progress Fraction of process that is complete 0 - 1.0
-   */
+  ///
+  /// Call the supplied progress callback function if there is one
+  /// currently active.
+  ///
+  /// @param progress Fraction of process that is complete 0 - 1.0
+  ///
   void do_callback( float progress );
 
-  /**
-   * Call the supplied progress callback function if there is one
-   * currently active.
-   *
-   * @param progress Number of "steps" completed
-   * @param total Total number of "steps" for the process
-   */
+  ///
+  /// Call the supplied progress callback function if there is one
+  /// currently active.
+  ///
+  /// @param progress Number of "steps" completed
+  /// @param total Total number of "steps" for the process
+  ///
   void do_callback( int progress, int total );
 
   // Instance data
@@ -88,4 +88,4 @@ protected:
 
 } } } // end namespace
 
-#endif /* VITAL_ALGO_INTERPOLATE_TRACK_H */
+#endif // VITAL_ALGO_INTERPOLATE_TRACK_H

--- a/vital/algo/keyframe_selection.h
+++ b/vital/algo/keyframe_selection.h
@@ -14,12 +14,12 @@
 #include <vital/algo/algorithm.h>
 #include <vital/types/track_set.h>
 
-/**
- * \file
- * \brief Header defining abstract \link
- * kwiver::vital::algo::keyframe_selection
- *        keyframe selection \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link
+/// kwiver::vital::algo::keyframe_selection
+///       keyframe selection \endlink algorithm
+///
 
 namespace kwiver {
 
@@ -36,17 +36,16 @@ public:
   static std::string static_type_name() { return "keyframe_selection"; }
 
   /// Select keyframes from a set of tracks.
-
-  /** Different implementations can select key-frames in different ways.
-   *   For example, one method could only add key-frames for frames that are
-   * new.  Another could increase the
-   * density of key-frames near existing frames so dense processing can be
-   * done.
-   */
-  /**
-   * \param [in] tracks The tracks over which to select key-frames
-   * \returns a track set that includes the selected keyframe data structure
-   */
+  /// Different implementations can select key-frames in different ways.
+  ///  For example, one method could only add key-frames for frames that are
+  /// new.  Another could increase the
+  /// density of key-frames near existing frames so dense processing can be
+  /// done.
+  ///
+  ///
+  /// \param [in] tracks The tracks over which to select key-frames
+  /// \returns a track set that includes the selected keyframe data structure
+  ///
   virtual kwiver::vital::track_set_sptr
   select( kwiver::vital::track_set_sptr tracks ) const = 0;
 

--- a/vital/algo/match_descriptor_sets.cxx
+++ b/vital/algo/match_descriptor_sets.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of bag of words matching
- */
+///
+/// \file
+/// \brief Implementation of bag of words matching
+///
 
 #include <vital/algo/match_descriptor_sets.h>
 #include <vital/algo/algorithm.txx>

--- a/vital/algo/match_descriptor_sets.h
+++ b/vital/algo/match_descriptor_sets.h
@@ -2,11 +2,11 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for match_descriptor_sets \link kwiver::vital::algo::algorithm_def
- *   algorithm definition \endlink.
- */
+///
+/// \file
+/// \brief Interface for match_descriptor_sets \link kwiver::vital::algo::algorithm_def
+///  algorithm definition \endlink.
+///
 
 #ifndef VITAL_ALGO_MATCH_DESCRIPTOR_SETS_H_
 #define VITAL_ALGO_MATCH_DESCRIPTOR_SETS_H_
@@ -24,10 +24,10 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for matching sets of descriptors
-/**
- * A common use for this algorithm is bag of visual words matching on sets of
- * descriptor extracted around features detected in images.
- */
+///
+/// A common use for this algorithm is bag of visual words matching on sets of
+/// descriptor extracted around features detected in images.
+///
 class VITAL_ALGO_EXPORT match_descriptor_sets
   : public kwiver::vital::algorithm_def<match_descriptor_sets>
 {
@@ -40,41 +40,41 @@ public:
   static std::string static_type_name() { return "match_descriptor_sets"; }
 
   /// Add a descriptor set to the inverted file system.
-  /**
-  * Add a descriptor set and frame number to the inverted file system.
-  * Future matching results may include this frame in their results.
-  *
-  * \param[in] desc   set of descriptors associated with this frame
-  * \param[in] frame  frame number indexing the descriptors
-  * \returns None
-  */
+  ///
+  /// Add a descriptor set and frame number to the inverted file system.
+  /// Future matching results may include this frame in their results.
+  ///
+  /// \param[in] desc   set of descriptors associated with this frame
+  /// \param[in] frame  frame number indexing the descriptors
+  /// \returns None
+  ///
   virtual
   void
   append_to_index(const vital::descriptor_set_sptr desc,
                   vital::frame_id_t frame) = 0;
 
   /// Query the inverted file system for similar sets of descriptors.
-  /**
-  * Query the inverted file system and return the frames containing the most
-  * similar sets descriptors.
-  *
-  * \param[in] desc  set of descriptors to match
-  * \returns vector of possibly matching frames found by the query
-  */
+  ///
+  /// Query the inverted file system and return the frames containing the most
+  /// similar sets descriptors.
+  ///
+  /// \param[in] desc  set of descriptors to match
+  /// \returns vector of possibly matching frames found by the query
+  ///
   virtual
   std::vector<vital::frame_id_t>
   query(const vital::descriptor_set_sptr desc) = 0;
 
   /// Query the inverted file system and append the descriptors.
-  /**
-  * This method is equivalent to calling query() followed by append_to_index();
-  * however, depending on the implementation, it may be faster to call this
-  * single function when both operations are required.
-  *
-  * \param[in] desc   set of descriptors to match and append
-  * \param[in] frame  frame number indexing the descriptors
-  * \returns vector of possibly matching frames found by the query
-  */
+  ///
+  /// This method is equivalent to calling query() followed by append_to_index();
+  /// however, depending on the implementation, it may be faster to call this
+  /// single function when both operations are required.
+  ///
+  /// \param[in] desc   set of descriptors to match and append
+  /// \param[in] frame  frame number indexing the descriptors
+  /// \returns vector of possibly matching frames found by the query
+  ///
   virtual
   std::vector<vital::frame_id_t>
   query_and_append(const vital::descriptor_set_sptr desc,

--- a/vital/algo/match_features.cxx
+++ b/vital/algo/match_features.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief match_features algorithm instantiation
- */
+///
+/// \file
+/// \brief match_features algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/match_features.h>

--- a/vital/algo/match_features.h
+++ b/vital/algo/match_features.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief match_features algorithm definition interface
- */
+///
+/// \file
+/// \brief match_features algorithm definition interface
+///
 
 #ifndef VITAL_ALGO_MATCH_FEATURES_H_
 #define VITAL_ALGO_MATCH_FEATURES_H_
@@ -32,14 +32,13 @@ public:
   static std::string static_type_name() { return "match_features"; }
 
   /// Match one set of features and corresponding descriptors to another
-
-  /**
-   * \param feat1 the first set of features to match
-   * \param desc1 the descriptors corresponding to \a feat1
-   * \param feat2 the second set fof features to match
-   * \param desc2 the descriptors corresponding to \a feat2
-   * \returns a set of matching indices from \a feat1 to \a feat2
-   */
+  ///
+  /// \param feat1 the first set of features to match
+  /// \param desc1 the descriptors corresponding to \a feat1
+  /// \param feat2 the second set fof features to match
+  /// \param desc2 the descriptors corresponding to \a feat2
+  /// \returns a set of matching indices from \a feat1 to \a feat2
+  ///
   virtual kwiver::vital::match_set_sptr
   match( kwiver::vital::feature_set_sptr feat1,
          kwiver::vital::descriptor_set_sptr desc1,

--- a/vital/algo/metadata_filter.h
+++ b/vital/algo/metadata_filter.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface to abstract filter metadata algorithm
- */
+///
+/// \file
+/// \brief Interface to abstract filter metadata algorithm
+///
 
 #ifndef VITAL_ALGO_METADATA_FILTER_H
 #define VITAL_ALGO_METADATA_FILTER_H

--- a/vital/algo/metadata_map_io.cxx
+++ b/vital/algo/metadata_map_io.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "metadata_map_io.h"
 

--- a/vital/algo/metadata_map_io.h
+++ b/vital/algo/metadata_map_io.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for serialize_metadata \link
- * kwiver::vital::algo::algorithm_def algorithm
- *        definition \endlink.
- */
+///
+/// \file
+/// \brief Interface for serialize_metadata \link
+/// kwiver::vital::algo::algorithm_def algorithm
+///       definition \endlink.
+///
 
 #ifndef VITAL_ALGO_METADATA_MAP_IO_H_
 #define VITAL_ALGO_METADATA_MAP_IO_H_

--- a/vital/algo/optimize_cameras.cxx
+++ b/vital/algo/optimize_cameras.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- *        algorithm_def<T> \endlink for \link
- *        kwiver::vital::algo::optimize_cameras optimize_cameras
- *        \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+///       algorithm_def<T> \endlink for \link
+///       kwiver::vital::algo::optimize_cameras optimize_cameras
+///       \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/optimize_cameras.h>

--- a/vital/algo/optimize_cameras.h
+++ b/vital/algo/optimize_cameras.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::optimize_cameras
- * camera
- *        optimization \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::optimize_cameras
+/// camera
+///       optimization \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_OPTIMIZE_CAMERAS_H_
 #define VITAL_ALGO_OPTIMIZE_CAMERAS_H_
@@ -36,21 +36,20 @@ public:
   static std::string static_type_name() { return "optimize_cameras"; }
 
   /// Optimize camera parameters given sets of landmarks and feature tracks
-
-  /**
-   * We only optimize cameras that have associating tracks and landmarks in
-   * the given maps.  The default implementation collects the corresponding
-   * features and landmarks for each camera and calls the single camera
-   * optimize function.
-   *
-   * \throws invalid_value When one or more of the given pointer is Null.
-   *
-   * \param[in,out] cameras   Cameras to optimize.
-   * \param[in]     tracks    The feature tracks to use as constraints.
-   * \param[in]     landmarks The landmarks the cameras are viewing.
-   * \param[in]     metadata  The optional metadata to constrain the
-   *                          optimization.
-   */
+  ///
+  /// We only optimize cameras that have associating tracks and landmarks in
+  /// the given maps.  The default implementation collects the corresponding
+  /// features and landmarks for each camera and calls the single camera
+  /// optimize function.
+  ///
+  /// \throws invalid_value When one or more of the given pointer is Null.
+  ///
+  /// \param[in,out] cameras   Cameras to optimize.
+  /// \param[in]     tracks    The feature tracks to use as constraints.
+  /// \param[in]     landmarks The landmarks the cameras are viewing.
+  /// \param[in]     metadata  The optional metadata to constrain the
+  ///                         optimization.
+  ///
   virtual void
   optimize( kwiver::vital::camera_map_sptr& cameras,
             kwiver::vital::feature_track_set_sptr tracks,
@@ -58,20 +57,19 @@ public:
             kwiver::vital::sfm_constraints_sptr constraints = nullptr ) const;
 
   /// Optimize a single camera given corresponding features and landmarks
-
-  /**
-   * This function assumes that 2D features viewed by this camera have
-   * already been put into correspondence with 3D landmarks by aligning
-   * them into two parallel vectors
-   *
-   * \param[in,out] camera    The camera to optimize.
-   * \param[in]     features  The vector of features observed by \p camera
-   *                          to use as constraints.
-   * \param[in]     landmarks The vector of landmarks corresponding to
-   *                          \p features.
-   * \param[in]     metadata  The optional metadata to constrain the
-   *                          optimization.
-   */
+  ///
+  /// This function assumes that 2D features viewed by this camera have
+  /// already been put into correspondence with 3D landmarks by aligning
+  /// them into two parallel vectors
+  ///
+  /// \param[in,out] camera    The camera to optimize.
+  /// \param[in]     features  The vector of features observed by \p camera
+  ///                         to use as constraints.
+  /// \param[in]     landmarks The vector of landmarks corresponding to
+  ///                         \p features.
+  /// \param[in]     metadata  The optional metadata to constrain the
+  ///                         optimization.
+  ///
   virtual void
   optimize( kwiver::vital::camera_perspective_sptr& camera,
             const std::vector< kwiver::vital::feature_sptr >& features,

--- a/vital/algo/read_object_track_set.cxx
+++ b/vital/algo/read_object_track_set.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load wrapping functionality.
+///
 
 #include "read_object_track_set.h"
 

--- a/vital/algo/read_object_track_set.h
+++ b/vital/algo/read_object_track_set.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for read_object_track_set
- */
+///
+/// \file
+/// \brief Interface for read_object_track_set
+///
 
 #ifndef VITAL_READ_OBJECT_TRACK_SET_H
 #define VITAL_READ_OBJECT_TRACK_SET_H
@@ -26,16 +26,16 @@ namespace algo {
 
 // ----------------------------------------------------------------------------------
 
-/**
- * @brief Read object track sets
- *
- * This class is the abstract base class for the object track set writer.
- *
- * Track sets from multiple images are stored in a single file with enough
- * information to recreate a unique image identifier, usually the frame number,
- * and an associated set of object tracks. Alternatively, tracks can be read in
- * batch mode.
- */
+///
+/// @brief Read object track sets
+///
+/// This class is the abstract base class for the object track set writer.
+///
+/// Track sets from multiple images are stored in a single file with enough
+/// information to recreate a unique image identifier, usually the frame number,
+/// and an associated set of object tracks. Alternatively, tracks can be read in
+/// batch mode.
+///
 class VITAL_ALGO_EXPORT read_object_track_set
   : public kwiver::vital::algorithm_def< read_object_track_set >
 {
@@ -46,61 +46,56 @@ public:
   static std::string static_type_name() { return "read_object_track_set"; }
 
   /// Open a file of object track sets.
-
-  /**
-   * This method opens a object track set file for reading.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   *    exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \throws kwiver::vital::file_not_found_exception
-   */
+  ///
+  /// This method opens a object track set file for reading.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  ///   exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \throws kwiver::vital::file_not_found_exception
+  ///
   virtual void open( std::string const& filename );
 
   /// Read object tracks from an existing stream
-
-  /**
-   * This method specifies the input stream to use for reading
-   * object tracks. Using a stream is handy when the object tracks are
-   * available in a stream format.
-   *
-   * @param strm input stream to use
-   */
+  ///
+  /// This method specifies the input stream to use for reading
+  /// object tracks. Using a stream is handy when the object tracks are
+  /// available in a stream format.
+  ///
+  /// @param strm input stream to use
+  ///
   void use_stream( std::istream* strm );
 
   /// Close object track set file.
-
-  /**
-   * The currently open object track set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open object track set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Read next object track set
-
-  /**
-   * This method reads the next set of track objects from the
-   * file. \b False is returned when the end of file is reached.
-   *
-   * \param[out] set Pointer to the new set of object tracks. Set may be
-   * empty if there are no object tracks on an image.
-   *
-   * @return \b true if object tracks are returned, \b false if end of file.
-   */
+  ///
+  /// This method reads the next set of track objects from the
+  /// file. \b False is returned when the end of file is reached.
+  ///
+  /// \param[out] set Pointer to the new set of object tracks. Set may be
+  /// empty if there are no object tracks on an image.
+  ///
+  /// @return \b true if object tracks are returned, \b false if end of file.
+  ///
   virtual bool read_set( kwiver::vital::object_track_set_sptr& set ) = 0;
 
   /// Determine if input file is at end of file.
-
-  /**
-   * This method reports the end of file status for a file open for reading.
-   *
-   * @return \b true if file is at end.
-   */
+  ///
+  /// This method reports the end of file status for a file open for reading.
+  ///
+  /// @return \b true if file is at end.
+  ///
   bool at_eof() const;
 
 protected:

--- a/vital/algo/read_track_descriptor_set.cxx
+++ b/vital/algo/read_track_descriptor_set.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "read_track_descriptor_set.h"
 

--- a/vital/algo/read_track_descriptor_set.h
+++ b/vital/algo/read_track_descriptor_set.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for read_track_descriptor_set
- */
+///
+/// \file
+/// \brief Interface for read_track_descriptor_set
+///
 
 #ifndef VITAL_READ_TRACK_DESCRIPTOR_SET_H
 #define VITAL_READ_TRACK_DESCRIPTOR_SET_H
@@ -23,16 +23,16 @@ namespace vital {
 namespace algo {
 
 // ----------------------------------------------------------------------------------
-/**
- * @brief Read detected object sets
- *
- * This class is the abstract base class for the detected object set
- * writer.
- *
- * Detection sets from multiple images are stored in a single file
- * with enough information to recreate a unique image identifier,
- * usually the file name, and an associated set of track descriptors.
- */
+///
+/// @brief Read detected object sets
+///
+/// This class is the abstract base class for the detected object set
+/// writer.
+///
+/// Detection sets from multiple images are stored in a single file
+/// with enough information to recreate a unique image identifier,
+/// usually the file name, and an associated set of track descriptors.
+///
 class VITAL_ALGO_EXPORT read_track_descriptor_set
   : public kwiver::vital::algorithm_def<read_track_descriptor_set>
 {
@@ -43,55 +43,55 @@ public:
   static std::string static_type_name() { return "read_track_descriptor_set"; }
 
   /// Open a file of track descriptor sets.
-  /**
-   * This method opens a track descriptor set file for reading.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   *
-   * \throws kwiver::vital::file_not_found_exception
-   */
+  ///
+  /// This method opens a track descriptor set file for reading.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
+  /// \throws kwiver::vital::file_not_found_exception
+  ///
   virtual void open( std::string const& filename );
 
   /// Read track descriptors from an existing stream
-  /**
-   * This method specifies the input stream to use for reading
-   * track descriptors. Using a stream is handy when the track descriptors are
-   * available in a stream format.
-   *
-   * @param strm input stream to use
-   */
+  ///
+  /// This method specifies the input stream to use for reading
+  /// track descriptors. Using a stream is handy when the track descriptors are
+  /// available in a stream format.
+  ///
+  /// @param strm input stream to use
+  ///
   void use_stream( std::istream* strm );
 
   /// Close track descriptor set file.
-  /**
-   * The currently open track descriptor set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open track descriptor set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Read next detected object set
-  /**
-   * This method reads the next set of detected objects from the
-   * file. \b False is returned when the end of file is reached.
-   *
-   * \param[out] set Pointer to the new set of track descriptors. Set may be
-   * empty if there are no track descriptors on an image.
-   *
-   * @return \b true if track descriptors are returned, \b false if end of file.
-   */
+  ///
+  /// This method reads the next set of detected objects from the
+  /// file. \b False is returned when the end of file is reached.
+  ///
+  /// \param[out] set Pointer to the new set of track descriptors. Set may be
+  /// empty if there are no track descriptors on an image.
+  ///
+  /// @return \b true if track descriptors are returned, \b false if end of file.
+  ///
   virtual bool read_set( kwiver::vital::track_descriptor_set_sptr& set ) = 0;
 
   /// Determine if input file is at end of file.
-  /**
-   * This method reports the end of file status for a file open for reading.
-   *
-   * @return \b true if file is at end.
-   */
+  ///
+  /// This method reports the end of file status for a file open for reading.
+  ///
+  /// @return \b true if file is at end.
+  ///
   bool at_eof() const;
 
 protected:

--- a/vital/algo/refine_detections.cxx
+++ b/vital/algo/refine_detections.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief refine_detections algorithm instantiation
- */
+///
+/// \file
+/// \brief refine_detections algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/refine_detections.h>

--- a/vital/algo/refine_detections.h
+++ b/vital/algo/refine_detections.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract image object detector
- */
+///
+/// \file
+/// \brief Header defining abstract image object detector
+///
 
 #ifndef VITAL_ALGO_REFINE_DETECTIONS_H_
 #define VITAL_ALGO_REFINE_DETECTIONS_H_
@@ -24,10 +24,10 @@ namespace algo {
 
 // ----------------------------------------------------------------
 
-/**
- * @brief Case class for refining detected object sets.
- *
- */
+///
+/// @brief Case class for refining detected object sets.
+///
+///
 class VITAL_ALGO_EXPORT refine_detections
   : public algorithm_def< refine_detections >
 {
@@ -36,15 +36,14 @@ public:
   static std::string static_type_name() { return "refine_detections"; }
 
   /// Refine all object detections on the provided image
-
-  /**
-   * This method analyzes the supplied image and and detections on it,
-   * returning a refined set of detections.
-   *
-   * \param image_data the image pixels
-   * \param detections detected objects
-   * \returns vector of image objects refined
-   */
+  ///
+  /// This method analyzes the supplied image and and detections on it,
+  /// returning a refined set of detections.
+  ///
+  /// \param image_data the image pixels
+  /// \param detections detected objects
+  /// \returns vector of image objects refined
+  ///
   virtual detected_object_set_sptr
   refine( image_container_sptr image_data,
           detected_object_set_sptr detections ) const = 0;

--- a/vital/algo/track_features.cxx
+++ b/vital/algo/track_features.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief track_feature algorithm instantiation
- */
+///
+/// \file
+/// \brief track_feature algorithm instantiation
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/track_features.h>

--- a/vital/algo/track_features.h
+++ b/vital/algo/track_features.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link kwiver::vital::algo::track_features
- * feature
- *        tracking \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link kwiver::vital::algo::track_features
+/// feature
+///       tracking \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_TRACK_FEATURES_H_
 #define VITAL_ALGO_TRACK_FEATURES_H_
@@ -31,21 +31,20 @@ public:
   static std::string static_type_name() { return "track_features"; }
 
   /// Extend a previous set of feature tracks using the current frame
-
-  /**
-   * \throws image_size_mismatch_exception
-   *    When the given non-zero mask image does not match the size of the
-   *    dimensions of the given image data.
-   *
-   * \param [in] prev_tracks the feature tracks from previous tracking steps
-   * \param [in] frame_number the frame number of the current frame
-   * \param [in] image_data the image pixels for the current frame
-   * \param [in] mask Optional mask image that uses positive values to denote
-   *                  regions of the input image to consider for feature
-   *                  tracking. An empty sptr indicates no mask (default
-   *                  value).
-   * \returns an updated set of feature tracks including the current frame
-   */
+  ///
+  /// \throws image_size_mismatch_exception
+  ///   When the given non-zero mask image does not match the size of the
+  ///   dimensions of the given image data.
+  ///
+  /// \param [in] prev_tracks the feature tracks from previous tracking steps
+  /// \param [in] frame_number the frame number of the current frame
+  /// \param [in] image_data the image pixels for the current frame
+  /// \param [in] mask Optional mask image that uses positive values to denote
+  ///                 regions of the input image to consider for feature
+  ///                 tracking. An empty sptr indicates no mask (default
+  ///                 value).
+  /// \returns an updated set of feature tracks including the current frame
+  ///
   virtual feature_track_set_sptr
   track( feature_track_set_sptr prev_tracks,
          frame_id_t frame_number,

--- a/vital/algo/train_detector.cxx
+++ b/vital/algo/train_detector.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief train_detector algorithm definition instantiation
- */
+///
+/// \file
+/// \brief train_detector algorithm definition instantiation
+///
 
 #include "train_detector.h"
 

--- a/vital/algo/train_detector.h
+++ b/vital/algo/train_detector.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief train_detector algorithm definition
- */
+///
+/// \file
+/// \brief train_detector algorithm definition
+///
 
 #ifndef VITAL_ALGO_TRAIN_DETECTOR_H_
 #define VITAL_ALGO_TRAIN_DETECTOR_H_
@@ -31,16 +31,15 @@ public:
   static std::string static_type_name() { return "train_detector"; }
 
   /// Train a detection model given a list of images and detections
-
-  /**
-   * This varient is geared towards offline training.
-   *
-   * \param object_labels object category labels for training
-   * \param train_image_list list of train image filenames
-   * \param train_groundtruth annotations loaded for each image
-   * \param test_image_list list of test image filenames
-   * \param test_groundtruth annotations loaded for each image
-   */
+  ///
+  /// This varient is geared towards offline training.
+  ///
+  /// \param object_labels object category labels for training
+  /// \param train_image_list list of train image filenames
+  /// \param train_groundtruth annotations loaded for each image
+  /// \param test_image_list list of test image filenames
+  /// \param test_groundtruth annotations loaded for each image
+  ///
   virtual void
   train_from_disk( vital::category_hierarchy_sptr object_labels,
                    std::vector< std::string > train_image_names,
@@ -50,19 +49,18 @@ public:
                    = std::vector< kwiver::vital::detected_object_set_sptr >( ) );
 
   /// Train a detection model given images and detections
-
-  /**
-   * This varient is geared towards online training, and is not required
-   * to be defined.
-   *
-   * \throws runtime_exception if not defined.
-   *
-   * \param object_labels object category labels for training
-   * \param train_images vector of input train images
-   * \param train_groundtruth annotations loaded for each train image
-   * \param test_images optional vector of input test images
-   * \param test_groundtruth optional annotations loaded for each test image
-   */
+  ///
+  /// This varient is geared towards online training, and is not required
+  /// to be defined.
+  ///
+  /// \throws runtime_exception if not defined.
+  ///
+  /// \param object_labels object category labels for training
+  /// \param train_images vector of input train images
+  /// \param train_groundtruth annotations loaded for each train image
+  /// \param test_images optional vector of input test images
+  /// \param test_groundtruth optional annotations loaded for each test image
+  ///
   virtual void
   train_from_memory( vital::category_hierarchy_sptr object_labels,
                      std::vector< kwiver::vital::image_container_sptr > train_images,

--- a/vital/algo/transform_2d_io.cxx
+++ b/vital/algo/transform_2d_io.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "transform_2d_io.h"
 

--- a/vital/algo/transform_2d_io.h
+++ b/vital/algo/transform_2d_io.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for transform_2d_io
- *        \link kwiver::vital::algo::algorithm_def algorithm definition
- *        \endlink.
- */
+///
+/// \file
+/// \brief Interface for transform_2d_io
+///       \link kwiver::vital::algo::algorithm_def algorithm definition
+///       \endlink.
+///
 
 #ifndef VITAL_ALGO_TRANSFORM_2D_IO_H_
 #define VITAL_ALGO_TRANSFORM_2D_IO_H_
@@ -26,11 +26,10 @@ namespace vital {
 namespace algo {
 
 /// An abstract base class for reading and writing transforms
-
-/**
- * This class represents an abstract interface for reading and writing
- * transforms.
- */
+///
+/// This class represents an abstract interface for reading and writing
+/// transforms.
+///
 class VITAL_ALGO_EXPORT transform_2d_io
   : public kwiver::vital::algorithm_def< transform_2d_io >
 {
@@ -41,40 +40,38 @@ public:
   static std::string static_type_name() { return "transform_2d_io"; }
 
   /// Load transform from the file
-
-  /**
-   * \throws kwiver::vital::path_not_exists
-   *   Thrown when the given path does not exist.
-   *
-   * \throws kwiver::vital::path_not_a_file
-   *   Thrown when the given path does not point to a file (i.e. it points to a
-   *   directory).
-   *
-   * \param filename the path to the file to load
-   * \returns a transform instance referring to the loaded transform
-   */
+  ///
+  /// \throws kwiver::vital::path_not_exists
+  ///  Thrown when the given path does not exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file
+  ///  Thrown when the given path does not point to a file (i.e. it points to a
+  ///  directory).
+  ///
+  /// \param filename the path to the file to load
+  /// \returns a transform instance referring to the loaded transform
+  ///
   kwiver::vital::transform_2d_sptr load( std::string const& filename ) const;
 
   /// Save transform to a file
-
-  /**
-   * Transform file format is based on the algorithm instance.
-   *
-   * \throws kwiver::vital::path_not_exists
-   *   Thrown when the expected containing directory of the given path does not
-   *   exist.
-   *
-   * \throws kwiver::vital::path_not_a_directory
-   *   Thrown when the expected containing directory of the given path is not
-   *   actually a directory.
-   *
-   * \throws kwiver::vital::invalid_data
-   *   Thrown when the algorithm does not recognize the concrete type of the
-   *   transformation instance.
-   *
-   * \param filename the path to the file to save
-   * \param data the transform instance referring to the transform to write
-   */
+  ///
+  /// Transform file format is based on the algorithm instance.
+  ///
+  /// \throws kwiver::vital::path_not_exists
+  ///  Thrown when the expected containing directory of the given path does not
+  ///  exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_directory
+  ///  Thrown when the expected containing directory of the given path is not
+  ///  actually a directory.
+  ///
+  /// \throws kwiver::vital::invalid_data
+  ///  Thrown when the algorithm does not recognize the concrete type of the
+  ///  transformation instance.
+  ///
+  /// \param filename the path to the file to save
+  /// \param data the transform instance referring to the transform to write
+  ///
   void save( std::string const& filename,
              kwiver::vital::transform_2d_sptr data ) const;
 
@@ -83,26 +80,24 @@ protected:
 
 private:
   /// Implementation specific load functionality.
-
-  /**
-   * Concrete implementations of transform_2d_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file the load
-   * \returns a transform instance referring to the loaded transform
-   */
+  ///
+  /// Concrete implementations of transform_2d_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file the load
+  /// \returns a transform instance referring to the loaded transform
+  ///
   virtual kwiver::vital::transform_2d_sptr load_(
     std::string const& filename ) const = 0;
 
   /// Implementation specific save functionality.
-
-  /**
-   * Concrete implementations of transform_2d_io class must provide an
-   * implementation for this method.
-   *
-   * \param filename the path to the file to save
-   * \param data the transform instance referring to the transform to write
-   */
+  ///
+  /// Concrete implementations of transform_2d_io class must provide an
+  /// implementation for this method.
+  ///
+  /// \param filename the path to the file to save
+  /// \param data the transform instance referring to the transform to write
+  ///
   virtual void save_( std::string const& filename,
                       kwiver::vital::transform_2d_sptr data ) const = 0;
 };

--- a/vital/algo/triangulate_landmarks.cxx
+++ b/vital/algo/triangulate_landmarks.cxx
@@ -2,13 +2,13 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Instantiation of \link kwiver::vital::algo::algorithm_def
- *        algorithm_def<T> \endlink for \link
- *        kwiver::vital::algo::triangulate_landmarks triangulate_landmarks
- *        \endlink
- */
+///
+/// \file
+/// \brief Instantiation of \link kwiver::vital::algo::algorithm_def
+///       algorithm_def<T> \endlink for \link
+///       kwiver::vital::algo::triangulate_landmarks triangulate_landmarks
+///       \endlink
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/triangulate_landmarks.h>

--- a/vital/algo/triangulate_landmarks.h
+++ b/vital/algo/triangulate_landmarks.h
@@ -2,12 +2,12 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Header defining abstract \link
- * kwiver::vital::algo::triangulate_landmarks
- *        triangulate landmarks \endlink algorithm
- */
+///
+/// \file
+/// \brief Header defining abstract \link
+/// kwiver::vital::algo::triangulate_landmarks
+///       triangulate landmarks \endlink algorithm
+///
 
 #ifndef VITAL_ALGO_TRIANGULATE_LANDMARKS_H_
 #define VITAL_ALGO_TRIANGULATE_LANDMARKS_H_
@@ -37,15 +37,14 @@ public:
 
   /// Triangulate the landmark locations given sets of cameras and feature
   /// tracks
-
-  /**
-   * \param [in] cameras the cameras viewing the landmarks
-   * \param [in] tracks the feature tracks to use as constraints
-   * \param [in,out] landmarks the landmarks to triangulate
-   *
-   * This function only triangulates the landmarks with indices in the
-   * landmark map and which have support in the feature tracks and cameras
-   */
+  ///
+  /// \param [in] cameras the cameras viewing the landmarks
+  /// \param [in] tracks the feature tracks to use as constraints
+  /// \param [in,out] landmarks the landmarks to triangulate
+  ///
+  /// This function only triangulates the landmarks with indices in the
+  /// landmark map and which have support in the feature tracks and cameras
+  ///
   virtual void
   triangulate( kwiver::vital::camera_map_sptr cameras,
                kwiver::vital::feature_track_set_sptr tracks,
@@ -53,16 +52,15 @@ public:
 
   /// Triangulate the landmark locations given sets of cameras and feature
   /// tracks
-
-  /**
-   * \param [in] cameras the cameras viewing the landmarks
-   * \param [in] tracks the feature tracks to use as constraints stored in a
-   * track map
-   * \param [in,out] landmarks the landmarks to triangulate
-   *
-   * This function only triangulates the landmarks with indices in the
-   * landmark map and which have support in the feature tracks and cameras.
-   */
+  ///
+  /// \param [in] cameras the cameras viewing the landmarks
+  /// \param [in] tracks the feature tracks to use as constraints stored in a
+  /// track map
+  /// \param [in,out] landmarks the landmarks to triangulate
+  ///
+  /// This function only triangulates the landmarks with indices in the
+  /// landmark map and which have support in the feature tracks and cameras.
+  ///
   virtual void
   triangulate( vital::camera_map_sptr cameras,
                vital::track_map_t tracks,

--- a/vital/algo/uuid_factory.cxx
+++ b/vital/algo/uuid_factory.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation for uid factory
- */
+///
+/// \file
+/// \brief Implementation for uid factory
+///
 
 #include <vital/algo/algorithm.txx>
 #include <vital/algo/uuid_factory.h>

--- a/vital/algo/uuid_factory.h
+++ b/vital/algo/uuid_factory.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface to uid factory
- */
+///
+/// \file
+/// \brief Interface to uid factory
+///
 
 #ifndef VITAL_ALGO_UUID_FACTORY_H
 #define VITAL_ALGO_UUID_FACTORY_H
@@ -21,10 +21,9 @@ namespace vital {
 namespace algo {
 
 /// Abstract base class for creating uuid's
-
-/**
- *
- */
+///
+///
+///
 class VITAL_ALGO_EXPORT uuid_factory
   : public kwiver::vital::algorithm_def< uuid_factory >
 {
@@ -46,4 +45,4 @@ typedef std::shared_ptr< uuid_factory > uuid_factory_sptr;
 
 } // namespace kwiver
 
-#endif /* VITAL_ALGO_UUID_FACTORY_H */
+#endif // VITAL_ALGO_UUID_FACTORY_H

--- a/vital/algo/uv_unwrap_mesh.cxx
+++ b/vital/algo/uv_unwrap_mesh.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief uv_unwrap_mesh algorithm instantiation
- */
+///
+/// \file
+/// \brief uv_unwrap_mesh algorithm instantiation
+///
 
 #include "uv_unwrap_mesh.h"
 #include <vital/algo/algorithm.txx>

--- a/vital/algo/uv_unwrap_mesh.h
+++ b/vital/algo/uv_unwrap_mesh.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief uv_unwrap_mesh algorithm definition
- */
+///
+/// \file
+/// \brief uv_unwrap_mesh algorithm definition
+///
 
 #ifndef VITAL_ALGO_UV_UNWRAP_MESH_H
 #define VITAL_ALGO_UV_UNWRAP_MESH_H
@@ -30,10 +30,9 @@ public:
   static std::string static_type_name() { return "uv_unwrap_mesh"; }
 
   /// Unwrap a mesh and generate texture coordinates
-
-  /**
-   * \param mesh [in/out] mesh to unwrap
-   */
+  ///
+  /// \param mesh [in/out] mesh to unwrap
+  ///
   virtual void unwrap( kwiver::vital::mesh_sptr mesh ) const = 0;
 
 protected:

--- a/vital/algo/video_input.cxx
+++ b/vital/algo/video_input.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief video_input algorithm definition instantiation
- */
+///
+/// \file
+/// \brief video_input algorithm definition instantiation
+///
 
 #include <vital/algo/video_input.h>
 #include <vital/algo/algorithm.txx>

--- a/vital/algo/video_input.h
+++ b/vital/algo/video_input.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for video_input
- */
+///
+/// \file
+/// \brief Interface for video_input
+///
 
 #ifndef VITAL_ALGO_VIDEO_INPUT_H_
 #define VITAL_ALGO_VIDEO_INPUT_H_
@@ -32,81 +32,80 @@ namespace algo {
 
 // ==================================================================
 /// An abstract base class for reading videos
-
-/**
- * This class represents an abstract interface for reading
- * videos. Once the video is opened, the frames are returned in order.
- *
- * Use cases:
- * ----------
- *
- * 1) Reading video from a directory of images.
- *
- * 2) Reading video frames from a list of file names.
- *
- * 3) Reading video from mpeg/video file (one of many formats) (e.g. FMV)
- *
- * 4) Reading video from mpeg/video file (one of many formats) with
- *    cropping (e.g. WAMI). This includes Providing geostationary
- *    images by cropping to a specific region from an image. This may
- *    result in no data if the geo region and image do not intersect.
- *
- * 5) Reading video from network stream. (RTSP) This may result in
- *    unexpected end of video conditions and network related
- *    disruptions (e.g. missing frames, connection terminating, ...)
- *
- * A note about the basic capabilities:
- *
- * HAS_EOV - This capability is set to true if the video source can
- *     determine end of video. This is usually the case if the video
- *     is being read from a file, but may not be known if the video is
- *     coming from a streaming source.
- *
- * HAS_FRAME_NUMBERS - This capability is set to true if the video source
- *     supplies frame numbers. If the video source specifies a frame
- *     number, then that number is used when forming a time stamp. If
- *     the video does not supply a frame number, the time stamp will
- *     not have a frame number.
- *
- * HAS_FRAME_TIME - This capability is set to true if the video source
- *     supplies a frame time. If a frame time is supplied, it is made
- *     available in the time stamp for that frame. If the frame time
- *     is not supplied, then the timestamp will not have the time set.
- *
- * HAS_FRAME_DATA - This capability is set to true if the video source
- *     supplies frame images. It may seem strange for a video input
- *     algorithm to not supply image data, but happens with a reader
- *     that only supplies the metadata.
- *
- * HAS_ABSOLUTE_FRAME_TIME - This capability is set to true if the
- *     video source supplies an absolute, rather than relative frame
- *     time. This capability is not set if an absolute frame time can
- *     not be found, or if the absolute frame time is configured as
- *     "none".
- *
- * HAS_METADATA - This capability is set if the video source supplies
- *     some type of metadata. The metadata could be in 0601 or 0104 data
- *     formats or a different source.
- *
- * HAS_TIMEOUT - This capability is set if the implementation supports the
- *     timeout parameter on the next_frame() method.
- *
- * IS_SEEKABLE - This capability is set if the video source can seek to a
- *      specific frame.
- *
- * All implementations \b must support the basic traits, in that they
- * are registered with a \b true or \b false value. Additional
- * implementation specific (extended) traits may be added. The
- * application should first check to see if a extended trait is
- * registered by calling has_trait() since the actual implementation
- * is set by a configuration entry and not directly known by the
- * application.
- *
- * Extended capabilities can be created to publish capabilities of
- * non-standard video sources. These capabilities should be namespaced using
- * the name (or abbreviation) of the concrete algorithm followed by
- * the abbreviation of the capability.
- */
+///
+/// This class represents an abstract interface for reading
+/// videos. Once the video is opened, the frames are returned in order.
+///
+/// Use cases:
+/// ----------
+///
+/// 1) Reading video from a directory of images.
+///
+/// 2) Reading video frames from a list of file names.
+///
+/// 3) Reading video from mpeg/video file (one of many formats) (e.g. FMV)
+///
+/// 4) Reading video from mpeg/video file (one of many formats) with
+///   cropping (e.g. WAMI). This includes Providing geostationary
+///   images by cropping to a specific region from an image. This may
+///   result in no data if the geo region and image do not intersect.
+///
+/// 5) Reading video from network stream. (RTSP) This may result in
+///   unexpected end of video conditions and network related
+///   disruptions (e.g. missing frames, connection terminating, ...)
+///
+/// A note about the basic capabilities:
+///
+/// HAS_EOV - This capability is set to true if the video source can
+///    determine end of video. This is usually the case if the video
+///    is being read from a file, but may not be known if the video is
+///    coming from a streaming source.
+///
+/// HAS_FRAME_NUMBERS - This capability is set to true if the video source
+///    supplies frame numbers. If the video source specifies a frame
+///    number, then that number is used when forming a time stamp. If
+///    the video does not supply a frame number, the time stamp will
+///    not have a frame number.
+///
+/// HAS_FRAME_TIME - This capability is set to true if the video source
+///    supplies a frame time. If a frame time is supplied, it is made
+///    available in the time stamp for that frame. If the frame time
+///    is not supplied, then the timestamp will not have the time set.
+///
+/// HAS_FRAME_DATA - This capability is set to true if the video source
+///    supplies frame images. It may seem strange for a video input
+///    algorithm to not supply image data, but happens with a reader
+///    that only supplies the metadata.
+///
+/// HAS_ABSOLUTE_FRAME_TIME - This capability is set to true if the
+///    video source supplies an absolute, rather than relative frame
+///    time. This capability is not set if an absolute frame time can
+///    not be found, or if the absolute frame time is configured as
+///    "none".
+///
+/// HAS_METADATA - This capability is set if the video source supplies
+///    some type of metadata. The metadata could be in 0601 or 0104 data
+///    formats or a different source.
+///
+/// HAS_TIMEOUT - This capability is set if the implementation supports the
+///    timeout parameter on the next_frame() method.
+///
+/// IS_SEEKABLE - This capability is set if the video source can seek to a
+///     specific frame.
+///
+/// All implementations \b must support the basic traits, in that they
+/// are registered with a \b true or \b false value. Additional
+/// implementation specific (extended) traits may be added. The
+/// application should first check to see if a extended trait is
+/// registered by calling has_trait() since the actual implementation
+/// is set by a configuration entry and not directly known by the
+/// application.
+///
+/// Extended capabilities can be created to publish capabilities of
+/// non-standard video sources. These capabilities should be namespaced using
+/// the name (or abbreviation) of the concrete algorithm followed by
+/// the abbreviation of the capability.
+///
 class VITAL_ALGO_EXPORT video_input
   : public kwiver::vital::algorithm_def< video_input >
 {
@@ -128,257 +127,257 @@ public:
   /// Return the name of this algorithm
   static std::string static_type_name() { return "video_input"; }
 
-  /**
-   * \brief Open a video stream.
-   *
-   * This method opens the specified video stream for reading. The
-   * format of the name depends on the concrete implementation. It
-   * could be a file name or it could be a URI.
-   *
-   * Capabilities are set in this call, so they are available after.
-   *
-   * \param video_name Identifier of the video stream.
-   *
-   * \note Once a video is opened, it starts in an invalid state
-   * (i.e. before the first frame of video). You must call \c next_frame()
-   * to step to the first frame of video before calling \c frame_image().
-   *
-   * \throws exception if open failed
-   */
+  ///
+  /// \brief Open a video stream.
+  ///
+  /// This method opens the specified video stream for reading. The
+  /// format of the name depends on the concrete implementation. It
+  /// could be a file name or it could be a URI.
+  ///
+  /// Capabilities are set in this call, so they are available after.
+  ///
+  /// \param video_name Identifier of the video stream.
+  ///
+  /// \note Once a video is opened, it starts in an invalid state
+  /// (i.e. before the first frame of video). You must call \c next_frame()
+  /// to step to the first frame of video before calling \c frame_image().
+  ///
+  /// \throws exception if open failed
+  ///
   virtual void open( std::string video_name ) = 0;
 
-  /**
-   * \brief Close video stream.
-   *
-   * Close the currently opened stream and release resources.  Closing
-   * a stream that is already closed does not cause a problem.
-   */
+  ///
+  /// \brief Close video stream.
+  ///
+  /// Close the currently opened stream and release resources.  Closing
+  /// a stream that is already closed does not cause a problem.
+  ///
   virtual void close() = 0;
 
-  /**
-   * \brief Return end of video status.
-   *
-   * This method returns the end-of-video status of the input
-   * video. \b true is returned if the last frame has been returned.
-   *
-   * This method will always return \b false for video streams that have
-   * no ability to detect end of video, such as network streams.
-   *
-   * \return \b true if at end of video, \b false otherwise.
-   */
+  ///
+  /// \brief Return end of video status.
+  ///
+  /// This method returns the end-of-video status of the input
+  /// video. \b true is returned if the last frame has been returned.
+  ///
+  /// This method will always return \b false for video streams that have
+  /// no ability to detect end of video, such as network streams.
+  ///
+  /// \return \b true if at end of video, \b false otherwise.
+  ///
   virtual bool end_of_video() const = 0;
 
-  /**
-   * \brief Check whether state of video stream is good.
-   *
-   * This method checks the current state of the video stream to see
-   * if it is good. A stream is good if it refers to a valid frame
-   * such that calls to \c frame_image() and \c frame_metadata()
-   * are expected to return meaningful data.  After calling \c open()
-   * the initial video state is not good until the first call to
-   * \c next_frame().
-   *
-   * \return \b true if video stream is good, \b false if not good.
-   */
+  ///
+  /// \brief Check whether state of video stream is good.
+  ///
+  /// This method checks the current state of the video stream to see
+  /// if it is good. A stream is good if it refers to a valid frame
+  /// such that calls to \c frame_image() and \c frame_metadata()
+  /// are expected to return meaningful data.  After calling \c open()
+  /// the initial video state is not good until the first call to
+  /// \c next_frame().
+  ///
+  /// \return \b true if video stream is good, \b false if not good.
+  ///
   virtual bool good() const = 0; // like io stream API
 
-  /**
-   * \brief Return whether video stream is seekable.
-   *
-   * This method returns whether the video stream is seekable.
-   *
-   * \return \b true if video stream is seekable, \b false otherwise.
-   */
+  ///
+  /// \brief Return whether video stream is seekable.
+  ///
+  /// This method returns whether the video stream is seekable.
+  ///
+  /// \return \b true if video stream is seekable, \b false otherwise.
+  ///
   virtual bool seekable() const = 0;
 
-  /**
-   * \brief Get the number of frames in the video stream.
-   *
-   * Get the number of frames available in the video stream.
-   *
-   * \return the number of frames in the video stream, or 0 if the video stream
-   * is not seekable.
-   *
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Get the number of frames in the video stream.
+  ///
+  /// Get the number of frames available in the video stream.
+  ///
+  /// \return the number of frames in the video stream, or 0 if the video stream
+  /// is not seekable.
+  ///
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual size_t num_frames() const = 0;
 
-  /**
-   * \brief Advance to next frame in video stream.
-   *
-   * This method advances the video stream to the next frame, making
-   * the image and metadata available. The returned timestamp is for
-   * new current frame.
-   *
-   * The timestamp returned may be missing either frame number or time
-   * or both, depending on the actual implementation.
-   *
-   * Calling this method will make a new image and metadata packets
-   * available. They can be retrieved by calling frame_image() and
-   * frame_metadata().
-   *
-   * Check the HAS_TIMEOUT capability from the concrete implementation to
-   * see if the timeout feature is supported.
-   *
-   * If the video input is already an end, then calling this method
-   * will return \b false.
-   *
-   * \param[out] ts Time stamp of new frame.
-   * \param[in] timeout Number of seconds to wait. 0 = no timeout.
-   *
-   * \return \b true if frame returned, \b false if end of video.
-   *
-   * \throws video_input_timeout_exception when the timeout expires.
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Advance to next frame in video stream.
+  ///
+  /// This method advances the video stream to the next frame, making
+  /// the image and metadata available. The returned timestamp is for
+  /// new current frame.
+  ///
+  /// The timestamp returned may be missing either frame number or time
+  /// or both, depending on the actual implementation.
+  ///
+  /// Calling this method will make a new image and metadata packets
+  /// available. They can be retrieved by calling frame_image() and
+  /// frame_metadata().
+  ///
+  /// Check the HAS_TIMEOUT capability from the concrete implementation to
+  /// see if the timeout feature is supported.
+  ///
+  /// If the video input is already an end, then calling this method
+  /// will return \b false.
+  ///
+  /// \param[out] ts Time stamp of new frame.
+  /// \param[in] timeout Number of seconds to wait. 0 = no timeout.
+  ///
+  /// \return \b true if frame returned, \b false if end of video.
+  ///
+  /// \throws video_input_timeout_exception when the timeout expires.
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual bool next_frame( kwiver::vital::timestamp& ts,
                            uint32_t timeout = 0 ) = 0;
 
-  /**
-   * \brief Seek to the given frame number in video stream.
-   *
-   * This method seeks the video stream to the requested frame, making
-   * the image and metadata available. The returned timestamp is for
-   * new current frame.
-   *
-   * The timestamp returned may be missing the time.
-   *
-   * Calling this method will make a new image and metadata packets
-   * available. They can be retrieved by calling frame_image() and
-   * frame_metadata().
-   *
-   * Check the HAS_TIMEOUT capability from the concrete implementation to
-   * see if the timeout feature is supported.
-   *
-   * If the frame requested does not exist, then calling this method
-   * will return \b false.
-   *
-   * If the video input is not seekable then calling this method will return
-   * \b false.
-   *
-   * \param[out] ts Time stamp of new frame.
-   * \param[in] frame_number The frame to seek to.
-   * \param[in] timeout Number of seconds to wait. 0 = no timeout.
-   *
-   * \return \b true if frame returned, \b false if end of video.
-   *
-   * \throws video_input_timeout_exception when the timeout expires.
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Seek to the given frame number in video stream.
+  ///
+  /// This method seeks the video stream to the requested frame, making
+  /// the image and metadata available. The returned timestamp is for
+  /// new current frame.
+  ///
+  /// The timestamp returned may be missing the time.
+  ///
+  /// Calling this method will make a new image and metadata packets
+  /// available. They can be retrieved by calling frame_image() and
+  /// frame_metadata().
+  ///
+  /// Check the HAS_TIMEOUT capability from the concrete implementation to
+  /// see if the timeout feature is supported.
+  ///
+  /// If the frame requested does not exist, then calling this method
+  /// will return \b false.
+  ///
+  /// If the video input is not seekable then calling this method will return
+  /// \b false.
+  ///
+  /// \param[out] ts Time stamp of new frame.
+  /// \param[in] frame_number The frame to seek to.
+  /// \param[in] timeout Number of seconds to wait. 0 = no timeout.
+  ///
+  /// \return \b true if frame returned, \b false if end of video.
+  ///
+  /// \throws video_input_timeout_exception when the timeout expires.
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual bool seek_frame( kwiver::vital::timestamp& ts,
                            kwiver::vital::timestamp::frame_t frame_number,
                            uint32_t timeout = 0 ) = 0;
 
-  /**
-   * \brief Obtain the time stamp of the current frame.
-   *
-   * This method returns the time stamp of the current frame, if any, or an
-   * invalid time stamp. The returned time stamp shall have the same value
-   * as was set by the most recent call to \c next_frame().
-   *
-   * This method is idempotent. Calling it multiple times without
-   * calling next_frame() will return the same time stamp.
-   *
-   * \return The time stamp of the current frame.
-   */
+  ///
+  /// \brief Obtain the time stamp of the current frame.
+  ///
+  /// This method returns the time stamp of the current frame, if any, or an
+  /// invalid time stamp. The returned time stamp shall have the same value
+  /// as was set by the most recent call to \c next_frame().
+  ///
+  /// This method is idempotent. Calling it multiple times without
+  /// calling next_frame() will return the same time stamp.
+  ///
+  /// \return The time stamp of the current frame.
+  ///
   virtual kwiver::vital::timestamp frame_timestamp() const = 0;
 
-  /**
-   * \brief Get current frame from video stream.
-   *
-   * This method returns the image from the current frame.  If the
-   * video input is already an end, then calling this method will
-   * return a null pointer.
-   *
-   * This method is idempotent. Calling it multiple times without
-   * calling next_frame() will return the same image.
-   *
-   * \return Pointer to image container.
-   *
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Get current frame from video stream.
+  ///
+  /// This method returns the image from the current frame.  If the
+  /// video input is already an end, then calling this method will
+  /// return a null pointer.
+  ///
+  /// This method is idempotent. Calling it multiple times without
+  /// calling next_frame() will return the same image.
+  ///
+  /// \return Pointer to image container.
+  ///
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual kwiver::vital::image_container_sptr frame_image() = 0;
 
-  /**
-   * \brief Get metadata collection for current frame.
-   *
-   * This method returns the metadata collection for the current
-   * frame. It is best to call this after calling next_frame() to make
-   * sure the metadata and video are synchronized and that no metadata
-   * collections are lost.
-   *
-   * Metadata typically occurs less frequently than video frames, so
-   * if you call next_frame() and frame_metadata() together while
-   * processing a video, there may be times where no metadata is
-   * returned. In this case an empty metadata vector will be returned.
-   *
-   * Also note that the metadata collection contains a timestamp that
-   * can be used to determine where the metadata fits in the video
-   * stream.
-   *
-   * In video streams without metadata (as determined by the stream
-   * capability), this method may return and empty vector, indicating no
-   * new metadata has been found.
-   *
-   * Calling this method at end of video will return an empty metadata
-   * vector.
-   *
-   * Metadata is returned as a vector, instead of a single object, to
-   * handle cases where there is multiple metadata packets between
-   * frames. This can happen in video streams with a fast metadata
-   * rate and slow frame rate. Multiple metadata objects can be also
-   * returned from video streams that contain metadata in multiple
-   * standards, such as MISB-601 and MISB-104.
-   *
-   * In cases where there are multiple metadata packets between
-   * frames, it is inappropriate for the reader to try to select the
-   * best metadata packet. That is why they are all returned.
-   *
-   * This method is idempotent. Calling it multiple times without
-   * calling next_frame() will return the same metadata.
-   *
-   * @return Vector of metadata pointers.
-   *
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Get metadata collection for current frame.
+  ///
+  /// This method returns the metadata collection for the current
+  /// frame. It is best to call this after calling next_frame() to make
+  /// sure the metadata and video are synchronized and that no metadata
+  /// collections are lost.
+  ///
+  /// Metadata typically occurs less frequently than video frames, so
+  /// if you call next_frame() and frame_metadata() together while
+  /// processing a video, there may be times where no metadata is
+  /// returned. In this case an empty metadata vector will be returned.
+  ///
+  /// Also note that the metadata collection contains a timestamp that
+  /// can be used to determine where the metadata fits in the video
+  /// stream.
+  ///
+  /// In video streams without metadata (as determined by the stream
+  /// capability), this method may return and empty vector, indicating no
+  /// new metadata has been found.
+  ///
+  /// Calling this method at end of video will return an empty metadata
+  /// vector.
+  ///
+  /// Metadata is returned as a vector, instead of a single object, to
+  /// handle cases where there is multiple metadata packets between
+  /// frames. This can happen in video streams with a fast metadata
+  /// rate and slow frame rate. Multiple metadata objects can be also
+  /// returned from video streams that contain metadata in multiple
+  /// standards, such as MISB-601 and MISB-104.
+  ///
+  /// In cases where there are multiple metadata packets between
+  /// frames, it is inappropriate for the reader to try to select the
+  /// best metadata packet. That is why they are all returned.
+  ///
+  /// This method is idempotent. Calling it multiple times without
+  /// calling next_frame() will return the same metadata.
+  ///
+  /// @return Vector of metadata pointers.
+  ///
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual kwiver::vital::metadata_vector frame_metadata() = 0;
 
-  /**
-   * \brief Get metadata map for video.
-   *
-   * This method returns a metadata map for the video assuming the video is
-   * seekable. If the video is not seekable it will return an empty map.
-   * Depending on the implementation if the metamap has not been previously
-   * requested then the video will have to loop over to create and store the
-   * metadata map.
-   *
-   * In video streams without metadata (as determined by the stream
-   * capability), this method will return an empty map, indicating no
-   * metadata has been found.
-   *
-   * @return Map of vectors of metadata pointers.
-   *
-   * \throws video_stream_exception when there is an error in the video stream.
-   */
+  ///
+  /// \brief Get metadata map for video.
+  ///
+  /// This method returns a metadata map for the video assuming the video is
+  /// seekable. If the video is not seekable it will return an empty map.
+  /// Depending on the implementation if the metamap has not been previously
+  /// requested then the video will have to loop over to create and store the
+  /// metadata map.
+  ///
+  /// In video streams without metadata (as determined by the stream
+  /// capability), this method will return an empty map, indicating no
+  /// metadata has been found.
+  ///
+  /// @return Map of vectors of metadata pointers.
+  ///
+  /// \throws video_stream_exception when there is an error in the video stream.
+  ///
   virtual kwiver::vital::metadata_map_sptr metadata_map() = 0;
 
-  /**
-   * \brief Get frame rate from the video.
-   *
-   * If frame rate is not supported, return -1.
-   *
-   * \return Frame rate.
-   */
+  ///
+  /// \brief Get frame rate from the video.
+  ///
+  /// If frame rate is not supported, return -1.
+  ///
+  /// \return Frame rate.
+  ///
   virtual double frame_rate();
 
-  /**
-   * \brief Return capabilities of concrete implementation.
-   *
-   * This method returns the capabilities for the currently opened
-   * video.
-   *
-   * \return Reference to supported video capabilities.
-   */
+  ///
+  /// \brief Return capabilities of concrete implementation.
+  ///
+  /// This method returns the capabilities for the currently opened
+  /// video.
+  ///
+  /// \return Reference to supported video capabilities.
+  ///
   algorithm_capabilities const& get_implementation_capabilities() const;
 
 protected:

--- a/vital/algo/write_object_track_set.cxx
+++ b/vital/algo/write_object_track_set.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of save wrapping functionality.
+///
 
 #include "write_object_track_set.h"
 

--- a/vital/algo/write_object_track_set.h
+++ b/vital/algo/write_object_track_set.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for write_object_track_set
- */
+///
+/// \file
+/// \brief Interface for write_object_track_set
+///
 
 #ifndef VITAL_WRITE_OBJECT_TRACK_SET_H
 #define VITAL_WRITE_OBJECT_TRACK_SET_H
@@ -26,15 +26,15 @@ namespace algo {
 
 // ----------------------------------------------------------------------------------
 
-/**
- * @brief Read and write object track sets
- *
- * This class is the abstract base class for the object track set writer.
- *
- * Track sets from multiple images are stored in a single file with
- * enough information to recreate a unique image identifier, usually a frame
- * number, and an associated set of object tracks.
- */
+///
+/// @brief Read and write object track sets
+///
+/// This class is the abstract base class for the object track set writer.
+///
+/// Track sets from multiple images are stored in a single file with
+/// enough information to recreate a unique image identifier, usually a frame
+/// number, and an associated set of object tracks.
+///
 class VITAL_ALGO_EXPORT write_object_track_set
   : public kwiver::vital::algorithm_def< write_object_track_set >
 {
@@ -45,48 +45,44 @@ public:
   static std::string static_type_name() { return "write_object_track_set"; }
 
   /// Open a file of object track sets.
-
-  /**
-   * This method opens a object track set file for reading.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   * exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   */
+  ///
+  /// This method opens a object track set file for reading.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  /// exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
   virtual void open( std::string const& filename );
 
   /// Write object tracks to an existing stream
-
-  /**
-   * This method specifies the output stream to use for writing
-   * object tracks.
-   *
-   * @param strm output stream to use
-   */
+  ///
+  /// This method specifies the output stream to use for writing
+  /// object tracks.
+  ///
+  /// @param strm output stream to use
+  ///
   virtual void use_stream( std::ostream* strm );
 
   /// Close object track set file.
-
-  /**
-   * The currently open object track set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open object track set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Write object track set.
-
-  /**
-   * This method writes the specified object track set and image
-   * name to the currently open file.
-   *
-   * \param set Track object set
-   * \param ts Timestamp for the current frame
-   * \param frame_identifier Identifier for the current frame (e.g. file name)
-   */
+  ///
+  /// This method writes the specified object track set and image
+  /// name to the currently open file.
+  ///
+  /// \param set Track object set
+  /// \param ts Timestamp for the current frame
+  /// \param frame_identifier Identifier for the current frame (e.g. file name)
+  ///
   virtual void write_set(
     kwiver::vital::object_track_set_sptr const& set,
     kwiver::vital::timestamp const& ts = {},

--- a/vital/algo/write_track_descriptor_set.cxx
+++ b/vital/algo/write_track_descriptor_set.cxx
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Implementation of load/save wrapping functionality.
- */
+///
+/// \file
+/// \brief Implementation of load/save wrapping functionality.
+///
 
 #include "write_track_descriptor_set.h"
 

--- a/vital/algo/write_track_descriptor_set.h
+++ b/vital/algo/write_track_descriptor_set.h
@@ -2,10 +2,10 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-/**
- * \file
- * \brief Interface for track_descriptor_set output
- */
+///
+/// \file
+/// \brief Interface for track_descriptor_set output
+///
 
 #ifndef VITAL_WRITE_TRACK_DESCRIPTOR_SET_H
 #define VITAL_WRITE_TRACK_DESCRIPTOR_SET_H
@@ -26,17 +26,17 @@ namespace algo {
 
 // ----------------------------------------------------------------------------------
 
-/**
- * @brief Read and write detected object sets
- *
- * This class is the abstract base class for the detected object set
- * reader and writer.
- *
- * Detection sets from multiple images are stored in a single file
- * with enough information to recreate a unique image identifier,
- * usually the file name, and an associated wet of track descriptors.
- *
- */
+///
+/// @brief Read and write detected object sets
+///
+/// This class is the abstract base class for the detected object set
+/// reader and writer.
+///
+/// Detection sets from multiple images are stored in a single file
+/// with enough information to recreate a unique image identifier,
+/// usually the file name, and an associated wet of track descriptors.
+///
+///
 class VITAL_ALGO_EXPORT write_track_descriptor_set
   : public kwiver::vital::algorithm_def< write_track_descriptor_set >
 {
@@ -51,46 +51,42 @@ public:
   }
 
   /// Open a file of track descriptor sets.
-
-  /**
-   * This method opens a track descriptor set file for reading.
-   *
-   * \param filename Name of file to open
-   *
-   * \throws kwiver::vital::path_not_exists Thrown when the given path does not
-   * exist.
-   *
-   * \throws kwiver::vital::path_not_a_file Thrown when the given path does
-   *    not point to a file (i.e. it points to a directory).
-   */
+  ///
+  /// This method opens a track descriptor set file for reading.
+  ///
+  /// \param filename Name of file to open
+  ///
+  /// \throws kwiver::vital::path_not_exists Thrown when the given path does not
+  /// exist.
+  ///
+  /// \throws kwiver::vital::path_not_a_file Thrown when the given path does
+  ///   not point to a file (i.e. it points to a directory).
+  ///
   virtual void open( std::string const& filename );
 
   /// Write track descriptors to an existing stream
-
-  /**
-   * This method specifies the output stream to use for reading
-   * track descriptors. Using a stream is handy when the track descriptors are
-   * available in a stream format.
-   *
-   * @param strm output stream to use
-   */
+  ///
+  /// This method specifies the output stream to use for reading
+  /// track descriptors. Using a stream is handy when the track descriptors are
+  /// available in a stream format.
+  ///
+  /// @param strm output stream to use
+  ///
   void use_stream( std::ostream* strm );
 
   /// Close track descriptor set file.
-
-  /**
-   * The currently open track descriptor set file is closed. If there is no
-   * currently open file, then this method does nothing.
-   */
+  ///
+  /// The currently open track descriptor set file is closed. If there is no
+  /// currently open file, then this method does nothing.
+  ///
   virtual void close();
 
   /// Write detected object set.
-
-  /**
-   * This method writes the specified detected object to file.
-   *
-   * \param set Detected object set
-   */
+  ///
+  /// This method writes the specified detected object to file.
+  ///
+  /// \param set Detected object set
+  ///
   virtual void write_set( const kwiver::vital::track_descriptor_set_sptr set )
   = 0;
 


### PR DESCRIPTION
This branch is not intended to be merged, but is for comment only.  This commit has had all files in `vital/algo` processed to convert their comment format to use only triple-slash (`///`) format.  I'm not sure it's perfect, but it compiles, and in a spot-check of 13 files I saw no glaring errors.  I did have to manually fix one instance of a `\code` Doxygen block, but those will be few enough that they can be rooted out and fixed individually.