### PR TITLE
Revert line incorrectly identified as separator

### DIFF
--- a/vital/plugin_loader/plugin_manager_internal.h
+++ b/vital/plugin_loader/plugin_manager_internal.h
@@ -10,9 +10,8 @@ namespace kwiver {
 namespace vital {
 
 // ----------------------------------------------------------------------------
-//  This class just exposes the protected members of the base class.
-// ----------------------------------------------------------------------------
- For internal use only ----
+// This class just exposes the protected members of the base class.
+// ---- For internal use only ----
 class plugin_manager_internal
   : public plugin_manager
 {


### PR DESCRIPTION
Currently, `master` fails to build due to the automatic separator-fixing tool mistaking this line for a separator.