### PR TITLE
Change GSD to center pixel instead of average

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -231,7 +231,8 @@ double
 compute_horizontal_gsd( double slant_range, double sensor_horizontal_fov,
                         double frame_width )
 {
-  return 2.0 * slant_range * tan( sensor_horizontal_fov / 2.0 ) / frame_width;
+  return 2.0 * slant_range *
+         std::tan( sensor_horizontal_fov / frame_width / 2.0 );
 }
 
 // ----------------------------------------------------------------------------
@@ -243,11 +244,9 @@ compute_vertical_gsd( double slant_range, double sensor_vertical_fov,
   {
     VITAL_THROW( kv::invalid_value, "pitch must be negative" );
   }
-  double const interior_angle = kv::pi_over_2 + pitch;
-  double const altitude = slant_range * std::cos( interior_angle );
-  double const vertical_gsd = 2.0 * altitude * std::sin( sensor_vertical_fov ) /
-    ( frame_height * ( 1.0 + std::cos( 2.0 * interior_angle ) ) );
-  return vertical_gsd;
+  return 2.0 * slant_range *
+         std::tan( sensor_vertical_fov / frame_height / 2.0 ) /
+         std::sin( -pitch );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/core/tests/test_derive_metadata.cxx
+++ b/arrows/core/tests/test_derive_metadata.cxx
@@ -103,7 +103,7 @@ TEST_F( derive_metadata, compute_derived )
   EXPECT_NEAR( 0.202224, gsd_value.as_double(), 0.000001);
 
   // This only takes into account terms a0 and a1
-  EXPECT_NEAR( 6.578680, vniirs_value.as_double(), 0.000001 );
+  EXPECT_NEAR( 6.578685, vniirs_value.as_double(), 0.000001 );
   EXPECT_DOUBLE_EQ( 13296.55762, slant_range_value.as_double() );
 
   auto const wavelength =


### PR DESCRIPTION
Use the MISB standard equation for calculating GSD. If you use trigonometric identities, namely `1 + cos(2x) = cos^2(x)` and `cos(pi/2 - x) = sin(x)`, you can simplify our existing vertical formula down to `slant_range * sin( fov ) / sin( -pitch ) / image_height`. This has two main differences from the new formula: `sin( fov )` is replaced with `tan( fov )` in the new version and the **angle** is divided by `image_height` instead of the whole quantity. The `sin/tan` mixup I think was just a mistake which got through our test because `sin` and `tan` are approximately equal for small angles - and most drone footage has very small field of view due to the distances involved. The decision of where to divide by image height is a change between estimating the average GSD over the whole image and estimating the GSD of the central pixel of the image. This difference also varies with FOV; at typical angles (like in our unit test) it doesn't show up until after the sixth decimal place. But the closer you get to a fisheye-lens sort of situation, the bigger the difference is between the center and edges of the image.

Again, the changes are small enough at typical FOVs that we didn't even have to change our reference GSD value, and only changed the sixth digit of VNIIRS, which is a nonlinear function of GSD. But, it's probably best to used standardized and technically more correct methods when possible.