### PR TITLE
Make metadata_map.frames() const

### DIFF
--- a/python/kwiver/vital/types/metadata_map.cxx
+++ b/python/kwiver/vital/types/metadata_map.cxx
@@ -24,7 +24,7 @@ public:
   bool has_item( kv::vital_metadata_tag tag, kv::frame_id_t fid ) const override;
   kv::metadata_item const& get_item( kv::vital_metadata_tag tag, kv::frame_id_t fid ) const override;
   kv::metadata_vector get_vector( kv::frame_id_t fid ) const override;
-  std::set< kv::frame_id_t > frames() override;
+  std::set< kv::frame_id_t > frames() const override;
 };
 
 PYBIND11_MODULE( metadata_map, m )
@@ -114,7 +114,7 @@ metadata_map_trampoline
 
 std::set< kv::frame_id_t >
 metadata_map_trampoline
-::frames()
+::frames() const
 {
   VITAL_PYBIND11_OVERLOAD_PURE(
     std::set< kv::frame_id_t >,

--- a/vital/types/metadata_map.h
+++ b/vital/types/metadata_map.h
@@ -93,7 +93,7 @@ public:
   }
 
   /// Returns the frame ids that have associated metadata
-  virtual std::set<frame_id_t> frames() = 0;
+  virtual std::set<frame_id_t> frames() const = 0;
 
 };
 
@@ -119,7 +119,7 @@ public:
   virtual map_metadata_t metadata() const { return data_; }
 
   /// Returns the frame ids that have associated metadata
-  virtual std::set<frame_id_t> frames()
+  virtual std::set<frame_id_t> frames() const
   {
     std::set<frame_id_t> fids;
     for (auto &m : data_)


### PR DESCRIPTION
The modified function returns the set of frames for which data is present in a `metadata_map`. As nothing is or should be modified internally, `frames()` should be declared `const`. 