### PR TITLE
Implement ST0601 tag 122: country codes

### DIFF
--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -10,8 +10,11 @@
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
+#include "klv_0102.h"
 #include "klv_set.h"
 #include "klv_packet.h"
+
+#include "vital/optional.h"
 
 #include <ostream>
 
@@ -417,6 +420,57 @@ private:
 
   size_t
   length_of_typed( klv_0601_frame_rate const& value,
+                   size_t length_hint ) const override;
+};
+
+// ----------------------------------------------------------------------------
+/// Record of involvement of various countries in production of the FMV.
+struct klv_0601_country_codes
+{
+  klv_0102_country_coding_method coding_method;
+  kwiver::vital::optional< std::string > overflight_country;
+  kwiver::vital::optional< std::string > operator_country;
+  kwiver::vital::optional< std::string > country_of_manufacture;
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_0601_country_codes const& value );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator==( klv_0601_country_codes const& lhs,
+            klv_0601_country_codes const& rhs );
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool
+operator<( klv_0601_country_codes const& lhs,
+           klv_0601_country_codes const& rhs );
+
+// ----------------------------------------------------------------------------
+/// Interprets data as country codes.
+class KWIVER_ALGO_KLV_EXPORT klv_0601_country_codes_format
+  : public klv_data_format_< klv_0601_country_codes >
+{
+public:
+  klv_0601_country_codes_format();
+
+  std::string
+  description() const override;
+
+private:
+  klv_0601_country_codes
+  read_typed( klv_read_iter_t& data, size_t length ) const override;
+
+  void
+  write_typed( klv_0601_country_codes const& value,
+               klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( klv_0601_country_codes const& value,
                    size_t length_hint ) const override;
 };
 

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -802,6 +802,7 @@ klv_imap_format
 KLV_INSTANTIATE( double );
 KLV_INSTANTIATE( int64_t );
 KLV_INSTANTIATE( klv_0601_control_command );
+KLV_INSTANTIATE( klv_0601_country_codes );
 KLV_INSTANTIATE( klv_0601_frame_rate );
 KLV_INSTANTIATE( klv_1108_metric_implementer );
 KLV_INSTANTIATE( klv_1108_metric_period_pack );

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -407,6 +407,7 @@ KLV_INSTANTIATE( int64_t );
 KLV_INSTANTIATE( klv_0102_country_coding_method );
 KLV_INSTANTIATE( klv_0102_security_classification );
 KLV_INSTANTIATE( klv_0601_control_command );
+KLV_INSTANTIATE( klv_0601_country_codes );
 KLV_INSTANTIATE( klv_0601_frame_rate );
 KLV_INSTANTIATE( klv_0601_icing_detected );
 KLV_INSTANTIATE( klv_0601_operational_mode );

--- a/arrows/klv/tests/test_klv_0601.cxx
+++ b/arrows/klv/tests/test_klv_0601.cxx
@@ -164,8 +164,9 @@ auto const expected_result = klv_local_set{
   { KLV_0601_ONBOARD_MI_STORAGE_PERCENT_FULL,   72.000000000000000 },
   { KLV_0601_ACTIVE_WAVELENGTH_LIST,           klv_blob{ { 0x01, 0x03 } } },
   { KLV_0601_COUNTRY_CODES,
-    klv_blob{ {
-      0x01, 0x0E, 0x03, 0x43, 0x41, 0x4E, 0x00, 0x03, 0x46, 0x52, 0x41 } } },
+    klv_0601_country_codes{
+      KLV_0102_COUNTRY_CODING_METHOD_GENC_THREE_LETTER,
+      std::string{ "CAN" }, kv::nullopt, std::string{ "FRA" } } },
   { KLV_0601_NUMBER_OF_NAVSATS_IN_VIEW,        uint64_t{ 7 } },
   { KLV_0601_POSITIONING_METHOD_SOURCE,        klv_blob{ { 0x03 } } },
   { KLV_0601_PLATFORM_STATUS,


### PR DESCRIPTION
An implementation of this tag, one of perhaps 20 in ST0601 which are not yet implemented, was requested. This PR implements it according to the standard. One thing this PR doesn't do is decode all the various country coding methods (i.e. `FRA` means `France` in the GENC Three-Letter system), since there are ~15 of those, and 15 times 200+ countries equals a lot of typing. For now, the users of this field or the three similar fields in ST0102 will have to wrangle that translation themselves. This could possibly change in the future should the need be sufficiently great.