### PR TITLE
Add KLV demuxer

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -11,6 +11,7 @@ set( sources
   klv_convert_vital.cxx
   klv_data.cxx
   klv_data_format.cxx
+  klv_demuxer.cxx
   klv_key.cxx
   klv_packet.cxx
   klv_parse.cxx
@@ -19,25 +20,38 @@ set( sources
   klv_tag_traits.cxx
   klv_timeline.cxx
   klv_value.cxx
-  klv_0601.cxx
-  klv_0601_new.cxx
   klv_0104.cxx
   klv_0104_new.cxx
+  klv_0601.cxx
+  klv_0601_new.cxx
   klv_1108.cxx
   klv_1108_metric_set.cxx
   )
 
 set( public_headers
   convert_metadata.h
+  klv_blob.h
   klv_data.h
+  klv_demuxer.h
   klv_key.h
+  klv_packet.h
   klv_parse.h
-  klv_0601.h
+  klv_set.h
+  klv_timeline.h
+  klv_value.h
   klv_0104.h
+  klv_0104_new.h
+  klv_0601.h
+  klv_0601_new.h
+  klv_1108.h
+  klv_1108_metric_set.h
   misp_time.h
   )
 
 set( private_headers
+  klv_data_format.h
+  klv_read_write.h
+  klv_tag_traits.h
   klv_0601_traits.h
 )
 

--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -33,11 +33,26 @@ namespace {
 // ----------------------------------------------------------------------------
 struct klv_to_vital_visitor
 {
-  template < class T >
+  template < class T,
+             typename std::enable_if< std::is_same< T, uint64_t >::value ||
+                                      std::is_same< T, double >::value ||
+                                      std::is_same< T, std::string >::value,
+                                      bool >::type = true >
   kv::metadata_value
   operator()() const
   {
     return value.get< T >();
+  }
+
+  template < class T,
+             typename std::enable_if< !std::is_same< T, uint64_t >::value &&
+                                      !std::is_same< T, double >::value &&
+                                      !std::is_same< T, std::string >::value,
+                                      bool >::type = true >
+  kv::metadata_value
+  operator()() const
+  {
+    throw std::logic_error( "type does not exist in klv_value" );
   }
 
   klv_value const& value;
@@ -174,7 +189,7 @@ klv_0104_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
     klv_data.at( standard, KLV_0104_EPISODE_NUMBER, timestamp );
   if( episode_number.valid() )
   {
-    auto const value = episode_number.get< float >();
+    auto const value = episode_number.get< double >();
     std::stringstream ss;
     ss << std::fixed << value;
     vital_data.add< kv::VITAL_META_MISSION_NUMBER >( ss.str() );

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -126,118 +126,26 @@ public:
   using data_type = T;
 
   explicit
-  klv_data_format_( size_t fixed_length ) : klv_data_format{ fixed_length }
-  {}
+  klv_data_format_( size_t fixed_length );
 
   virtual
-  ~klv_data_format_() = default;
+  ~klv_data_format_();
 
   klv_value
-  read( klv_read_iter_t& data, size_t length ) const override final
-  {
-    if( !length )
-    {
-      // Zero length: null / unknown value
-      return klv_value{};
-    }
-    else if( m_fixed_length && length != m_fixed_length )
-    {
-      // Invalid length
-      std::stringstream ss;
-      ss        << "fixed-length format `" << description()
-                << "` received wrong number of bytes ( " << length << " )";
-      VITAL_THROW( kwiver::vital::metadata_exception, ss.str() );
-    }
-
-    try
-    {
-      // Try to parse using this data format
-      return klv_value{ read_typed( data, length ), length };
-    }
-    catch ( std::exception const& e )
-    {
-      // Return blob if parsing failed
-      LOG_ERROR( kwiver::vital::get_logger( "klv.read" ),
-                 "error occurred during parsing: " << e.what() );
-      return klv_value{ klv_read_blob( data, length ), length };
-    }
-  }
+  read( klv_read_iter_t& data, size_t length ) const override final;
 
   void
   write( klv_value const& value, klv_write_iter_t& data,
-         size_t max_length ) const override final
-  {
-    if( value.empty() )
-    {
-      // Null / unknown value: write nothing
-      return;
-    }
-    else if( !value.valid() )
-    {
-      // Unparsed value: write raw bytes
-      klv_write_blob( value.get< klv_blob >(), data, max_length );
-    }
-    else
-    {
-      // Ensure we have enough bytes
-      auto const value_length = length_of( value );
-      if( value_length > max_length )
-      {
-        VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
-                     "write will overflow buffer" );
-      }
-
-      // Write the value
-      auto const begin = data;
-      write_typed( value.get< T >(), data, value_length );
-
-      // Ensure the number of bytes we wrote was how many we said we were going
-      // to write
-      auto const written_length =
-        static_cast< size_t >( std::distance( begin, data ) );
-      if( written_length != value_length )
-      {
-        std::stringstream ss;
-        ss      << "format `" << description() << "`: "
-                << "written length (" << written_length << ") and "
-                << "calculated length (" << value_length <<  ") not equal";
-        throw std::logic_error( ss.str() );
-      }
-    }
-  }
+         size_t max_length ) const override final;
 
   size_t
-  length_of( klv_value const& value ) const override final
-  {
-    if( value.empty() )
-    {
-      return 0;
-    }
-    else if( !value.valid() )
-    {
-      return value.get< klv_blob >()->size();
-    }
-    else
-    {
-      return m_fixed_length
-             ? m_fixed_length
-             : length_of_typed( value.get< T >(), value.length_hint() );
-    }
-  }
+  length_of( klv_value const& value ) const override final;
 
   std::type_info const&
-  type() const override final
-  {
-    return typeid( T );
-  }
+  type() const override final;
 
   std::ostream&
-  print( std::ostream& os, klv_value const& value ) const override final
-  {
-    return !value.valid()
-           ? ( os << value )
-           : print_typed( os, value.get< T >(), value.length_hint() );
-  }
+  print( std::ostream& os, klv_value const& value ) const override final;
 
 protected:
   // These functions are overridden by the specific data format classes.
@@ -252,32 +160,10 @@ protected:
                size_t length ) const = 0;
 
   virtual size_t
-  length_of_typed( VITAL_UNUSED T const& value, size_t length_hint ) const
-  {
-    if( length_hint )
-    {
-      return length_hint;
-    }
-
-    std::stringstream ss;
-    ss  << "application must provide length of variable-length format `"
-        << description() << "`";
-    throw std::logic_error( ss.str() );
-  }
+  length_of_typed( T const& value, size_t length_hint ) const;
 
   virtual std::ostream&
-  print_typed( std::ostream& os, T const& value,
-               VITAL_UNUSED size_t length_hint ) const
-  {
-    if( std::is_same< T, std::string >::value )
-    {
-      return os << '"' << value << '"';
-    }
-    else
-    {
-      return os << value;
-    }
-  }
+  print_typed( std::ostream& os, T const& value, size_t length_hint ) const;
 };
 
 // ----------------------------------------------------------------------------
@@ -391,43 +277,25 @@ class KWIVER_ALGO_KLV_EXPORT klv_enum_format
 public:
   using data_type = typename std::decay< T >::type;
 
-  klv_enum_format( size_t fixed_length = 1 )
-    : klv_data_format_< data_type >{ fixed_length }
-  {}
+  klv_enum_format( size_t fixed_length = 1 );
 
   virtual
-  ~klv_enum_format() = default;
+  ~klv_enum_format();
 
   std::string
-  description() const override
-  {
-    std::stringstream ss;
-    ss << this->type_name() << " enumeration of "
-       << this->length_description();
-    return ss.str();
-  }
+  description() const override;
 
 protected:
   data_type
-  read_typed( klv_read_iter_t& data, size_t length ) const override
-  {
-    return static_cast< data_type >(
-      klv_read_int< uint64_t >( data, length ) );
-  }
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
 
   void
   write_typed( data_type const& value,
-               klv_write_iter_t& data, size_t length ) const override
-  {
-    klv_write_int( static_cast< uint64_t >( value ), data, length );
-  }
+               klv_write_iter_t& data, size_t length ) const override;
 
   size_t
   length_of_typed( data_type const& value,
-                   VITAL_UNUSED size_t length_hint ) const override
-  {
-    return klv_int_length( static_cast< uint64_t >( value ) );
-  }
+                   VITAL_UNUSED size_t length_hint ) const override;
 
   size_t m_length;
 };

--- a/arrows/klv/klv_demuxer.cxx
+++ b/arrows/klv/klv_demuxer.cxx
@@ -1,0 +1,431 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Implementation of KLV demuxer.
+
+#include "klv_0104_new.h"
+#include "klv_0601_new.h"
+#include "klv_1108.h"
+#include "klv_1108_metric_set.h"
+#include "klv_demuxer.h"
+
+#include <vital/logger/logger.h>
+#include <vital/range/iota.h>
+
+namespace kv = kwiver::vital;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Values are valid for 30 seconds if not explicitly overridden.
+constexpr uint64_t klv_packet_default_duration = 30000000;
+constexpr uint64_t klv_0104_default_duration = klv_packet_default_duration;
+constexpr uint64_t klv_0601_default_duration = klv_packet_default_duration;
+
+// ----------------------------------------------------------------------------
+uint64_t
+klv_find_or_insert_1108( klv_timeline& timeline,
+                         klv_local_set const& parent_set,
+                         klv_value const& metric_set_value )
+{
+  constexpr auto standard = KLV_PACKET_MISB_1108_LOCAL_SET;
+
+  // Invalid metric sets are all treated as unique and therefore an equivalent
+  // sub-timeline cannot be found
+  if( metric_set_value.valid() )
+  {
+    auto const& metric_set = metric_set_value.get< klv_local_set >();
+
+    // The METRIC_LOCAL_SET tag is used to get all the unique metrics being
+    // tracked.
+    auto const candidates =
+      timeline.find_all( standard, KLV_1108_METRIC_LOCAL_SET );
+    for( auto candidate : candidates )
+    {
+      // We are trying to find out if this candidate set of sub-timelines is
+      // tracking the same metric as the new one we want to insert
+      auto is_match = true;
+      auto const index = candidate.first.index;
+
+      // Either of these tags in the parent set being different would mean the
+      // new metric should be tracked separately
+      for( auto const tag : { KLV_1108_ASSESSMENT_POINT,
+                              KLV_1108_WINDOW_CORNERS_PACK } )
+      {
+        auto const it = timeline.find( standard, tag, index );
+
+        // All this to check whether the values are different, the complexity
+        // coming from the fact that we don't assume either value exists in the
+        // first place, since WINDOWS_CORNER_PACK is optional
+        if( it != timeline.end() && !it->second.empty() &&
+            ( it->second.begin()->value.empty() != !parent_set.has( tag ) ||
+              ( parent_set.has( tag ) &&
+                it->second.begin()->value != parent_set.at( tag ) ) ) )
+        {
+          is_match = false;
+          break;
+        }
+      }
+
+      // Early exit
+      if( !is_match )
+      {
+        continue;
+      }
+
+      // Find the embedded metric set for this candidate, ensuring it exists
+      auto const metric_set_it =
+        timeline.find( standard, KLV_1108_METRIC_LOCAL_SET, index );
+      if( metric_set_it == timeline.end() || metric_set_it->second.empty() )
+      {
+        continue;
+      }
+
+      auto const& candidate_metric_set =
+        metric_set_it->second.begin()->value.get< klv_local_set >();
+
+      // Any of these tags being different would mean the new metric should be
+      // tracked separately
+      for( auto const tag : { KLV_1108_METRIC_SET_NAME,
+                              KLV_1108_METRIC_SET_VERSION,
+                              KLV_1108_METRIC_SET_IMPLEMENTER,
+                              KLV_1108_METRIC_SET_PARAMETERS } )
+      {
+        // These are all mandatory tags, so we assume they exist
+        if( candidate_metric_set.at( tag ) != metric_set.at( tag ) )
+        {
+          is_match = false;
+          break;
+        }
+      }
+
+      // Return the index found if successful
+      if( is_match )
+      {
+        return index;
+      }
+    }
+  }
+
+  // Finding an existing sub-timeline to use failed; insert new one
+  auto const index =
+    timeline.insert( standard, KLV_1108_ASSESSMENT_POINT )->first.index;
+  for( auto const i :
+       kv::range::iota( static_cast< klv_lds_key >( KLV_1108_ENUM_END ) ) )
+  {
+    auto const tag = static_cast< klv_1108_tag >( i );
+    // We don't track these tags
+    if( tag == KLV_1108_METRIC_PERIOD_PACK || tag == KLV_1108_CHECKSUM )
+    {
+      continue;
+    }
+
+    timeline.insert_or_find( standard, tag, index );
+  }
+
+  return index;
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+klv_demuxer
+::klv_demuxer( klv_timeline& timeline )
+  : m_last_timestamp{ 0 }, m_unknown_key_indices{}, m_timeline( timeline ) {}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_packet( klv_packet const& packet )
+{
+  auto const& trait = klv_lookup_packet_traits().by_uds_key( packet.key );
+
+  // Invalid or unrecognized packets are still saved in raw byte form
+  if( !packet.value.valid() )
+  {
+    demux_unknown( packet );
+    return;
+  }
+
+  // Demux based on type of packet
+  switch( trait.tag() )
+  {
+    case KLV_PACKET_MISB_0601_LOCAL_SET:
+      demux_0601( packet.value.get< klv_local_set >() );
+      break;
+    case KLV_PACKET_MISB_0104_UNIVERSAL_SET:
+      demux_0104( packet.value.get< klv_universal_set >() );
+      break;
+    case KLV_PACKET_MISB_1108_LOCAL_SET:
+      demux_1108( packet.value.get< klv_local_set >() );
+      break;
+    case KLV_PACKET_UNKNOWN:
+    default:
+      throw std::logic_error( "klv packet with unknown key but valid value" );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::seek( uint64_t timestamp )
+{
+  m_last_timestamp = timestamp;
+}
+
+// ----------------------------------------------------------------------------
+klv_timeline&
+klv_demuxer
+::timeline() const
+{
+  return m_timeline;
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_unknown( klv_packet const& packet )
+{
+  // Keep track of which unknown keys map to which timelines
+  auto index_it = m_unknown_key_indices.find( packet.key );
+
+  // Create new timeline for this key if it's new
+  if( index_it == m_unknown_key_indices.end() )
+  {
+    auto const index = m_timeline.insert( KLV_PACKET_UNKNOWN, 0 )->first.index;
+    index_it = m_unknown_key_indices.emplace( packet.key, index ).first;
+  }
+
+  auto& unknown_timeline =
+    m_timeline.find( KLV_PACKET_UNKNOWN, 0, index_it->second )->second;
+
+  // Add this packet to a list (created here if necessary) of unknown packets
+  // at this timestamp.
+  // m_last_timestamp used here because we can't extract a timestamp from a
+  // packet of unknown format
+  auto const unknown_it = unknown_timeline.find( m_last_timestamp );
+  if( unknown_it == unknown_timeline.end() )
+  {
+    unknown_timeline.set( { m_last_timestamp, m_last_timestamp + 1 },
+                          std::vector< klv_packet >{ packet } );
+  }
+  else
+  {
+    unknown_it->value.get< std::vector< klv_packet > >()
+      .emplace_back( packet );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_0104( klv_universal_set const& value )
+{
+  constexpr auto standard = KLV_PACKET_MISB_0104_UNIVERSAL_SET;
+
+  // Extract timestamp
+  auto const& lookup = klv_0104_traits_lookup();
+  auto const timestamp_key =
+    lookup.by_tag( KLV_0104_USER_DEFINED_TIMESTAMP ).uds_key();
+  auto const timestamp = value.at( timestamp_key ).get< uint64_t >();
+  if( !check_timestamp( timestamp ) )
+  {
+    return;
+  }
+
+  // By default, valid for 30 seconds
+  auto const time_interval =
+    interval_t{ timestamp, timestamp + klv_0104_default_duration };
+
+  for( auto const& entry : value )
+  {
+    // Timestamp already implicitly encoded
+    if( entry.first == timestamp_key )
+    {
+      continue;
+    }
+
+    // No duplicate entries allowed, so this is relatively straightforward
+    auto const& trait = lookup.by_uds_key( entry.first );
+    demux_single_entry( standard, trait.tag(), 0, time_interval,
+                        entry.second );
+  }
+
+  // Update timestamp
+  m_last_timestamp = timestamp;
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_0601( klv_local_set const& value )
+{
+  auto const standard = KLV_PACKET_MISB_0601_LOCAL_SET;
+
+  // Extract timestamp
+  auto const timestamp =
+    value.at( KLV_0601_PRECISION_TIMESTAMP ).get< uint64_t >();
+  if( !check_timestamp( timestamp ) )
+  {
+    return;
+  }
+
+  // By default, valid for 30 seconds
+  auto const time_interval =
+    interval_t{ timestamp, timestamp + klv_0601_default_duration };
+
+  for( auto const& entry : value )
+  {
+    auto const tag = entry.first;
+
+    // Timestamp already implicitly encoded
+    if( tag == KLV_0601_PRECISION_TIMESTAMP )
+    {
+      continue;
+    }
+
+    // TODO: Add special list accumulation logic for tags:
+    // KLV_0601_CONTROL_COMMAND_VERIFICATION_LIST
+    // KLV_0601_ACTIVE_WAVELENGTH_LIST
+    // KLV_0601_WAVELENGTHS_LIST
+    // KLV_0601_PAYLOAD_LIST
+    // KLV_0601_WAYPOINT_LIST
+
+    // TODO: Deal with tags which can have multiple entries:
+    // KLV_0601_SEGMENT_LOCAL_SET
+    // KLV_0601_AMEND_LOCAL_SET
+    // KLV_0601_SDCC_FLP
+
+    // CONTROL_COMMAND is a special case. It supports multiple entries, but is
+    // nonetheless easy to implement, since it gives us a unique id that we can
+    // use to track each entry over time, allowing it to be treated similarly
+    // to a single-entry tag
+    auto index = 0;
+    if( entry.first == KLV_0601_CONTROL_COMMAND )
+    {
+      index = entry.second.get< klv_0601_control_command >().id;
+    }
+
+    // Single-entry tags passed off here
+    demux_single_entry( standard, entry.first, index, time_interval,
+                        entry.second );
+  }
+
+  // Update timestamp
+  m_last_timestamp = timestamp;
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_1108( klv_local_set const& value )
+{
+  constexpr auto standard = KLV_PACKET_MISB_1108_LOCAL_SET;
+
+  // Extract timestamp
+  auto const metric_period = value.at( KLV_1108_METRIC_PERIOD_PACK )
+    .get< klv_1108_metric_period_pack >();
+  if( !check_timestamp( metric_period.timestamp ) )
+  {
+    return;
+  }
+
+  // Valid for the period of time specified in METRIC_PERIOD_PACK field
+  auto const time_interval =
+    interval_t{ metric_period.timestamp,
+                metric_period.timestamp + metric_period.offset };
+
+  // Each 1108 local set can have multiple metrics, each contained in its own
+  // metric local set. Items in the parent set are shared among the metric
+  // sets. We want to create one index for each *metric set*, copying the
+  // parent set's common data to each.
+  for( auto const& metric_set_entry :
+       value.all_at( KLV_1108_METRIC_LOCAL_SET ) )
+  {
+    // Create the and fill the index for this metric set
+    auto const index =
+      klv_find_or_insert_1108( m_timeline, value, metric_set_entry.second );
+    demux_single_entry( standard, KLV_1108_METRIC_LOCAL_SET, index,
+                        time_interval, metric_set_entry.second );
+
+    // Copy the parent's data to this metric set's index
+    for( auto const& entry : value )
+    {
+      auto const tag = entry.first;
+
+      // We've already encoded these
+      if( tag == KLV_1108_METRIC_LOCAL_SET ||
+          tag == KLV_1108_METRIC_PERIOD_PACK )
+      {
+        continue;
+      }
+
+      demux_single_entry( standard, tag, index, time_interval, entry.second );
+    }
+  }
+
+  // Update timestamp
+  m_last_timestamp = metric_period.timestamp;
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::demux_single_entry( klv_top_level_tag standard, klv_lds_key tag,
+                      uint64_t index, interval_t const& time_interval,
+                      klv_value const& value )
+{
+  if( value.empty() )
+  {
+    // Null value: erase timespan instead of adding a null entry
+    auto const it = m_timeline.find( standard, tag );
+    if( it == m_timeline.end() )
+    {
+      return;
+    }
+
+    auto const inner_it = it->second.find( time_interval.lower() );
+    if( inner_it == it->second.end() )
+    {
+      return;
+    }
+    it->second.erase( { time_interval.lower(),
+                        inner_it->key_interval.upper() } );
+  }
+  else
+  {
+    // Non-null value: add new entry
+    auto const it = m_timeline.insert_or_find( standard, tag, index );
+    it->second.set( time_interval, value );
+  }
+}
+
+// ----------------------------------------------------------------------------
+bool
+klv_demuxer
+::check_timestamp( uint64_t timestamp ) const
+{
+  // Packets *must* be fed to demuxer in chronological order to prevent older
+  // packets from incorrectly overriding newer packets.
+  auto const result = timestamp >= m_last_timestamp;
+  if( !result )
+  {
+    LOG_ERROR( kv::get_logger( "klv" ),
+               "demuxer: dropping out-of-order packet" );
+  }
+  return result;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_demuxer.h
+++ b/arrows/klv/klv_demuxer.h
@@ -1,0 +1,69 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Declaration of KLV demuxer.
+
+#include "klv_timeline.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Holds state for the process of assembling a \c klv_timeline from a
+/// sequence of \c klv_packet.
+class KWIVER_ALGO_KLV_EXPORT klv_demuxer
+{
+public:
+  using interval_t = typename klv_timeline::interval_t;
+  using interval_map_t = typename klv_timeline::interval_map_t;
+
+  /// \param timeline KLV timeline to modify.
+  explicit klv_demuxer( klv_timeline& timeline );
+
+  /// Incorporate next \p packet into the timeline.
+  void demux_packet( klv_packet const& packet );
+
+  /// Move the current time to \p timestamp.
+  ///
+  /// Data in the timeline ahead of \p timestamp is not deleted, but loses its
+  /// guarantee of correctness: older packets may overwrite newer data.
+  void seek( uint64_t timestamp );
+
+  /// Return the timeline being modified.
+  klv_timeline&
+  timeline() const;
+
+private:
+  using key_t = typename klv_timeline::key_t;
+
+  void demux_unknown( klv_packet const& packet );
+
+  void demux_0104( klv_universal_set const& value );
+
+  void demux_0601( klv_local_set const& value );
+
+  void demux_1108( klv_local_set const& value );
+
+  void demux_single_entry( klv_top_level_tag standard,
+                           klv_lds_key tag,
+                           uint64_t index,
+                           interval_t const& time_interval,
+                           klv_value const& value );
+
+  bool check_timestamp( uint64_t timestamp ) const;
+
+  uint64_t m_last_timestamp;
+  std::map< klv_uds_key, uint64_t > m_unknown_key_indices;
+  klv_timeline& m_timeline;
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -23,6 +23,21 @@ namespace klv {
 
 // ----------------------------------------------------------------------------
 bool
+operator<( klv_packet const& lhs, klv_packet const& rhs )
+{
+  if( lhs.key < rhs.key )
+  {
+    return true;
+  }
+  if( rhs.key < lhs.key )
+  {
+    return false;
+  }
+  return lhs.value < rhs.value;
+}
+
+// ----------------------------------------------------------------------------
+bool
 operator==( klv_packet const& lhs, klv_packet const& rhs )
 {
   return lhs.key == rhs.key && lhs.value == rhs.value;

--- a/arrows/klv/klv_packet.h
+++ b/arrows/klv/klv_packet.h
@@ -45,6 +45,11 @@ struct KWIVER_ALGO_KLV_EXPORT klv_packet
 // ----------------------------------------------------------------------------
 KWIVER_ALGO_KLV_EXPORT
 bool
+operator<( klv_packet const& lhs, klv_packet const& rhs );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
 operator==( klv_packet const& lhs, klv_packet const& rhs );
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_set.cxx
+++ b/arrows/klv/klv_set.cxx
@@ -13,11 +13,351 @@ namespace arrows {
 
 namespace klv {
 
-template class klv_set< klv_lds_key >;
-template class klv_set< klv_uds_key >;
+// ----------------------------------------------------------------------------
+template < class Key >
+klv_set< Key >
 
-template class klv_set_format< klv_lds_key >;
-template class klv_set_format< klv_uds_key >;
+::klv_set() {}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+klv_set< Key >
+
+::klv_set( container const& items ) : m_items{ items } {}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+klv_set< Key >
+
+::klv_set( std::initializer_list< value_type > const& items )
+  : m_items{ items } {}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::iterator
+
+klv_set< Key >
+::begin()
+{
+  return m_items.begin();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_iterator
+
+klv_set< Key >
+::begin() const
+{
+  return m_items.cbegin();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_iterator
+
+klv_set< Key >
+::cbegin() const
+{
+  return m_items.cbegin();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::iterator
+
+klv_set< Key >
+::end()
+{
+  return m_items.end();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_iterator
+
+klv_set< Key >
+::end() const
+{
+  return m_items.cend();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_iterator
+
+klv_set< Key >
+::cend() const
+{
+  return m_items.cend();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+size_t
+klv_set< Key >
+::size() const
+{
+  return m_items.size();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+size_t
+klv_set< Key >
+::count( Key const& key ) const
+{
+  return m_items.count( key );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+bool
+klv_set< Key >
+::has( Key const& key ) const
+{
+  return m_items.count( key );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+void
+klv_set< Key >
+::add( Key const& key, klv_value const& datum )
+{
+  m_items.emplace( key, datum );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+void
+klv_set< Key >
+::erase( const_iterator it )
+{
+  m_items.erase( it );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+void
+klv_set< Key >
+::erase( Key const& key )
+{
+  m_items.erase( key );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+void
+klv_set< Key >
+::clear()
+{
+  m_items.clear();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::iterator
+
+klv_set< Key >
+::find( Key const& key )
+{
+  auto const it = m_items.lower_bound( key );
+  if( it != m_items.end() )
+  {
+    auto const next_it = std::next( it );
+    if( next_it == m_items.end() || next_it->first != key )
+    {
+      return it;
+    }
+  }
+  return m_items.end();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_iterator
+
+klv_set< Key >
+::find( Key const& key ) const
+{
+  auto const it = m_items.lower_bound( key );
+  if( it != m_items.end() )
+  {
+    auto const next_it = std::next( it );
+    if( next_it == m_items.end() || next_it->first != key )
+    {
+      return it;
+    }
+  }
+  return m_items.cend();
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+klv_value&
+klv_set< Key >
+::at( Key const& key )
+{
+  auto const it = m_items.lower_bound( key );
+  if( it != m_items.end() )
+  {
+    auto const next_it = std::next( it );
+    if( next_it == m_items.end() || next_it->first != key )
+    {
+      return it->second;
+    }
+    throw std::logic_error( "more than one instance of key found" );
+  }
+  throw std::out_of_range( "key not found" );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+klv_value const&
+klv_set< Key >
+::at( Key const& key ) const
+{
+  auto const it = m_items.lower_bound( key );
+  if( it != m_items.cend() )
+  {
+    auto const next_it = std::next( it );
+    if( next_it == m_items.cend() || next_it->first != key )
+    {
+      return it->second;
+    }
+    throw std::runtime_error( "more than one instance of key found" );
+  }
+  throw std::out_of_range( "key not found" );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::range
+
+klv_set< Key >
+::all_at( Key const& key )
+{
+  auto const equal_range = m_items.equal_range( key );
+  return { equal_range.first, equal_range.second };
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+typename klv_set< Key >::const_range
+
+klv_set< Key >
+::all_at( Key const& key ) const
+{
+  auto const equal_range = m_items.equal_range( key );
+  return { equal_range.first, equal_range.second };
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+std::vector< typename klv_set< Key >::const_iterator >
+klv_set< Key >
+::fully_sorted() const
+{
+  std::vector< const_iterator > result;
+  for( auto it = cbegin(); it != cend(); ++it )
+  {
+    result.push_back( it );
+  }
+  std::sort( result.begin(), result.end(), value_compare );
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+bool
+operator==( klv_set< Key > const& lhs, klv_set< Key > const& rhs )
+{
+  using const_iterator = typename klv_set< Key >::const_iterator;
+  if( lhs.size() != rhs.size() )
+  {
+    return false;
+  }
+
+  auto const lhs_values = lhs.fully_sorted();
+  auto const rhs_values = rhs.fully_sorted();
+
+  return std::equal( lhs_values.cbegin(), lhs_values.cend(),
+                     rhs_values.cbegin(),
+                     []( const_iterator lhs_value, const_iterator rhs_value ){
+                       return *lhs_value == *rhs_value;
+                     } );
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+bool
+operator<( klv_set< Key > const& lhs, klv_set< Key > const& rhs )
+{
+  if( lhs.size() < rhs.size() )
+  {
+    return true;
+  }
+  else if( lhs.size() == rhs.size() )
+  {
+    auto const lhs_values = lhs.fully_sorted();
+    auto const rhs_values = rhs.fully_sorted();
+    return std::lexicographical_compare(
+      lhs_values.cbegin(), lhs_values.cend(),
+      rhs_values.cbegin(), rhs_values.cend(),
+      klv_set< Key >::value_compare );
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+std::ostream&
+operator<<( std::ostream& os, klv_set< Key > const& rhs )
+{
+  auto const values = rhs.fully_sorted();
+  os << "{ ";
+
+  bool first = true;
+  for( auto const pair : values )
+  {
+    first = first ? false : ( os << ", ", false );
+    os << pair->first << ": " << pair->second;
+  }
+  os << " }";
+  return os;
+}
+
+// ----------------------------------------------------------------------------
+template < class Key >
+bool
+klv_set< Key >
+::value_compare( const_iterator lhs, const_iterator rhs )
+{
+  if( lhs->first < rhs->first )
+  {
+    return true;
+  }
+  else if( lhs->first == rhs->first )
+  {
+    return lhs->second < rhs->second;
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+#define KLV_INSTANTIATE( Key )                                 \
+  template class KWIVER_ALGO_KLV_EXPORT klv_set< Key >;        \
+  template class KWIVER_ALGO_KLV_EXPORT klv_set_format< Key >; \
+  template bool operator== < Key >( klv_set< Key > const&,     \
+                                    klv_set< Key > const& );   \
+  template bool operator< < Key >( klv_set< Key > const&,      \
+                                   klv_set< Key > const& );    \
+  template std::ostream& operator<< < Key >( std::ostream&,    \
+                                             klv_set< Key > const& )
+
+KLV_INSTANTIATE( klv_lds_key );
+KLV_INSTANTIATE( klv_uds_key );
 
 } // namespace klv
 

--- a/arrows/klv/klv_set.h
+++ b/arrows/klv/klv_set.h
@@ -44,258 +44,100 @@ public:
   using range = kwiver::vital::range::iterator_range< iterator >;
   using const_range = kwiver::vital::range::iterator_range< const_iterator >;
 
-  klv_set() {}
+  klv_set();
 
-  klv_set( container const& items ) : m_items{ items } {}
+  klv_set( container const& items );
 
-  klv_set( std::initializer_list< value_type > const& items )
-    : m_items{ items } {}
-
-  iterator
-  begin()
-  {
-    return m_items.begin();
-  }
-
-  const_iterator
-  begin() const
-  {
-    return m_items.cbegin();
-  }
-
-  const_iterator
-  cbegin() const
-  {
-    return m_items.cbegin();
-  }
+  klv_set( std::initializer_list< value_type > const& items );
 
   iterator
-  end()
-  {
-    return m_items.end();
-  }
+  begin();
 
   const_iterator
-  end() const
-  {
-    return m_items.cend();
-  }
+  begin() const;
 
   const_iterator
-  cend() const
-  {
-    return m_items.cend();
-  }
+  cbegin() const;
+
+  iterator
+  end();
+
+  const_iterator
+  end() const;
+
+  const_iterator
+  cend() const;
 
   size_t
-  size() const
-  {
-    return m_items.size();
-  }
+  size() const;
 
   size_t
-  count( Key const& key ) const
-  {
-    return m_items.count( key );
-  }
+  count( Key const& key ) const;
 
   bool
-  has( Key const& key ) const
-  {
-    return m_items.count( key );
-  }
+  has( Key const& key ) const;
 
   void
-  add( Key const& key, klv_value const& datum )
-  {
-    m_items.emplace( key, datum );
-  }
+  add( Key const& key, klv_value const& datum );
 
   void
-  erase( const_iterator it )
-  {
-    m_items.erase( it );
-  }
+  erase( const_iterator it );
 
   void
-  erase( Key const& key )
-  {
-    m_items.erase( key );
-  }
+  erase( Key const& key );
 
   void
-  clear()
-  {
-    m_items.clear();
-  }
+  clear();
 
   /// Return single entry corresponding to \p key, or end iterator on failure.
   iterator
-  find( Key const& key )
-  {
-    auto const it = m_items.lower_bound( key );
-    if( it != m_items.end() )
-    {
-      auto const next_it = std::next( it );
-      if( next_it == m_items.end() || next_it->first != key )
-      {
-        return it;
-      }
-    }
-    return m_items.end();
-  }
+  find( Key const& key );
 
   /// \copydoc iterator find( Key const& key )
   const_iterator
-  find( Key const& key ) const
-  {
-    auto const it = m_items.lower_bound( key );
-    if( it != m_items.end() )
-    {
-      auto const next_it = std::next( it );
-      if( next_it == m_items.end() || next_it->first != key )
-      {
-        return it;
-      }
-    }
-    return m_items.cend();
-  }
+  find( Key const& key ) const;
 
   /// Return single value corresponding to \p key.
   ///
   /// \throws out_of_range If no \p key entry is present.
   /// \throws logic_error If more than one \p key entry is present.
   klv_value&
-  at( Key const& key )
-  {
-    auto const it = m_items.lower_bound( key );
-    if( it != m_items.end() )
-    {
-      auto const next_it = std::next( it );
-      if( next_it == m_items.end() || next_it->first != key )
-      {
-        return it->second;
-      }
-      throw std::logic_error( "more than one instance of key found" );
-    }
-    throw std::out_of_range( "key not found" );
-  }
+  at( Key const& key );
 
   /// \copydoc klv_value& at( Key const& key )
   klv_value const&
-  at( Key const& key ) const
-  {
-    auto const it = m_items.lower_bound( key );
-    if( it != m_items.cend() )
-    {
-      auto const next_it = std::next( it );
-      if( next_it == m_items.cend() || next_it->first != key )
-      {
-        return it->second;
-      }
-      throw std::runtime_error( "more than one instance of key found" );
-    }
-    throw std::out_of_range( "key not found" );
-  }
+  at( Key const& key ) const;
 
   /// Return the range of entries corresponding to \p key.
   ///
   /// \note Order of entries returned is not defined.
   range
-  all_at( Key const& key )
-  {
-    auto const equal_range = m_items.equal_range( key );
-    return { equal_range.first, equal_range.second };
-  }
+  all_at( Key const& key );
 
   /// \copydoc range all_at( Key const& key )
   const_range
-  all_at( Key const& key ) const
-  {
-    auto const equal_range = m_items.equal_range( key );
-    return { equal_range.first, equal_range.second };
-  }
+  all_at( Key const& key ) const;
 
   /// Returns iterators to all entries, sorted by key, then by value.
   std::vector< const_iterator >
-  fully_sorted() const
-  {
-    std::vector< const_iterator > result;
-    for( auto it = cbegin(); it != cend(); ++it )
-    {
-      result.push_back( it );
-    }
-    std::sort( result.begin(), result.end(), value_compare );
-    return result;
-  }
+  fully_sorted() const;
 
+  template < class K >
   friend bool
-  operator==( klv_set< Key > const& lhs, klv_set< Key > const& rhs )
-  {
-    if( lhs.size() != rhs.size() )
-    {
-      return false;
-    }
+  operator==( klv_set< K > const& lhs, klv_set< K > const& rhs );
 
-    auto const lhs_values = lhs.fully_sorted();
-    auto const rhs_values = rhs.fully_sorted();
-
-    return std::equal( lhs_values.cbegin(), lhs_values.cend(),
-                       rhs_values.cbegin(),
-                       []( const_iterator lhs_value, const_iterator rhs_value ){
-                         return *lhs_value == *rhs_value;
-                       } );
-  }
-
+  template < class K >
   friend bool
-  operator<( klv_set< Key > const& lhs, klv_set< Key > const& rhs )
-  {
-    if( lhs.size() < rhs.size() )
-    {
-      return true;
-    }
-    else if( lhs.size() == rhs.size() )
-    {
-      auto const lhs_values = lhs.fully_sorted();
-      auto const rhs_values = rhs.fully_sorted();
-      return std::lexicographical_compare(
-        lhs_values.cbegin(), lhs_values.cend(),
-        rhs_values.cbegin(), rhs_values.cend(), value_compare );
-    }
-    return false;
-  }
+  operator<( klv_set< K > const& lhs, klv_set< K > const& rhs );
 
+  template < class K >
   friend std::ostream&
-  operator<<( std::ostream& os, klv_set< Key > const& rhs )
-  {
-    auto const values = rhs.fully_sorted();
-    os << "{ ";
-
-    bool first = true;
-    for( auto const pair : values )
-    {
-      first = first ? false : ( os << ", ", false );
-      os << pair->first << ": " << pair->second;
-    }
-    os << " }";
-    return os;
-  }
+  operator<<( std::ostream& os, klv_set< K > const& rhs );
 
 private:
   // Sort by key, then value.
   static bool
-  value_compare( const_iterator lhs, const_iterator rhs )
-  {
-    if( lhs->first < rhs->first )
-    {
-      return true;
-    }
-    else if( lhs->first == rhs->first )
-    {
-      return lhs->second < rhs->second;
-    }
-    return false;
-  }
+  value_compare( const_iterator lhs, const_iterator rhs );
 
   std::multimap< Key, klv_value > m_items;
 };

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -7,7 +7,13 @@
 
 #include "klv_value.h"
 
+#include "klv_0104_new.h"
+#include "klv_0601_new.h"
+#include "klv_1108.h"
+#include "klv_1108_metric_set.h"
 #include "klv_blob.h"
+#include "klv_packet.h"
+#include "klv_set.h"
 
 #include <vital/util/demangle.h>
 
@@ -39,8 +45,112 @@ klv_bad_value_cast
 }
 
 // ---------------------------------------------------------------------------
+class klv_value::internal_base
+{
+public:
+  virtual ~internal_base() = default;
+
+  virtual std::type_info const& type() const noexcept = 0;
+  virtual bool less_than( internal_base const& rhs ) const = 0;
+  virtual bool equal_to( internal_base const& rhs ) const = 0;
+  virtual std::ostream& print( std::ostream& os ) const = 0;
+  virtual internal_base* clone() const = 0;
+  virtual kwiver::vital::any to_any() const = 0;
+};
+
+// ---------------------------------------------------------------------------
+template < class T >
+class klv_value::internal_ : public internal_base
+{
+public:
+  explicit
+  internal_( T const& value ) : m_item( value ) {}
+
+  explicit
+  internal_( T&& value ) : m_item( value ) {}
+
+  std::type_info const&
+  type() const noexcept override final
+  {
+    return typeid( T );
+  }
+
+  bool
+  less_than( internal_base const& rhs ) const override final
+  {
+    auto const& lhs = *this;
+    // First, compare types
+    if( lhs.type().before( rhs.type() ) )
+    {
+      return true;
+    }
+    else if( lhs.type() == rhs.type() )
+    {
+      auto const& rhs_item =
+        dynamic_cast< internal_< T > const& >( rhs ).m_item;
+      // Second, compare values
+      return lhs.m_item < rhs_item;
+    }
+    return false;
+  }
+
+  bool
+  equal_to( internal_base const& rhs ) const override final
+  {
+    auto const& lhs = *this;
+
+    // First, compare types
+    if( lhs.type() != rhs.type() )
+    {
+      return false;
+    }
+
+    auto const& rhs_item =
+      dynamic_cast< internal_< T > const& >( rhs ).m_item;
+    // Second, compare values
+    return lhs.m_item == rhs_item;
+  }
+
+  std::ostream&
+  print( std::ostream& os ) const override final
+  {
+    return os << m_item;
+  }
+
+  internal_base*
+  clone() const override final
+  {
+    return new internal_< T >{ m_item };
+  }
+
+  kwiver::vital::any
+  to_any() const override final
+  {
+    return m_item;
+  }
+
+  T m_item;
+};
+
+// ---------------------------------------------------------------------------
 klv_value
 ::klv_value() : m_length_hint{ 0 } {}
+
+// ---------------------------------------------------------------------------
+template < class T, typename > klv_value
+::klv_value( T&& value ) : m_length_hint{ 0 }
+{
+  m_item.reset( new internal_< typename std::decay< T >::type >{
+                  std::forward< T >( value ) } );
+}
+
+// ---------------------------------------------------------------------------
+template < class T > klv_value
+::klv_value( T&& value, size_t length_hint )
+{
+  klv_value{ std::forward< T >( value ) }.swap( *this );
+  m_length_hint = length_hint;
+}
 
 // ---------------------------------------------------------------------------
 klv_value
@@ -54,6 +164,38 @@ klv_value
 ::klv_value( klv_value&& other )
 {
   swap( other );
+}
+
+// ---------------------------------------------------------------------------
+klv_value
+::~klv_value() {}
+
+// ---------------------------------------------------------------------------
+klv_value&
+klv_value
+::operator=( klv_value const& other )
+{
+  m_item.reset( other.m_item ? other.m_item->clone() : nullptr );
+  m_length_hint = other.m_length_hint;
+  return *this;
+}
+
+// ---------------------------------------------------------------------------
+klv_value&
+klv_value
+::operator=( klv_value&& other )
+{
+  return swap( other );
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+klv_value&
+klv_value
+::operator=( T&& rhs )
+{
+  klv_value{ rhs }.swap( *this );
+  return *this;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +283,64 @@ klv_value
 }
 
 // ---------------------------------------------------------------------------
+template < class T >
+T&
+klv_value
+::get()
+{
+  auto const ptr = get_ptr< T >();
+  if( !ptr )
+  {
+    throw klv_bad_value_cast( typeid( T ), type() );
+  }
+  return *ptr;
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+T const&
+klv_value
+::get() const
+{
+  auto const ptr = get_ptr< T >();
+  if( !ptr )
+  {
+    throw klv_bad_value_cast( typeid( T ), type() );
+  }
+  return *ptr;
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+T*
+klv_value
+::get_ptr() noexcept
+{
+  if( !m_item )
+  {
+    return nullptr;
+  }
+
+  auto const ptr = dynamic_cast< internal_< T >* >( m_item.get() );
+  return ptr ? &ptr->m_item : nullptr;
+}
+
+// ---------------------------------------------------------------------------
+template < class T >
+T const*
+klv_value
+::get_ptr() const noexcept
+{
+  if( !m_item )
+  {
+    return nullptr;
+  }
+
+  auto const ptr = dynamic_cast< internal_< T > const* >( m_item.get() );
+  return ptr ? &ptr->m_item : nullptr;
+}
+
+// ---------------------------------------------------------------------------
 bool
 operator<( klv_value const& lhs, klv_value const& rhs )
 {
@@ -177,6 +377,51 @@ operator<<( std::ostream& os, klv_value const& rhs )
 {
   return rhs.empty() ? os << "(empty)" : rhs.m_item->print( os );
 }
+
+// ---------------------------------------------------------------------------
+#define KLV_INSTANTIATE( T )                         \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  klv_value::klv_value( T&& );                       \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  klv_value::klv_value( T& );                        \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  klv_value::klv_value( T const& );                  \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  klv_value::klv_value( T&&, size_t );               \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  klv_value & klv_value::operator= < T >( T && );    \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  T & klv_value::get< T >();                         \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  T const& klv_value::get< T >() const;              \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  T * klv_value::get_ptr< T >() noexcept;            \
+  template KWIVER_ALGO_KLV_EXPORT                    \
+  T const* klv_value::get_ptr< T >() const noexcept; \
+  template class KWIVER_ALGO_KLV_EXPORT              \
+  klv_value::internal_< T >;
+
+KLV_INSTANTIATE( double );
+KLV_INSTANTIATE( int64_t );
+KLV_INSTANTIATE( klv_0601_control_command );
+KLV_INSTANTIATE( klv_0601_frame_rate );
+KLV_INSTANTIATE( klv_0601_icing_detected );
+KLV_INSTANTIATE( klv_0601_operational_mode );
+KLV_INSTANTIATE( klv_0601_platform_status );
+KLV_INSTANTIATE( klv_0601_sensor_control_mode );
+KLV_INSTANTIATE( klv_0601_sensor_fov_name );
+KLV_INSTANTIATE( klv_1108_assessment_point );
+KLV_INSTANTIATE( klv_1108_compression_profile );
+KLV_INSTANTIATE( klv_1108_compression_type );
+KLV_INSTANTIATE( klv_1108_metric_implementer );
+KLV_INSTANTIATE( klv_1108_metric_period_pack );
+KLV_INSTANTIATE( klv_1108_window_corners_pack );
+KLV_INSTANTIATE( klv_blob );
+KLV_INSTANTIATE( klv_local_set );
+KLV_INSTANTIATE( klv_universal_set );
+KLV_INSTANTIATE( std::string );
+KLV_INSTANTIATE( std::vector< klv_packet > );
+KLV_INSTANTIATE( uint64_t );
 
 } // namespace klv
 

--- a/arrows/klv/tests/CMakeLists.txt
+++ b/arrows/klv/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set( test_libraries kwiver_algo_core kwiver_algo_klv vital )
 
 kwiver_discover_gtests( klv klv_blob            LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_checksum        LIBRARIES ${test_libraries} )
+kwiver_discover_gtests( klv klv_demuxer         LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_read_write      LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_0104            LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_0601            LIBRARIES ${test_libraries} )

--- a/arrows/klv/tests/test_klv_demuxer.cxx
+++ b/arrows/klv/tests/test_klv_demuxer.cxx
@@ -1,0 +1,271 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Test KLV demuxer.
+
+#include <arrows/klv/klv_0601_new.h>
+#include <arrows/klv/klv_1108.h>
+#include <arrows/klv/klv_1108_metric_set.h>
+#include <arrows/klv/klv_demuxer.h>
+
+#include <tests/test_gtest.h>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+using namespace kwiver::arrows::klv;
+
+// ----------------------------------------------------------------------------
+TEST ( klv, demuxer_invalid )
+{
+  // Unknown UDS keys or unparsed data
+  {
+    using packet_vector = std::vector< klv_packet >;
+    klv_uds_key const key1{ 0x060E2B34FFFFFFFF, 0x0A0B0C0D00000000 };
+    klv_uds_key const key2{ 0x060E2B34FFFFFFFF, 0x0000000000000000 };
+    klv_blob const data1{ { 0xAA, 0xBB, 0xCC, 0xDD } };
+    klv_blob const data2{ { 0xAA, 0xBB } };
+    klv_blob const data3{ { 0xAB, 0xCD } };
+    auto const packets = packet_vector{
+      { key1, data1 },
+      { key1, data2 },
+      { key2, data3 },
+      { klv_0601_key(), klv_blob{ { 0x00 } } }, };
+
+    klv_timeline timeline;
+    klv_demuxer demuxer( timeline );
+    demuxer.seek( 123 );
+    for( auto const& packet : packets )
+    {
+      demuxer.demux_packet( packet );
+    }
+    auto const result_range = timeline.find_all( KLV_PACKET_UNKNOWN, 0 );
+    ASSERT_EQ( 3, std::distance( result_range.begin(), result_range.end() ) );
+    EXPECT_EQ( packet_vector( { packets[ 0 ], packets[ 1 ] } ),
+               std::next( result_range.begin(), 0 )->second.at( 123 )->get< packet_vector >() );
+    EXPECT_EQ( packet_vector( { packets[ 2 ] } ),
+               std::next( result_range.begin(), 1 )->second.at( 123 )->get< packet_vector >() );
+    EXPECT_EQ( packet_vector( { packets[ 3 ] } ),
+               std::next( result_range.begin(), 2 )->second.at( 123 )->get< packet_vector >() ); }
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, demuxer_0601 )
+{
+  auto const packets = std::vector< klv_packet >{
+    { klv_0601_key(),
+      klv_local_set{
+        { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 10 } },
+        { KLV_0601_ICING_DETECTED, KLV_0601_ICING_DETECTED_FALSE },
+        { KLV_0601_PLATFORM_HEADING_ANGLE, 13.0 },
+        { KLV_0601_LASER_PRF_CODE, uint64_t{ 1111 } },
+        { KLV_0601_PLATFORM_CALL_SIGN, std::string{ "BOB" } },
+        { KLV_0601_PLATFORM_DESIGNATION, std::string{ "Bob" } } } },
+    { klv_0601_key(),
+      klv_local_set{
+        { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 20 } },
+        // Implicitly unchanged
+        { KLV_0601_PLATFORM_HEADING_ANGLE, 14.0 }, // Explicitly changed
+        { KLV_0601_LASER_PRF_CODE, klv_value{} },  // Explicitly erased
+        { KLV_0601_PLATFORM_CALL_SIGN,             // Changed to invalid
+          klv_blob{ { 0xAA } } },
+        { KLV_0601_PLATFORM_DESIGNATION,           // Repeated but unchanged
+          std::string{ "Bob" } }
+      } },
+    { klv_0601_key(),
+      klv_local_set{
+        // All new values
+        { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 30 } },
+        { KLV_0601_ICING_DETECTED, KLV_0601_ICING_DETECTED_TRUE },
+        { KLV_0601_PLATFORM_HEADING_ANGLE, 15.0 },
+        { KLV_0601_LASER_PRF_CODE, uint64_t{ 2222 } },
+        { KLV_0601_PLATFORM_CALL_SIGN, std::string{ "ALICE" } },
+        { KLV_0601_PLATFORM_DESIGNATION, std::string{ "Alice" } } } }, };
+
+  klv_timeline timeline;
+  klv_demuxer demuxer( timeline );
+  for( auto const& packet : packets )
+  {
+    demuxer.demux_packet( packet );
+  }
+
+  auto const standard = KLV_PACKET_MISB_0601_LOCAL_SET;
+
+  // Before assignment
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_ICING_DETECTED,         9 )
+               .empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE, 9 )
+               .empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_LASER_PRF_CODE,         9 )
+               .empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,     9 )
+               .empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,   9 )
+               .empty() );
+
+  // After first assignment
+  EXPECT_EQ( KLV_0601_ICING_DETECTED_FALSE,
+             timeline.at( standard, KLV_0601_ICING_DETECTED,         10 ) );
+  EXPECT_EQ( 13.0,
+             timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE, 10 ) );
+  EXPECT_EQ( uint64_t{ 1111 },
+             timeline.at( standard, KLV_0601_LASER_PRF_CODE,         10 ) );
+  EXPECT_EQ( std::string{ "BOB" },
+             timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,     10 ) );
+  EXPECT_EQ( std::string{ "Bob" },
+             timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,   10 ) );
+
+  // After tricky assignments
+  EXPECT_EQ( KLV_0601_ICING_DETECTED_FALSE,
+             timeline.at( standard, KLV_0601_ICING_DETECTED,         20 ) );
+  EXPECT_EQ( 14.0,
+             timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE, 20 ) );
+  EXPECT_EQ( klv_value{},
+             timeline.at( standard, KLV_0601_LASER_PRF_CODE,         20 ) );
+  EXPECT_EQ( klv_blob{ { 0xAA } },
+             timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,     20 ) );
+  EXPECT_EQ( std::string{ "Bob" },
+             timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,   20 ) );
+
+  // After full reassignment
+  EXPECT_EQ( KLV_0601_ICING_DETECTED_TRUE,
+             timeline.at( standard, KLV_0601_ICING_DETECTED,         30 ) );
+  EXPECT_EQ( 15.0,
+             timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE, 30 ) );
+  EXPECT_EQ( uint64_t{ 2222 },
+             timeline.at( standard, KLV_0601_LASER_PRF_CODE,         30 ) );
+  EXPECT_EQ( std::string{ "ALICE" },
+             timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,     30 ) );
+  EXPECT_EQ( std::string{ "Alice" },
+             timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,   30 ) );
+
+  // Check final time boundary
+  EXPECT_EQ( KLV_0601_ICING_DETECTED_TRUE,
+             timeline.at( standard, KLV_0601_ICING_DETECTED,
+                          30000029 ) );
+  EXPECT_EQ( 15.0,
+             timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE,
+                          30000029 ) );
+  EXPECT_EQ( uint64_t{ 2222 },
+             timeline.at( standard, KLV_0601_LASER_PRF_CODE,
+                          30000029 ) );
+  EXPECT_EQ( std::string{ "ALICE" },
+             timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,
+                          30000029 ) );
+  EXPECT_EQ( std::string{ "Alice" },
+             timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,
+                          30000029 ) );
+
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_ICING_DETECTED,
+                            30000030 ).empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_HEADING_ANGLE,
+                            30000030 ).empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_LASER_PRF_CODE,
+                            30000030 ).empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_CALL_SIGN,
+                            30000030 ).empty() );
+  EXPECT_TRUE( timeline.at( standard, KLV_0601_PLATFORM_DESIGNATION,
+                            30000030 ).empty() );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, demuxer_1108 )
+{
+  auto const metric_sets = std::vector< klv_local_set >{
+    { { KLV_1108_METRIC_SET_NAME,       std::string{ "VNIIRS" } },
+      { KLV_1108_METRIC_SET_VERSION,    std::string{ "3.0" } },
+      { KLV_1108_METRIC_SET_IMPLEMENTER,
+        klv_1108_metric_implementer{ "KW", "CV" } },
+      { KLV_1108_METRIC_SET_PARAMETERS, std::string{ "A0+A1" } },
+      { KLV_1108_METRIC_SET_TIME,       uint64_t{ 1630000000000000 } },
+      { KLV_1108_METRIC_SET_VALUE,      7.0 } },
+    { { KLV_1108_METRIC_SET_NAME,       std::string{ "GSD" } },
+      { KLV_1108_METRIC_SET_VERSION,    klv_value{} },
+      { KLV_1108_METRIC_SET_IMPLEMENTER,
+        klv_1108_metric_implementer{ "KW", "CV" } },
+      { KLV_1108_METRIC_SET_PARAMETERS, std::string{ "" } },
+      { KLV_1108_METRIC_SET_TIME,       uint64_t{ 1630000000000000 } },
+      { KLV_1108_METRIC_SET_VALUE,      9.0 } },
+    { { KLV_1108_METRIC_SET_NAME,       std::string{ "VNIIRS" } },
+      { KLV_1108_METRIC_SET_VERSION,    std::string{ "3.1" } },
+      { KLV_1108_METRIC_SET_IMPLEMENTER,
+        klv_1108_metric_implementer{ "OTHER", "OTHER" } },
+      { KLV_1108_METRIC_SET_PARAMETERS, std::string{ "" } },
+      { KLV_1108_METRIC_SET_TIME,       uint64_t{ 1600000000000000 } },
+      { KLV_1108_METRIC_SET_VALUE,      6.0 } },
+    { { KLV_1108_METRIC_SET_NAME,       std::string{ "VNIIRS" } },
+      { KLV_1108_METRIC_SET_VERSION,    std::string{ "3.0" } },
+      { KLV_1108_METRIC_SET_IMPLEMENTER,
+        klv_1108_metric_implementer{ "KW", "CV" } },
+      { KLV_1108_METRIC_SET_PARAMETERS, std::string{ "A0+A1" } },
+      { KLV_1108_METRIC_SET_TIME,       uint64_t{ 1630000000000000 } },
+      { KLV_1108_METRIC_SET_VALUE,      8.0 } }, };
+
+  auto const packets = std::vector< klv_packet >{
+    { klv_1108_key(),
+      klv_local_set{
+        { KLV_1108_ASSESSMENT_POINT,    KLV_1108_ASSESSMENT_POINT_ARCHIVE },
+        { KLV_1108_METRIC_PERIOD_PACK,
+          klv_1108_metric_period_pack{ 100, 100 } },
+        { KLV_1108_METRIC_LOCAL_SET,    metric_sets[ 0 ] },
+        { KLV_1108_METRIC_LOCAL_SET,    metric_sets[ 2 ] },
+        { KLV_1108_COMPRESSION_TYPE,    KLV_1108_COMPRESSION_TYPE_H264 },
+        { KLV_1108_COMPRESSION_PROFILE, KLV_1108_COMPRESSION_PROFILE_HIGH },
+        { KLV_1108_COMPRESSION_LEVEL,   std::string{ "5.1" } },
+        { KLV_1108_COMPRESSION_RATIO,   klv_value{ 25.2, 4 } },
+        { KLV_1108_STREAM_BITRATE,      uint64_t{ 1024 } },
+        { KLV_1108_DOCUMENT_VERSION,    uint64_t{ 3 } } } },
+    { klv_1108_key(),
+      klv_local_set{
+        { KLV_1108_ASSESSMENT_POINT,    KLV_1108_ASSESSMENT_POINT_SENSOR },
+        { KLV_1108_METRIC_PERIOD_PACK,
+          klv_1108_metric_period_pack{ 150, 100 } },
+        { KLV_1108_METRIC_LOCAL_SET,    metric_sets[ 1 ] },
+        { KLV_1108_COMPRESSION_TYPE,    KLV_1108_COMPRESSION_TYPE_H264 },
+        { KLV_1108_COMPRESSION_PROFILE, KLV_1108_COMPRESSION_PROFILE_HIGH },
+        { KLV_1108_COMPRESSION_LEVEL,   std::string{ "5.2" } },
+        { KLV_1108_COMPRESSION_RATIO,   klv_value{ 13.0, 4 } },
+        { KLV_1108_STREAM_BITRATE,      uint64_t{ 1024 } },
+        { KLV_1108_DOCUMENT_VERSION,    uint64_t{ 3 } } } },
+    { klv_1108_key(),
+      klv_local_set{
+        { KLV_1108_ASSESSMENT_POINT,    KLV_1108_ASSESSMENT_POINT_ARCHIVE },
+        { KLV_1108_METRIC_PERIOD_PACK,
+          klv_1108_metric_period_pack{ 180, 100 } },
+        { KLV_1108_METRIC_LOCAL_SET,    metric_sets[ 3 ] },
+        { KLV_1108_METRIC_LOCAL_SET,    klv_blob{ { 0xAA } } } } } };
+
+  klv_timeline timeline;
+  klv_demuxer demuxer( timeline );
+  for( auto const& packet : packets )
+  {
+    demuxer.demux_packet( packet );
+  }
+
+  auto const standard = KLV_PACKET_MISB_1108_LOCAL_SET;
+  {
+    auto const tag = KLV_1108_METRIC_LOCAL_SET;
+    EXPECT_EQ( 0, timeline.all_at( standard, tag, 99  ).size() );
+    EXPECT_EQ( 2, timeline.all_at( standard, tag, 100 ).size() );
+    EXPECT_EQ( 2, timeline.all_at( standard, tag, 120 ).size() );
+    EXPECT_EQ( 3, timeline.all_at( standard, tag, 150 ).size() );
+    EXPECT_EQ( 4, timeline.all_at( standard, tag, 180 ).size() );
+    EXPECT_EQ( 3, timeline.all_at( standard, tag, 200 ).size() );
+    EXPECT_EQ( 2, timeline.all_at( standard, tag, 250 ).size() );
+    EXPECT_EQ( 0, timeline.all_at( standard, tag, 280 ).size() );
+  }
+
+  EXPECT_TRUE( timeline.all_at( standard, KLV_1108_METRIC_PERIOD_PACK, 180 )
+               .empty() );
+  EXPECT_EQ( std::vector< klv_value >( { std::string{ "5.1" },
+                                         std::string{ "5.1" },
+                                         std::string{ "5.2" } } ),
+             timeline.all_at( standard, KLV_1108_COMPRESSION_LEVEL, 155 ) );
+}


### PR DESCRIPTION
This PR adds the de-multiplexer (demuxer) for KLV. This is a coroutine-like object which holds state for the process of turning parsed KLV packets into a KLV timeline. Using this object, packets can be added to the timeline frame by frame as the video is read. The user could then erase old data on the timeline after is has been used, minimizing the memory footprint of the KLV decoding process, or retain all data and efficiently contain metadata for the entire video stream, perhaps for export.

The possibilities of empty, unparsed/invalid, incorrectly duplicated, or missing data complicate some of the logic here, and there's valid questions to be asked weighing the likelihood of these things and how rigid or accommodating our system should be. At the moment, the priority is to parse correctly-encoded packets correctly, and ideally retain enough information about incorrect or unfamiliar packets to replace them in the stream when re-encoding.

The unit tests added here are not intended to be exhaustive, but merely ensure the bulk of the functionality works as intended.