### PR TITLE
Avoid dereferencing an end iterator in track_features_core

### DIFF
--- a/arrows/core/track_features_core.cxx
+++ b/arrows/core/track_features_core.cxx
@@ -370,8 +370,11 @@ track_features_core
     return new_track_set;
   }
 
-  // get the last track id in the existing set of tracks and increment it
-  next_track_id = (*prev_tracks->all_track_ids().crbegin()) + 1;
+  if( !prev_tracks->empty() )
+  {
+    // get the last track id in the existing set of tracks and increment it
+    next_track_id = (*prev_tracks->all_track_ids().crbegin()) + 1;
+  }
 
   const vital::frame_id_t last_frame = prev_tracks->last_frame();
   vital::frame_id_t prev_frame = last_frame;

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -1,0 +1,13 @@
+KWIVER (unreleased) Release Notes
+=================================
+
+Updates
+-------
+
+Bug Fixes
+---------
+
+Arrows: Core
+
+* Fixed undefined behavior leading to a crash in track_features_core when the
+  track set remained empty after the first frame.


### PR DESCRIPTION
This PR fixes undefined behavior in the `core` implementation of `track_features`. In the event that no tracks were created on the first frame, the attempt to dereference `prev_tracks->all_track_ids().crbegin()` is undefined behavior (and in practice seems to lead to a crash). Now `next_track_id` will be left as 0 if `prev_tracks` is empty.