### PR TITLE
Move packet timestamp logic inside klv_demuxer

### DIFF
--- a/arrows/klv/klv_demuxer.cxx
+++ b/arrows/klv/klv_demuxer.cxx
@@ -73,7 +73,62 @@ indexify_1108( klv_local_set const& parent_set,
 // ----------------------------------------------------------------------------
 klv_demuxer
 ::klv_demuxer( klv_timeline& timeline )
-  : m_last_timestamp{ 0 }, m_timeline( timeline ) {}
+  : m_frame_timestamp{ 0 }, m_prev_frame_timestamp{ 0 }, m_timeline( timeline ) {}
+
+// ----------------------------------------------------------------------------
+void
+klv_demuxer
+::send_frame( std::vector< klv_packet > const& packets,
+              kv::optional< uint64_t > backup_timestamp )
+{
+  m_prev_frame_timestamp = m_frame_timestamp;
+
+  auto found_timestamp = false;
+  for( auto const& packet : packets )
+  {
+    auto const derived_timestamp = klv_packet_timestamp( packet );
+    if( derived_timestamp )
+    {
+      if( found_timestamp )
+      {
+        m_frame_timestamp = std::min( m_frame_timestamp, *derived_timestamp );
+      }
+      else
+      {
+        m_frame_timestamp = *derived_timestamp;
+        found_timestamp = true;
+      }
+    }
+  }
+
+  if( !found_timestamp )
+  {
+    if( backup_timestamp )
+    {
+      LOG_DEBUG( kv::get_logger( "klv" ),
+                 "demuxer: using backup timestamping method" );
+      m_frame_timestamp = *backup_timestamp;
+    }
+    else
+    {
+      LOG_WARN( kv::get_logger( "klv" ),
+                "demuxer: unable to update timestamp for new frame" );
+    }
+  }
+
+  for( auto const& packet : packets )
+  {
+    demux_packet( packet );
+  }
+}
+
+// ----------------------------------------------------------------------------
+uint64_t
+klv_demuxer
+::frame_time() const
+{
+  return m_frame_timestamp;
+}
 
 // ----------------------------------------------------------------------------
 void
@@ -82,10 +137,13 @@ klv_demuxer
 {
   auto const& trait = klv_lookup_packet_traits().by_uds_key( packet.key );
 
+  auto const derived_timestamp = klv_packet_timestamp( packet );
+  auto const timestamp = derived_timestamp ? *derived_timestamp : m_frame_timestamp;
+
   // Invalid or unrecognized packets are still saved in raw byte form
   if( !packet.value.valid() )
   {
-    demux_unknown( packet );
+    demux_unknown( packet, timestamp );
     return;
   }
 
@@ -93,35 +151,18 @@ klv_demuxer
   switch( trait.tag() )
   {
     case KLV_PACKET_MISB_0601_LOCAL_SET:
-      demux_0601( packet.value.get< klv_local_set >() );
+      demux_0601( packet.value.get< klv_local_set >(), timestamp );
       break;
     case KLV_PACKET_MISB_0104_UNIVERSAL_SET:
-      demux_0104( packet.value.get< klv_universal_set >() );
+      demux_0104( packet.value.get< klv_universal_set >(), timestamp );
       break;
     case KLV_PACKET_MISB_1108_LOCAL_SET:
-      demux_1108( packet.value.get< klv_local_set >() );
+      demux_1108( packet.value.get< klv_local_set >(), timestamp );
       break;
     case KLV_PACKET_UNKNOWN:
     default:
-      throw std::logic_error( "klv packet with unknown key but valid value" );
-  }
-}
-
-// ----------------------------------------------------------------------------
-void
-klv_demuxer
-::seek( uint64_t timestamp )
-{
-  m_last_timestamp = timestamp;
-  // TODO (C++20): replace with std::erase_if()
-  for( auto it = m_cancel_points.begin(); it != m_cancel_points.end(); )
-  {
-    auto const next_it = std::next( it );
-    if( it->second > timestamp )
-    {
-      m_cancel_points.erase( it );
-    }
-    it = next_it;
+      throw std::logic_error(
+        "klv_demuxer: packet with unknown key but valid value" );
   }
 }
 
@@ -138,7 +179,10 @@ void
 klv_demuxer
 ::reset()
 {
-  m_last_timestamp = 0;
+  m_prev_frame_timestamp = 0;
+  m_frame_timestamp = 0;
+  m_cancel_points.clear();
+  m_timeline.clear();
 }
 
 // ----------------------------------------------------------------------------
@@ -160,19 +204,17 @@ klv_demuxer
 // ----------------------------------------------------------------------------
 void
 klv_demuxer
-::demux_unknown( klv_packet const& packet )
+::demux_unknown( klv_packet const& packet, uint64_t timestamp )
 {
   auto& unknown_timeline =
     m_timeline.insert_or_find( KLV_PACKET_UNKNOWN, 0, packet.key )->second;
 
   // Add this packet to a list (created here if necessary) of unknown packets
   // at this timestamp.
-  // m_last_timestamp used here because we can't extract a timestamp from a
-  // packet of unknown format
-  auto const unknown_it = unknown_timeline.find( m_last_timestamp );
+  auto const unknown_it = unknown_timeline.find( timestamp );
   if( unknown_it == unknown_timeline.end() )
   {
-    unknown_timeline.set( { m_last_timestamp, m_last_timestamp + 1 },
+    unknown_timeline.set( { timestamp, timestamp + 1 },
                           std::set< klv_packet >{ packet } );
   }
   else
@@ -184,25 +226,20 @@ klv_demuxer
 // ----------------------------------------------------------------------------
 void
 klv_demuxer
-::demux_0104( klv_universal_set const& value )
+::demux_0104( klv_universal_set const& value, uint64_t timestamp )
 {
   constexpr auto standard = KLV_PACKET_MISB_0104_UNIVERSAL_SET;
-
-  // Extract timestamp
-  auto const& lookup = klv_0104_traits_lookup();
-  auto const timestamp_key =
-    lookup.by_tag( KLV_0104_USER_DEFINED_TIMESTAMP ).uds_key();
-  auto const timestamp = value.at( timestamp_key ).get< uint64_t >();
-  check_timestamp( timestamp );
 
   // By default, valid for 30 seconds
   auto const time_interval =
     interval_t{ timestamp, timestamp + klv_0104_default_duration };
 
+  auto const& lookup = klv_0104_traits_lookup();
   for( auto const& entry : value )
   {
     // Timestamp already implicitly encoded
-    if( entry.first == timestamp_key )
+    if( entry.first ==
+        lookup.by_tag( KLV_0104_USER_DEFINED_TIMESTAMP ).uds_key() )
     {
       continue;
     }
@@ -212,22 +249,14 @@ klv_demuxer
     demux_single_entry( standard, trait.tag(), {}, time_interval,
                         entry.second );
   }
-
-  // Update timestamp
-  m_last_timestamp = timestamp;
 }
 
 // ----------------------------------------------------------------------------
 void
 klv_demuxer
-::demux_0601( klv_local_set const& local_set )
+::demux_0601( klv_local_set const& local_set, uint64_t timestamp )
 {
   auto const standard = KLV_PACKET_MISB_0601_LOCAL_SET;
-
-  // Extract timestamp
-  auto const timestamp =
-    local_set.at( KLV_0601_PRECISION_TIMESTAMP ).get< uint64_t >();
-  check_timestamp( timestamp );
 
   // By default, valid for 30 seconds
   auto const time_interval =
@@ -294,27 +323,22 @@ klv_demuxer
         break;
     };
   }
-
-  // Update timestamp
-  m_last_timestamp = timestamp;
 }
 
 // ----------------------------------------------------------------------------
 void
 klv_demuxer
-::demux_1108( klv_local_set const& value )
+::demux_1108( klv_local_set const& value, uint64_t timestamp )
 {
   constexpr auto standard = KLV_PACKET_MISB_1108_LOCAL_SET;
 
   // Extract timestamp
   auto const metric_period = value.at( KLV_1108_METRIC_PERIOD_PACK )
     .get< klv_1108_metric_period_pack >();
-  check_timestamp( metric_period.timestamp );
 
   // Valid for the period of time specified in METRIC_PERIOD_PACK field
   auto const time_interval =
-    interval_t{ metric_period.timestamp,
-                metric_period.timestamp + metric_period.offset };
+    interval_t{ timestamp, timestamp + metric_period.offset };
 
   // Each 1108 local set can have multiple metrics, each contained in its own
   // metric local set. Items in the parent set are shared among the metric
@@ -343,9 +367,6 @@ klv_demuxer
       demux_single_entry( standard, tag, index, time_interval, entry.second );
     }
   }
-
-  // Update timestamp
-  m_last_timestamp = metric_period.timestamp;
 }
 
 // ----------------------------------------------------------------------------
@@ -378,39 +399,24 @@ klv_demuxer
   else
   {
     // Non-null value: add new entry
-    auto const it = m_timeline.insert_or_find( standard, tag, index );
-    if( time_interval.lower() < m_last_timestamp )
+    auto adjusted_interval = time_interval;
+    auto const cancel_range = m_cancel_points.equal_range( key );
+    for( auto it = cancel_range.first; it != cancel_range.second; ++it )
     {
-      auto adjusted_interval = time_interval;
-      auto const cancel_range = m_cancel_points.equal_range( key );
-      for( auto jt = cancel_range.first; jt != cancel_range.second; ++jt )
+      auto const cancel_time = it->second;
+      if( cancel_time >= adjusted_interval.lower() )
       {
-        auto const cancel_time = jt->second;
-        if( cancel_time >= adjusted_interval.lower() )
-        {
-          adjusted_interval.truncate_upper( cancel_time );
-        }
+        adjusted_interval.truncate_upper( cancel_time );
       }
-      it->second.weak_set( adjusted_interval, value );
     }
-    else
+    auto const it = m_timeline.insert_or_find( standard, tag, index );
+    it->second.weak_set( adjusted_interval, value );
+    auto const jt = it->second.find( adjusted_interval.lower() );
+    if( jt != it->second.end() )
     {
-      it->second.set( time_interval, value );
+      it->second.set( { adjusted_interval.lower(), jt->key_interval.upper() },
+                      value );
     }
-  }
-}
-
-// ----------------------------------------------------------------------------
-void
-klv_demuxer
-::check_timestamp( uint64_t timestamp ) const
-{
-  if( timestamp < m_last_timestamp )
-  {
-    LOG_DEBUG( kv::get_logger( "klv" ),
-               "demuxer: out-of-order packet "
-               "( packet timestamp " << timestamp << " less than "
-               "most recent timestamp " << m_last_timestamp << " )" );
   }
 }
 

--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -195,13 +195,15 @@ klv_packet_length( klv_packet const& packet )
 }
 
 // ----------------------------------------------------------------------------
-uint64_t
+kv::optional< uint64_t >
 klv_packet_timestamp( klv_packet const& packet )
 {
   if( !packet.value.valid() )
   {
-    return 0;
+    return kv::nullopt;
   }
+
+  kv::optional< uint64_t > result;
   switch( klv_lookup_packet_traits().by_uds_key( packet.key ).tag() )
   {
     case KLV_PACKET_MISB_0104_UNIVERSAL_SET:
@@ -210,27 +212,37 @@ klv_packet_timestamp( klv_packet const& packet )
         .by_tag( KLV_0104_USER_DEFINED_TIMESTAMP ).uds_key();
       auto const& set = packet.value.get< klv_universal_set >();
       auto const it = set.find( key );
-      return ( it != set.end() && it->second.valid() )
-             ? it->second.get< uint64_t >() : 0;
+      if ( it != set.end() && it->second.valid() )
+      {
+        result = it->second.get< uint64_t >();
+      }
+      break;
     }
     case KLV_PACKET_MISB_0601_LOCAL_SET:
     {
       auto const& set = packet.value.get< klv_local_set >();
       auto const it = set.find( KLV_0601_PRECISION_TIMESTAMP );
-      return ( it != set.end() && it->second.valid() )
-             ? it->second.get< uint64_t >() : 0;
+      if ( it != set.end() && it->second.valid() )
+      {
+        result = it->second.get< uint64_t >();
+      }
+      break;
     }
     case KLV_PACKET_MISB_1108_LOCAL_SET:
     {
       auto const& set = packet.value.get< klv_local_set >();
       auto const it = set.find( KLV_1108_METRIC_PERIOD_PACK );
-      return ( it != set.end() && it->second.valid() )
-             ? it->second.get< klv_1108_metric_period_pack >().timestamp : 0;
+      if ( it != set.end() && it->second.valid() )
+      {
+        result = it->second.get< klv_1108_metric_period_pack >().timestamp;
+      }
+      break;
     }
     case KLV_PACKET_UNKNOWN:
     default:
-      return 0;
+      break;
   }
+  return result;
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_packet.h
+++ b/arrows/klv/klv_packet.h
@@ -122,9 +122,9 @@ klv_packet_length( klv_packet const& packet );
 ///
 /// \param packet KLV packet being queried.
 ///
-/// \returns Packet timestamp in microseconds, or \c 0 on failure.
+/// \returns Packet timestamp in microseconds, or \c nullopt on failure.
 KWIVER_ALGO_KLV_EXPORT
-uint64_t
+kwiver::vital::optional< uint64_t >
 klv_packet_timestamp( klv_packet const& packet );
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/tests/test_klv_muxer.cxx
+++ b/arrows/klv/tests/test_klv_muxer.cxx
@@ -160,7 +160,7 @@ TEST_F ( klv_muxer_test, round_trip_buffered )
   klv_demuxer demuxer( new_timeline );
   for( auto const& packet : packets1 )
   {
-    demuxer.demux_packet( packet.packet );
+    demuxer.send_frame( { packet.packet } );
   }
 
   // Compare timelines
@@ -206,7 +206,7 @@ TEST_F ( klv_muxer_test, round_trip_immediate )
   klv_demuxer demuxer( new_timeline );
   for( auto const& packet : packets1 )
   {
-    demuxer.demux_packet( packet.packet );
+    demuxer.send_frame( { packet.packet } );
   }
 
   // Compare timelines


### PR DESCRIPTION
This PR addresses a bug in which, under certain circumstances, KLV packets with no extractable timestamp will be associated with the wrong frame. Solving this problem was more complicated than one might think, and involved giving up on `klv_demuxer.seek()` (which wasn't actually used anywhere, anyway). A unit test is included to verify resolution of the bug.

Additional reviewer: @hdefazio 