### PR TITLE
[VIAME] Fix undefined or incorrect behavior in darknet_trainer

### DIFF
--- a/arrows/darknet/darknet_trainer.cxx
+++ b/arrows/darknet/darknet_trainer.cxx
@@ -845,7 +845,8 @@ darknet_trainer::priv
       {
         if( m_category_map.find( category ) == m_category_map.end() )
         {
-          m_category_map[ category ] = m_category_map.size() - 1;
+          int id = m_category_map.size();
+          m_category_map[ category ] = id;
         }
         category = std::to_string( m_category_map[ category ] );
       }


### PR DESCRIPTION
Per rule 20 of the "Sequenced-before rules" at <https://en.cppreference.com/w/cpp/language/eval_order>, starting in C++17 the right-hand side of an assignment is evaluated before the left-hand side, which is not the desired behavior.

Prior to C++17, the behavior is, as I understand it, undefined.