### PR TITLE
Implement direct video stream copying

### DIFF
--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -21,6 +21,8 @@ set(ffmpeg_headers_public
   ffmpeg_init.h
   ffmpeg_video_input.h
   ffmpeg_video_output.h
+  ffmpeg_video_raw_image.cxx
+  ffmpeg_video_raw_metadata.cxx
   ffmpeg_video_settings.h
   )
 
@@ -38,6 +40,8 @@ set(ffmpeg_sources
   ffmpeg_init.cxx
   ffmpeg_video_input.cxx
   ffmpeg_video_output.cxx
+  ffmpeg_video_raw_image.cxx
+  ffmpeg_video_raw_metadata.cxx
   ffmpeg_video_settings.cxx
   )
 

--- a/arrows/ffmpeg/ffmpeg_util.h
+++ b/arrows/ffmpeg/ffmpeg_util.h
@@ -1,0 +1,47 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of FFmpeg internal utility classes and functions.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_UTIL_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_UTIL_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+#include <memory>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+namespace ffmpeg_detail {
+
+struct av_packet_deleter
+{
+  void
+  operator()( AVPacket* ptr ) const
+  {
+    av_packet_free( &ptr );
+  }
+};
+
+using av_packet_uptr =
+  std::unique_ptr< AVPacket, av_packet_deleter >;
+
+} // namespace ffmpeg_detail
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/ffmpeg_video_input.h
+++ b/arrows/ffmpeg/ffmpeg_video_input.h
@@ -61,7 +61,9 @@ public:
 
   ::kwiver::vital::timestamp frame_timestamp() const override;
   ::kwiver::vital::image_container_sptr frame_image() override;
+  ::kwiver::vital::video_raw_image_sptr raw_frame_image() override;
   ::kwiver::vital::metadata_vector frame_metadata() override;
+  ::kwiver::vital::video_raw_metadata_sptr raw_frame_metadata() override;
   ::kwiver::vital::metadata_map_sptr metadata_map() override;
 
   ::kwiver::vital::video_settings_uptr implementation_settings() const override;

--- a/arrows/ffmpeg/ffmpeg_video_output.h
+++ b/arrows/ffmpeg/ffmpeg_video_output.h
@@ -15,6 +15,10 @@
 # include <vital/types/image_container.h>
 # include <vital/types/timestamp.h>
 
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
 namespace kwiver {
 
 namespace arrows {
@@ -49,8 +53,11 @@ public:
   void add_image(
     kwiver::vital::image_container_sptr const& image,
     kwiver::vital::timestamp const& ts ) override;
+  void add_image( vital::video_raw_image const& image );
 
   void add_metadata( kwiver::vital::metadata const& md ) override;
+
+  vital::video_settings_uptr implementation_settings() const override;
 
 private:
   class impl;

--- a/arrows/ffmpeg/ffmpeg_video_raw_image.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_raw_image.cxx
@@ -1,0 +1,24 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of FFmpeg video raw image.
+
+#include "ffmpeg_video_raw_image.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+ffmpeg_video_raw_image
+::ffmpeg_video_raw_image() : packets{}
+{}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_video_raw_image.h
+++ b/arrows/ffmpeg/ffmpeg_video_raw_image.h
@@ -1,0 +1,43 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of FFmpeg video raw image.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_RAW_IMAGE_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_RAW_IMAGE_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+#include <arrows/ffmpeg/ffmpeg_util.h>
+
+#include <vital/types/video_raw_image.h>
+
+#include <list>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_raw_image
+  : public vital::video_raw_image
+{
+  ffmpeg_video_raw_image();
+
+  ffmpeg_video_raw_image( ffmpeg_video_raw_image const& ) = delete;
+  ffmpeg_video_raw_image&
+  operator=( ffmpeg_video_raw_image const& ) = delete;
+
+  std::list< ffmpeg_detail::av_packet_uptr > packets;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/ffmpeg_video_raw_metadata.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_raw_metadata.cxx
@@ -1,0 +1,24 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of FFmpeg video raw metadata.
+
+#include "ffmpeg_video_raw_metadata.h"
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+ffmpeg_video_raw_metadata
+::ffmpeg_video_raw_metadata() : packets{}
+{}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_video_raw_metadata.h
+++ b/arrows/ffmpeg/ffmpeg_video_raw_metadata.h
@@ -1,0 +1,43 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of FFmpeg video raw metadata.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_RAW_METADATA_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_RAW_METADATA_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+#include <arrows/ffmpeg/ffmpeg_util.h>
+
+#include <vital/types/video_raw_metadata.h>
+
+#include <list>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_raw_metadata
+  : public vital::video_raw_metadata
+{
+  ffmpeg_video_raw_metadata();
+
+  ffmpeg_video_raw_metadata( ffmpeg_video_raw_metadata const& ) = delete;
+  ffmpeg_video_raw_metadata&
+  operator=( ffmpeg_video_raw_metadata const& ) = delete;
+
+  std::list< ffmpeg_detail::av_packet_uptr > packets;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/vital/algo/video_output.cxx
+++ b/vital/algo/video_output.cxx
@@ -59,6 +59,14 @@ video_output
 }
 
 // ----------------------------------------------------------------------------
+vital::video_settings_uptr
+video_output
+::implementation_settings() const
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
 void
 video_output
 ::set_capability( algorithm_capabilities::capability_name_t const& name,

--- a/vital/algo/video_output.h
+++ b/vital/algo/video_output.h
@@ -137,6 +137,16 @@ public:
   /// nothing.
   virtual void add_metadata( video_raw_metadata const& md );
 
+  /// Extract implementation-specific video encoding settings.
+  ///
+  /// The returned structure is intended to be passed to a video encoder of
+  /// similar implementation to produce similarly formatted output. The
+  /// returned value may not be identical to the one passed to this object via
+  /// open().
+  ///
+  /// \return Implementation video settings, or \c nullptr if none are needed.
+  virtual vital::video_settings_uptr implementation_settings() const;
+
   /// Return capabilities of concrete implementation.
   ///
   /// This method returns the capabilities of the algorithm implementation.


### PR DESCRIPTION
Implement direct video-stream copying for our FFmpeg video input/output. Metadata stream copying not fully implemented here. The unit test verifies that no video fidelity is lost in the copy, and using the `--copy-video` option in the `transcode` applet provides ~3x speedup on my machine over re-encoding the video. 

Additional reviewer: @hdefazio 