### PR TITLE
Remove unused VXL arrow import in FFMPEG arrow test

### DIFF
--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
@@ -16,8 +16,6 @@
 #include <vital/exceptions/video.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
-#include <arrows/vxl/vidl_ffmpeg_video_input.h>
-
 #include <memory>
 #include <string>
 #include <iostream>


### PR DESCRIPTION
Under the condition where the FFMPEG arrow is enabled but the VXL arrow
is not, a certain generated header file does not get generated, which
causes this specific test CXX file to fail to compile. This header was
not actually needed so has been removed.