### PR TITLE
Print n, not n squared, commas for empty multicolumns

### DIFF
--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -540,7 +540,7 @@ metadata_map_io_csv
         // Write empty fields
         {
           auto const& trait = kv::tag_traits_by_tag( info.id.tag );
-          fout << std::string( get_column_count( trait.type() ), ',' );
+          fout << ',';
         }
       }
       fout << "\n";


### PR DESCRIPTION
This PR fixes a bug in which, when a vital tag is being exported to CSV and maps to `n` different columns (e.g. a point mapped to `n=3` columns, one for each dimension), but the value of the tag is empty, `n*n` blank fields will be printed instead of `n`. 