### PR TITLE
Ensure the timestamp gets added to each vital::metadata

### DIFF
--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -126,9 +126,11 @@ klv_0104_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
                             kv::metadata& vital_data )
 {
   constexpr auto standard = KLV_PACKET_MISB_0104_UNIVERSAL_SET;
+
+  // Add the timestamp
+  vital_data.add< kv::VITAL_META_UNIX_TIMESTAMP >( timestamp );
+
   static std::map< klv_lds_key, kv::vital_metadata_tag > const direct_map = {
-    { KLV_0104_USER_DEFINED_TIMESTAMP,
-      kv::VITAL_META_UNIX_TIMESTAMP },
     { KLV_0104_PLATFORM_HEADING_ANGLE,
       kv::VITAL_META_PLATFORM_HEADING_ANGLE },
     { KLV_0104_PLATFORM_PITCH_ANGLE,
@@ -265,9 +267,11 @@ klv_0601_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
                             kv::metadata& vital_data )
 {
   constexpr auto standard = KLV_PACKET_MISB_0601_LOCAL_SET;
+
+  // Add the timestamp
+  vital_data.add< kv::VITAL_META_UNIX_TIMESTAMP >( timestamp );
+
   static std::map< klv_lds_key, kv::vital_metadata_tag > const direct_map = {
-    { KLV_0601_PRECISION_TIMESTAMP,
-      kv::VITAL_META_UNIX_TIMESTAMP },
     { KLV_0601_MISSION_ID,
       kv::VITAL_META_MISSION_ID },
     { KLV_0601_PLATFORM_TAIL_NUMBER,
@@ -511,6 +515,10 @@ klv_1108_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
                             kv::metadata& vital_data )
 {
   constexpr auto standard = KLV_PACKET_MISB_1108_LOCAL_SET;
+
+  // Add the timestamp
+  vital_data.add< kv::VITAL_META_UNIX_TIMESTAMP >( timestamp );
+
   static std::map< std::string, kv::vital_metadata_tag > const metrics = {
     { "GSD", kv::VITAL_META_AVERAGE_GSD },
     { "VNIIRS", kv::VITAL_META_VNIIRS }, };


### PR DESCRIPTION
For each supported standard, when converting to `vital::metadata`, add the timestamp to the converted packet. This being a special case was missed during the initial writing of `klv_convert_vital`.