### PR TITLE
Refactor metadata to use variant

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -161,7 +161,7 @@ get_sensor_location( kwiver::vital::metadata_sptr const& metadata )
                  "metadata does not contain sensor location" );
   }
 
-  return kv::any_cast< kv::geo_point >( item.data() );
+  return item.get< kv::geo_point >();
 }
 
 // ----------------------------------------------------------------------------
@@ -177,7 +177,7 @@ get_frame_center( kwiver::vital::metadata_sptr const& metadata )
                  "metadata does not contain frame center" );
   }
 
-  return kv::any_cast< kv::geo_point >( item.data() );
+  return item.get< kv::geo_point >();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/gdal/tests/test_image.cxx
+++ b/arrows/gdal/tests/test_image.cxx
@@ -145,8 +145,8 @@ TEST_F(image_io, load_geotiff)
   ASSERT_TRUE( md->has( kwiver::vital::VITAL_META_CORNER_POINTS ) )
     << "Metadata should include corner points.";
 
-  kwiver::vital::geo_polygon corner_pts;
-  md->find( kwiver::vital::VITAL_META_CORNER_POINTS ).data( corner_pts );
+  auto corner_pts = md->find( kwiver::vital::VITAL_META_CORNER_POINTS )
+                      .get< kwiver::vital::geo_polygon >();
   EXPECT_EQ( corner_pts.crs(), 4326);
   EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( -16.0, 0.0) );
   EXPECT_TRUE( corner_pts.polygon( 4326 ).contains( 0.0, 32.0) );

--- a/arrows/serialize/json/tests/test_load_save.cxx
+++ b/arrows/serialize/json/tests/test_load_save.cxx
@@ -406,7 +406,7 @@ void compare_meta_collection( const kwiver::vital::metadata& lhs,
     const auto& rhs_item = rhs.find( lhs_item->tag() );
 
     // test for data being the same
-    EXPECT_EQ( lhs_item->data().type(), rhs_item.data().type() );
+    EXPECT_EQ( lhs_item->type(), rhs_item.type() );
 
     //+ TBD check data values for equal
   } // end for

--- a/vital/internal/variant/config.hpp
+++ b/vital/internal/variant/config.hpp
@@ -43,10 +43,10 @@
 #define MPARK_CPP14_CONSTEXPR
 #endif
 
-#if __has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
-    (defined(_MSC_VER) && defined(_CPPUNWIND))
+// #if __has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
+//     (defined(_MSC_VER) && defined(_CPPUNWIND))
 #define MPARK_EXCEPTIONS
-#endif
+// #endif
 
 #if defined(__cpp_generic_lambdas) || defined(_MSC_VER)
 #define MPARK_GENERIC_LAMBDAS

--- a/vital/io/camera_from_metadata.cxx
+++ b/vital/io/camera_from_metadata.cxx
@@ -204,8 +204,7 @@ initialize_cameras_with_metadata(std::map<frame_id_t,
       }
       if(auto& mdi = m.second->find(VITAL_META_SENSOR_LOCATION))
       {
-        geo_point gloc;
-        mdi.data(gloc);
+        auto gloc = mdi.get< geo_point >();
 
         // set the origin to the ground
         vital::vector_3d loc = gloc.location();
@@ -284,33 +283,33 @@ update_camera_from_metadata(metadata const& md,
   double platform_yaw = 0.0, platform_pitch = 0.0, platform_roll = 0.0;
   if (auto& mdi = md.find(VITAL_META_PLATFORM_HEADING_ANGLE))
   {
-    mdi.data(platform_yaw);
+    platform_yaw = mdi.get< double >();
     has_platform_yaw = true;
   }
   if (auto& mdi = md.find(VITAL_META_PLATFORM_PITCH_ANGLE))
   {
-    mdi.data(platform_pitch);
+    platform_pitch = mdi.get< double >();
     has_platform_pitch = true;
   }
   if (auto& mdi = md.find(VITAL_META_PLATFORM_ROLL_ANGLE))
   {
-    mdi.data(platform_roll);
+    platform_roll = mdi.get< double >();
     has_platform_roll = true;
   }
   double sensor_yaw = 0.0, sensor_pitch = 0.0, sensor_roll = 0.0;
   if (auto& mdi = md.find(VITAL_META_SENSOR_REL_AZ_ANGLE))
   {
-    mdi.data(sensor_yaw);
+    sensor_yaw = mdi.get< double >();
     has_sensor_yaw = true;
   }
   if (auto& mdi = md.find(VITAL_META_SENSOR_REL_EL_ANGLE))
   {
-    mdi.data(sensor_pitch);
+    sensor_pitch = mdi.get< double >();
     has_sensor_pitch = true;
   }
   if (auto& mdi = md.find(VITAL_META_SENSOR_REL_ROLL_ANGLE))
   {
-    mdi.data(sensor_roll);
+    sensor_roll = mdi.get< double >();
   }
 
   if (has_platform_yaw && has_platform_pitch && has_platform_roll &&
@@ -333,8 +332,7 @@ update_camera_from_metadata(metadata const& md,
 
   if (auto& mdi = md.find(VITAL_META_SENSOR_LOCATION))
   {
-    geo_point gloc;
-    mdi.data(gloc);
+    auto const gloc = mdi.get< geo_point >();
 
     // get the location in the same UTM zone as the origin
     vector_3d loc = gloc.location(lgcs.origin().crs())

--- a/vital/io/metadata_io.cxx
+++ b/vital/io/metadata_io.cxx
@@ -207,8 +207,7 @@ write_pos_file( metadata const& md,
 
   if ( auto& mdi = md.find( VITAL_META_SENSOR_LOCATION ) )
   {
-    kwiver::vital::geo_point geo_pt;
-    mdi.data( geo_pt );
+    auto const geo_pt = mdi.get< kwiver::vital::geo_point >();
     auto const& raw_loc = geo_pt.location( SRID::lat_lon_WGS84 );
     // altitude is in feet in a POS file and needs to be converted to feet
     constexpr double feet2meters = 0.3048;

--- a/vital/tests/test_metadata_io.cxx
+++ b/vital/tests/test_metadata_io.cxx
@@ -88,10 +88,7 @@ void compare_tag( kwiver::vital::metadata_item const& expected,
   }
   else if ( expected.type() == typeid(int) )
   {
-    int v1 = 0, v2 = 0;
-    expected.data(v1);
-    actual.data(v2);
-    EXPECT_EQ( v1, v2 );
+    EXPECT_EQ( expected.get< int >(), actual.get< int >() );
   }
   else if ( expected.type() == typeid(std::string) )
   {
@@ -99,9 +96,8 @@ void compare_tag( kwiver::vital::metadata_item const& expected,
   }
   else if ( expected.type() == typeid(kwiver::vital::geo_point) )
   {
-    kwiver::vital::geo_point v1, v2;
-    expected.data(v1);
-    actual.data(v2);
+    auto const v1 = expected.get< kwiver::vital::geo_point >();
+    auto const v2 = actual.get< kwiver::vital::geo_point >();
     auto const& rv1 = v1.location( kwiver::vital::SRID::lat_lon_WGS84 );
     auto const& rv2 = v2.location( kwiver::vital::SRID::lat_lon_WGS84 );
     EXPECT_NEAR( rv1[1], rv2[1], epsilon ) << " (lat)";

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -8,7 +8,6 @@
  */
 
 #include "metadata.h"
-#include "metadata_traits.h"
 
 #include <vital/types/metadata_traits.h>
 #include <vital/util/demangle.h>
@@ -16,35 +15,46 @@
 #include <typeindex>
 
 namespace kwiver {
+
 namespace vital {
 
-// ----------------------------------------------------------------------------
-metadata_item
-::metadata_item( vital_metadata_tag p_tag,
-                 kwiver::vital::any const& p_data )
-    : m_data{ p_data },
-      m_tag{ p_tag }
-{
-  if( tag_traits_by_tag( m_tag ).type() != m_data.type() )
-  {
-    throw bad_any_cast( m_data.type_name(),
-                        tag_traits_by_tag( m_tag ).type_name() );
-  }
-}
+namespace {
 
 // ----------------------------------------------------------------------------
-metadata_item
-::metadata_item( vital_metadata_tag p_tag,
-                 kwiver::vital::any&& p_data )
-    : m_data{ std::move( p_data ) },
-      m_tag{ p_tag }
-{
-  if( tag_traits_by_tag( m_tag ).type() != m_data.type() )
+struct print_visitor {
+  template< class T >
+  std::ostream& operator()( T const& value ) const
   {
-    throw bad_any_cast( m_data.type_name(),
-                        tag_traits_by_tag( m_tag ).type_name() );
+    return os << value;
   }
+
+  std::ostream& os;
+};
+
+// ----------------------------------------------------------------------------
+struct convert_from_any_visitor {
+  template< class T >
+  metadata_value operator()() const
+  {
+    return any_cast< T >( data );
+  }
+
+  any const& data;
+};
+
+} // namespace <anonymous>
+
+namespace metadata_detail {
+// ----------------------------------------------------------------------------
+template<>
+metadata_value
+convert_data< any >( vital_metadata_tag tag, any const& data ) {
+  auto const& type = tag_traits_by_tag( tag ).type();
+  auto const visitor = convert_from_any_visitor{ data };
+  return visit_metadata_types_return< metadata_value >( visitor, type );
 }
+
+} // namespace metadata_detail
 
 // ----------------------------------------------------------------------------
 bool
@@ -71,7 +81,15 @@ metadata_item
 }
 
 // ----------------------------------------------------------------------------
-kwiver::vital::any
+std::string
+metadata_item
+::type_name() const
+{
+  return tag_traits_by_tag( m_tag ).type_name();
+}
+
+// ----------------------------------------------------------------------------
+metadata_value const&
 metadata_item
 ::data() const
 {
@@ -83,7 +101,7 @@ double
 metadata_item
 ::as_double() const
 {
-  return kwiver::vital::any_cast< double > ( this->m_data );
+  return kwiver::vital::get< double >( this->m_data );
 }
 
 // ----------------------------------------------------------------------------
@@ -91,7 +109,7 @@ bool
 metadata_item
 ::has_double() const
 {
-  return m_data.type() == typeid( double );
+  return this->type() == typeid( double );
 }
 
 // ----------------------------------------------------------------------------
@@ -99,7 +117,7 @@ uint64_t
 metadata_item
 ::as_uint64() const
 {
-  return kwiver::vital::any_cast< uint64_t > ( this->m_data );
+  return kwiver::vital::get< uint64_t >( this->m_data );
 }
 
 // ----------------------------------------------------------------------------
@@ -107,7 +125,7 @@ bool
 metadata_item
 ::has_uint64() const
 {
-  return m_data.type() == typeid( uint64_t );
+  return this->type() == typeid( uint64_t );
 }
 
 // ----------------------------------------------------------------------------
@@ -117,7 +135,7 @@ metadata_item
 {
   if( this->has_string() )
   {
-    return any_cast< string_t >( m_data );
+    return kwiver::vital::get< std::string >( m_data );
   }
 
   std::stringstream ss;
@@ -130,7 +148,7 @@ bool
 metadata_item
 ::has_string() const
 {
-  return m_data.type() == typeid( std::string );
+  return this->type() == typeid( std::string );
 }
 
 // ----------------------------------------------------------------------------
@@ -138,39 +156,7 @@ std::ostream&
 metadata_item
 ::print_value( std::ostream& os ) const
 {
-  if( m_data.is_type< bool >() )
-  {
-    os << any_cast< bool >( m_data );
-  }
-  else if( m_data.is_type< uint64_t >() )
-  {
-    os << any_cast< uint64_t >( m_data );
-  }
-  else if ( m_data.is_type< int >() )
-  {
-    os << any_cast< int >( m_data );
-  }
-  else if( m_data.is_type< double >() )
-  {
-    os << any_cast< double >( m_data );
-  }
-  else if( m_data.is_type< string_t >() )
-  {
-    os << any_cast< string_t >( m_data );
-  }
-  else if( m_data.is_type< geo_point >() )
-  {
-    os << any_cast< geo_point >( m_data );
-  }
-  else if ( m_data.is_type< geo_polygon >() )
-  {
-    os << any_cast< geo_polygon >( m_data );
-  }
-  else
-  {
-    throw std::logic_error( "unsupported type" );
-  }
-  return os;
+  return visit( print_visitor{ os }, m_data );
 }
 
 // ---------------------------------------------------------------------
@@ -463,4 +449,6 @@ bool test_equal_content( const kwiver::vital::metadata& one,
   return true;
 }
 
-} } // end namespace
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/types/metadata_map.h
+++ b/vital/types/metadata_map.h
@@ -89,9 +89,7 @@ public:
   type_of_tag<tag>
   get(frame_id_t fid) const
   {
-    type_of_tag<tag> val {};
-    this->get_item(tag, fid).data(val);
-    return val;
+    return this->get_item( tag, fid ).get< type_of_tag< tag > >();
   }
 
   /// Returns the frame ids that have associated metadata

--- a/vital/types/metadata_traits.h
+++ b/vital/types/metadata_traits.h
@@ -10,8 +10,8 @@
 
 #include <vital/types/geo_point.h>
 #include <vital/types/geo_polygon.h>
-#include <vital/types/metadata.h>
-#include <vital/types/metadata_types.h>
+#include <vital/types/metadata_tags.h>
+#include <vital/vital_types.h>
 #include <vital/vital_export.h>
 
 #include <typeinfo>


### PR DESCRIPTION
`vital::metadata_item` currently uses `any` to hold its data. However, its design encourages the use of only a few small data types, and in fact less than a dozen are used in any vital tags. Given the small number of small types, `variant`, C++'s type-safe union, is perhaps a better choice for this situation, since it provides more compile-time checks and allows for more elegant and complete solutions when trying to deal with any of the possible internal types. Since `any` could contain any possible type, the only way to handle an `any` of unknown internal type is:
```
if( object.type() == typeid( double ) ) { ... }
else if( object.type() == typeid( int ) ) { ... }
else if( ... ) 
...
```
which requires manually naming and casting to each possible contained type, resulting in long, repetitive, messy code which isn't guaranteed to handle all cases, especially if another type is added to `metadata_item`'s list of supported types in the future. `variant`, however, has convenient `visit` functionality which comes in handy in these common scenarios, allowing one to write generalizable code using templates. Additionally, `variant` requires no heap allocation, making it more efficient than `any` in most cases.

Care was taken to disturb the metadata interface as little as possible to avoid having to change too much code across KWIVER. Thus, `metadata` and `metadata_item` still accept `any` objects, but will convert them to `variant` internally.