### PR TITLE
Vital mesh vertex_array has inconsistent dimension template

### DIFF
--- a/vital/types/mesh.h
+++ b/vital/types/mesh.h
@@ -97,7 +97,7 @@ class mesh_vertex_array : public mesh_vertex_array_base
   ///
   /// \note Eigen::Matrix<double,2,1> == vector_2d
   ///   and Eigen::Matrix<double,3,1> == vector_3d
-  typedef Eigen::Matrix< double, 3, 1 > vert_t;
+  typedef Eigen::Matrix< double, d, 1 > vert_t;
 
   /// vector of d-dimensional points
   std::vector< vert_t > verts_;


### PR DESCRIPTION
[mesh.h's](https://github.com/Kitware/kwiver/blob/master/vital/types/mesh.h#L92-L183) `mesh_vertex_array<d>` claims to be an array of vertices of dimension `d`, however the [typedef](https://github.com/Kitware/kwiver/blob/master/vital/types/mesh.h#L92-L183) for the internal vertex representation `vert_t` is hardcoded to have a dimension of `3`. 

It seems to me that the internal representation should either reflect the description provided in the doc comments, or the template should be removed entirely.  I can only find one use case where `mesh_vertex_array<d>` is used with a `d != 3` [here](https://github.com/Kitware/kwiver/blob/master/vital/io/mesh_io.cxx#L761), and the fact that `d = 2` has no effect on the usage.