### PR TITLE
Add implementation_settings() for inputs which contain other inputs

### DIFF
--- a/arrows/core/video_input_filter.cxx
+++ b/arrows/core/video_input_filter.cxx
@@ -427,4 +427,12 @@ video_input_filter
   return std::make_shared<kwiver::vital::simple_metadata_map>(output_map);
 }
 
+// ----------------------------------------------------------------------------
+kwiver::vital::video_settings_uptr
+video_input_filter
+::implementation_settings() const
+{
+  return d->d_video_input->implementation_settings();
+}
+
 } } }     // end namespace

--- a/arrows/core/video_input_filter.h
+++ b/arrows/core/video_input_filter.h
@@ -61,6 +61,8 @@ public:
   virtual kwiver::vital::metadata_vector frame_metadata();
   virtual kwiver::vital::metadata_map_sptr metadata_map();
 
+  kwiver::vital::video_settings_uptr implementation_settings() const override;
+
 private:
   /// private implementation class
   class priv;

--- a/arrows/core/video_input_metadata_filter.cxx
+++ b/arrows/core/video_input_metadata_filter.cxx
@@ -300,6 +300,14 @@ video_input_metadata_filter
 }
 
 // ----------------------------------------------------------------------------
+kwiver::vital::video_settings_uptr
+video_input_metadata_filter
+::implementation_settings() const
+{
+  return m_d->video_input->implementation_settings();
+}
+
+// ----------------------------------------------------------------------------
 #define FORWARD_OR( name, fallback ) \
   auto video_input_metadata_filter::name() const \
     -> decltype( m_d->video_input->name() ) \

--- a/arrows/core/video_input_metadata_filter.h
+++ b/arrows/core/video_input_metadata_filter.h
@@ -54,6 +54,8 @@ public:
   kwiver::vital::metadata_vector frame_metadata() override;
   kwiver::vital::metadata_map_sptr metadata_map() override;
 
+  kwiver::vital::video_settings_uptr implementation_settings() const override;
+
 private:
   class priv;
 

--- a/arrows/core/video_input_splice.cxx
+++ b/arrows/core/video_input_splice.cxx
@@ -450,4 +450,12 @@ video_input_splice
   return std::make_shared<kwiver::vital::simple_metadata_map>(d->d_metadata_map);
 }
 
+// ----------------------------------------------------------------------------
+kwiver::vital::video_settings_uptr
+video_input_splice
+::implementation_settings() const
+{
+  return ( *d->d_active_source )->implementation_settings();
+}
+
 } } }     // end namespace

--- a/arrows/core/video_input_splice.h
+++ b/arrows/core/video_input_splice.h
@@ -59,6 +59,8 @@ public:
   virtual kwiver::vital::metadata_vector frame_metadata();
   virtual kwiver::vital::metadata_map_sptr metadata_map();
 
+  kwiver::vital::video_settings_uptr implementation_settings() const override;
+
 private:
   /// private implementation class
   class priv;

--- a/arrows/core/video_input_split.cxx
+++ b/arrows/core/video_input_split.cxx
@@ -344,6 +344,14 @@ video_input_split
   return std::make_shared<kwiver::vital::simple_metadata_map>(md_map1);
 }
 
+// ----------------------------------------------------------------------------
+kwiver::vital::video_settings_uptr
+video_input_split
+::implementation_settings() const
+{
+  return d->d_image_source->implementation_settings();
+}
+
 // ------------------------------------------------------------------
 kwiver::vital::timestamp
 video_input_split

--- a/arrows/core/video_input_split.h
+++ b/arrows/core/video_input_split.h
@@ -61,6 +61,8 @@ public:
   virtual kwiver::vital::metadata_vector frame_metadata();
   virtual kwiver::vital::metadata_map_sptr metadata_map();
 
+  kwiver::vital::video_settings_uptr implementation_settings() const override;
+
 private:
   kwiver::vital::timestamp merge_timestamps(
     kwiver::vital::timestamp const& image_ts,


### PR DESCRIPTION
Some of our core video_inputs rely on internal video_inputs of some other sort. This PR causes the parent video_inputs to pass on their child's video implementation settings (e.g. fps, bitrate) when asked.

Additional reviewer: @hdefazio 