### PR TITLE
Add klv_timeline class

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -16,6 +16,7 @@ set( sources
   klv_read_write.cxx
   klv_set.cxx
   klv_tag_traits.cxx
+  klv_timeline.cxx
   klv_value.cxx
   klv_0601.cxx
   klv_0601_new.cxx

--- a/arrows/klv/klv_timeline.cxx
+++ b/arrows/klv/klv_timeline.cxx
@@ -1,0 +1,300 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Implementation of KLV timeline class.
+
+#include "klv_timeline.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+bool
+klv_timeline::key_t
+::operator<( key_t const& other ) const
+{
+  if( standard < other.standard )
+  {
+    return true;
+  }
+  if( standard > other.standard )
+  {
+    return false;
+  }
+  if( tag < other.tag )
+  {
+    return true;
+  }
+  if( tag > other.tag )
+  {
+    return false;
+  }
+  return index < other.index;
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::begin()
+{
+  return m_map.begin();
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::end()
+{
+  return m_map.end();
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::begin() const
+{
+  return m_map.begin();
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::end() const
+{
+  return m_map.end();
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::cbegin() const
+{
+  return m_map.cbegin();
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::cend() const
+{
+  return m_map.cend();
+}
+
+// ----------------------------------------------------------------------------
+klv_value
+klv_timeline
+::at( klv_top_level_tag standard, klv_lds_key tag, uint64_t time ) const
+{
+  auto const matches = find_all( standard, tag );
+  if( matches.begin() == matches.end() )
+  {
+    return {};
+  }
+
+  klv_value const* result = nullptr;
+  for( auto const& match : matches )
+  {
+    auto const it = match.second.find( time );
+    if( it != match.second.end() )
+    {
+      if( result )
+      {
+        throw std::logic_error(
+                "klv_timeline.at(): more than one entry found" );
+      }
+      result = &it->value;
+    }
+  }
+
+  return result ? *result : klv_value{};
+}
+
+// ----------------------------------------------------------------------------
+klv_value
+klv_timeline
+::at( klv_top_level_tag standard, klv_lds_key tag, uint64_t index,
+      uint64_t time ) const
+{
+  auto const it = find( standard, tag, index );
+  if( it == end() )
+  {
+    return {};
+  }
+  auto const inner_it = it->second.find( time );
+  return ( inner_it != it->second.end() ) ? inner_it->value : klv_value{};
+}
+
+// ----------------------------------------------------------------------------
+std::vector< klv_value >
+klv_timeline
+::all_at( klv_top_level_tag standard, klv_lds_key tag, uint64_t time ) const
+{
+  std::vector< klv_value > results;
+
+  for( auto const& entry : find_all( standard, tag ) )
+  {
+    auto const it = entry.second.find( time );
+    if( it != entry.second.end() )
+    {
+      results.emplace_back( it->value );
+    }
+  }
+
+  return results;
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::range
+klv_timeline
+::find_all( klv_top_level_tag standard )
+{
+  auto const max_tag = std::numeric_limits< klv_lds_key >::max();
+  return { m_map.lower_bound( { standard, 0, 0 } ),
+           m_map.upper_bound( { standard, max_tag, UINT64_MAX } ) };
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_range
+klv_timeline
+::find_all( klv_top_level_tag standard ) const
+{
+  auto const max_tag = std::numeric_limits< klv_lds_key >::max();
+  return { m_map.lower_bound( { standard, 0, 0 } ),
+           m_map.upper_bound( { standard, max_tag, UINT64_MAX } ) };
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::range
+klv_timeline
+::find_all( klv_top_level_tag standard, klv_lds_key tag )
+{
+  return { m_map.lower_bound( { standard, tag, 0 } ),
+           m_map.upper_bound( { standard, tag, UINT64_MAX } ) };
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_range
+klv_timeline
+::find_all( klv_top_level_tag standard, klv_lds_key tag ) const
+{
+  return { m_map.lower_bound( { standard, tag, 0 } ),
+           m_map.upper_bound( { standard, tag, UINT64_MAX } ) };
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::find( klv_top_level_tag standard, klv_lds_key tag, uint64_t index )
+{
+  return m_map.find( { standard, tag, index } );
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::find( klv_top_level_tag standard, klv_lds_key tag, uint64_t index ) const
+{
+  return m_map.find( { standard, tag, index } );
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::find( klv_top_level_tag standard, klv_lds_key tag )
+{
+  auto const it_range = find_all( standard, tag );
+  switch( std::distance( it_range.begin(), it_range.end() ) )
+  {
+    case 0:
+      return m_map.end();
+    case 1:
+      return it_range.begin();
+    default:
+      throw std::logic_error( "klv_timeline.find(): multiple entries found" );
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::const_iterator
+klv_timeline
+::find( klv_top_level_tag standard, klv_lds_key tag ) const
+{
+  auto const it_range = find_all( standard, tag );
+  switch( std::distance( it_range.begin(), it_range.end() ) )
+  {
+    case 0:
+      return m_map.end();
+    case 1:
+      return it_range.begin();
+    default:
+      throw std::logic_error( "klv_timeline.find(): multiple entries found" );
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::insert( klv_top_level_tag standard, klv_lds_key tag )
+{
+  auto const it_range = find_all( standard, tag );
+
+  // Find unused index
+  auto index = 0;
+  if( it_range.begin() != it_range.end() )
+  {
+    auto const last_index = std::prev( it_range.end() )->first.index;
+    if( last_index == UINT64_MAX )
+    {
+      // Integer overflow, have to find by linear iteration
+      // Unlikely this will ever happen
+      while( find( standard, tag, index ) != end() )
+      {
+        ++index;
+      }
+    }
+    else
+    {
+      // Usual case - one greater than the greatest index
+      index = last_index + 1;
+    }
+  }
+  return insert_or_find( standard, tag, index );
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::insert_or_find( klv_top_level_tag standard, klv_lds_key tag )
+{
+  auto it_range = find_all( standard, tag );
+  switch( std::distance( it_range.begin(), it_range.end() ) )
+  {
+    case 0:
+      return insert_or_find( standard, tag, 0 );
+    case 1:
+      return it_range.begin();
+    default:
+      throw std::logic_error(
+              "klv_timeline.insert_or_find(): multiple entries found" );
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline::iterator
+klv_timeline
+::insert_or_find( klv_top_level_tag standard, klv_lds_key tag, uint64_t index )
+{
+  return m_map.emplace( key_t{ standard, tag, index },
+                        interval_map_t{} ).first;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_timeline.h
+++ b/arrows/klv/klv_timeline.h
@@ -1,0 +1,129 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Declaration of KLV timeline class.
+
+#include <arrows/klv/klv_packet.h>
+#include <arrows/klv/klv_set.h>
+
+#include <vital/util/interval_map.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Tracks the value of KLV fields over time.
+///
+/// This class is the final intended product of KLV parsing, efficiently
+/// holding data from all standards over any period of time. Enough information
+/// is stored to validly (though not necessarily identically) re-encode the KLV
+/// stream.
+class KWIVER_ALGO_KLV_EXPORT klv_timeline
+{
+public:
+  struct key_t
+  {
+    klv_top_level_tag standard;
+    klv_lds_key tag;
+    uint64_t index;
+
+    bool operator<( key_t const& other ) const;
+  };
+
+  using interval_t = kwiver::vital::interval< uint64_t >;
+  using interval_map_t = kwiver::vital::interval_map< uint64_t, klv_value >;
+  using container_t = std::map< key_t, interval_map_t >;
+  using iterator = typename container_t::iterator;
+  using const_iterator = typename container_t::const_iterator;
+  using range = kwiver::vital::range::iterator_range< iterator >;
+  using const_range = kwiver::vital::range::iterator_range< const_iterator >;
+
+  iterator begin();
+  iterator end();
+
+  const_iterator begin() const;
+  const_iterator end() const;
+
+  const_iterator cbegin() const;
+  const_iterator cend() const;
+
+  /// Return the value at the given location, or an empty \c klv_value if no
+  /// value exists.
+  ///
+  /// \throws logic_error If more than one value is present.
+  klv_value at( klv_top_level_tag standard, klv_lds_key tag,
+                uint64_t time ) const;
+
+  /// Return the value at the given location, or an empty \c klv_value if no
+  /// value exists.
+  klv_value at( klv_top_level_tag standard, klv_lds_key tag,
+                uint64_t index, uint64_t time ) const;
+
+  /// Return all values at the given location.
+  std::vector< klv_value > all_at( klv_top_level_tag standard, klv_lds_key tag,
+                                   uint64_t time ) const;
+
+  /// Return the range of all entries using \p standard.
+  range find_all( klv_top_level_tag standard );
+
+  /// \copydoc range find_all( klv_top_level_tag standard )
+  const_range find_all( klv_top_level_tag standard ) const;
+
+  /// Return the range of all entries using \p standard and \p tag.
+  range find_all( klv_top_level_tag standard, klv_lds_key tag );
+
+  /// \copydoc range find_all( klv_top_level_tag, klv_lds_key );
+  const_range find_all( klv_top_level_tag standard, klv_lds_key tag ) const;
+
+  /// Return an iterator to the given location, or the end iterator if none
+  /// exists.
+  ///
+  /// \throws logic_error If more than one entry is present at the given
+  /// location.
+  iterator find( klv_top_level_tag standard, klv_lds_key tag );
+
+  /// \copydoc iterator find( klv_top_level_tag, klv_lds_key )
+  const_iterator find( klv_top_level_tag standard, klv_lds_key tag ) const;
+
+  /// Return an iterator to the given location, or the end iterator if none
+  /// exists.
+  iterator find( klv_top_level_tag standard, klv_lds_key tag, uint64_t index );
+
+  /// \copydoc iterator find( klv_top_level_tag, klv_lds_key )
+  const_iterator find( klv_top_level_tag standard, klv_lds_key tag,
+                       uint64_t index ) const;
+
+  /// Insert a new timeline, even if one already exists.
+  ///
+  /// \note The index of the inserted timeline is not guaranteed to be any
+  /// particular number.
+  ///
+  /// \returns An iterator to the new timeline.
+  iterator insert( klv_top_level_tag standard, klv_lds_key tag );
+
+  /// Return an iterator to the given location, creating a new timeline if none
+  /// exists.
+  ///
+  /// \throws logic_error If more than one entry is present at the given
+  /// location.
+  iterator insert_or_find( klv_top_level_tag standard, klv_lds_key tag );
+
+  /// Return an iterator to the given location, creating a new timeline if none
+  /// exists.
+  iterator insert_or_find( klv_top_level_tag standard, klv_lds_key tag,
+                           uint64_t index );
+
+private:
+  container_t m_map;
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver


### PR DESCRIPTION
Create a class to track KLV data over time. This is the final intended product of KLV parsing, capable of efficiently holding data from any standard(s) over any period of time in a form which can be manipulated relatively easily. Enough information is retained here to validly (re-)encode any supported KLV stream.

Just like in a `klv_set`, of which this is a sort of amalgamation, some tags can have multiple values, though most tags only support one value at a time. This is reflected in the interface, which has options for working under both single- and multi-value paradigms.