### PR TITLE
Add video_settings

### DIFF
--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 set(ffmpeg_headers_public
   ffmpeg_init.h
   ffmpeg_video_input.h
+  ffmpeg_video_settings.h
   )
 
 kwiver_install_headers(
@@ -35,6 +36,7 @@ kwiver_install_headers(
 set(ffmpeg_sources
   ffmpeg_init.cxx
   ffmpeg_video_input.cxx
+  ffmpeg_video_settings.cxx
   )
 
 kwiver_add_library( kwiver_algo_ffmpeg

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -7,6 +7,7 @@
 
 #include "ffmpeg_init.h"
 #include "ffmpeg_video_input.h"
+#include "ffmpeg_video_settings.h"
 
 #include <arrows/klv/klv_convert_vital.h>
 #include <arrows/klv/klv_demuxer.h>
@@ -1338,6 +1339,34 @@ ffmpeg_video_input
 
   return d->number_of_frames;
 }
+
+// ----------------------------------------------------------------------------
+kwiver::vital::video_settings_uptr
+ffmpeg_video_input
+::implementation_settings() const
+{
+  if( !d->is_opened() )
+  {
+    return nullptr;
+  }
+
+  auto const result = new ffmpeg_video_settings{};
+  result->bit_rate = d->f_video_encoding->bit_rate;
+  result->bit_rate_tolerance = d->f_video_encoding->bit_rate_tolerance;
+  result->codec_id = d->f_video_encoding->codec_id;
+  result->frame_rate = d->f_video_stream->avg_frame_rate;
+  result->gop_size = d->f_video_encoding->gop_size;
+  result->height = d->f_video_encoding->height;
+  result->level = d->f_video_encoding->level;
+  result->pixel_format = d->f_video_encoding->pix_fmt;
+  result->profile = d->f_video_encoding->profile;
+  result->sample_aspect_ratio = d->f_video_encoding->sample_aspect_ratio;
+  result->stream_id = d->f_video_stream->id;
+  result->time_base = d->f_video_stream->time_base;
+  result->width = d->f_video_encoding->width;
+  return kwiver::vital::video_settings_uptr{ result };
+}
+
 
 } // namespace ffmpeg
 

--- a/arrows/ffmpeg/ffmpeg_video_input.h
+++ b/arrows/ffmpeg/ffmpeg_video_input.h
@@ -64,6 +64,8 @@ public:
   ::kwiver::vital::metadata_vector frame_metadata() override;
   ::kwiver::vital::metadata_map_sptr metadata_map() override;
 
+  ::kwiver::vital::video_settings_uptr implementation_settings() const override;
+
 private:
   /// private implementation class
   class priv;

--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -1,0 +1,52 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Implementation of FFmpeg video settings.
+
+#include <arrows/ffmpeg/ffmpeg_video_settings.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings
+::ffmpeg_video_settings()
+  : width{ 0 },
+    height{ 0 },
+    codec_id{ AV_CODEC_ID_H264 },
+    pixel_format{ AV_PIX_FMT_RGB24 },
+    frame_rate{ 0, 1 },
+    time_base{ 0, 1 },
+    sample_aspect_ratio{ 1, 1 },
+    bit_rate{ 0 },
+    gop_size{ 0 },
+    profile{ 0 },
+    level{ 0 },
+    stream_id{ 0 } {}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings
+::ffmpeg_video_settings( size_t width, size_t height, AVRational frame_rate )
+  : width{ width },
+    height{ height },
+    codec_id{ AV_CODEC_ID_H264 },
+    pixel_format{ AV_PIX_FMT_RGB24 },
+    frame_rate( frame_rate ),
+    time_base{ frame_rate.den, frame_rate.num },
+    sample_aspect_ratio{ 1, 1 },
+    bit_rate{ 0 },
+    gop_size{ 0 },
+    profile{ 0 },
+    level{ 0 },
+    stream_id{ 0 } {}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -1,0 +1,54 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Declaration of FFmpeg video settings.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_SETTINGS_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_SETTINGS_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+
+#include <vital/types/video_settings.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
+  : public vital::video_settings
+{
+  ffmpeg_video_settings();
+
+  ffmpeg_video_settings( size_t width, size_t height, AVRational frame_rate );
+
+  size_t width;
+  size_t height;
+  AVCodecID codec_id;
+  AVPixelFormat pixel_format;
+  AVRational frame_rate;
+  AVRational time_base;
+  AVRational sample_aspect_ratio;
+  int64_t bit_rate;
+  int bit_rate_tolerance;
+  int gop_size;
+  int profile;
+  int level;
+  int stream_id;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -225,6 +225,7 @@ set( vital_sources
   types/track.cxx
   types/track_descriptor.cxx
   types/track_set.cxx
+  types/video_settings.cxx
   types/uid.cxx
 )
 

--- a/vital/algo/video_input.cxx
+++ b/vital/algo/video_input.cxx
@@ -47,6 +47,15 @@ video_input
 }
 
 // ----------------------------------------------------------------------------
+video_settings_uptr
+video_input
+::implementation_settings() const
+{
+  return nullptr;
+}
+
+
+// ----------------------------------------------------------------------------
 algorithm_capabilities const&
 video_input
 ::get_implementation_capabilities() const

--- a/vital/algo/video_input.h
+++ b/vital/algo/video_input.h
@@ -18,6 +18,7 @@
 #include <vital/types/metadata.h>
 #include <vital/types/metadata_map.h>
 #include <vital/types/timestamp.h>
+#include <vital/types/video_settings.h>
 
 #include <string>
 #include <vector>
@@ -340,6 +341,15 @@ public:
   ///
   /// \return Frame rate.
   virtual double frame_rate();
+
+  /// Extract implementation-specific video encoding settings.
+  ///
+  /// The returned structure is intended to be passed to a video encoder of
+  /// similar implementation so that the output video can be encoded using the
+  /// settings of the input video.
+  ///
+  /// \return Implementation video settings, or \c nullptr if none are needed.
+  virtual video_settings_uptr implementation_settings() const;
 
   /// \brief Return capabilities of concrete implementation.
   ///

--- a/vital/types/video_settings.cxx
+++ b/vital/types/video_settings.cxx
@@ -1,0 +1,18 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Definition of base video settings type.
+
+#include <vital/types/video_settings.h>
+
+namespace kwiver {
+
+namespace vital {
+
+video_settings::~video_settings() {}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/types/video_settings.h
+++ b/vital/types/video_settings.h
@@ -1,0 +1,33 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Declaration of base video settings type.
+
+#ifndef VITAL_VIDEO_SETTINGS_H_
+#define VITAL_VIDEO_SETTINGS_H_
+
+#include <vital/vital_export.h>
+
+#include <memory>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/// Base class for holding information about how to encode a video.
+struct VITAL_EXPORT video_settings
+{
+  virtual ~video_settings();
+};
+
+using video_settings_sptr = std::shared_ptr< video_settings >;
+using video_settings_uptr = std::unique_ptr< video_settings >;
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
This PR is meant to address two design problems relating to video writers.

First, each video writer implementation may **require** different parameters to start encoding a video. For example, FFmpeg needs to know the video size and frame rate before you give it the first image. In contrast, an image list writer doesn't necessarily need the images to be the same size all the way through, and giving it a frame rate doesn't even make sense. Some hypothetical future encoder may require additional implementation-specific information, like which encoding format to use.

Second, video writer implementations may **allow** for any number of quality/format parameters to be tweaked, even if they're not required to be set by the user. If we just go with "reasonable defaults", we may end up re-encoding a high-fidelity original video with much lower compression, or a very-compressed original video with a much larger file size than necessary. Ideally, we would be able to transfer all the fiddly settings from a video input to a video output, but it's not easy do that without knowing implementation details.

These problems make setting the parameters for `video_input.open()` tricky - do we have a bunch of parameters, most of which may go unused, or very few parameters, allowing little flexibility? So here we decide to use RTTI. `video_settings` is a base class whose only purpose right now is to be specialized into an implementation-specific version (`ffmpeg_video_settings`). A given `video_input` can export its settings into its respective derived class, cast it to a generic `video_settings`, and these settings can be handed off to a `video_output` in the future. If that `video_output` can read the implementation-specific settings, it will do so. Otherwise, it will use reasonable defaults.

In the future, we may add virtual methods to `video_input` so the user can generically get/set common parameters like frame dimensions and frame rate. But not in this PR. 