### PR TITLE
Use vital::bounding_box in ST 1108

### DIFF
--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -11,6 +11,8 @@
 #include <arrows/klv/klv_set.h>
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
+#include <vital/types/bounding_box.h>
+
 #include <ostream>
 
 namespace kwiver {
@@ -161,10 +163,7 @@ public:
 /// Indicates the bounding box for which the metrics were calculated.
 struct KWIVER_ALGO_KLV_EXPORT klv_1108_window_corners_pack
 {
-  uint16_t top_row;
-  uint16_t left_column;
-  uint16_t bottom_row;
-  uint16_t right_column;
+  kwiver::vital::bounding_box< uint16_t > bbox;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/tests/test_klv_1108.cxx
+++ b/arrows/klv/tests/test_klv_1108.cxx
@@ -44,7 +44,7 @@ TEST ( klv, read_write_1108 )
     { KLV_1108_METRIC_PERIOD_PACK,
       klv_1108_metric_period_pack{ 1630000000000000, 7000000 } },
     { KLV_1108_WINDOW_CORNERS_PACK,
-      klv_1108_window_corners_pack{ 0, 0, 1280, 720 } },
+      klv_1108_window_corners_pack{ { 0, 0, 1280, 720 } } },
     { KLV_1108_METRIC_LOCAL_SET,    expected_metric_set },
     { KLV_1108_COMPRESSION_TYPE,    KLV_1108_COMPRESSION_TYPE_H264 },
     { KLV_1108_COMPRESSION_PROFILE, KLV_1108_COMPRESSION_PROFILE_HIGH },
@@ -57,7 +57,7 @@ TEST ( klv, read_write_1108 )
     KLV_1108_ASSESSMENT_POINT,       1,  KLV_1108_ASSESSMENT_POINT_ARCHIVE,
     KLV_1108_METRIC_PERIOD_PACK,     12,
     0x00, 0x05, 0xCA, 0x79, 0xF2, 0xFB, 0xe0, 0x00, 0x00, 0x6A, 0xCF, 0xC0,
-    KLV_1108_WINDOW_CORNERS_PACK,    6,  0x00, 0x00, 0x8A, 0x00, 0x85, 0x50,
+    KLV_1108_WINDOW_CORNERS_PACK,    6,  0x00, 0x00, 0x85, 0x50, 0x8A, 0x00,
     KLV_1108_METRIC_LOCAL_SET,       47,
     KLV_1108_METRIC_SET_NAME,        6,  'V', 'N', 'I', 'I', 'R', 'S',
     KLV_1108_METRIC_SET_VERSION,     3,  '3', '.', '0',
@@ -73,7 +73,7 @@ TEST ( klv, read_write_1108 )
     KLV_1108_COMPRESSION_RATIO,      4,  0x41, 0xC9, 0x99, 0x9A,
     KLV_1108_STREAM_BITRATE,         2,  0x04, 0x00,
     KLV_1108_DOCUMENT_VERSION,       1,  0x03,
-    KLV_1108_CHECKSUM,               2,  0x6D, 0x88 };
+    KLV_1108_CHECKSUM,               2,  0xC1, 0xE4 };
 
   CALL_TEST( test_read_write, {}, {} );
   CALL_TEST( test_read_write, expected_result, input_bytes );


### PR DESCRIPTION
As per review suggestion, use `vital::bounding_box` to represent a KLV 1108 Window Corners Pack, which is a bounding box indicating that a given metric was only calculated on that subimage. However, the `klv_1108_windows_corner_pack`  struct remains as a wrapper around `vital::bounding_box`, since `klv_value` objects are required to override the less-than operator, and `vital::bounding_box` does not. 