### PR TITLE
Fix race condition in close_loops_exhaustive

### DIFF
--- a/arrows/core/close_loops_exhaustive.cxx
+++ b/arrows/core/close_loops_exhaustive.cxx
@@ -152,10 +152,17 @@ close_loops_exhaustive
     all_matches[f] = pool.enqueue(match_func, f);
   }
 
+  std::map<vital::frame_id_t, track_pairs_t> all_matches_done;
+  // ensure all parallel jobs are finished before modifying input
+  for(auto& pair : all_matches)
+  {
+    all_matches_done[pair.first] = std::move(pair.second.get());
+  }
+
   // retrieve match results and stitch frames together
   for(vital::frame_id_t f = frame_number - 2; f >= last_frame; f-- )
   {
-    auto const& matches = all_matches[f].get();
+    auto const& matches = all_matches_done[f];
     size_t num_matched = matches.size();
     int num_linked = 0;
     if( num_matched >= d_->match_req )

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -9,5 +9,8 @@ Bug Fixes
 
 Arrows: Core
 
+* Fixed race condition in close_loops_exhaustive that could result in a crash
+  when matching and merging feature tracks.
+
 * Fixed undefined behavior leading to a crash in track_features_core when the
   track set remained empty after the first frame.


### PR DESCRIPTION
I discovered when using `close_loops_exhaustive` that it would sometimes crash, and debugging revealed a race condition, namely that the call to `merge_tracks` can ultimately call `erase` on `simple_track_set_implementation::data_`, which can cause the call to `simple_track_set_implementation::tracks`, which copies `data_` and is indirectly made by `match_tracks`, to copy `data_` while elements are actively being removed from it. This manifests as empty `shared_ptrs` in the return value of tracks that are dereferenced in `track_set_implementation::active_tracks` to cause a segfault.

This PR removes the race by finishing computing the matches before modifying the feature tracks. This is straightforward, but perhaps something more involved would be more performant.

With some digging I found 17c7936e6b3514fc9ce677f74eb2b283cfe36ebf, which at a glance may have created the issue or made it worse. It also suggests that `close_loops_keyframe` may have a similar issue.