### PR TITLE
Update test for mvg applet track-features command

### DIFF
--- a/arrows/mvg/applets/tests/CMakeLists.txt
+++ b/arrows/mvg/applets/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
 include(kwiver-test-setup)
 
-add_test(NAME mvg:track_features COMMAND kwiver track-features "${kwiver_test_data_directory}/aphill_240_1fps_crf32.mp4")
+add_test(NAME mvg:applets:track_features
+  COMMAND kwiver track-features
+            --config "${kwiver_test_data_directory}/track_features_testing.conf"
+            "${kwiver_test_data_directory}/aphill_240_1fps_crf32.mp4")

--- a/arrows/mvg/applets/tests/data/track_features_testing.conf
+++ b/arrows/mvg/applets/tests/data/track_features_testing.conf
@@ -1,0 +1,2 @@
+# Only process a subset of frames for testing
+feature_tracker:max_frames = 100


### PR DESCRIPTION
Test name changed from "mvg:track_features" to "mvg:applets:track_features"

Test now runs command on a custom config file, "track_features_testing.conf", which can be updated with custom options as needed. Currently it lowers the max_frames from 500 to 100