### PR TITLE
Prevent frame number from being printed twice

### DIFF
--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -427,7 +427,8 @@ metadata_map_io_csv
       {
         auto const tag = metadata_item.first;
         auto const& type = metadata_item.second->type();
-        if( tag != kv::VITAL_META_VIDEO_URI )
+        if( tag != kv::VITAL_META_VIDEO_URI &&
+            tag != kv::VITAL_META_VIDEO_FRAME_NUMBER )
         {
           for( auto const i : kvr::iota( get_column_count( type ) ) )
           {


### PR DESCRIPTION
The frame number is automatically printed as the first column, so no need to automatically insert it in an additional column later on. It can still be re-requested by the configuration if that is truly desired, but double-printing shouldn't be the default behavior.