### PR TITLE
Enforce compliance for C++17

### DIFF
--- a/arrows/mvg/algo/initialize_cameras_landmarks.cxx
+++ b/arrows/mvg/algo/initialize_cameras_landmarks.cxx
@@ -383,7 +383,7 @@ public:
   vital::track_map_t m_track_map;
 
   // random-number engine used (Mersenne-Twister in this case)
-  std::mt19937 m_rng{std::random_device{}()};
+  mutable std::mt19937 m_rng{std::random_device{}()};
 
   double m_reverse_ba_error_ratio = 0.0;
   bool m_solution_was_fit_to_constraints = false;
@@ -2917,7 +2917,7 @@ initialize_cameras_landmarks::priv
   }
   if (!min_diff_cams.empty())
   {
-    std::random_shuffle(min_diff_cams.begin(), min_diff_cams.end());
+    std::shuffle(min_diff_cams.begin(), min_diff_cams.end(), m_rng);
     fid_to_register = min_diff_cams.begin()->first;
     closest_frame = min_diff_cams.begin()->second;
     return true;
@@ -2975,7 +2975,7 @@ initialize_cameras_landmarks::priv
   {
     lm_ids.push_back(lm.first);
   }
-  std::random_shuffle(lm_ids.begin(), lm_ids.end());
+  std::shuffle(lm_ids.begin(), lm_ids.end(), m_rng);
   map_landmark_t cur_landmarks_rand_sub;
   for (auto lm_id : lm_ids)
   {

--- a/python/kwiver/vital/types/metadata.cxx
+++ b/python/kwiver/vital/types/metadata.cxx
@@ -49,7 +49,7 @@ from_py( vital_metadata_tag tag, py::object data ) {
 // ----------------------------------------------------------------------------
 py::object
 to_py( metadata_value const& data ) {
-  return visit( to_py_visitor{}, data );
+  return kwiver::vital::visit( to_py_visitor{}, data );
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/util/tests/test_interval_map.cxx
+++ b/vital/util/tests/test_interval_map.cxx
@@ -136,10 +136,10 @@ TEST ( interval_map, iterators )
 TEST ( interval_map, find_point )
 {
   using map_type = interval_map< float, int >;
-  using opt_type = optional< int >;
+  using opt_type = kwiver::vital::optional< int >;
 
   auto const empty_map = map_type{};
-  EXPECT_EQ( nullopt, empty_map.at( 0.0f ) );
+  EXPECT_EQ( kwiver::vital::nullopt, empty_map.at( 0.0f ) );
 
   auto const test_map = map_type{
     { { -finf, -100.0f }, -1 },
@@ -148,7 +148,7 @@ TEST ( interval_map, find_point )
     { { 10.0f, finf }, 2 }, };
 
   // Key with no value
-  EXPECT_EQ( nullopt, test_map.at( -1.0f ) );
+  EXPECT_EQ( kwiver::vital::nullopt, test_map.at( -1.0f ) );
 
   // Bottom of interval
   EXPECT_EQ( opt_type{ 0 }, test_map.at( 0.0f ) );
@@ -160,7 +160,7 @@ TEST ( interval_map, find_point )
   EXPECT_EQ( opt_type{ 2 }, test_map.at( 100.0f ) );
 
   // Top of interval
-  EXPECT_EQ( nullopt, test_map.at( 5.0f ) );
+  EXPECT_EQ( kwiver::vital::nullopt, test_map.at( 5.0f ) );
 
   // Between adjacent intervals
   EXPECT_EQ( opt_type{ 1 }, test_map.at( 1.0f ) );
@@ -171,7 +171,7 @@ TEST ( interval_map, find_point )
   // value of a given type (e.g. infinity, SIZE_MAX). Practically, unsure
   // whether this limitation is particularly pressing.
   EXPECT_EQ( opt_type{ -1 }, test_map.at( -finf ) );
-  EXPECT_EQ( nullopt, test_map.at( finf ) );
+  EXPECT_EQ( kwiver::vital::nullopt, test_map.at( finf ) );
 
   // NaN
   EXPECT_THROW( test_map.at( fnan ), std::invalid_argument );


### PR DESCRIPTION
This PR will make building KWIVER require a compiler which supports C++17. This will allow KWIVER developers to use C++17 features going forward. The changes here are meant to be minimal in order to get the current codebase to compile under C++17 for all supported platforms; they aren't intended to address the other issues with the surrounding code (including style issues).

Compile errors addressed here:
1. Removal due to deprecation in C++17 of `std::random_shuffle`, `std::bind1st`, `std::mem_fun`. 
2. Additions in C++17 of `std::variant`, `std::optional`, `std::visit`, which create an ambiguity with our KWIVER-embedded implementations of those features. We should remove our versions of these (and `std::any` and probably others) in future PRs.

**Important note: this should not compile with Boost 1.65.1**, which was the default Boost version to build in fletch until [recently](https://github.com/Kitware/fletch/pull/709/files). It might compile anyway with certain lenient compilers, but that should not be relied upon.