### PR TITLE
Move internal variant.hpp to the cxx file

### DIFF
--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -11,6 +11,7 @@
 
 #include <vital/types/metadata_traits.h>
 #include <vital/util/demangle.h>
+#include <vital/internal/variant/variant.hpp>
 
 #include <typeindex>
 

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -12,7 +12,6 @@
 
 #include <vital/any.h>
 #include <vital/exceptions/metadata.h>
-#include <vital/internal/variant/variant.hpp>
 #include <vital/types/geo_point.h>
 #include <vital/types/geo_polygon.h>
 #include <vital/types/metadata_tags.h>


### PR DESCRIPTION
Having the internal/variant/variant.hpp include in metadata.h prevents consuming packages from building. Move variant.hpp to metadata.cxx as designed.