### PR TITLE
Bugfix: set_origin referencing geo_point with wrong crs

### DIFF
--- a/vital/tests/test_local_geo_cs.cxx
+++ b/vital/tests/test_local_geo_cs.cxx
@@ -50,7 +50,7 @@ TEST_F(local_geo_cs, read_local_geo_cs_from_file)
   valid = read_local_geo_cs_from_file(lgcs, geo_origin_valid);
   EXPECT_TRUE(valid);
   // Expect the local geo cs to be valid
-  kv::vector_3d origin = lgcs.origin().location(crs);
+  kv::vector_3d origin = lgcs.origin().location();
   EXPECT_NEAR(origin[0], -77.3578172263, 1e-8);
   EXPECT_NEAR(origin[1], 38.1903504278, 1e-8);
   EXPECT_NEAR(origin[2], -68.0169758322, 1e-8);
@@ -60,7 +60,7 @@ TEST_F(local_geo_cs, read_local_geo_cs_from_file)
   valid = kv::read_local_geo_cs_from_file(lgcs, geo_origin_invalid);
   EXPECT_FALSE(valid);
   // Expect the origin to be unchanged
-  origin = lgcs.origin().location(crs);
+  origin = lgcs.origin().location();
   EXPECT_NEAR(origin[0], 0.0, 1e-8);
   EXPECT_NEAR(origin[1], 0.0, 1e-8);
   EXPECT_NEAR(origin[2], 0.0, 1e-8);

--- a/vital/types/local_geo_cs.cxx
+++ b/vital/types/local_geo_cs.cxx
@@ -35,7 +35,7 @@ local_geo_cs
   vector_3d lon_lat_alt = origin.location( SRID::lat_lon_WGS84 );
   auto zone = utm_ups_zone( lon_lat_alt );
   int crs = (zone.north ? SRID::UTM_WGS84_north : SRID::UTM_WGS84_south) + zone.number;
-  geo_origin_ = geo_point(origin.location(crs), crs);
+  geo_origin_ = geo_point(origin.location(), crs);
 }
 
 /// Read a local_geo_cs from a text file
@@ -62,7 +62,7 @@ write_local_geo_cs_to_file(local_geo_cs const& lgcs,
   kwiver::vital::logger_handle_t logger(kwiver::vital::get_logger(
     "write_local_geo_cs_to_file"));
   // write out the origin of the local coordinate system
-  auto lon_lat_alt = lgcs.origin().location( SRID::lat_lon_WGS84 );
+  auto lon_lat_alt = lgcs.origin().location();
   std::ofstream ofs(file_path);
   if (ofs)
   {


### PR DESCRIPTION
Background: `local_geo_cs::set_origin(const geo_point& origin)` is a function that modifies the `geo_origin_` to use a different coordinate referencing system (`crs`). Calling `geo_point::location(int crs)` returns a geopoint indexed by the `crs` variable. 

The existing code for `set_origin` creates a new `crs` to change the coordinate referencing system, but mistakenly uses that new `crs` to index the prexisting point. This leads to unexpected data (most likely garbage) being put in the `geo_point()` constructor.