### PR TITLE
Visit.h needs to be installed

### DIFF
--- a/vital/util/CMakeLists.txt
+++ b/vital/util/CMakeLists.txt
@@ -39,6 +39,7 @@ set( public_headers
   variant/in_place.hpp
   variant/lib.hpp
   variant/variant.hpp
+  visit.h
   wrap_text_block.h
   file_md5.h
   )


### PR DESCRIPTION
This PR adds visit.h to the list of public_headers.