### PR TITLE
Fix 16-bit sum parity bug

### DIFF
--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -1619,7 +1619,8 @@ klv_0601_local_set_format
 ::calculate_checksum( klv_read_iter_t data, size_t length ) const
 {
   return klv_running_sum_16( checksum_header.begin(), checksum_header.end(),
-                             klv_running_sum_16( data, data + length ) );
+                             klv_running_sum_16( data, data + length ),
+                             length % 2 );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_checksum.cxx
+++ b/arrows/klv/klv_checksum.cxx
@@ -22,10 +22,10 @@ namespace klv {
 template < class Iterator >
 uint16_t
 klv_running_sum_16( Iterator data_begin, Iterator data_end,
-                    uint16_t initial_value )
+                    uint16_t initial_value, bool parity )
 {
   // Counter to check even / odd byte
-  size_t i = 0;
+  size_t i = parity;
   auto accumulator =
     [ &i ]( uint16_t sum, uint8_t byte ) -> uint16_t {
       uint16_t const new_value = ( ++i % 2 ) ? ( byte << 8 ) : byte;
@@ -95,15 +95,16 @@ klv_crc_32_mpeg( Iterator data_begin, Iterator data_end,
 
 // ----------------------------------------------------------------------------
 // Instantiate templates for common iterators
-#define KLV_INSTANTIATE( FN, T, RETURN ) \
-  template KWIVER_ALGO_KLV_EXPORT FN< T >( T, T, RETURN )
-#define KLV_INSTANTIATE_ALL( FN, RETURN ) \
-  KLV_INSTANTIATE( RETURN FN, uint8_t const*, RETURN ); \
-  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::iterator, RETURN ); \
-  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::const_iterator, RETURN )
+#define KLV_INSTANTIATE( FN, T, RETURN, ... ) \
+  template KWIVER_ALGO_KLV_EXPORT FN< T >( T, T, RETURN __VA_ARGS__ )
+#define KLV_INSTANTIATE_ALL( FN, RETURN, ... ) \
+  KLV_INSTANTIATE( RETURN FN, uint8_t const*, RETURN, __VA_ARGS__ ); \
+  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::iterator, RETURN, __VA_ARGS__ ); \
+  KLV_INSTANTIATE( RETURN FN, typename std::vector< uint8_t >::const_iterator, RETURN, __VA_ARGS__ )
 
+// Double comma is intentional
+KLV_INSTANTIATE_ALL( klv_running_sum_16, uint16_t,, bool );
 KLV_INSTANTIATE_ALL( klv_crc_16_ccitt, uint16_t );
-KLV_INSTANTIATE_ALL( klv_running_sum_16, uint16_t );
 KLV_INSTANTIATE_ALL( klv_crc_32_mpeg, uint32_t );
 
 #undef KLV_INSTANTIATE

--- a/arrows/klv/klv_checksum.h
+++ b/arrows/klv/klv_checksum.h
@@ -32,7 +32,7 @@ template < class Iterator >
 KWIVER_ALGO_KLV_EXPORT
 uint16_t
 klv_running_sum_16( Iterator data_begin, Iterator data_end,
-                    uint16_t initial_value = 0x0000 );
+                    uint16_t initial_value = 0x0000, bool parity = false );
 
 // ----------------------------------------------------------------------------
 /// Calculate the CRC-16-CCITT checksum of the given bytes.


### PR DESCRIPTION
When concatenating `klv_running_sum_16()` results, we need to take into account whether the previous checksum ended on an even or odd byte, since the checksum operates on two-byte chunks instead of one-byte chunks like a sensible checksum.

Additional reviewer: @hdefazio 