### PR TITLE
Adding tests for landmark file

### DIFF
--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ kwiver_discover_gtests(vital image_container_set            LIBRARIES ${test_lib
 kwiver_discover_gtests(vital iqr_feedback                   LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterable                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital iterator                       LIBRARIES ${test_libraries})
+kwiver_discover_gtests(vital landmark                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital local_geo_cs                   LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vital local_cartesian                LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital metadata                       LIBRARIES ${test_libraries})

--- a/vital/tests/test_landmark.cxx
+++ b/vital/tests/test_landmark.cxx
@@ -1,0 +1,56 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// \brief test core landmark class
+
+#include <vital/types/landmark.h>
+
+#include <gtest/gtest.h>
+
+// ----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST(landmark, template_print)
+{
+  // TODO include covariance once stream operators are defined
+  // (just uncomment the last EXPECT_EQ)
+
+  kwiver::vital::landmark_<double> original;
+  kwiver::vital::landmark_<double> from_output;
+
+  // Non-default values for all landmark_ variables
+  Eigen::Matrix< double, 3, 1 > loc( 1.2, 2.3, 3.4 );
+  double scale = 4.5;
+  Eigen::Matrix< double, 3, 1 > normal( 5.6, 6.7, 7.8 );
+  kwiver::vital::rgb_color color( 16, 32, 64 );
+  int observations = 321;
+  double cos_obs_angle = 8.9;
+  kwiver::vital::covariance_< 3, double > covar( 12.34 );
+
+  original.set_loc( loc );
+  original.set_scale( scale );
+  original.set_normal( normal );
+  original.set_color( color );
+  original.set_observations( observations );
+  original.set_cos_observation_angle( cos_obs_angle );
+  original.set_covar( covar );
+
+  std::stringstream output;
+  output << original;
+  output >> from_output;
+
+  EXPECT_EQ( original.get_loc(), from_output.get_loc() );
+  EXPECT_EQ( original.get_scale(), from_output.get_scale() );
+  EXPECT_EQ( original.get_normal(), from_output.get_normal() );
+  EXPECT_EQ( original.color(), from_output.color() );
+  EXPECT_EQ( original.observations(), from_output.observations() );
+  EXPECT_EQ( original.get_cos_obs_angle(), from_output.get_cos_obs_angle() );
+  // EXPECT_EQ( original.get_covar(), from_output.get_covar() );
+}

--- a/vital/tests/test_landmark.cxx
+++ b/vital/tests/test_landmark.cxx
@@ -17,6 +17,46 @@ int main(int argc, char** argv)
 }
 
 // ----------------------------------------------------------------------------
+TEST(landmark, base_print)
+{
+  // TODO include covariance once stream operators are defined
+  // (just uncomment the last EXPECT_EQ)
+
+  kwiver::vital::landmark_<double> original;
+  kwiver::vital::landmark_<double> from_output;
+  kwiver::vital::landmark* original_ptr = &original;
+
+  // Non-default values for all landmark_ variables
+  Eigen::Matrix< double, 3, 1 > loc( 1.2, 2.3, 3.4 );
+  double scale = 4.5;
+  Eigen::Matrix< double, 3, 1 > normal( 5.6, 6.7, 7.8 );
+  kwiver::vital::rgb_color color( 16, 32, 64 );
+  int observations = 321;
+  double cos_obs_angle = 8.9;
+  kwiver::vital::covariance_< 3, double > covar( 12.34 );
+
+  original.set_loc( loc );
+  original.set_scale( scale );
+  original.set_normal( normal );
+  original.set_color( color );
+  original.set_observations( observations );
+  original.set_cos_observation_angle( cos_obs_angle );
+  original.set_covar( covar );
+
+  std::stringstream output;
+  output << *original_ptr;
+  output >> from_output;
+
+  EXPECT_EQ( original_ptr->loc(), from_output.get_loc() );
+  EXPECT_EQ( original_ptr->scale(), from_output.get_scale() );
+  EXPECT_EQ( original_ptr->normal(), from_output.get_normal() );
+  EXPECT_EQ( original_ptr->color(), from_output.color() );
+  EXPECT_EQ( original_ptr->observations(), from_output.observations() );
+  EXPECT_EQ( original_ptr->cos_obs_angle(), from_output.get_cos_obs_angle() );
+  // EXPECT_EQ( original_ptr->covar(), from_output.get_covar() );
+}
+
+// ----------------------------------------------------------------------------
 TEST(landmark, template_print)
 {
   // TODO include covariance once stream operators are defined

--- a/vital/types/landmark.cxx
+++ b/vital/types/landmark.cxx
@@ -21,7 +21,7 @@ operator<<( std::ostream& s, landmark const& m )
     << m.scale() << " "
     << m.normal() << " "
     << m.color() << " "
-    << m.observations() << ""
+    << m.observations() << " "
     << m.cos_obs_angle();
   return s;
 }


### PR DESCRIPTION
Adding unit tests for untested portions of vital/types/landmark.cxx

Tests now cover the operator<< and operator>> for the templated derived class, as well as the operator<< for the base abstract class. This involved making a slight fix to the base class (replacing a "" with a " ").

currently none of the operators take into account the covariance_ variable (as the covariance_ class currently has no operator<< or operator>>), and there are just TODO comments for adding it. If I test that the covariance is properly printed and received, the tests fail (as they should), so for the moment I've commented out the line that checks the covariance and added my own TODO comments in both my tests.