### PR TITLE
Fix bug when building with VTK 9.0

### DIFF
--- a/arrows/vtk/CMakeLists.txt
+++ b/arrows/vtk/CMakeLists.txt
@@ -25,9 +25,8 @@ set( plugin_vtk_sources
 if (VTK_VERSION VERSION_GREATER_EQUAL 9.1)
   list(APPEND plugin_vtk_headers mesh_coloration.h)
   list(APPEND plugin_vtk_sources mesh_coloration.cxx)
+  add_definitions( -DVTK_ENABLE_COLOR_MESH )
 endif()
-
-
 
 kwiver_add_library( kwiver_algo_vtk
   ${plugin_vtk_headers}

--- a/arrows/vtk/applets/register_applets.cxx
+++ b/arrows/vtk/applets/register_applets.cxx
@@ -9,7 +9,9 @@
 #include <vital/plugin_loader/plugin_loader.h>
 #include <vital/applets/applet_registrar.h>
 
+#ifdef VTK_ENABLE_COLOR_MESH
 #include <arrows/vtk/applets/color_mesh.h>
+#endif
 #include <arrows/vtk/applets/estimate_depth.h>
 #include <arrows/vtk/applets/fuse_depth.h>
 
@@ -31,7 +33,9 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   }
 
   // -- register applets --
+#ifdef VTK_ENABLE_COLOR_MESH
   reg.register_tool< color_mesh >();
+#endif
   reg.register_tool< estimate_depth >();
   reg.register_tool< fuse_depth >();
 


### PR DESCRIPTION
With the upgrade to VTK 9.1-exclusive functionality `color_mesh` is now [only built](https://github.com/Kitware/kwiver/blob/master/arrows/vtk/applets/CMakeLists.txt#L16-L19) if the VTK version is at least 9.1. If the source is not built (i.e. for VTK <=9.0), `register_applets.cxx` fails to build because of its [reference](https://github.com/Kitware/kwiver/blob/master/arrows/vtk/applets/register_applets.cxx#L12) to `color_mesh.h`.