### PR TITLE
Implement CRC-32-MPEG

### DIFF
--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -1614,7 +1614,7 @@ klv_0601_local_set_format
 }
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_0601_local_set_format
 ::calculate_checksum( klv_read_iter_t data, size_t length ) const
 {
@@ -1623,7 +1623,7 @@ klv_0601_local_set_format
 }
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_0601_local_set_format
 ::read_checksum( klv_read_iter_t data, size_t length ) const
 {
@@ -1647,7 +1647,7 @@ klv_0601_local_set_format
 // ----------------------------------------------------------------------------
 void
 klv_0601_local_set_format
-::write_checksum( uint16_t checksum,
+::write_checksum( uint32_t checksum,
                   klv_write_iter_t& data, size_t max_length ) const
 {
   if( max_length < checksum_packet_length )
@@ -1656,7 +1656,7 @@ klv_0601_local_set_format
                  "writing checksum packet overflows data buffer" );
   }
   data = std::copy( checksum_header.cbegin(), checksum_header.cend(), data );
-  klv_write_int( checksum, data, 2 );
+  klv_write_int( static_cast< uint16_t >( checksum ), data, 2 );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -510,14 +510,14 @@ private:
   read_typed( klv_read_iter_t& data, size_t length ) const override;
 
 
-  uint16_t
+  uint32_t
   calculate_checksum( klv_read_iter_t data, size_t length ) const override;
 
-  uint16_t
+  uint32_t
   read_checksum( klv_read_iter_t data, size_t length ) const override;
 
   void
-  write_checksum( uint16_t checksum,
+  write_checksum( uint32_t checksum,
                   klv_write_iter_t& data, size_t max_length ) const override;
 
   size_t

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -255,7 +255,7 @@ klv_1108_local_set_format
 {}
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_1108_local_set_format
 ::calculate_checksum( klv_read_iter_t data, size_t length ) const
 {
@@ -264,7 +264,7 @@ klv_1108_local_set_format
 }
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_1108_local_set_format
 ::read_checksum( klv_read_iter_t data, size_t length ) const
 {
@@ -288,7 +288,7 @@ klv_1108_local_set_format
 // ----------------------------------------------------------------------------
 void
 klv_1108_local_set_format
-::write_checksum( uint16_t checksum,
+::write_checksum( uint32_t checksum,
                   klv_write_iter_t& data, size_t max_length ) const
 {
   if( max_length < checksum_packet_length )
@@ -297,7 +297,7 @@ klv_1108_local_set_format
                  "writing checksum packet overflows data buffer" );
   }
   data = std::copy( checksum_header.cbegin(), checksum_header.cend(), data );
-  klv_write_int( checksum, data, 2 );
+  klv_write_int( static_cast< uint16_t >( checksum ), data, 2 );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -218,14 +218,14 @@ public:
   description() const override;
 
 private:
-  uint16_t
+  uint32_t
   calculate_checksum( klv_read_iter_t data, size_t length ) const override;
 
-  uint16_t
+  uint32_t
   read_checksum( klv_read_iter_t data, size_t length ) const override;
 
   void
-  write_checksum( uint16_t checksum,
+  write_checksum( uint32_t checksum,
                   klv_write_iter_t& data, size_t max_length ) const override;
 
   size_t

--- a/arrows/klv/klv_checksum.cxx
+++ b/arrows/klv/klv_checksum.cxx
@@ -68,16 +68,43 @@ klv_crc_16_ccitt( Iterator data_begin, Iterator data_end,
 }
 
 // ----------------------------------------------------------------------------
-// Instantiate templates for common iterators
-#define KLV_INSTANTIATE( FN, T ) \
-  template KWIVER_ALGO_KLV_EXPORT FN< T >( T, T, uint16_t )
-#define KLV_INSTANTIATE_ALL( FN ) \
-  KLV_INSTANTIATE( FN, uint8_t const* ); \
-  KLV_INSTANTIATE( FN, typename std::vector< uint8_t >::iterator ); \
-  KLV_INSTANTIATE( FN, typename std::vector< uint8_t >::const_iterator )
+template < class Iterator >
+uint32_t
+klv_crc_32_mpeg( Iterator data_begin, Iterator data_end,
+                 uint32_t initial_value )
+{
+  auto accumulator =
+    []( uint32_t crc, uint8_t byte ) -> uint32_t {
+      constexpr uint32_t polynomial = 0x04C11DB7;
+      crc ^= static_cast< uint32_t >( byte ) << 24;
+      for( size_t i = 0; i < 8; ++i )
+      {
+        bool const high_bit = crc & 0x80000000;
+        crc <<= 1;
+        if( high_bit )
+        {
+          crc ^= polynomial;
+        }
+      }
+      return crc;
+    };
 
-KLV_INSTANTIATE_ALL( uint16_t klv_crc_16_ccitt );
-KLV_INSTANTIATE_ALL( uint16_t klv_running_sum_16 );
+  // CRC of given data
+  return std::accumulate( data_begin, data_end, initial_value, accumulator );
+}
+
+// ----------------------------------------------------------------------------
+// Instantiate templates for common iterators
+#define KLV_INSTANTIATE( FN, T, RETURN ) \
+  template KWIVER_ALGO_KLV_EXPORT FN< T >( T, T, RETURN )
+#define KLV_INSTANTIATE_ALL( FN, RETURN ) \
+  KLV_INSTANTIATE( RETURN FN, uint8_t const*, RETURN ); \
+  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::iterator, RETURN ); \
+  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::const_iterator, RETURN )
+
+KLV_INSTANTIATE_ALL( klv_crc_16_ccitt, uint16_t );
+KLV_INSTANTIATE_ALL( klv_running_sum_16, uint16_t );
+KLV_INSTANTIATE_ALL( klv_crc_32_mpeg, uint32_t );
 
 #undef KLV_INSTANTIATE
 #undef KLV_INSTANTIATE_ALL

--- a/arrows/klv/klv_checksum.h
+++ b/arrows/klv/klv_checksum.h
@@ -51,6 +51,23 @@ uint16_t
 klv_crc_16_ccitt( Iterator data_begin, Iterator data_end,
                   uint16_t initial_value = 0xFFFF );
 
+// ----------------------------------------------------------------------------
+/// Calculate the CRC-32-MPEG checksum of the given bytes.
+///
+/// The CRC-32-MPEG specification is a 32-bit CRC with the polynomial \c
+/// 0x04C11DB7 and an initial value of \c 0xFFFFFFFF. No special modification
+/// is made to the input data or output CRC.
+///
+/// \param data_begin Iterator to the beginning of a buffer of \c uint8_t.
+/// \param data_end Iterator to the end of a buffer of \c uint8_t.
+///
+/// \return Checksum of the data buffer.
+template < class Iterator >
+KWIVER_ALGO_KLV_EXPORT
+uint32_t
+klv_crc_32_mpeg( Iterator data_begin, Iterator data_end,
+                  uint32_t initial_value = 0xFFFFFFFF );
+
 } // namespace klv
 
 } // namespace arrows

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -77,7 +77,7 @@ klv_data_format
 }
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_data_format
 ::calculate_checksum( VITAL_UNUSED klv_read_iter_t data,
                       VITAL_UNUSED size_t length ) const
@@ -86,7 +86,7 @@ klv_data_format
 }
 
 // ----------------------------------------------------------------------------
-uint16_t
+uint32_t
 klv_data_format
 ::read_checksum( VITAL_UNUSED klv_read_iter_t data,
                  VITAL_UNUSED size_t length ) const
@@ -97,7 +97,7 @@ klv_data_format
 // ----------------------------------------------------------------------------
 void
 klv_data_format
-::write_checksum( VITAL_UNUSED uint16_t checksum,
+::write_checksum( VITAL_UNUSED uint32_t checksum,
                   VITAL_UNUSED klv_write_iter_t& data,
                   VITAL_UNUSED size_t max_length ) const
 {}

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -85,16 +85,16 @@ public:
   description() const = 0;
 
   /// Return the checksum value of the given bytes.
-  virtual uint16_t
+  virtual uint32_t
   calculate_checksum( klv_read_iter_t data, size_t length ) const;
 
   /// Extract the written checksum value from the end of the given bytes.
-  virtual uint16_t
+  virtual uint32_t
   read_checksum( klv_read_iter_t data, size_t length ) const;
 
   /// Write the given checksum packet.
   virtual void
-  write_checksum( uint16_t checksum,
+  write_checksum( uint32_t checksum,
                   klv_write_iter_t& data, size_t max_length ) const;
 
   /// Return the length of the checksum packet.

--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -123,9 +123,9 @@ klv_read_packet( klv_read_iter_t& data, size_t max_length )
   {
     LOG_ERROR( kv::get_logger( "klv" ), std::hex << std::setfill( '0' )
                << "calculated checksum "
-               << "(0x" << std::setw( 4 ) << actual_checksum << ") "
+               << "(0x" << std::setw( 8 ) << actual_checksum << ") "
                << "does not equal checksum contained in packet "
-               << "(0x" << std::setw( 4 ) << expected_checksum << ")" );
+               << "(0x" << std::setw( 8 ) << expected_checksum << ")" );
   }
 
   // Read value

--- a/arrows/klv/tests/test_klv_checksum.cxx
+++ b/arrows/klv/tests/test_klv_checksum.cxx
@@ -63,3 +63,20 @@ TEST ( klv, klv_crc_16_ccitt )
   CALL_TEST( test_crc_16_ccitt, 0xE5CC,
              { '1', '2', '3', '4', '5', '6', '7', '8', '9' } );
 }
+
+// ----------------------------------------------------------------------------
+void
+test_crc_32_mpeg( uint32_t checksum, vec_t const& data )
+{
+  EXPECT_EQ( checksum, klv_crc_32_mpeg( data.cbegin(), data.cend() ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( klv, klv_crc_32_mpeg )
+{
+  // Verified via https://crccalc.com/
+  CALL_TEST( test_crc_32_mpeg, 0xFFFFFFFF, {} );
+  CALL_TEST( test_crc_32_mpeg, 0x7E4FD274, { 'A' } );
+  CALL_TEST( test_crc_32_mpeg, 0x0376E6E7,
+             { '1', '2', '3', '4', '5', '6', '7', '8', '9' } );
+}


### PR DESCRIPTION
Implement the CRC-32-MPEG checksum function, and change some KLV function signatures to be able to handle 32-bit checksums.
