### PR TITLE
Set ST0104 Episode Number type to string

### DIFF
--- a/arrows/klv/klv_0104.cxx
+++ b/arrows/klv/klv_0104.cxx
@@ -76,7 +76,7 @@ klv_0104_traits_lookup()
       1 },
     { { 0x060E2B3401010101, 0x0105050000000000 },
       ENUM_AND_NAME( KLV_0104_EPISODE_NUMBER ),
-      std::make_shared< klv_float_format >(),
+      std::make_shared< klv_string_format >(),
       "Episode Number",
       "Number to distinguish different missions started on a given day.",
       { 0, 1 } },

--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -246,7 +246,9 @@ klv_0104_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
     { KLV_0104_ANGLE_TO_NORTH,
       kv::VITAL_META_ANGLE_TO_NORTH },
     { KLV_0104_OBLIQUITY_ANGLE,
-      kv::VITAL_META_OBLIQUITY_ANGLE }, };
+      kv::VITAL_META_OBLIQUITY_ANGLE },
+    { KLV_0104_EPISODE_NUMBER,
+      kv::VITAL_META_MISSION_NUMBER } };
 
   // Convert all the direct mappings en masse
   for( auto const& entry : direct_map )
@@ -259,17 +261,6 @@ klv_0104_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
       auto const converted_value = klv_to_vital_value( value );
       vital_data.add( vital_tag, converted_value );
     }
-  }
-
-  // Convert the episode/mission number (an actual number here) to a string
-  auto const episode_number =
-    klv_data.at( standard, KLV_0104_EPISODE_NUMBER, timestamp );
-  if( episode_number.valid() )
-  {
-    auto const value = episode_number.get< double >();
-    std::stringstream ss;
-    ss << std::fixed << value;
-    vital_data.add< kv::VITAL_META_MISSION_NUMBER >( ss.str() );
   }
 
   // Parse the datetime strings into UNIX microsecond timestamps

--- a/arrows/klv/tests/test_klv_0104.cxx
+++ b/arrows/klv/tests/test_klv_0104.cxx
@@ -44,8 +44,8 @@ auto const input_bytes = klv_bytes_t{
   // KLV_0104_EPISODE_NUMBER
   0x06, 0x0E, 0x2B, 0x34, 0x01, 0x01, 0x01, 0x01,
   0x01, 0x05, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x04,
-  0x3F, 0x80, 0x00, 0x00,
+  0x02,
+  '4', '2',
 
   // KLV_0104_IMAGE_SOURCE_DEVICE
   0x06, 0x0E, 0x2B, 0x34, 0x01, 0x01, 0x01, 0x01,
@@ -260,7 +260,7 @@ auto const expected_result = klv_universal_set{
   { to_key( KLV_0104_DEVICE_LATITUDE ),          kld{  60.176822966978335 } },
   { to_key( KLV_0104_DEVICE_LONGITUDE ),         kld{  128.42675904204452 } },
   { to_key( KLV_0104_IMAGE_SOURCE_DEVICE ),      std::string{ "EO" } },
-  { to_key( KLV_0104_EPISODE_NUMBER ),           kld{  1.0f } },
+  { to_key( KLV_0104_EPISODE_NUMBER ),           std::string{ "42" } },
   { to_key( KLV_0104_DEVICE_DESIGNATION ),       std::string{ "MQ1-B" } },
   { to_key( KLV_0104_SECURITY_LOCAL_SET ),       {} }, };
 
@@ -277,7 +277,7 @@ TEST ( klv, read_write_0104_packet )
   auto const packet_header = klv_bytes_t{
     0x06, 0x0E, 0x2B, 0x34, 0x02, 0x01, 0x01, 0x01,
     0x0E, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00,
-    0x82, 0x02, 0xE4 };
+    0x82, 0x02, 0xE2 };
   auto const packet_footer = klv_bytes_t{};
 
   // Assemble the target packet's serialized form

--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -84,7 +84,7 @@ klv_universal_set const test_0104_set = {
   { key_0104( KLV_0104_USER_DEFINED_TIMESTAMP ),
     uint64_t{ 4321 } },
   { key_0104( KLV_0104_EPISODE_NUMBER ),
-    kld{ 4.2, 4 } },
+    std::string{ "4.2" } },
   { key_0104( KLV_0104_DEVICE_DESIGNATION ),
     std::string{ "Bob" } } };
 

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -121,10 +121,7 @@
 					"hex": "060e2b34 01010101 01050500 00000000",
 					"string": "Episode Number"
 				},
-				"value": {
-					"length": 4,
-					"value": 4.2
-				}
+				"value": "4.2"
 			},
 			{
 				"key": {


### PR DESCRIPTION
MISB EG0104 was never really "finished" - its finished form was ST0601. Trying to parse the paper trail of intermediate draft documents leaves some ambiguities, one of which I apparently got wrong - the "Episode Number" field is a string, not a float. The EG0104 document itself is contradictory on this point, but I've found two external sources which treat it as a string, and none that treat it as a float, so I think the switch is warranted.