### PR TITLE
Log, don't throw, on wrong checksum

### DIFF
--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -105,13 +105,11 @@ klv_read_packet( klv_read_iter_t& data, size_t max_length )
     format.calculate_checksum( begin, packet_length - checksum_length );
   if( expected_checksum != actual_checksum )
   {
-    std::stringstream ss;
-    ss  << std::hex << std::setfill( '0' )
-        << "calculated checksum "
-        << "(0x" << std::setw( 4 ) << actual_checksum << ") "
-        << "does not equal checksum contained in packet "
-        << "(0x" << std::setw( 4 ) << expected_checksum << ")";
-    VITAL_THROW( kv::metadata_exception, ss.str() );
+    LOG_ERROR( kv::get_logger( "klv" ), std::hex << std::setfill( '0' )
+               << "calculated checksum "
+               << "(0x" << std::setw( 4 ) << actual_checksum << ") "
+               << "does not equal checksum contained in packet "
+               << "(0x" << std::setw( 4 ) << expected_checksum << ")" );
   }
 
   // Read value


### PR DESCRIPTION
There is a large depository of videos we would like to read the KLV for, except whoever encoded them implemented the checksum algorithm incorrectly. Currently we throw an exception and don't try to parse a packet when the checksums don't match. This PR changes this to a logged error and still attempts to parse the packet anyway. Not ideal, but such concessions need to be made given the apparent state of existing KLV encoders.