### PR TITLE
Fix issue with default logger stripping leading zeros off frac seconds

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -39,3 +39,8 @@ Build System
    if CUDA is not installed in standard system locations.
 
  * Enable the CUDA arrow in the Docker container.
+
+Vital: Logging
+
+ * Fixed an issue in the default logger where leading zeros of fractional
+   seconds were being stripped leading to the printing of the incorrect time.

--- a/vital/logger/default_logger.cxx
+++ b/vital/logger/default_logger.cxx
@@ -212,7 +212,7 @@ private:
       while ( getline( ss, msg_part ) )
       {
         *str << buf
-             << '.' << fractional_seconds
+             << '.' << std::setfill('0') << std::setw(3) << fractional_seconds
              << ' ' << level_str << ' ' << location << msg_part << '\n';
       }
     }


### PR DESCRIPTION
I found when trying to spot-check a program some of the log time was jumping "forward and backward" in time. Below is a example of logging outputs before this fix (with the message portions removed):
```
2022-01-06 17:21:53.990 DEBUG
2022-01-06 17:21:53.992 DEBUG
2022-01-06 17:21:54.4 DEBUG
2022-01-06 17:21:54.6 DEBUG
2022-01-06 17:21:54.6 DEBUG
2022-01-06 17:21:54.9 DEBUG
2022-01-06 17:21:54.9 DEBUG
2022-01-06 17:21:54.9 DEBUG
2022-01-06 17:21:54.9 DEBUG
2022-01-06 17:21:54.9 DEBUG
2022-01-06 17:21:54.10 DEBUG
2022-01-06 17:21:54.10 DEBUG
```
As can be seen, when time moved from `2022-01-06 17:21:53.992` to what likely should have been `2022-01-06 17:21:54.004`, the fractional seconds leading zeros have been dropped.