### PR TITLE
Add transcoder applet

### DIFF
--- a/arrows/core/applets/CMakeLists.txt
+++ b/arrows/core/applets/CMakeLists.txt
@@ -7,11 +7,13 @@ set( sources
 
   dump_klv.cxx
   render_mesh.cxx
+  transcode.cxx
   )
 
 set( headers
   dump_klv.h
   render_mesh.h
+  transcode.h
   )
 
 ###

--- a/arrows/core/applets/register_applets.cxx
+++ b/arrows/core/applets/register_applets.cxx
@@ -13,6 +13,7 @@
 
 #include <arrows/core/applets/dump_klv.h>
 #include <arrows/core/applets/render_mesh.h>
+#include <arrows/core/applets/transcode.h>
 
 namespace kwiver {
 namespace arrows {
@@ -34,6 +35,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   // -- register applets --
   reg.register_tool< dump_klv >();
   reg.register_tool< render_mesh >();
+  reg.register_tool< transcode_applet >();
 
   reg.mark_module_as_loaded();
 }

--- a/arrows/core/applets/transcode.cxx
+++ b/arrows/core/applets/transcode.cxx
@@ -1,0 +1,127 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#include "transcode.h"
+
+#include <vital/algo/video_input.h>
+#include <vital/algo/video_output.h>
+
+#include <vital/config/config_block_io.h>
+
+#include <iostream>
+
+namespace kv = kwiver::vital;
+namespace kva = kwiver::vital::algo;
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+// ----------------------------------------------------------------------------
+transcode_applet
+::transcode_applet()
+{}
+
+// ----------------------------------------------------------------------------
+void
+transcode_applet
+::add_command_options()
+{
+  m_cmd_options->add_options()                   //
+    ( "h,help",   "Display applet usage.",
+    ::cxxopts::value< bool >() )                 //
+    ( "c,config", "Specify configuration file.",
+    ::cxxopts::value< std::string >(), "file" )  //
+    ( "i,input",  "Specify input video file.",
+    ::cxxopts::value< std::string >(), "file" )  //
+    ( "o,output", "Specify output video file.",
+    ::cxxopts::value< std::string >(), "file" );
+}
+
+// ----------------------------------------------------------------------------
+int
+transcode_applet
+::run()
+{
+  auto& cmd_args = command_args();
+
+  // Parse help flag
+  if( cmd_args[ "help" ].as< bool >() )
+  {
+    std::cerr << m_cmd_options->help();
+    return EXIT_SUCCESS;
+  }
+
+  // Parse input argument
+  if( !cmd_args.count( "input" ) )
+  {
+    std::cerr << "Specify input video file with -i/--input." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  auto const& input_filename = cmd_args[ "input" ].as< std::string >();
+
+  // Parse output argument
+  if( !cmd_args.count( "output" ) )
+  {
+    std::cerr << "Specify output video file with -o/--output." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  auto const& output_filename = cmd_args[ "output" ].as< std::string >();
+
+  // Assemble configuration
+  auto config = find_configuration( "applets/transcode.conf" );
+  if( cmd_args.count( "config" ) )
+  {
+    auto const& config_filename = cmd_args[ "config" ].as< std::string >();
+    config->merge_config( kv::read_config_file( config_filename ) );
+  }
+
+  // Setup video input
+  kva::video_input_sptr input;
+  kva::video_input
+  ::set_nested_algo_configuration( "video_reader", config, input );
+  kva::video_input
+  ::get_nested_algo_configuration( "video_reader", config, input );
+  input->open( input_filename );
+
+  auto const video_settings = input->implementation_settings();
+
+  // Setup video output
+  kva::video_output_sptr output;
+  kva::video_output
+  ::set_nested_algo_configuration( "video_writer", config, output );
+  kva::video_output
+  ::get_nested_algo_configuration( "video_writer", config, output );
+  output->open( output_filename, video_settings.get() );
+
+  // Transcode frames
+  kv::timestamp timestamp;
+  for( input->next_frame( timestamp );
+       !input->end_of_video();
+       input->next_frame( timestamp ) )
+  {
+    auto const image = input->frame_image();
+    for( auto const& metadata : input->frame_metadata() )
+    {
+      output->add_metadata( *metadata );
+    }
+    output->add_image( image, timestamp );
+  }
+
+  // Clean up
+  input->close();
+  output->close();
+
+  return EXIT_SUCCESS;
+}
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/applets/transcode.h
+++ b/arrows/core/applets/transcode.h
@@ -1,0 +1,37 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#ifndef KWIVER_ARROWS_CORE_APPLETS_TRANSCODE_H_
+#define KWIVER_ARROWS_CORE_APPLETS_TRANSCODE_H_
+
+#include <vital/applets/kwiver_applet.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+class transcode_applet : public tools::kwiver_applet
+{
+public:
+  transcode_applet();
+
+  PLUGIN_INFO( "transcode",
+               "Transcode video.\n\n"
+               "This program reads video from one format, "
+               "then writes it to another format." );
+
+  void add_command_options() override;
+
+  int run() override;
+};
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -201,6 +201,7 @@ ffmpeg_video_output
     VITAL_THROW( kv::video_runtime_exception,
                  "Failed to allocate format context" );
   }
+  d->output_format = d->format_context->oformat;
 
   // Configure video codec
   d->codec = avcodec_find_encoder( d->output_format->video_codec );
@@ -298,7 +299,7 @@ ffmpeg_video_output
                    "Failed to write video header" );
     }
   }
-  if( output_status != AVSTREAM_INIT_IN_INIT_OUTPUT )
+  else if( output_status != AVSTREAM_INIT_IN_INIT_OUTPUT )
   {
     VITAL_THROW( kv::video_runtime_exception,
                  "Failed to initialize output stream" );
@@ -493,7 +494,7 @@ ffmpeg_video_output
 // ----------------------------------------------------------------------------
 void
 ffmpeg_video_output
-::add_metadata( kwiver::vital::metadata_sptr const& md )
+::add_metadata( kwiver::vital::metadata const& md )
 {
   // TODO
 }

--- a/arrows/ffmpeg/ffmpeg_video_output.h
+++ b/arrows/ffmpeg/ffmpeg_video_output.h
@@ -50,7 +50,7 @@ public:
     kwiver::vital::image_container_sptr const& image,
     kwiver::vital::timestamp const& ts ) override;
 
-  void add_metadata( kwiver::vital::metadata_sptr const& md ) override;
+  void add_metadata( kwiver::vital::metadata const& md ) override;
 
 private:
   class impl;

--- a/config/applets/CMakeLists.txt
+++ b/config/applets/CMakeLists.txt
@@ -1,10 +1,11 @@
 set(config_files
+  color_mesh.conf
   dump_klv.conf
   estimate_depth.conf
   fuse_depth.conf
   init_cameras_landmarks.conf
   track_features.conf
-  color_mesh.conf
+  transcode.conf
   )
 
 # Ensure target directory exists

--- a/config/applets/transcode.conf
+++ b/config/applets/transcode.conf
@@ -1,0 +1,5 @@
+# Default configuration for core transcode applet
+
+video_reader:type = ffmpeg
+
+video_writer:type = ffmpeg

--- a/vital/algo/video_output.h
+++ b/vital/algo/video_output.h
@@ -116,7 +116,7 @@ public:
   ///
   /// \throws video_stream_exception
   ///   Thrown if is an error in the video stream.
-  virtual void add_metadata( kwiver::vital::metadata_sptr const& md ) = 0;
+  virtual void add_metadata( kwiver::vital::metadata const& md ) = 0;
 
   /// Return capabilities of concrete implementation.
   ///


### PR DESCRIPTION
Add a basic applet for transcoding video. Some more work is yet to be done, but the core functionality is here.
Sample usage:

```cpp
kwiver transcode -i aphill_short.ts -o test.ts
```

Already approved by @mleotta through other channels, so will be merging as soon as tests pass.