### PR TITLE
Add basic ffmpeg output config params

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -1,0 +1,15 @@
+KWIVER v1.8.0 Release Notes
+===========================
+
+This is a minor release of KWIVER that provides both new functionality and fixes
+over the previous v1.7.0 release.
+
+
+Updates
+-------
+
+Arrows
+
+Arrows: FFmpeg
+
+* Added basic configuration options to ffmpeg_video_output.


### PR DESCRIPTION
Add a few basic configuration options to `ffmpeg_video_output`, allowing opening files (by specifying the required width/height/frame rate) and some other knob-turning without having to pass in a `ffmpeg_video_settings`. An example of a successful `open()` is given in the short unit test added here.

Additional reviewer: @hdefazio 