### PR TITLE
Refactor ST1010 sigma encoding

### DIFF
--- a/arrows/klv/klv_1010.h
+++ b/arrows/klv/klv_1010.h
@@ -32,8 +32,12 @@ struct klv_1010_sdcc_flp
   std::vector< double > rho;
 
   // Directives concerning how that data is to be written
-  std::shared_ptr< klv_data_format > sigma_format;
-  std::shared_ptr< klv_data_format > rho_format;
+  size_t sigma_length;
+  size_t rho_length;
+
+  bool sigma_uses_imap;
+  bool rho_uses_imap;
+
   bool long_parse_control;
   bool sparse;
 };
@@ -52,12 +56,18 @@ class KWIVER_ALGO_KLV_EXPORT klv_1010_sdcc_flp_format
   : public klv_data_format_< klv_1010_sdcc_flp >
 {
 public:
+  using imap_from_key_fn =
+    klv_lengthless_imap_format ( * )( klv_lds_key, size_t );
+
   klv_1010_sdcc_flp_format();
 
-  klv_1010_sdcc_flp_format( double sigma_minimum, double sigma_maximum );
+  explicit klv_1010_sdcc_flp_format( imap_from_key_fn sigma_imap );
 
   std::string
   description() const override;
+
+  void
+  set_preceding( std::vector< klv_lds_key > const& preceding_keys );
 
 private:
   klv_1010_sdcc_flp
@@ -70,9 +80,8 @@ private:
   size_t
   length_of_typed( klv_1010_sdcc_flp const& value ) const override;
 
-  bool m_sigma_uses_imap;
-  double m_sigma_minimum;
-  double m_sigma_maximum;
+  imap_from_key_fn m_sigma_imap;
+  std::vector< klv_lds_key > m_preceding_keys;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -733,6 +733,8 @@ protected:
 
   Format m_format;
 };
+using klv_lengthless_float_format = klv_lengthless_format< klv_float_format >;
+using klv_lengthless_imap_format = klv_lengthless_format< klv_imap_format >;
 
 // ----------------------------------------------------------------------------
 template< class Enum, class Int >

--- a/arrows/klv/tests/test_klv_1010.cxx
+++ b/arrows/klv/tests/test_klv_1010.cxx
@@ -42,8 +42,8 @@ auto const expected_result = klv_local_set{
         KLV_0601_PLATFORM_HEADING_ANGLE },
       { 1.0, 2.0, 0.0 },
       { -0.5, 0.0, 0.0 },
-      std::make_shared< klv_float_format >( 4 ),
-      std::make_shared< klv_imap_format >( 1.0, 1.0, 3 ),
+      4, 3,
+      false, true,
       true,
       true, } } };
 

--- a/arrows/serialize/json/klv/load_save_klv.cxx
+++ b/arrows/serialize/json/klv/load_save_klv.cxx
@@ -825,8 +825,10 @@ public:
     SAVE_MEMBER( members );
     SAVE_MEMBER( sigma );
     SAVE_MEMBER( rho );
-    SAVE_MEMBER( sigma_format );
-    SAVE_MEMBER( rho_format );
+    SAVE_MEMBER( sigma_length );
+    SAVE_MEMBER( rho_length );
+    SAVE_MEMBER( sigma_uses_imap );
+    SAVE_MEMBER( rho_uses_imap );
     SAVE_MEMBER( long_parse_control );
     SAVE_MEMBER( sparse );
   }
@@ -1589,15 +1591,19 @@ struct klv_json_loader : public klv_json_base< load_archive >
     LOAD_MEMBER( members );
     LOAD_MEMBER( sigma );
     LOAD_MEMBER( rho );
-    LOAD_MEMBER( sigma_format );
-    LOAD_MEMBER( rho_format );
+    LOAD_MEMBER( sigma_length );
+    LOAD_MEMBER( rho_length );
+    LOAD_MEMBER( sigma_uses_imap );
+    LOAD_MEMBER( rho_uses_imap );
     LOAD_MEMBER( long_parse_control );
     LOAD_MEMBER( sparse );
     return { std::move( members ),
              std::move( sigma ),
              std::move( rho ),
-             std::move( sigma_format ),
-             std::move( rho_format ),
+             std::move( sigma_length ),
+             std::move( rho_length ),
+             std::move( sigma_uses_imap ),
+             std::move( rho_uses_imap ),
              std::move( long_parse_control ),
              std::move( sparse ) };
   }

--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -228,8 +228,8 @@ klv_local_set const test_0601_set = {
       { KLV_0601_SENSOR_LATITUDE, KLV_0601_SENSOR_LONGITUDE },
       { 4.0, 2.0 },
       { 0.5 },
-      std::make_shared< klv_float_format >( 4 ),
-      std::make_shared< klv_imap_format >( -1.0, 1.0, 3 ),
+      4, 3,
+      false, true,
       true,
       false } },
   { KLV_0601_MISSION_ID, klv_blob{ 0x00, 0xFF } } };

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -540,16 +540,10 @@
 					"rho": [
 						0.5
 					],
-					"sigma-format": {
-						"type": "float",
-						"length": 4
-					},
-					"rho-format": {
-						"type": "imap",
-						"lower-bound": -1.0,
-						"upper-bound": 1.0,
-						"length": 3
-					},
+					"sigma-length": 4,
+					"rho-length": 3,
+					"sigma-uses-imap": false,
+					"rho-uses-imap": true,
 					"long-parse-control": true,
 					"sparse": false
 				}


### PR DESCRIPTION
In preparation for implementing the ST1107 standard, refactor the ST1010 standard to allow its standard deviation members to have separate IMAP parameters. 

Additional reviewer: @hdefazio 