### PR TITLE
Add klv_packet_timestamp

### DIFF
--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -170,6 +170,45 @@ klv_packet_length( klv_packet const& packet )
 }
 
 // ----------------------------------------------------------------------------
+uint64_t
+klv_packet_timestamp( klv_packet const& packet )
+{
+  if( !packet.value.valid() )
+  {
+    return 0;
+  }
+  switch( klv_lookup_packet_traits().by_uds_key( packet.key ).tag() )
+  {
+    case KLV_PACKET_MISB_0104_UNIVERSAL_SET:
+    {
+      static auto const key = klv_0104_traits_lookup()
+        .by_tag( KLV_0104_USER_DEFINED_TIMESTAMP ).uds_key();
+      auto const& set = packet.value.get< klv_universal_set >();
+      auto const it = set.find( key );
+      return ( it != set.end() && it->second.valid() )
+             ? it->second.get< uint64_t >() : 0;
+    }
+    case KLV_PACKET_MISB_0601_LOCAL_SET:
+    {
+      auto const& set = packet.value.get< klv_local_set >();
+      auto const it = set.find( KLV_0601_PRECISION_TIMESTAMP );
+      return ( it != set.end() && it->second.valid() )
+             ? it->second.get< uint64_t >() : 0;
+    }
+    case KLV_PACKET_MISB_1108_LOCAL_SET:
+    {
+      auto const& set = packet.value.get< klv_local_set >();
+      auto const it = set.find( KLV_1108_METRIC_PERIOD_PACK );
+      return ( it != set.end() && it->second.valid() )
+             ? it->second.get< klv_1108_metric_period_pack >().timestamp : 0;
+    }
+    case KLV_PACKET_UNKNOWN:
+    default:
+      return 0;
+  }
+}
+
+// ----------------------------------------------------------------------------
 klv_tag_traits_lookup const&
 klv_lookup_packet_traits()
 {

--- a/arrows/klv/klv_packet.h
+++ b/arrows/klv/klv_packet.h
@@ -104,6 +104,16 @@ size_t
 klv_packet_length( klv_packet const& packet );
 
 // ----------------------------------------------------------------------------
+/// Return the time \p packet takes effect.
+///
+/// \param packet KLV packet being queried.
+///
+/// \returns Packet timestamp in microseconds, or \c 0 on failure.
+KWIVER_ALGO_KLV_EXPORT
+uint64_t
+klv_packet_timestamp( klv_packet const& packet );
+
+// ----------------------------------------------------------------------------
 /// Return a traits lookup object for top-level keys.
 KWIVER_ALGO_KLV_EXPORT
 klv_tag_traits_lookup const&


### PR DESCRIPTION
Technically, all frames in videos with KLV data should come with a MISP timestamp that allows precise correlation between KLV data and frame images. Practically, however, the presence or validity of these timestamps is not guaranteed - in fact, our current embedded test video has invalid timestamps. Backup methods of correlating these two streams may find it useful to query the embedded timestamp in each KLV packet to determine the approximate MISP time of a frame. The `klv_packet_timestamp()` function provides this ability.