### PR TITLE
Toggle ffmpeg reader in VXL is ffmpeg isn't compatible

### DIFF
--- a/arrows/vxl/CMakeLists.txt
+++ b/arrows/vxl/CMakeLists.txt
@@ -36,17 +36,6 @@ set(vxl_headers_public
   threshold.h
   triangulate_landmarks.h
   vil_image_memory.h
-  vidl_ffmpeg_video_input.h
-  )
-
-kwiver_install_headers(
-  SUBDIR     arrows/vxl
-  ${vxl_headers_public}
-  )
-
-kwiver_install_headers(
-  ${CMAKE_CURRENT_BINARY_DIR}/kwiver_algo_vxl_export.h
-  NOPATH   SUBDIR     arrows/vxl
   )
 
 set(vxl_sources
@@ -78,7 +67,26 @@ set(vxl_sources
   threshold.cxx
   triangulate_landmarks.cxx
   vil_image_memory.cxx
-  vidl_ffmpeg_video_input.cxx
+  )
+
+if( fletch_ENABLE_FFmpeg AND _FFmpeg_version VERSION_LESS 4 )
+  list(APPEND vxl_headers_public
+    vidl_ffmpeg_video_input.h
+  )
+  list(APPEND vxl_sources
+    vidl_ffmpeg_video_input.cxx
+  )
+  add_definitions( -DVXL_ENABLE_FFMPEG )
+endif()
+
+kwiver_install_headers(
+  SUBDIR     arrows/vxl
+  ${vxl_headers_public}
+  )
+
+kwiver_install_headers(
+  ${CMAKE_CURRENT_BINARY_DIR}/kwiver_algo_vxl_export.h
+  NOPATH   SUBDIR     arrows/vxl
   )
 
 kwiver_add_library( kwiver_algo_vxl

--- a/arrows/vxl/register_algorithms.cxx
+++ b/arrows/vxl/register_algorithms.cxx
@@ -30,7 +30,10 @@
 #include <arrows/vxl/triangulate_landmarks.h>
 #include <arrows/vxl/match_features_constrained.h>
 #include <arrows/vxl/morphology.h>
+
+#ifdef VXL_ENABLE_FFMPEG
 #include <arrows/vxl/vidl_ffmpeg_video_input.h>
+#endif
 
 namespace kwiver {
 namespace arrows {
@@ -70,7 +73,10 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   reg.register_algorithm< triangulate_landmarks >();
   reg.register_algorithm< match_features_constrained >();
   reg.register_algorithm< morphology >();
+
+#ifdef VXL_ENABLE_FFMPEG
   reg.register_algorithm< vidl_ffmpeg_video_input >();
+#endif
 
   reg.mark_module_as_loaded();
 }

--- a/arrows/vxl/tests/CMakeLists.txt
+++ b/arrows/vxl/tests/CMakeLists.txt
@@ -25,8 +25,10 @@ kwiver_discover_gtests(vxl image_io                       LIBRARIES ${test_libra
 kwiver_discover_gtests(vxl morphology                     LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vxl pixel_feature_extractor        LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vxl polygon                        LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vxl vidl_ffmpeg_video_input        LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
 
+if( fletch_ENABLE_FFmpeg AND _FFmpeg_version VERSION_LESS 4 )
+kwiver_discover_gtests(vxl vidl_ffmpeg_video_input        LIBRARIES ${test_libraries}  ARGUMENTS "${kwiver_test_data_directory}")
+endif()
 
 # Additional tests that depend on the MVG arrow
 list(APPEND test_libraries kwiver_algo_mvg)


### PR DESCRIPTION
Disable the video input implementation in vxl when ffmpeg isn't present or is an incompatible version.