### PR TITLE
Refactor and expand MISP timestamp code

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -75,7 +75,7 @@ public:
   int64_t f_pts;
 
   // MISP timestamp (microseconds)
-  std::map< uint64_t, uint64_t > m_pts_to_misp;
+  std::map< uint64_t, klv::misp_timestamp > m_pts_to_misp;
   uint64_t m_last_klv_timestamp = 0;
 
   // Number of frames to back step when seek fails to land on frame before
@@ -493,15 +493,11 @@ public:
       {
         auto const packet_begin = f_packet->data;
         auto const packet_end = f_packet->data + f_packet->size;
-        auto const misp_it =
-          klv::find_misp_timestamp( packet_begin, packet_end );
+        auto misp_it = klv::find_misp_timestamp( packet_begin, packet_end );
         if( misp_it != packet_end )
         {
           auto const timestamp = klv::read_misp_timestamp( misp_it );
-          if( timestamp )
-          {
-            m_pts_to_misp.emplace( f_packet->pts, timestamp );
-          }
+          m_pts_to_misp.emplace( f_packet->pts, timestamp );
         }
 
         int err =
@@ -790,7 +786,7 @@ public:
       auto const it = m_pts_to_misp.find( f_frame->pts );
       if( it != m_pts_to_misp.end() )
       {
-        frame_timestamp = it->second;
+        frame_timestamp = it->second.timestamp;
       }
     }
     else

--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -20,6 +20,7 @@ set( sources
   klv_0601.cxx
   klv_1108.cxx
   klv_1108_metric_set.cxx
+  misp_time.cxx
   )
 
 set( public_headers

--- a/arrows/klv/misp_time.cxx
+++ b/arrows/klv/misp_time.cxx
@@ -1,0 +1,49 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief Define MISP timestamp utility functions.
+
+#include "misp_time.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+namespace {
+
+// Indicates a functioning clock of unknown absolute-ness
+constexpr uint8_t default_status = 0x9F;
+
+} // namespace
+
+// ----------------------------------------------------------------------------
+misp_timestamp
+::misp_timestamp()
+  : timestamp{ 0 }, status{ default_status } {}
+
+// ----------------------------------------------------------------------------
+misp_timestamp
+::misp_timestamp( uint64_t timestamp )
+  : timestamp{ timestamp }, status{ default_status } {}
+
+// ----------------------------------------------------------------------------
+misp_timestamp
+::misp_timestamp( uint64_t timestamp, uint8_t status )
+  : timestamp{ timestamp }, status{ status } {}
+
+// ----------------------------------------------------------------------------
+size_t
+misp_timestamp_length()
+{
+  return misp_detail::packet_length;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/misp_time.h
+++ b/arrows/klv/misp_time.h
@@ -17,8 +17,10 @@
 #include <vital/range/iota.h>
 
 #include <algorithm>
+#include <string>
 #include <vector>
 
+#include <cstddef>
 #include <cstdint>
 
 namespace kwiver {
@@ -29,16 +31,49 @@ namespace klv {
 
 namespace misp_detail {
 
-constexpr ptrdiff_t tag_length = 16;
-constexpr ptrdiff_t status_length = 1;
-constexpr ptrdiff_t timestamp_length = 8 + 3;
-constexpr ptrdiff_t packet_length =
+constexpr std::ptrdiff_t tag_length = 16;
+constexpr std::ptrdiff_t status_length = 1;
+constexpr std::ptrdiff_t timestamp_length = 8 + 3;
+constexpr std::ptrdiff_t packet_length =
   tag_length + status_length + timestamp_length;
+auto const tag_bytes = std::string{ "MISPmicrosectime" };
 
 } // namespace misp_detail
 
 // ----------------------------------------------------------------------------
-/// Locate a MISP timestamp packet in a sequence of bytes.
+/// Bit indices for the MISP timestamp status.
+enum misp_timestamp_status_bit
+{
+  // Bits 0-4 reserved for future use; should be set to 1 for now
+
+  // 0 = jump forward in time, 1 = jump backward in time
+  MISP_TIMESTAMP_STATUS_BIT_DISCONTINUITY_REVERSE = 5,
+
+  // 0 = normal, 1 = time discontinuity (jump forward or backward)
+  MISP_TIMESTAMP_STATUS_BIT_DISCONTINUITY = 6,
+
+  // 0 = time is locked to absolute reference, 1 = time may not be locked
+  MISP_TIMESTAMP_STATUS_BIT_NOT_LOCKED = 7,
+
+  MISP_TIMESTAMP_STATUS_BIT_ENUM_END,
+};
+
+// ----------------------------------------------------------------------------
+/// Frame timestamp information embedded in the video stream.
+struct KWIVER_ALGO_KLV_EXPORT misp_timestamp
+{
+  misp_timestamp();
+
+  misp_timestamp( uint64_t timestamp );
+
+  misp_timestamp( uint64_t timestamp, uint8_t status );
+
+  uint64_t timestamp;
+  uint8_t status;
+};
+
+// ----------------------------------------------------------------------------
+/// Locate a MISP microsecond timestamp packet in a sequence of bytes.
 ///
 /// \param begin Iterator to beginning of byte sequence.
 /// \param end Iterator to end of byte sequence.
@@ -48,7 +83,7 @@ template < class Iterator >
 Iterator
 find_misp_timestamp( Iterator begin, Iterator end )
 {
-  static auto const tag = std::string{ "MISPmicrosectime" };
+  auto const& tag = misp_detail::tag_bytes;
   auto const it = std::search( begin, end, tag.cbegin(), tag.cend() );
   return ( std::distance( it, end ) < misp_detail::packet_length ) ? end : it;
 }
@@ -56,18 +91,21 @@ find_misp_timestamp( Iterator begin, Iterator end )
 // ----------------------------------------------------------------------------
 /// Read a MISP timestamp from a sequence of bytes.
 ///
-/// \param begin Iterator to beginning of MISP packet.
+/// \param data Iterator to beginning of MISP packet. Set to end of read bytes
+///             on success.
 ///
 /// \return MISP microsecond timestamp.
 template < class Iterator >
-uint64_t
-read_misp_timestamp( Iterator begin )
+misp_timestamp
+read_misp_timestamp( Iterator& data )
 {
-  // Skip tag and status to get to timestamp
-  auto it = std::next( begin,
-                       misp_detail::tag_length +
-                       misp_detail::status_length );
-  uint64_t result = 0;
+  // Skip tag to get to status and timestamp
+  std::advance( data, misp_detail::tag_length );
+
+  auto const status = *data;
+  ++data;
+
+  uint64_t timestamp = 0;
   for( auto const i :
        kwiver::vital::range::iota( misp_detail::timestamp_length ) )
   {
@@ -75,14 +113,58 @@ read_misp_timestamp( Iterator begin )
     // start tag for some other sort of data
     if( i % 3 != 2 )
     {
-      result <<= 8;
-      result |= *it;
+      timestamp <<= 8;
+      timestamp |= *data;
     }
-    ++it;
+    ++data;
   }
 
-  return result;
+  return { timestamp, status };
 }
+
+// ----------------------------------------------------------------------------
+/// Write a MISP timestamp to a sequence of bytes.
+///
+/// \param value Timestamp value to write.
+/// \param data Iterator to sequence of \c uint8_t. Set to end of written bytes
+//              on success.
+template < class Iterator >
+void
+write_misp_timestamp( misp_timestamp value, Iterator& data )
+{
+  // Write tag
+  auto const& tag = misp_detail::tag_bytes;
+  data = std::copy( tag.begin(), tag.end(), data );
+
+  // Write status
+  *data = value.status;
+  ++data;
+
+  for( auto const i :
+       kwiver::vital::range::iota( misp_detail::timestamp_length ) )
+  {
+    if( i % 3 == 2 )
+    {
+      // Every third byte is set to 0xFF to avoid the timestamp being read as a
+      // start tag for some other sort of data
+      *data = 0xFF;
+    }
+    else
+    {
+      // Write the next most significant byte
+      constexpr uint64_t mask = 0xFF << 7;
+      *data = value.timestamp & mask;
+      value.timestamp <<= 8;
+    }
+    ++data;
+  }
+}
+
+// ----------------------------------------------------------------------------
+/// Return the length of a MISP timestamp packet in bytes.
+KWIVER_ALGO_KLV_EXPORT
+size_t
+misp_timestamp_length();
 
 } // namespace klv
 

--- a/arrows/vxl/vidl_ffmpeg_video_input.cxx
+++ b/arrows/vxl/vidl_ffmpeg_video_input.cxx
@@ -311,12 +311,11 @@ public:
     do
     {
       auto const packet_data = d_video_stream.current_packet_data();
-      auto const it =
-        kwiver::arrows::klv::find_misp_timestamp( packet_data.cbegin(),
-                                                  packet_data.cend() );
+      auto it = kwiver::arrows::klv::find_misp_timestamp( packet_data.cbegin(),
+                                                          packet_data.cend() );
       if ( it != packet_data.cend() )
       {
-        meta_ts = kwiver::arrows::klv::read_misp_timestamp( it );
+        meta_ts = kwiver::arrows::klv::read_misp_timestamp( it ).timestamp;
         LOG_DEBUG( this->d_logger, "Found MISP frame time:" << meta_ts );
 
         d_have_abs_frame_time = true;


### PR DESCRIPTION
Refactor the MISP timestamp functions to look more like the KLV read/write functions. Read (and newly write) the timestamp status byte as well as the raw timestamps. Relevant standard: [ST0603](https://nsgreg.nga.mil/doc/view?i=4501)