### PR TITLE
Ensure FFmpeg drains buffered frames

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -117,6 +117,7 @@ public:
   bool collected_all_metadata = false;
   bool estimated_num_frames = false;
   bool sync_metadata = true;
+  bool is_draining = false;
   size_t max_seek_back_attempts = 10;
 
   // ==================================================================
@@ -269,6 +270,7 @@ public:
     this->f_video_index = -1;
     this->metadata.clear();
     this->f_start_time = -1;
+    this->is_draining = false;
 
     if (this->f_video_stream)
     {
@@ -385,6 +387,28 @@ public:
     return true;
   }
 
+  // --------------------------------------------------------------------------
+  // Try to get a decoded frame from FFmpeg, return FFmpeg error code.
+  int query_frame()
+  {
+    auto const result = avcodec_receive_frame( f_video_encoding, f_frame );
+
+    if( result < 0 )
+    {
+      return result;
+    }
+
+    f_pts = av_frame_get_best_effort_timestamp( f_frame );
+    if( f_pts == AV_NOPTS_VALUE )
+    {
+      f_pts = 0;
+    }
+
+    frame_advanced = true;
+
+    return result;
+  }
+
   // ==================================================================
   /*
   * @brief Advance to the next frame (but don't acquire an image).
@@ -393,19 +417,23 @@ public:
   */
   bool advance()
   {
+    this->frame_advanced = false;
+    
     // Quick return if the file isn't open.
     if (!this->is_opened())
     {
-      this->frame_advanced = false;
       return false;
     }
-
-    this->frame_advanced = false;
 
     // clear the metadata from the previous frame
     for (auto& md : this->curr_metadata)
     {
       md.second.clear();
+    }
+
+    if( is_draining )
+    {
+      return query_frame() >= 0;
     }
 
     while (!this->frame_advanced &&
@@ -421,7 +449,7 @@ public:
           return false;
         }
 
-        err = avcodec_receive_frame(this->f_video_encoding, this->f_frame);
+        err = query_frame();
 
         // Ignore the frame and move to the next
         if (err == AVERROR_INVALIDDATA || err == AVERROR(EAGAIN))
@@ -435,14 +463,6 @@ public:
           av_packet_unref(this->f_packet);
           return false;
         }
-
-        this->f_pts = av_frame_get_best_effort_timestamp(this->f_frame);
-        if (this->f_pts == AV_NOPTS_VALUE)
-        {
-          this->f_pts = 0;
-        }
-
-        this->frame_advanced = true;
       }
 
       // grab the metadata from this packet if from the metadata stream
@@ -457,6 +477,17 @@ public:
 
       // De-reference previous packet
       av_packet_unref(this->f_packet);
+    }
+
+    // End of video? Get all still-buffered frames from decoder
+    if( !frame_advanced && !is_draining )
+    {
+      is_draining = true;
+      avcodec_send_packet( f_video_encoding, nullptr );
+      if( query_frame() < 0 )
+      {
+        return false;
+      }
     }
 
     // The cached frame is out of date, whether we managed to get a new
@@ -500,6 +531,8 @@ public:
   */
   bool seek( uint64_t frame )
   {
+    is_draining = false;
+
     // Time for frame before requested frame. The frame before is requested so
     // advance will called at least once in case the request lands on a keyframe.
     int64_t frame_ts = (static_cast<int>(f_frame_number_offset) + frame - 1) *
@@ -758,6 +791,7 @@ public:
                                        frame_ts,
                                        AVSEEK_FLAG_BACKWARD);
         avcodec_flush_buffers(this->f_video_encoding);
+        is_draining = false;
 
         if (seek_rslt < 0)
         {

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -16,6 +16,9 @@ Arrows: FFMPEG
  * Fixed a bug in which slight variations in presentation timestamps would
    sometimes cause frames to be skipped while decoding.
 
+ * Fixed a bug in which the video reader would not request any frames at end of
+   video that FFmpeg still had buffered internally.
+
 Arrows: MVG
 
  * Fixed a typo in the command line argument name for camera path in the


### PR DESCRIPTION
Our current FFmpeg video input treats the failure of `av_read_frame()` as the end of the video. However, there still may be frames buffered in the FFmpeg decoder, e.g. if the last frame of the input is not a keyframe, the decoder may be waiting in vain for the next keyframe packet before emitting another frame image. The correct behavior when the last packet has been read from file is to then call `av_send_packet()` with a `NULL` packet, which signals the decoder to enter 'draining mode'. Any remaining decodable frames can then be read out, preventing the previously observed loss of a few frames at the end of some videos.