### PR TITLE
[VIAME] Add loop closure support to multi-camera processes

### DIFF
--- a/python/kwiver/sprokit/processes/homography_reader.py
+++ b/python/kwiver/sprokit/processes/homography_reader.py
@@ -1,31 +1,6 @@
-# ckwg +29
-# Copyright 2020 by Kitware, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-#
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-#  * Neither name of Kitware, Inc. nor the names of any contributors may be used
-#    to endorse or promote products derived from this software without specific
-#    prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# This file is part of KWIVER, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 import numpy
 

--- a/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
+++ b/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
@@ -59,8 +59,24 @@ def get_suppression_homogs_and_sizes(
             in zip(prev_homogs_and_sizes, curr_homogs_and_sizes)]
 
 def arg_suppress_boxes(box_lists, suppression_homogs_and_sizes):
-    """Return a list of iterables of bools, False when the corresponding
-    BBox should have been in the previous frame.
+    """Compute whether bounding boxes should be kept after suppression
+
+    Arguments:
+    - box_lists (list[list[.simple_homog_tracker.BBox]]): bounding
+      boxes, where the elements of the outer list correspond to the
+      different cameras
+    - suppression_homogs_and_sizes (list[tuple[ndarray, ndarray]]):
+      transformations to previous frames and those frames' sizes.  The
+      elements of the list correspond to the different cameras.  Each
+      pair holds:
+      - homogs: Nx3x3 ndarray whose first dimension corresponds to
+        the previous frames that suppress detections for this camera.
+        Each element is a homography that warps camera coordinates to
+        previous-frame coordinates.
+      - sizes: Nx2 ndarray with the image sizes of the previous frames
+
+    Returns list[list[bool]], False when the corresponding BBox's
+    center should have been in a previous frame.
 
     """
     def center_in_bounds(box, homogs, sizes):

--- a/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
+++ b/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
@@ -1,31 +1,6 @@
-# ckwg +29
-# Copyright 2020 by Kitware, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-#
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-#  * Neither name of Kitware, Inc. nor the names of any contributors may be used
-#    to endorse or promote products derived from this software without specific
-#    prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# This file is part of KWIVER, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 import logging
 

--- a/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
+++ b/python/kwiver/sprokit/processes/multicam_homog_det_suppressor.py
@@ -182,6 +182,25 @@ def find_prev_suppression_homogs_and_sizes():
         prev_multihomog, prev_sizes = multihomog, sizes
 
 @Transformer.decorate
+def find_all_suppression_homogs_and_sizes():
+    frames_by_ref = {}
+    output = None
+    while True:
+        multihomog, sizes = yield output
+        try:
+            prev_homogs, prev_sizes = frames_by_ref[multihomog.to_id]
+        except KeyError:
+            prev_homogs, prev_sizes = [], zero_homog_and_size[1]
+            output = len(multihomog) * [zero_homog_and_size]
+        else:
+            output = [(
+                to_prev, prev_sizes,
+            ) for to_prev in diff_homogs(multihomog.homogs, prev_homogs)]
+        prev_homogs.extend(multihomog.homogs)
+        prev_sizes = np.concatenate([prev_sizes, sizes])
+        frames_by_ref[multihomog.to_id] = prev_homogs, prev_sizes
+
+@Transformer.decorate
 def suppress(suppression_poly_class=None):
     fpshs = find_prev_suppression_homogs_and_sizes()
     output = None

--- a/python/kwiver/sprokit/processes/multicam_homog_tracker.py
+++ b/python/kwiver/sprokit/processes/multicam_homog_tracker.py
@@ -1,31 +1,6 @@
-# ckwg +29
-# Copyright 2019-2020 by Kitware, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-#
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-#  * Neither name of Kitware, Inc. nor the names of any contributors may be used
-#    to endorse or promote products derived from this software without specific
-#    prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# This file is part of KWIVER, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 from __future__ import division
 from __future__ import print_function

--- a/python/kwiver/sprokit/processes/stabilize_many_images.py
+++ b/python/kwiver/sprokit/processes/stabilize_many_images.py
@@ -197,12 +197,14 @@ def estimate_homography(
             # CloseLoops.stitch technically requires the image data
             # for its third argument, but none of the currently
             # available implementations actually use it, so we don't
-            # bother trying to pass it here.
+            # bother trying to pass it here.  Also, the fourth
+            # argument, a mask, is supposed to be optional but the
+            # wrapping is imperfect.
             #
             # Also, at least some implementations mutate the
             # FeatureTrackSet, though fortunately this is irrelevant
             # to us since fts doesn't escape and is used linearly.
-            fts = close_loops(frame_id, fts, None)
+            fts = close_loops(frame_id, fts, None, None)
 
     output = None
     while True:

--- a/python/kwiver/sprokit/processes/stabilize_many_images.py
+++ b/python/kwiver/sprokit/processes/stabilize_many_images.py
@@ -1,31 +1,6 @@
-# ckwg +29
-# Copyright 2020 by Kitware, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-#
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-#  * Neither name of Kitware, Inc. nor the names of any contributors may be used
-#    to endorse or promote products derived from this software without specific
-#    prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# This file is part of KWIVER, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 import itertools
 


### PR DESCRIPTION
This PR adds loop closure support to `many_image_stabilizer` and `multicam_homog_det_suppressor`. Changes:

- `many_image_stabilizer` gets a new `loop_closer` configuration option to optionally configure a nested `close_loops`
- `multicam_homog_det_suppressor` gets a `previous_frames` configuration option to indicate what previous frames are used for suppression &ndash; current frames are used the same way regardless &ndash; that can be either:
  - `prev_neighbors` (default) for the current behavior where the same and neighboring cameras from the previous frame are used
  - `all` for new behavior where all cameras from all previous frames are used
- The copyright notices have been simplified both for these processes and others (in the same folder, at least) that are `viame/master`-specific