### PR TITLE
Fixes for essential_matrix.cxx

### DIFF
--- a/vital/types/essential_matrix.cxx
+++ b/vital/types/essential_matrix.cxx
@@ -102,7 +102,7 @@ essential_matrix_sptr
 essential_matrix_<T>
 ::clone() const
 {
-  return essential_matrix_sptr( new essential_matrix_<T>( *this ) );
+  return std::make_shared<essential_matrix_<T>>( *this );
 }
 
 /// Get a double-typed copy of the underlying matrix

--- a/vital/types/essential_matrix.h
+++ b/vital/types/essential_matrix.h
@@ -94,8 +94,8 @@ public:
   template <typename U>
   explicit
   essential_matrix_<T>( essential_matrix_<U> const &other )
-    : rot_( static_cast<rotation_<T> >(other.rot_) ),
-      trans_( other.trans_.template cast<T>() )
+    : rot_( static_cast<rotation_<T> >(other.rotation() ) ),
+      trans_( other.translation().template cast<T>() )
   {
   }
 


### PR DESCRIPTION
Contains a critical change to the conversion copy constructor ([here](https://github.com/Kitware/kwiver/blob/master/vital/types/essential_matrix.h#L97)) which fixes it accessing protected variables outside of scope.

Removed unused and unrunnable conversion copy constructors as they are generalized by the constructor above.

Changed `essential_matrix_<T>::clone()` to use `std::make_shared` when creating the shared pointer. 