### PR TITLE
Disable offending tests on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,18 @@ OPTION( KWIVER_ENABLE_C_BINDINGS               "Enable C bindings libraries" OFF
 CMAKE_DEPENDENT_OPTION( KWIVER_ENABLE_PYTHON   "Enable python code" OFF
   KWIVER_ENABLE_C_BINDINGS OFF )
 
+if (WIN32)
+  # Set default for python tests to OFF on windows for now
+  CMAKE_DEPENDENT_OPTION( KWIVER_ENABLE_PYTHON_TESTS "Enable python tests" OFF
+    "KWIVER_ENABLE_PYTHON; KWIVER_ENABLE_TESTS" OFF )
+  if (KWIVER_ENABLE_PYTHON_TESTS)
+    message( WARNING "Python tests are not currently supported for Windows." )
+  endif()
+else()
+  CMAKE_DEPENDENT_OPTION( KWIVER_ENABLE_PYTHON_TESTS "Enable python tests" ON
+    "KWIVER_ENABLE_PYTHON; KWIVER_ENABLE_TESTS" OFF )
+endif()
+
 if (KWIVER_ENABLE_SERIALIZE_PROTOBUF)
   if (WIN32)
     message( WARNING "Protobuf serialization not supported for windows. Being disabled." )

--- a/python/kwiver/arrows/CMakeLists.txt
+++ b/python/kwiver/arrows/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(serialize)
 add_subdirectory(core)
 
-if(KWIVER_ENABLE_TESTS)
+if(PYTHON_TEST AND NOT WIN32)
   add_subdirectory( tests )
 endif()
 

--- a/python/kwiver/arrows/CMakeLists.txt
+++ b/python/kwiver/arrows/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(serialize)
 add_subdirectory(core)
 
-if(PYTHON_TEST AND NOT WIN32)
+if(KWIVER_ENABLE_PYTHON_TESTS)
   add_subdirectory( tests )
 endif()
 

--- a/python/kwiver/sprokit/CMakeLists.txt
+++ b/python/kwiver/sprokit/CMakeLists.txt
@@ -14,6 +14,6 @@ if(NOT WIN32)
   add_subdirectory(util)
 endif()
 
-if(KWIVER_ENABLE_TESTS AND NOT SKBUILD)
+if(PYTHON_TEST AND NOT SKBUILD AND NOT WIN32)
   add_subdirectory(tests)
 endif()

--- a/python/kwiver/sprokit/CMakeLists.txt
+++ b/python/kwiver/sprokit/CMakeLists.txt
@@ -14,6 +14,6 @@ if(NOT WIN32)
   add_subdirectory(util)
 endif()
 
-if(PYTHON_TEST AND NOT SKBUILD AND NOT WIN32)
+if(KWIVER_ENABLE_PYTHON_TESTS AND NOT SKBUILD)
   add_subdirectory(tests)
 endif()

--- a/python/kwiver/vital/CMakeLists.txt
+++ b/python/kwiver/vital/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory( algo )
 add_subdirectory( exceptions )
 add_subdirectory( types )
 
-if(PYTHON_TEST)
+if(PYTHON_TEST AND NOT WIN32)
   add_subdirectory( tests )
 endif()
 

--- a/python/kwiver/vital/CMakeLists.txt
+++ b/python/kwiver/vital/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory( algo )
 add_subdirectory( exceptions )
 add_subdirectory( types )
 
-if(PYTHON_TEST AND NOT WIN32)
+if(KWIVER_ENABLE_PYTHON_TESTS)
   add_subdirectory( tests )
 endif()
 

--- a/python/kwiver/vital/CMakeLists.txt
+++ b/python/kwiver/vital/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory( algo )
 add_subdirectory( exceptions )
 add_subdirectory( types )
 
-if(KWIVER_ENABLE_TESTS)
+if(PYTHON_TEST)
   add_subdirectory( tests )
 endif()
 

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -139,7 +139,7 @@ set(schedulers
   sync
   thread_per_process)
 
-if (KWIVER_ENABLE_PYTHON)
+if (PYTHON_TEST AND NOT WIN32)
   list(APPEND schedulers
     pythread_per_process)
 endif ()
@@ -165,7 +165,7 @@ endfunction ()
 
 sprokit_add_tooled_run_test(run simple_pipeline)
 
-if (KWIVER_ENABLE_PYTHON)
+if (PYTHON_TEST AND NOT WIN32)
   sprokit_add_tooled_run_test(run pysimple_pipeline)
 endif ()
 

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -70,7 +70,9 @@ sprokit_add_test_plugin(schedulers_test multiple_load
 sprokit_add_test_plugin(not_a_plugin not_a_plugin
   not_a_plugin.cxx)
 
-sprokit_discover_tests(modules test_libraries test_modules.cxx)
+if (KWIVER_ENABLE_PYTHON_TESTS)
+  sprokit_discover_tests(modules test_libraries test_modules.cxx)
+endif()
 
 ##############################
 # Process tests

--- a/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -139,7 +139,7 @@ set(schedulers
   sync
   thread_per_process)
 
-if (PYTHON_TEST AND NOT WIN32)
+if (KWIVER_ENABLE_PYTHON_TESTS)
   list(APPEND schedulers
     pythread_per_process)
 endif ()
@@ -165,7 +165,7 @@ endfunction ()
 
 sprokit_add_tooled_run_test(run simple_pipeline)
 
-if (PYTHON_TEST AND NOT WIN32)
+if (KWIVER_ENABLE_PYTHON_TESTS)
   sprokit_add_tooled_run_test(run pysimple_pipeline)
 endif ()
 


### PR DESCRIPTION
Currently a subset of tests are failing on Windows. For now we should disable them, so that is does not inhibit the CI moving forward.