### PR TITLE
Made OCV_SURF dependent on NONFREE and XFEATURES2D

### DIFF
--- a/arrows/ocv/feature_detect_extract_SURF.cxx
+++ b/arrows/ocv/feature_detect_extract_SURF.cxx
@@ -11,7 +11,7 @@
 
 #include <vital/vital_config.h>
 
-#if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
+#ifdef KWIVER_OCV_HAS_SURF
 
 // Include the correct file and unify different namespace locations of SURF type
 // across versions
@@ -220,4 +220,4 @@ extract_descriptors_SURF
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif //defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
+#endif

--- a/arrows/ocv/feature_detect_extract_SURF.h
+++ b/arrows/ocv/feature_detect_extract_SURF.h
@@ -11,7 +11,7 @@
 #define KWIVER_ARROWS_FEATURE_DETECT_EXTRACT_SURF_H_
 
 #include <opencv2/opencv_modules.hpp>
-#if defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
+#if defined(HAVE_OPENCV_NONFREE) && defined(HAVE_OPENCV_XFEATURES2D)
 
 #include <arrows/ocv/detect_features.h>
 #include <arrows/ocv/extract_descriptors.h>
@@ -79,6 +79,6 @@ private:
 } // end namespace arrows
 } // end namespace kwiver
 
-#endif //defined(HAVE_OPENCV_NONFREE) || defined(HAVE_OPENCV_XFEATURES2D)
+#endif
 
 #endif


### PR DESCRIPTION
Previously OpenCV SURF tests were conditionally dependent on `HAVE_OPENCV_NONFREE` `or` `HAVE_OPENCV_XFEATURES2D`, however [both are needed](https://docs.opencv.org/3.4/d5/df7/classcv_1_1xfeatures2d_1_1SURF.html). For OpenCV versions prior to 4.5.1 `HAVE_OPENCV_XFEATURES2D` seems to be off by default, but with the update to `fletch`, `HAVE_OPENCV_XFEATURES2D` is defined and `SURF` tests are being executed and failing.