### PR TITLE
Add equality operators for geo_point, geo_polygon

### DIFF
--- a/vital/types/geo_point.cxx
+++ b/vital/types/geo_point.cxx
@@ -123,4 +123,19 @@ operator<<( std::ostream& str, vital::geo_point const& obj )
   return str;
 }
 
+// ----------------------------------------------------------------------------
+bool
+operator==( geo_point const& lhs, geo_point const& rhs )
+{
+  return ( lhs.is_empty() && rhs.is_empty() ) ||
+         ( lhs.crs() == rhs.crs() && lhs.location() == rhs.location() );
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator!=( geo_point const& lhs, geo_point const& rhs )
+{
+  return !( lhs == rhs );
+}
+
 } } // end namespace

--- a/vital/types/geo_point.h
+++ b/vital/types/geo_point.h
@@ -106,6 +106,12 @@ protected:
 
 VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, geo_point const& obj );
 
+VITAL_EXPORT
+bool operator==( geo_point const& lhs, geo_point const& rhs );
+
+VITAL_EXPORT
+bool operator!=( geo_point const& lhs, geo_point const& rhs );
+
 } } // end namespace
 
 #endif

--- a/vital/types/geo_polygon.cxx
+++ b/vital/types/geo_polygon.cxx
@@ -198,4 +198,19 @@ operator<<( std::ostream& str, vital::geo_polygon const& obj )
   return str;
 }
 
+// ----------------------------------------------------------------------------
+bool
+operator==( geo_polygon const& lhs, geo_polygon const& rhs )
+{
+  return ( lhs.is_empty() && rhs.is_empty() ) ||
+         ( lhs.crs() == rhs.crs() && lhs.polygon() == rhs.polygon() );
+}
+
+// ----------------------------------------------------------------------------
+bool
+operator!=( geo_polygon const& lhs, geo_polygon const& rhs )
+{
+  return !( lhs == rhs );
+}
+
 } } // end namespace

--- a/vital/types/geo_polygon.h
+++ b/vital/types/geo_polygon.h
@@ -95,6 +95,12 @@ template<> VITAL_EXPORT config_block_value_t config_block_set_value_cast( geo_po
 
 VITAL_EXPORT ::std::ostream& operator<< ( ::std::ostream& str, geo_polygon const& obj );
 
+VITAL_EXPORT
+bool operator==( geo_polygon const& lhs, geo_polygon const& rhs );
+
+VITAL_EXPORT
+bool operator!=( geo_polygon const& lhs, geo_polygon const& rhs );
+
 } } // end namespace
 
 #endif

--- a/vital/types/polygon.cxx
+++ b/vital/types/polygon.cxx
@@ -128,4 +128,16 @@ get_vertices() const
   return m_polygon;
 }
 
+// ------------------------------------------------------------------
+bool operator==( polygon const& lhs, polygon const& rhs )
+{
+  return lhs.get_vertices() == rhs.get_vertices();
+}
+
+// ------------------------------------------------------------------
+bool operator!=( polygon const& lhs, polygon const& rhs )
+{
+  return !( lhs == rhs );
+}
+
 } }    // end namespace

--- a/vital/types/polygon.h
+++ b/vital/types/polygon.h
@@ -137,6 +137,12 @@ private:
 typedef std::shared_ptr< polygon > polygon_sptr;
 typedef std::vector< polygon_sptr >  polygon_sptr_list;
 
+VITAL_EXPORT
+bool operator==( polygon const& lhs, polygon const& rhs );
+
+VITAL_EXPORT
+bool operator!=( polygon const& lhs, polygon const& rhs );
+
 } } // end namespace
 
 #endif // VITAL_TYPES_POLYGON_H


### PR DESCRIPTION
The additions are motivated by the desire to check if metadata is changing over time. Admittedly, these particular equality operators are of somewhat limited general utility, since they check for exact equality of floating-point values. However, they can still be used to tell if the two points or polygons were produced by the exact same process (e.g. reading the same value from a metadata file / packet), which is their intended use case.