### PR TITLE
Add metadata::clone()

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -469,7 +469,7 @@ derive_metadata
   for( auto const& metadata : input_metadata )
   {
     // Deep copy metadata
-    auto updated_metadata = std::make_shared< kv::metadata >( *metadata );
+    auto updated_metadata = kv::metadata_sptr( metadata->clone() );
 
     try
     {

--- a/arrows/klv/klv_metadata.cxx
+++ b/arrows/klv/klv_metadata.cxx
@@ -15,6 +15,14 @@ namespace arrows {
 namespace klv {
 
 // ----------------------------------------------------------------------------
+vital::metadata*
+klv_metadata
+::clone() const
+{
+  return new klv_metadata{ *this };
+}
+
+// ----------------------------------------------------------------------------
 void
 klv_metadata
 ::set_klv( std::vector< klv_packet > const& packets )

--- a/arrows/klv/klv_metadata.h
+++ b/arrows/klv/klv_metadata.h
@@ -25,6 +25,8 @@ class KWIVER_ALGO_KLV_EXPORT klv_metadata : public kwiver::vital::metadata
 public:
   virtual ~klv_metadata() = default;
 
+  vital::metadata* clone() const;
+
   void set_klv( std::vector< klv_packet > const& packets );
 
   std::vector< klv_packet > const& klv() const;

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -193,6 +193,14 @@ metadata::operator=( metadata const& other )
 }
 
 // ----------------------------------------------------------------------------
+metadata*
+metadata
+::clone() const
+{
+  return new metadata{ *this };
+}
+
+// ----------------------------------------------------------------------------
 void
 metadata
 ::add( std::unique_ptr< metadata_item >&& item )

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -250,6 +250,9 @@ public:
   metadata& operator=( metadata&& other ) = default;
   metadata& operator=( metadata const& other );
 
+  /// Create a deep copy of this object.
+  virtual metadata* clone() const;
+
   /// \brief Add metadata item to collection.
   ///
   /// This method adds a metadata item to the collection. The collection takes


### PR DESCRIPTION
Add a `clone()` method to `vital::metadata` which can avoid the loss of hidden derived-class data when copying a `metadata` object.

Additional reviewer: @hdefazio