### PR TITLE
Improve FFmpeg settings transfer

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1385,18 +1385,9 @@ ffmpeg_video_input
   }
 
   auto const result = new ffmpeg_video_settings{};
-  result->bit_rate = d->f_video_encoding->bit_rate;
-  result->bit_rate_tolerance = d->f_video_encoding->bit_rate_tolerance;
-  result->codec_id = d->f_video_encoding->codec_id;
   result->frame_rate = d->f_video_stream->avg_frame_rate;
-  result->gop_size = d->f_video_encoding->gop_size;
-  result->height = (size_t) d->f_video_encoding->height;
-  result->level = d->f_video_encoding->level;
-  result->pixel_format = d->f_video_encoding->pix_fmt;
-  result->profile = d->f_video_encoding->profile;
-  result->sample_aspect_ratio = d->f_video_encoding->sample_aspect_ratio;
-  result->stream_id = d->f_video_stream->id;
-  result->width = (size_t) d->f_video_encoding->width;
+  result->parameters.reset( avcodec_parameters_alloc() );
+  avcodec_parameters_from_context( result->parameters.get(), d->f_video_encoding );
   return kwiver::vital::video_settings_uptr{ result };
 }
 

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -210,7 +210,7 @@ ffmpeg_video_output
   auto const x264_codec = avcodec_find_encoder_by_name( "x264" );
   auto const x265_codec = avcodec_find_encoder_by_name( "x265" );
   AVCodec* requested_codec = nullptr;
-  switch( settings->codec_id )
+  switch( settings->parameters->codec_id )
   {
     case AV_CODEC_ID_H264:
       requested_codec = x264_codec;
@@ -219,7 +219,7 @@ ffmpeg_video_output
       requested_codec = x265_codec;
       break;
     default:
-      requested_codec = avcodec_find_encoder( settings->codec_id );
+      requested_codec = avcodec_find_encoder( settings->parameters->codec_id );
   }
 
   d->codec = avcodec_find_encoder( d->output_format->video_codec );
@@ -241,21 +241,8 @@ ffmpeg_video_output
   }
 
   // Find best pixel format
-  auto pixel_format = static_cast< AVPixelFormat >( -1 );
-  for( auto ptr = d->codec->pix_fmts; ptr && *ptr != -1; ++ptr )
-  {
-    if( *ptr == settings->pixel_format )
-    {
-      pixel_format = settings->pixel_format;
-      break;
-    }
-  }
-  if( pixel_format == -1 )
-  {
-    pixel_format =
-      avcodec_find_best_pix_fmt_of_list(
-        d->codec->pix_fmts, AV_PIX_FMT_RGB24, false, nullptr );
-  }
+  auto pixel_format = avcodec_find_best_pix_fmt_of_list(
+    d->codec->pix_fmts, AV_PIX_FMT_RGB24, false, nullptr );
 
   // Create and configure codec context
   d->codec_context = avcodec_alloc_context3( d->codec );
@@ -265,21 +252,17 @@ ffmpeg_video_output
                  "Failed to allocate codec context" );
   }
   d->codec_context->time_base = av_inv_q( settings->frame_rate );
-  d->codec_context->pix_fmt = pixel_format;
-  d->codec_context->width = settings->width;
-  d->codec_context->height = settings->height;
   d->codec_context->framerate = settings->frame_rate;
-  d->codec_context->sample_aspect_ratio = settings->sample_aspect_ratio;
-  if( d->codec_context->bit_rate > 0 )
+  d->codec_context->pix_fmt = pixel_format;
+  if( d->codec->id == settings->parameters->codec_id )
   {
-    d->codec_context->bit_rate = settings->bit_rate;
-    d->codec_context->bit_rate_tolerance = settings->bit_rate_tolerance;
+    avcodec_parameters_to_context( d->codec_context,
+                                   settings->parameters.get() );
   }
-  if( d->codec->id == settings->codec_id )
+  else
   {
-    d->codec_context->gop_size = settings->gop_size;
-    d->codec_context->level = settings->level;
-    d->codec_context->profile = settings->profile;
+    d->codec_context->width = settings->parameters->width;
+    d->codec_context->height = settings->parameters->height;
   }
 
   // Create video stream

--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -16,32 +16,18 @@ namespace ffmpeg {
 // ----------------------------------------------------------------------------
 ffmpeg_video_settings
 ::ffmpeg_video_settings()
-  : width{ 0 },
-    height{ 0 },
-    codec_id{ AV_CODEC_ID_H264 },
-    pixel_format{ AV_PIX_FMT_RGB24 },
-    frame_rate{ 0, 1 },
-    sample_aspect_ratio{ 1, 1 },
-    bit_rate{ 0 },
-    gop_size{ 0 },
-    profile{ 0 },
-    level{ 0 },
-    stream_id{ 0 } {}
+  : frame_rate{ 0, 1 },
+    parameters{ avcodec_parameters_alloc() } {}
 
 // ----------------------------------------------------------------------------
 ffmpeg_video_settings
 ::ffmpeg_video_settings( size_t width, size_t height, AVRational frame_rate )
-  : width{ width },
-    height{ height },
-    codec_id{ AV_CODEC_ID_H264 },
-    pixel_format{ AV_PIX_FMT_RGB24 },
-    frame_rate( frame_rate ),
-    sample_aspect_ratio{ 1, 1 },
-    bit_rate{ 0 },
-    gop_size{ 0 },
-    profile{ 0 },
-    level{ 0 },
-    stream_id{ 0 } {}
+  : frame_rate( frame_rate ),
+    parameters{ avcodec_parameters_alloc() }
+{
+  parameters->width = width;
+  parameters->height = height;
+}
 
 } // namespace ffmpeg
 

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -22,6 +22,22 @@ namespace arrows {
 
 namespace ffmpeg {
 
+namespace ffmpeg_detail {
+
+struct avcodec_parameters_deleter
+{
+  void
+  operator()( AVCodecParameters* ptr ) const
+  {
+    avcodec_parameters_free( &ptr );
+  }
+};
+
+using avcodec_parameters_uptr =
+  std::unique_ptr< AVCodecParameters, avcodec_parameters_deleter >;
+
+} // namespace ffmpeg_detail
+
 // ----------------------------------------------------------------------------
 struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   : public vital::video_settings
@@ -30,18 +46,8 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
 
   ffmpeg_video_settings( size_t width, size_t height, AVRational frame_rate );
 
-  size_t width;
-  size_t height;
-  AVCodecID codec_id;
-  AVPixelFormat pixel_format;
   AVRational frame_rate;
-  AVRational sample_aspect_ratio;
-  int64_t bit_rate;
-  int bit_rate_tolerance;
-  int gop_size;
-  int profile;
-  int level;
-  int stream_id;
+  ffmpeg_detail::avcodec_parameters_uptr parameters;
 };
 
 } // namespace ffmpeg


### PR DESCRIPTION
This PR changes how the video encoding settings are transferred from an FFmpeg reader to an FFmpeg writer. It uses the native FFmpeg `AVCodecParamaters` struct and FFmpeg's parameter-transfer functions, rather than manually copying each data field. It's easier and more reliable/complete this way.

Additional reviewer: @hdefazio 