### PR TITLE
Set dump-klv default serializer to CSV

### DIFF
--- a/config/applets/dump_klv.conf
+++ b/config/applets/dump_klv.conf
@@ -2,5 +2,6 @@
 
 video_reader:type = ffmpeg
 video_reader:vidl_ffmpeg:time_source = misp
+metadata_serializer:type = csv
 
 image_writer:type = ocv


### PR DESCRIPTION
Previous behavior was to infer serializer type from the name of the output file, e.g. `output.json` or `output.csv`. If the file extension didn't match any exporter e.g. `output.txt` or `output` and nothing was specified via config file, `dump-klv` would fail. This PR defaults the exporter to CSV.

Motivated by #1543.