### PR TITLE
Use base64 to encode bytestrings

### DIFF
--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -3,24 +3,7 @@
 		"frame": 0,
 		"microseconds": 0,
 		"key": {
-			"bytes": [
-				6,
-				14,
-				43,
-				52,
-				2,
-				3,
-				1,
-				1,
-				14,
-				1,
-				3,
-				3,
-				2,
-				0,
-				0,
-				0
-			],
+			"bytes": "Bg4rNAIDAQEOAQMDAgAAAA==",
 			"hex": "060e2b34 02030101 0e010303 02000000",
 			"string": "MISB ST 0102 Local Set"
 		},
@@ -51,48 +34,14 @@
 		"frame": null,
 		"microseconds": null,
 		"key": {
-			"bytes": [
-				6,
-				14,
-				43,
-				52,
-				2,
-				1,
-				1,
-				1,
-				14,
-				1,
-				1,
-				2,
-				1,
-				1,
-				0,
-				0
-			],
+			"bytes": "Bg4rNAIBAQEOAQECAQEAAA==",
 			"hex": "060e2b34 02010101 0e010102 01010000",
 			"string": "MISB ST 0104 Universal Set"
 		},
 		"value": [
 			{
 				"key": {
-					"bytes": [
-						6,
-						14,
-						43,
-						52,
-						1,
-						1,
-						1,
-						1,
-						1,
-						1,
-						32,
-						1,
-						0,
-						0,
-						0,
-						0
-					],
+					"bytes": "Bg4rNAEBAQEBASABAAAAAA==",
 					"hex": "060e2b34 01010101 01012001 00000000",
 					"string": "Device Designation"
 				},
@@ -100,24 +49,7 @@
 			},
 			{
 				"key": {
-					"bytes": [
-						6,
-						14,
-						43,
-						52,
-						1,
-						1,
-						1,
-						1,
-						1,
-						5,
-						5,
-						0,
-						0,
-						0,
-						0,
-						0
-					],
+					"bytes": "Bg4rNAEBAQEBBQUAAAAAAA==",
 					"hex": "060e2b34 01010101 01050500 00000000",
 					"string": "Episode Number"
 				},
@@ -128,24 +60,7 @@
 			},
 			{
 				"key": {
-					"bytes": [
-						6,
-						14,
-						43,
-						52,
-						1,
-						1,
-						1,
-						1,
-						7,
-						2,
-						1,
-						1,
-						1,
-						5,
-						0,
-						0
-					],
+					"bytes": "Bg4rNAEBAQEHAgEBAQUAAA==",
 					"hex": "060e2b34 01010101 07020101 01050000",
 					"string": "User Defined Timestamp"
 				},
@@ -157,24 +72,7 @@
 		"frame": 7,
 		"microseconds": 1024,
 		"key": {
-			"bytes": [
-				6,
-				14,
-				43,
-				52,
-				2,
-				11,
-				1,
-				1,
-				14,
-				1,
-				3,
-				1,
-				1,
-				0,
-				0,
-				0
-			],
+			"bytes": "Bg4rNAILAQEOAQMBAQAAAA==",
 			"hex": "060e2b34 020b0101 0e010301 01000000",
 			"string": "MISB ST 0601 Local Set"
 		},
@@ -199,10 +97,7 @@
 					"string": "Mission ID"
 				},
 				"value": null,
-				"value-unparsed-bytes": [
-					0,
-					255
-				]
+				"value-unparsed-bytes": "AP8="
 			},
 			{
 				"key": {
@@ -280,9 +175,7 @@
 									"integer": 2,
 									"string": "User Data"
 								},
-								"value": [
-									171
-								]
+								"value": "qw=="
 							}
 						]
 					},
@@ -537,24 +430,7 @@
 						"string": "None"
 					},
 					"sensor-id": {
-						"bytes": [
-							0,
-							1,
-							2,
-							3,
-							4,
-							5,
-							6,
-							7,
-							8,
-							9,
-							10,
-							11,
-							12,
-							13,
-							14,
-							15
-						],
+						"bytes": "AAECAwQFBgcICQoLDA0ODw==",
 						"hex": "0001-0203-0405-0607-0809-0a0b-0c0d-0e0f"
 					},
 					"platform-id": null,
@@ -874,24 +750,7 @@
 		"frame": 8,
 		"microseconds": 2048,
 		"key": {
-			"bytes": [
-				6,
-				14,
-				43,
-				52,
-				2,
-				3,
-				1,
-				1,
-				14,
-				1,
-				3,
-				3,
-				28,
-				0,
-				0,
-				0
-			],
+			"bytes": "Bg4rNAIDAQEOAQMDHAAAAA==",
 			"hex": "060e2b34 02030101 0e010303 1c000000",
 			"string": "MISB ST 1108 Local Set"
 		},


### PR DESCRIPTION
Since `cereal`'s JSON interface doesn't give us much control over formatting, sequences of bytes are currently printed one byte per line (see deleted lines in `klv_gold.json` for examples). This wastes a lot of space unnecessarily, which can make these JSON files quite unwieldy for longer videos; also much harder for a human to navigate. This PR addresses this problem by encoding sequences of bytes as base64 strings instead.

Additional reviewer: @hdefazio 