### PR TITLE
Fix image list video input to not crash when image-io not set

### DIFF
--- a/arrows/core/video_input_image_list.cxx
+++ b/arrows/core/video_input_image_list.cxx
@@ -162,10 +162,13 @@ video_input_image_list
     "image_reader", config, d->m_image_reader );
 
   // Check capabilities of image reader
-  auto const& reader_capabilities =
-    d->m_image_reader->get_implementation_capabilities();
-  set_capability( HAS_FRAME_TIME,
-                  reader_capabilities.capability( image_io::HAS_TIME ) );
+  if( d->m_image_reader != nullptr )
+  {
+    auto const& reader_capabilities =
+      d->m_image_reader->get_implementation_capabilities();
+    set_capability( HAS_FRAME_TIME,
+                    reader_capabilities.capability( image_io::HAS_TIME ) );
+  }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If the image-io algorithm is not correctly set on the first pass, then
the set-configuration method will seg-fault due to later in-line usage
that assumes a correct instance. This change adds a nullptr-check before
attempting those derivative actions.