### PR TITLE
Make klv_to_vital_metadata() return sptr

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -801,11 +801,9 @@ public:
     auto result =
       klv::klv_to_vital_metadata( m_klv_timeline, frame_timestamp );
 
-    auto result_sptr = std::make_shared< kwiver::vital::metadata >( result );
+    set_default_metadata( result );
 
-    set_default_metadata( result_sptr );
-
-    return { result_sptr };
+    return { result };
   }
 
   // --------------------------------------------------------------------------

--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -621,14 +621,14 @@ klv_1108_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
 } // namespace <anonymous>
 
 // ----------------------------------------------------------------------------
-kv::metadata
+kv::metadata_sptr
 klv_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp )
 {
-  kv::metadata result;
-  klv_0102_to_vital_metadata( klv_data, timestamp, result );
-  klv_0104_to_vital_metadata( klv_data, timestamp, result );
-  klv_0601_to_vital_metadata( klv_data, timestamp, result );
-  klv_1108_to_vital_metadata( klv_data, timestamp, result );
+  auto const result = std::make_shared< kv::metadata >();
+  klv_0102_to_vital_metadata( klv_data, timestamp, *result );
+  klv_0104_to_vital_metadata( klv_data, timestamp, *result );
+  klv_0601_to_vital_metadata( klv_data, timestamp, *result );
+  klv_1108_to_vital_metadata( klv_data, timestamp, *result );
   return result;
 }
 

--- a/arrows/klv/klv_convert_vital.h
+++ b/arrows/klv/klv_convert_vital.h
@@ -35,7 +35,7 @@ namespace klv {
 /// \return The vital-friendly metadata which can be extracted from
 ///         \p klv_data.
 KWIVER_ALGO_KLV_EXPORT
-kwiver::vital::metadata
+kwiver::vital::metadata_sptr
 klv_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp );
 
 } // namespace klv

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -216,11 +216,11 @@ public:
     {
       frame_timestamp.set_time_usec( d_frame_time );
     }
-    result.set_timestamp( frame_timestamp );
+    result->set_timestamp( frame_timestamp );
 
-    result.add< kwiver::vital::VITAL_META_VIDEO_URI >( video_path );
+    result->add< kwiver::vital::VITAL_META_VIDEO_URI >( video_path );
 
-    return { std::make_shared< kwiver::vital::metadata >( result ) };
+    return { result };
   }
 
   // -------------------------------------------------------------------------------------


### PR DESCRIPTION
Change the klv-to-vital conversion function so that it returns a shared pointer to a metadata object instead of by value. This is required by future changes which may make the `metadata` class `virtual`.