### PR TITLE
Make kwiversys regex compile() thread-safe

### DIFF
--- a/vital/kwiversys/RegularExpression.cxx
+++ b/vital/kwiversys/RegularExpression.cxx
@@ -37,6 +37,8 @@
 # include "RegularExpression.hxx.in"
 #endif
 
+#include <mutex>
+
 #include <stdio.h>
 #include <string.h>
 
@@ -295,6 +297,7 @@ const unsigned char MAGIC = 0234;
 /*
  * Global work variables for compile().
  */
+static std::mutex  compile_mut;
 static const char* regparse;    // Input-scan pointer.
 static       int   regnpar;     // () count.
 static       char  regdummy;
@@ -344,6 +347,8 @@ static int strcspn ();
 // for later pattern matching.
 
 bool RegularExpression::compile (const char* exp) {
+    std::lock_guard< std::mutex > lock( compile_mut );
+
     const char* scan;
     const char* longest;
     size_t      len;


### PR DESCRIPTION
KwiverSys' regex compiler uses global variables to store state, meaning if we compile multiple regexes simultaneously in different threads, there is a race condition which can cause crashes. This came up when trying to load two `.conf` files simultaneously in BurnOut.

This PR adds a mutex to prevent these race conditions, which is really a band-aid until we can replace KwiverSys regex with `std::regex`. Technically we should be able to do that _now_, since `<regex>` is in C++11, but the `gcc` version in our CentOS CI machine doesn't actually fully support C++11, so we're stuck with this for the time being.

Additional reviewer: @hdefazio 