### PR TITLE
Ensure NaN KLV values compare equal

### DIFF
--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -24,6 +24,30 @@ namespace arrows {
 
 namespace klv {
 
+namespace {
+
+// ----------------------------------------------------------------------------
+template < class T,
+           typename std::enable_if< !std::is_floating_point< T >::value,
+                                    bool >::type = true >
+bool
+equal_or_nan( T const& lhs, T const& rhs )
+{
+  return lhs == rhs;
+}
+
+// ----------------------------------------------------------------------------
+template < class T,
+           typename std::enable_if< std::is_floating_point< T >::value,
+                                    bool >::type = true >
+bool
+equal_or_nan( T const& lhs, T const& rhs )
+{
+  return lhs == rhs || ( std::isnan( lhs ) && std::isnan( rhs ) );
+}
+
+} // namespace
+
 // ----------------------------------------------------------------------------
 klv_bad_value_cast
 ::klv_bad_value_cast( std::type_info const& requested_type,
@@ -109,7 +133,7 @@ public:
     auto const& rhs_item =
       dynamic_cast< internal_< T > const& >( rhs ).m_item;
     // Second, compare values
-    return lhs.m_item == rhs_item;
+    return equal_or_nan( lhs.m_item, rhs_item );
   }
 
   std::ostream&


### PR DESCRIPTION
While C++ treats all `NaN` values as not equal to each other, for the purposes of KLV it is useful for `klv_value`s with `NaN`s to compare equal; else two copies of the same KLV packet with some `NaN` value buried somewhere can never compare as equal. This change makes testing/validation much easier in such cases.