### PR TITLE
Add interval utility class

### DIFF
--- a/vital/util/CMakeLists.txt
+++ b/vital/util/CMakeLists.txt
@@ -21,6 +21,7 @@ set( public_headers
   source_location.h
   data_stream_reader.h
   hex_dump.h
+  interval.h
   string.h
   string_editor.h
   simple_stats.h

--- a/vital/util/interval.h
+++ b/vital/util/interval.h
@@ -1,0 +1,144 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Definition of interval template class.
+
+#include <vital/util/numeric.h>
+#include <vital/util/vital_util_export.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <type_traits>
+
+#include <cmath>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/// Represents a numerical interval with an upper and lower bound.
+template < class T >
+class interval
+{
+public:
+  interval( T lower, T upper )
+    : m_lower{ std::min( lower, upper ) },
+      m_upper{ std::max( lower, upper ) }
+  {
+    assert_not_nan( lower );
+    assert_not_nan( upper );
+  }
+
+  /// Return lower bound.
+  T
+  lower() const
+  {
+    return m_lower;
+  }
+
+  /// Return upper bound.
+  T
+  upper() const
+  {
+    return m_upper;
+  }
+
+  /// Ensure the lower bound is at least \p new_lower.
+  ///
+  /// \throws invalid_argument If \p new_lower is greater than the current
+  /// upper bound.
+  void
+  truncate_lower( T new_lower )
+  {
+    assert_not_nan( new_lower );
+    if( new_lower > m_upper )
+    {
+      throw std::invalid_argument(
+              "interval.truncate_lower(): "
+              "new_lower cannot be greater than current upper" );
+    }
+    m_lower = std::max( m_lower, new_lower );
+  }
+
+  /// Ensure the upper bound is at most \p new_upper.
+  ///
+  /// \throws invalid_argument If \p new_upper is less than the current lower
+  /// bound.
+  void
+  truncate_upper( T new_upper )
+  {
+    assert_not_nan( new_upper );
+    if( new_upper < m_lower )
+    {
+      throw std::invalid_argument(
+              "interval.truncate_upper(): "
+              "new_upper cannot be less than current lower" );
+    }
+    m_upper = std::min( m_upper, new_upper );
+  }
+
+  /// Ensure the interval contains \p value.
+  void
+  encompass( T value )
+  {
+    assert_not_nan( value );
+    m_lower = std::min( m_lower, value );
+    m_upper = std::max( m_upper, value );
+  }
+
+  /// Return \c true if \p value is within in this half-open interval.
+  bool
+  contains( T value ) const
+  {
+    return m_lower <= value && value < m_upper;
+  }
+
+  /// Return \c true if \p value is within in this interval.
+  ///
+  /// \param inclusive_lower Whether to return \c true if \p value is equal to
+  /// the lower bound.
+  /// \param inclusive_upper Whether to return \c true if \p value is equal to
+  /// the upper bound.
+  bool
+  contains( T value, bool inclusive_lower, bool inclusive_upper ) const
+  {
+    return ( m_lower < value || ( inclusive_lower && m_lower == value ) ) &&
+           ( value < m_upper || ( inclusive_upper && m_upper == value ) );
+  }
+
+private:
+  static void
+  assert_not_nan( T value )
+  {
+    if( kwiver::vital::isnan( value ) )
+    {
+      throw std::invalid_argument( "interval: cannot accept NaN value" );
+    }
+  }
+
+  T m_lower;
+  T m_upper;
+};
+
+// ----------------------------------------------------------------------------
+template < class T >
+bool
+operator==( interval< T > const& lhs, interval< T > const& rhs )
+{
+  return lhs.lower() == rhs.lower() && lhs.upper() == rhs.upper();
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+bool
+operator!=( interval< T > const& lhs, interval< T > const& rhs )
+{
+  return !( lhs == rhs );
+}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/util/numeric.h
+++ b/vital/util/numeric.h
@@ -1,0 +1,39 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Utility functions regarding arithmetic types.
+
+#include <type_traits>
+
+#include <cmath>
+
+namespace kwiver {
+
+namespace vital {
+
+#ifdef _MSC_VER
+
+// isnan() wrapper which accepts integral types, even on noncompliant MSVC.
+// See https://github.com/microsoft/STL/issues/519
+template < class T >
+bool
+isnan( T value )
+{
+  // TODO(C++17): make if constexpr and remove the static_cast
+  if( std::is_floating_point< T >::value )
+  {
+    using promoted_t = typename std::common_type< T, float >::type;
+    return std::isnan( static_cast< promoted_t >( value ) );
+  }
+  return false;
+}
+
+#else
+using std::isnan;
+#endif
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/util/tests/CMakeLists.txt
+++ b/vital/util/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set( test_libraries vital vital_vpm kwiversys )
 
 kwiver_discover_gtests(vital any_converter      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital data_stream_reader LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital interval           LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital string             LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital string_editor      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital thread_pool        LIBRARIES ${test_libraries})

--- a/vital/util/tests/test_interval.cxx
+++ b/vital/util/tests/test_interval.cxx
@@ -1,0 +1,147 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Test interval template class.
+
+#include <vital/util/interval.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace kwiver::vital;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+constexpr auto fnan = std::numeric_limits< float >::quiet_NaN();
+constexpr auto dnan = std::numeric_limits< double >::quiet_NaN();
+constexpr auto dinf = std::numeric_limits< double >::infinity();
+
+// ----------------------------------------------------------------------------
+TEST ( interval, construct )
+{
+  {
+    auto const test_interval = interval< double >{ 5.0, 7.0 };
+    EXPECT_EQ( 5.0, test_interval.lower() );
+    EXPECT_EQ( 7.0, test_interval.upper() );
+  }
+
+  {
+    auto const test_interval = interval< int >{ 9, 2 };
+    EXPECT_EQ( 2, test_interval.lower() );
+    EXPECT_EQ( 9, test_interval.upper() );
+    EXPECT_EQ( interval< int >( 2, 9 ), test_interval );
+  }
+
+  {
+    auto const test_interval = interval< double >{ dinf, -dinf };
+    EXPECT_EQ( -dinf, test_interval.lower() );
+    EXPECT_EQ( dinf, test_interval.upper() );
+  }
+
+  {
+    EXPECT_THROW( interval< float >( fnan, 5.0f ), std::invalid_argument );
+    EXPECT_THROW( interval< double >( 1.0, dnan ), std::invalid_argument );
+  }
+}
+
+// ----------------------------------------------------------------------------
+TEST ( interval, truncate )
+{
+  {
+    auto test_interval = interval< double >{ 0.0, 15.0 };
+    test_interval.truncate_lower( -1.0 );
+    EXPECT_EQ( interval< double >( 0.0, 15.0 ), test_interval );
+    test_interval.truncate_lower( 0.0 );
+    EXPECT_EQ( interval< double >( 0.0, 15.0 ), test_interval );
+    test_interval.truncate_lower( 5.0 );
+    EXPECT_EQ( interval< double >( 5.0, 15.0 ), test_interval );
+    test_interval.truncate_lower( 15.0 );
+    EXPECT_EQ( interval< double >( 15.0, 15.0 ), test_interval );
+    EXPECT_THROW( test_interval.truncate_lower( 16.0 ),
+                  std::invalid_argument );
+    EXPECT_THROW( test_interval.truncate_lower( dnan ),
+                  std::invalid_argument );
+  }
+
+  {
+    auto test_interval = interval< double >{ 0.0, 15.0 };
+    test_interval.truncate_upper( 20.0 );
+    EXPECT_EQ( interval< double >( 0.0, 15.0 ), test_interval );
+    test_interval.truncate_upper( 15.0 );
+    EXPECT_EQ( interval< double >( 0.0, 15.0 ), test_interval );
+    test_interval.truncate_upper( 5.0 );
+    EXPECT_EQ( interval< double >( 0.0, 5.0 ), test_interval );
+    test_interval.truncate_upper( 0.0 );
+    EXPECT_EQ( interval< double >( 0.0, 0.0 ), test_interval );
+    EXPECT_THROW( test_interval.truncate_upper( -1.0 ),
+                  std::invalid_argument );
+    EXPECT_THROW( test_interval.truncate_upper( dnan ),
+                  std::invalid_argument );
+  }
+
+  {
+    auto test_interval = interval< double >{ -dinf, dinf };
+    test_interval.truncate_lower( -10.0 );
+    EXPECT_EQ( interval< double >( -10.0, dinf ), test_interval );
+    test_interval.truncate_upper( 10.0 );
+    EXPECT_EQ( interval< double >( -10.0, 10.0 ), test_interval );
+    test_interval.truncate_lower( -dinf );
+    EXPECT_EQ( interval< double >( -10.0, 10.0 ), test_interval );
+    test_interval.truncate_upper( dinf );
+    EXPECT_EQ( interval< double >( -10.0, 10.0 ), test_interval );
+  }
+}
+
+// ----------------------------------------------------------------------------
+TEST ( interval, encompass )
+{
+  auto test_interval = interval< double >{ 0.0, 15.0 };
+  test_interval.encompass( 5.0 );
+  EXPECT_EQ( interval< double >( 0.0, 15.0 ), test_interval );
+  test_interval.encompass( -100.0 );
+  EXPECT_EQ( interval< double >( -100.0, 15.0 ), test_interval );
+  test_interval.encompass( 100.0 );
+  EXPECT_EQ( interval< double >( -100.0, 100.0 ), test_interval );
+  test_interval.encompass( -dinf );
+  EXPECT_EQ( interval< double >( -dinf, 100.0 ), test_interval );
+  test_interval.encompass( dinf );
+  EXPECT_EQ( interval< double >( -dinf, dinf ), test_interval );
+  EXPECT_THROW( test_interval.encompass( dnan ), std::invalid_argument );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( interval, contains )
+{
+  EXPECT_FALSE( interval< int >( 0, 0 ).contains( 0 ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( 5 ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( 6 ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( -2 ) );
+  EXPECT_TRUE(  interval< int >( -1, 5 ).contains( 4 ) );
+  EXPECT_TRUE(  interval< int >( -1, 5 ).contains( -1 ) );
+  EXPECT_TRUE(  interval< double >( -dinf, dinf ).contains( 100.0 ) );
+  EXPECT_FALSE( interval< double >( -dinf, dinf ).contains( dinf ) );
+  EXPECT_FALSE( interval< double >( -dinf, dinf ).contains( dnan ) );
+
+  EXPECT_TRUE(  interval< int >( 0, 0 ).contains( 0, true, true ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( 5, false, false ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( 6, false, true ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( -2, true, true ) );
+  EXPECT_TRUE(  interval< int >( -1, 5 ).contains( 4, false, false ) );
+  EXPECT_FALSE( interval< int >( -1, 5 ).contains( -1, false, true ) );
+  EXPECT_TRUE(  interval< double >( 0, dinf )
+                  .contains( dinf, false, true ) );
+  EXPECT_FALSE( interval< double >( -dinf, 0 )
+                  .contains( -dinf, false, true ) );
+  EXPECT_FALSE( interval< double >( -dinf, dinf )
+                  .contains( dnan, true, true ) );
+}


### PR DESCRIPTION
Add a `span` template class for representing a range of numbers with a minimum and maximum. This class is useful because it allows treating these two values as a single object while enforcing common-sense invariants: the maximum cannot be less than the minimum, and neither of them can be `NaN`. 

The motivation for this addition is that KLV data is valid over specific spans of time, and implementing the logic relating to those timespans is made easier / clearer using this class.