### PR TITLE
Fix bundle adjust common intrinsics test

### DIFF
--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -382,9 +382,10 @@ camera_options
     // - we are forcing common intrinsics and this is the first frame
     // - we are auto detecting shared intrinsics and this is a new sptr
     if( this->camera_intrinsic_share_type == FORCE_UNIQUE_INTRINSICS ||
-        ( this->camera_intrinsic_share_type == FORCE_COMMON_INTRINSICS &&
-          int_params.empty() ) ||
-        camera_intr_map.count( K ) == 0 )
+      ( this->camera_intrinsic_share_type == FORCE_COMMON_INTRINSICS &&
+        int_params.empty() ) ||
+      ( this->camera_intrinsic_share_type == AUTO_SHARE_INTRINSICS &&
+        camera_intr_map.count( K ) == 0 ) )
     {
       this->extract_camera_intrinsics( K, &intrinsic_params[ 0 ] );
       // update the maps with the index of this new parameter vector

--- a/arrows/ceres/options.cxx
+++ b/arrows/ceres/options.cxx
@@ -385,7 +385,7 @@ camera_options
       ( this->camera_intrinsic_share_type == FORCE_COMMON_INTRINSICS &&
         int_params.empty() ) ||
       ( this->camera_intrinsic_share_type == AUTO_SHARE_INTRINSICS &&
-        camera_intr_map.count( K ) == 0 ) )
+        camera_intr_map.find( K ) == camera_intr_map.end() ) )
     {
       this->extract_camera_intrinsics( K, &intrinsic_params[ 0 ] );
       // update the maps with the index of this new parameter vector

--- a/arrows/ceres/tests/test_bundle_adjust.cxx
+++ b/arrows/ceres/tests/test_bundle_adjust.cxx
@@ -385,6 +385,24 @@ test_ba_intrinsic_sharing( camera_map_sptr cameras,
 }
 
 // ----------------------------------------------------------------------------
+// Make sure each camera has unique (not shared) intrinsics
+camera_map_sptr make_intrinsics_unique(camera_map_sptr cameras)
+{
+  camera_map::map_camera_t new_cams;
+  for (auto ci : cameras->cameras())
+  {
+    auto cam = std::dynamic_pointer_cast<camera_perspective>(ci.second);
+    if (cam)
+    {
+      auto new_cam = std::make_shared<simple_camera_perspective>(
+        cam->center(), cam->rotation(), cam->intrinsics()->clone());
+      new_cams[ci.first] = new_cam;
+    }
+  }
+  return std::make_shared<simple_camera_map>(new_cams);
+}
+
+// ----------------------------------------------------------------------------
 // Test bundle adjustment with forcing unique intrinsics
 TEST(bundle_adjust, unique_intrinsics)
 {
@@ -416,8 +434,12 @@ TEST(bundle_adjust, common_intrinsics)
 
   // create a camera sequence (elliptical path)
   camera_map_sptr cameras = kwiver::testing::camera_seq(20, K);
+
+  // ensure that some cameras are not shared to start
+  cameras = make_intrinsics_unique(cameras);
+
   EXPECT_EQ( 1, test_ba_intrinsic_sharing( cameras, cfg ) )
-    << "Resulting camera intrinsics should be unique";
+    << "Resulting camera intrinsics should be shared";
 }
 
 // ----------------------------------------------------------------------------

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -7,6 +7,12 @@ v1.6.0 release.
 Bug Fixes since v1.6.0
 ----------------------
 
+Arrows: Ceres
+
+ * Fixed a bug in which the FORCE_COMMON_INTRINSICS option in bundle
+   adjustment was not actually forcing intrinsics to be common.
+   
+
 Arrows: MVG
 
  * Fixed a typo in the command line argument name for camera path in the


### PR DESCRIPTION
The test was checking if all cameras are shared after bundle adjustment
when forcing shared cameras, but the problem was that the test cameras
were shared to begin with, so the test would pass if no sharing change
was made.  This change forces the test cameras to use unique intrincs
from the start to test of the bundle adjustment forces them to be common
again.