### PR TITLE
Fix deprecated FFmpeg functions on upgrade to 4.4.1

### DIFF
--- a/arrows/ffmpeg/ffmpeg_init.cxx
+++ b/arrows/ffmpeg/ffmpeg_init.cxx
@@ -14,6 +14,7 @@
 extern "C" {
 #include <libavfilter/avfilter.h>
 #include <libavformat/avformat.h>
+#include <libavutil/version.h>
 }
 
 #include <vital/logger/logger.h>
@@ -64,8 +65,11 @@ ffmpeg_init()
   static bool initialized = false;
   if( !initialized )
   {
+#if LIBAVFORMAT_VERSION_MAJOR < 58
+    // Unnecessary and deprecated in FFmpeg >= 4.0
     av_register_all();
     avfilter_register_all();
+#endif
     av_log_set_callback( ffmpeg_kwiver_log_callback );
     initialized = true;
   }

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -292,7 +292,7 @@ public:
       recv_err = avcodec_receive_frame( this->f_video_encoding, this->f_frame );
       av_packet_unref( this->f_packet );
     } while( send_err || recv_err );
-    this->f_start_time = av_frame_get_best_effort_timestamp( this->f_frame );
+    this->f_start_time = this->f_frame->best_effort_timestamp;
     // Seek back to start
     av_seek_frame( this->f_format_context, this->f_video_index, 0,
                    AVSEEK_FLAG_FRAME );
@@ -448,7 +448,7 @@ public:
       return result;
     }
 
-    f_pts = av_frame_get_best_effort_timestamp( f_frame );
+    f_pts = f_frame->best_effort_timestamp;
     if( f_pts == AV_NOPTS_VALUE )
     {
       f_pts = 0;


### PR DESCRIPTION
I believe these changes eliminate the deprecation warnings which appear when upgrading to FFmpeg v4.4.1.