### PR TITLE
Restore 0601 double and int value normalization

### DIFF
--- a/arrows/klv/convert_0601_metadata.cxx
+++ b/arrows/klv/convert_0601_metadata.cxx
@@ -90,6 +90,17 @@ convert_metadata
                            kwiver::vital::vital_metadata_tag vital_tag,
                            kwiver::vital::any const& data )
 {
+  auto const& type = convert_metadata::typeid_for_tag( vital_tag );
+  if( type == typeid( double ) )
+  {
+    return klv_0601_value_double( tag, data );
+  }
+
+  if( type == typeid( uint64_t ) )
+  {
+    return convert_to_int.convert( data );
+  }
+
   if( convert_metadata::typeid_for_tag( vital_tag ) != data.type() )
   {
     throw kwiver::vital::bad_any_cast(


### PR DESCRIPTION
PR #1407 removed some code in the existing ST0601 parser which converted data from its KLV type to its vital type. This removal was due to a misunderstanding of the code's function. Here, even though we will soon replace ST0601 entirely, we are restoring the missing normalization functionality in the old version, reversing the previous regression.