### PR TITLE
Add frame dump capability to dump-klv

### DIFF
--- a/arrows/core/applets/dump_klv.cxx
+++ b/arrows/core/applets/dump_klv.cxx
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <fstream>
 
+#include <vital/algo/image_io.h>
 #include <vital/algo/metadata_map_io.h>
 #include <vital/algo/video_input.h>
 
@@ -20,6 +21,8 @@
 #include <vital/config/config_block_io.h>
 #include <vital/config/config_block_formatter.h>
 
+#include <vital/io/metadata_io.h>
+
 #include <vital/util/get_paths.h>
 #include <vital/util/wrap_text_block.h>
 
@@ -28,6 +31,8 @@
 #include <vital/types/metadata_traits.h>
 
 #include <vital/exceptions.h>
+
+#include <kwiversys/SystemTools.hxx>
 
 namespace kv = kwiver::vital;
 namespace kva = kwiver::vital::algo;
@@ -58,6 +63,11 @@ add_command_options()
       "array of metadata fields. Alternatively, the configuration file, "
       "dump_klv.conf, can be updated to use CSV instead.",
       cxxopts::value< std::string >() )
+    ( "f,frames", "Dump frames into the given image format.",
+      cxxopts::value< std::string >(), "extension" )
+    ( "frames-dir", "Directory in which to dump frames. "
+      "Defaults to current directory.",
+      cxxopts::value< std::string >(), "path" )
     ( "d,detail", "Display a detailed description of the metadata" )
     ( "q,quiet", "Do not show metadata. Overrides -d/--detail." )
 
@@ -104,6 +114,7 @@ dump_klv
 
   kva::video_input_sptr video_reader;
   kva::metadata_map_io_sptr metadata_serializer_ptr;
+  kva::image_io_sptr image_writer;
   auto config = this->find_configuration("applets/dump_klv.conf");
 
   // If --config given, read in config file, merge in with default just generated
@@ -120,6 +131,10 @@ dump_klv
     "metadata_serializer", config, metadata_serializer_ptr );
   kva::metadata_map_io::get_nested_algo_configuration(
     "metadata_serializer", config, metadata_serializer_ptr );
+  kva::image_io::set_nested_algo_configuration(
+    "image_writer", config, image_writer );
+  kva::image_io::get_nested_algo_configuration(
+    "image_writer", config, image_writer );
 
   // Check to see if we are to dump config
   if ( cmd_args.count("output") )
@@ -152,6 +167,13 @@ dump_klv
     return EXIT_FAILURE;
   }
 
+  if( !kva::image_io::check_nested_algo_configuration(
+         "image_writer", config ) )
+  {
+    std::cerr << "Invalid image_writer config" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // instantiate a video reader
   try
   {
@@ -178,7 +200,6 @@ dump_klv
   }
 
   int count(1);
-  kv::image_container_sptr frame;
   kv::timestamp ts;
   kv::wrap_text_block wtb;
   kv::metadata_map::map_metadata_t frame_metadata;
@@ -237,6 +258,23 @@ dump_klv
         }
       } // end for over metadata collection vector
     } // The end of not quiet
+
+    if( cmd_args.count( "frames" ) )
+    {
+      std::string directory = ".";
+      if( cmd_args.count( "frames-dir" ) )
+      {
+        directory = cmd_args[ "frames-dir" ].as< std::string >();
+      }
+      auto const name = kv::basename_from_metadata( metadata, ts.get_frame() );
+      auto const extension = cmd_args[ "frames" ].as< std::string >();
+      auto const filename = name + "." + extension;
+      auto const filepath =
+        kwiversys::SystemTools::JoinPath( { "", directory, filename } );
+      auto const image = video_reader->frame_image();
+      image_writer->save( filepath, image );
+    }
+
     ++count;
   } // end while over video
 

--- a/config/applets/dump_klv.conf
+++ b/config/applets/dump_klv.conf
@@ -4,3 +4,5 @@ video_reader:type = ffmpeg
 video_reader:vidl_ffmpeg:time_source = misp
 
 metadata_serializer:type = json
+
+image_writer:type = ocv


### PR DESCRIPTION
Add the ability to dump frame images in addition to KLV metadata. Options are included to specify the image file format and output directory. OpenCV is specified as the default image writing implementation because the current `Dockerfile` guarantees it will be built.