### PR TITLE
Remove \brief

### DIFF
--- a/arrows/klv/klv_0102.cxx
+++ b/arrows/klv/klv_0102.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0102 parser.
+/// Implementation of the KLV 0102 parser.
 
 #include "klv_0102.h"
 

--- a/arrows/klv/klv_0102.h
+++ b/arrows/klv/klv_0102.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0102 parser.
+/// Interface to the KLV 0102 parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_0102_H_
 #define KWIVER_ARROWS_KLV_KLV_0102_H_

--- a/arrows/klv/klv_0104.cxx
+++ b/arrows/klv/klv_0104.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0104 parser.
+/// Implementation of the KLV 0104 parser.
 
 #include "klv_0104.h"
 

--- a/arrows/klv/klv_0104.h
+++ b/arrows/klv/klv_0104.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0104 parser.
+/// Interface to the KLV 0104 parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_0104_H_
 #define KWIVER_ARROWS_KLV_KLV_0104_H_

--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0601 parser.
+/// Interface to the KLV 0601 parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_0601_H_
 #define KWIVER_ARROWS_KLV_KLV_0601_H_

--- a/arrows/klv/klv_0806.cxx
+++ b/arrows/klv/klv_0806.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0806 parser.
+/// Implementation of the KLV 0806 parser.
 
 #include "klv_0806.h"
 

--- a/arrows/klv/klv_0806.h
+++ b/arrows/klv/klv_0806.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0806 parser.
+/// Interface to the KLV 0806 parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_0806_H_
 #define KWIVER_ARROWS_KLV_KLV_0806_H_

--- a/arrows/klv/klv_0806_aoi_set.cxx
+++ b/arrows/klv/klv_0806_aoi_set.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0806 AOI Set parser.
+/// Implementation of the KLV 0806 AOI Set parser.
 
 #include "klv_0806_aoi_set.h"
 

--- a/arrows/klv/klv_0806_aoi_set.h
+++ b/arrows/klv/klv_0806_aoi_set.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0806 AOI Set parser.
+/// Interface to the KLV 0806 AOI Set parser.
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 

--- a/arrows/klv/klv_0806_poi_set.cxx
+++ b/arrows/klv/klv_0806_poi_set.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0806 POI Set parser.
+/// Implementation of the KLV 0806 POI Set parser.
 
 #include "klv_0806_poi_set.h"
 

--- a/arrows/klv/klv_0806_poi_set.h
+++ b/arrows/klv/klv_0806_poi_set.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0806 POI Set parser.
+/// Interface to the KLV 0806 POI Set parser.
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 

--- a/arrows/klv/klv_0806_user_defined_set.cxx
+++ b/arrows/klv/klv_0806_user_defined_set.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 0806 User Defined Set parser.
+/// Implementation of the KLV 0806 User Defined Set parser.
 
 #include "klv_0806_user_defined_set.h"
 

--- a/arrows/klv/klv_0806_user_defined_set.h
+++ b/arrows/klv/klv_0806_user_defined_set.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 0806 User Defined Set parser.
+/// Interface to the KLV 0806 User Defined Set parser.
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 

--- a/arrows/klv/klv_1204.cxx
+++ b/arrows/klv/klv_1204.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV 1204 parser.
+/// Implementation of the KLV 1204 parser.
 
 #include "klv_1204.h"
 

--- a/arrows/klv/klv_1204.h
+++ b/arrows/klv/klv_1204.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV 1204 parser.
+/// Interface to the KLV 1204 parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_1204_H_
 #define KWIVER_ARROWS_KLV_KLV_1204_H_

--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of KLV-vital conversion functions.
+/// Implementation of KLV-vital conversion functions.
 
 #include "klv_convert_vital.h"
 

--- a/arrows/klv/klv_convert_vital.h
+++ b/arrows/klv/klv_convert_vital.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declaration of KLV-vital conversion functions.
+/// Declaration of KLV-vital conversion functions.
 
 #include "klv_timeline.h"
 

--- a/arrows/klv/klv_demuxer.cxx
+++ b/arrows/klv/klv_demuxer.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of KLV demuxer.
+/// Implementation of KLV demuxer.
 
 #include "klv_demuxer.h"
 

--- a/arrows/klv/klv_demuxer.h
+++ b/arrows/klv/klv_demuxer.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declaration of KLV demuxer.
+/// Declaration of KLV demuxer.
 
 #include "klv_timeline.h"
 

--- a/arrows/klv/klv_key.cxx
+++ b/arrows/klv/klv_key.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the implementation for the KLV key classes.
+/// This file contains the implementation for the KLV key classes.
 
 #include "klv_key.h"
 #include "klv_read_write.txx"

--- a/arrows/klv/klv_key.h
+++ b/arrows/klv/klv_key.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the interface for the KLV key classes.
+/// This file contains the interface for the KLV key classes.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_KEY_H_
 #define KWIVER_ARROWS_KLV_KLV_KEY_H_

--- a/arrows/klv/klv_metadata.cxx
+++ b/arrows/klv/klv_metadata.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the implementation for the KLV specialization of
+/// This file contains the implementation for the KLV specialization of
 /// the vital::metadata class.
 
 #include "klv_metadata.h"

--- a/arrows/klv/klv_metadata.h
+++ b/arrows/klv/klv_metadata.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the interface for the KLV specialization of the
+/// This file contains the interface for the KLV specialization of the
 /// vital::metadata class.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_METADATA_H_

--- a/arrows/klv/klv_muxer.cxx
+++ b/arrows/klv/klv_muxer.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Definition of KLV muxer.
+/// Definition of KLV muxer.
 
 #include "klv_0104.h"
 #include "klv_0601.h"

--- a/arrows/klv/klv_muxer.h
+++ b/arrows/klv/klv_muxer.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declaration of KLV muxer.
+/// Declaration of KLV muxer.
 
 #include "klv_timeline.h"
 

--- a/arrows/klv/klv_timeline.cxx
+++ b/arrows/klv/klv_timeline.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of KLV timeline class.
+/// Implementation of KLV timeline class.
 
 #include "klv_timeline.h"
 

--- a/arrows/klv/klv_timeline.h
+++ b/arrows/klv/klv_timeline.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declaration of KLV timeline class.
+/// Declaration of KLV timeline class.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_TIMELINE_H_
 #define KWIVER_ARROWS_KLV_KLV_TIMELINE_H_

--- a/arrows/klv/klv_util.h
+++ b/arrows/klv/klv_util.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declaration of internal KLV utility functions.
+/// Declaration of internal KLV utility functions.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_UTIL_H_
 #define KWIVER_ARROWS_KLV_KLV_UTIL_H_

--- a/arrows/klv/klv_uuid.cxx
+++ b/arrows/klv/klv_uuid.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Implementation of the KLV UUID parser.
+/// Implementation of the KLV UUID parser.
 
 #include "klv_uuid.h"
 

--- a/arrows/klv/klv_uuid.h
+++ b/arrows/klv/klv_uuid.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Interface to the KLV UUID parser.
+/// Interface to the KLV UUID parser.
 
 #ifndef KWIVER_ARROWS_KLV_KLV_UUID_H_
 #define KWIVER_ARROWS_KLV_KLV_UUID_H_

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the implementation of the \c klv_value class.
+/// This file contains the implementation of the \c klv_value class.
 
 #include "klv_value.h"
 

--- a/arrows/klv/klv_value.h
+++ b/arrows/klv/klv_value.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief This file contains the interface for the \c klv_value class.
+/// This file contains the interface for the \c klv_value class.
 
 #include <arrows/klv/klv_blob.h>
 #include <arrows/klv/kwiver_algo_klv_export.h>

--- a/arrows/klv/misp_time.cxx
+++ b/arrows/klv/misp_time.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Define MISP timestamp utility functions.
+/// Define MISP timestamp utility functions.
 
 #include "misp_time.h"
 

--- a/arrows/klv/misp_time.h
+++ b/arrows/klv/misp_time.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Declare MISP timestamp utility functions.
+/// Declare MISP timestamp utility functions.
 
 // Code here based on the following standards:
 // https://gwg.nga.mil/misb/docs/standards/ST0603.5.pdf

--- a/arrows/klv/tests/data_format.h
+++ b/arrows/klv/tests/data_format.h
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Utility function templates for testing read/write for KLV data
+/// Utility function templates for testing read/write for KLV data
 /// formats.
 
 #include <arrows/klv/klv_data_format.h>

--- a/arrows/klv/tests/test_klv_0102.cxx
+++ b/arrows/klv/tests/test_klv_0102.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 0102 read / write.
+/// Test KLV 0102 read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_0104.cxx
+++ b/arrows/klv/tests/test_klv_0104.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 0104 read / write.
+/// Test KLV 0104 read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_0601.cxx
+++ b/arrows/klv/tests/test_klv_0601.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 0601 read / write.
+/// Test KLV 0601 read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_0806.cxx
+++ b/arrows/klv/tests/test_klv_0806.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 0806 read / write.
+/// Test KLV 0806 read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_1108.cxx
+++ b/arrows/klv/tests/test_klv_1108.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 1108 read / write.
+/// Test KLV 1108 read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_1108_metric_set.cxx
+++ b/arrows/klv/tests/test_klv_1108_metric_set.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV 1108 metric set read / write.
+/// Test KLV 1108 metric set read / write.
 
 #include "data_format.h"
 

--- a/arrows/klv/tests/test_klv_blob.cxx
+++ b/arrows/klv/tests/test_klv_blob.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV blob functions.
+/// Test KLV blob functions.
 
 #include <arrows/klv/klv_blob.txx>
 

--- a/arrows/klv/tests/test_klv_checksum.cxx
+++ b/arrows/klv/tests/test_klv_checksum.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV checksum functions.
+/// Test KLV checksum functions.
 
 #include <arrows/klv/klv_checksum.h>
 

--- a/arrows/klv/tests/test_klv_demuxer.cxx
+++ b/arrows/klv/tests/test_klv_demuxer.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV demuxer.
+/// Test KLV demuxer.
 
 #include <arrows/klv/klv_0601.h>
 #include <arrows/klv/klv_1010.h>

--- a/arrows/klv/tests/test_klv_muxer.cxx
+++ b/arrows/klv/tests/test_klv_muxer.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test KLV muxer.
+/// Test KLV muxer.
 
 #include <arrows/klv/klv_0601.h>
 #include <arrows/klv/klv_1108.h>

--- a/arrows/klv/tests/test_klv_read_write.cxx
+++ b/arrows/klv/tests/test_klv_read_write.cxx
@@ -3,7 +3,7 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// \brief Test basic KLV read / write functions
+/// Test basic KLV read / write functions
 
 #include <arrows/klv/klv_read_write.txx>
 


### PR DESCRIPTION
Remove the `\brief` annotation from KLV files, for consistency with the style guide and other files.

Additional reviewer: @hdefazio 