### PR TITLE
Add unknown_stream_behavior option

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -59,6 +59,8 @@ Arrows: FFmpeg
 
 * Added support for multiple incoming KLV streams.
 
+* Added unknown_stream_behavior configuration option.
+
 Arrows: KLV
 
 * Moved KLV arrow from Vital.


### PR DESCRIPTION
Add an option to attempt to parse unknown streams as KLV streams, as some old videos do not mark their KLV streams as KLV.

Additional reviewers: @hdefazio 