### PR TITLE
Fix darknet arrow build

### DIFF
--- a/arrows/darknet/CMakeLists.txt
+++ b/arrows/darknet/CMakeLists.txt
@@ -14,7 +14,7 @@ set( sources
   darknet_trainer.cxx )
 
 set( darknet_linked_libs
-  darknet
+  Darknet::dark
   kwiversys
   kwiver_algo_ocv
   ${OpenCV_LIBS} )

--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -23,7 +23,8 @@
 #include <limits>
 #include <fstream>
 
-#include "darknet/yolo_v2_class.hpp"
+// Using DarknetConfig.cmake provides the exact directory to the header
+#include "yolo_v2_class.hpp"
 
 namespace kwiver {
 namespace arrows {

--- a/arrows/darknet/darknet_detector.cxx
+++ b/arrows/darknet/darknet_detector.cxx
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <exception>
 #include <limits>
+#include <fstream>
 
 #include "darknet/yolo_v2_class.hpp"
 


### PR DESCRIPTION
The following patches are required to get the darknet arrow to build. The first commit assumes Darknet_DIR is being used and points to a valid DarknetConfig.cmake.