### PR TITLE
Pass constant seeds to random point generator

### DIFF
--- a/arrows/ceres/tests/test_optimize_cameras.cxx
+++ b/arrows/ceres/tests/test_optimize_cameras.cxx
@@ -12,19 +12,9 @@ using namespace kwiver::vital;
 
 using kwiver::arrows::ceres::optimize_cameras;
 
-#if defined(_MSC_VER)
 static constexpr double noisy_center_tolerance = 1e-8;
 static constexpr double noisy_rotation_tolerance = 2e-9;
 static constexpr double noisy_intrinsics_tolerance = 2e-6;
-#elif defined(__clang__)
-static constexpr double noisy_center_tolerance = 1e-8;
-static constexpr double noisy_rotation_tolerance = 1e-9;
-static constexpr double noisy_intrinsics_tolerance = 5e-6;
-#else
-static constexpr double noisy_center_tolerance = 1e-9;
-static constexpr double noisy_rotation_tolerance = 1e-11;
-static constexpr double noisy_intrinsics_tolerance = 1e-7;
-#endif
 
 // ----------------------------------------------------------------------------
 int main(int argc, char** argv)

--- a/arrows/ocv/tests/test_distortion.cxx
+++ b/arrows/ocv/tests/test_distortion.cxx
@@ -44,9 +44,10 @@ static void test_distortion(const Eigen::VectorXd& d)
 
   std::cout << "K = " << cam_mat << "\nd = " << dist <<std::endl;
 
+  kwiver::testing::rng_t rng( 1 );
   for(unsigned int i = 1; i<100; ++i)
   {
-    vector_2d test_pt = kwiver::testing::random_point2d(0.5);
+    vector_2d test_pt = kwiver::testing::random_point2d( 0.5, rng );
     // the distortion model is only valid within about a unit distance
     // from the origin in normalized coordinates
     // project distant points back onto the unit circle

--- a/arrows/ocv/tests/test_estimate_fundamental_matrix.cxx
+++ b/arrows/ocv/tests/test_estimate_fundamental_matrix.cxx
@@ -13,7 +13,7 @@ using namespace kwiver::arrows;
 
 using ocv::estimate_fundamental_matrix;
 
-static constexpr double ideal_tolerance = 1e-6;
+static constexpr double ideal_tolerance = 3e-6;
 static constexpr double outlier_tolerance = 0.01;
 
 // ----------------------------------------------------------------------------

--- a/arrows/tests/test_estimate_fundamental_matrix.h
+++ b/arrows/tests/test_estimate_fundamental_matrix.h
@@ -192,12 +192,13 @@ TEST(estimate_fundamental_matrix, outlier_points)
   // extract corresponding image points
   unsigned int i = 0;
   std::vector<vector_2d> pts1, pts2;
+  kwiver::testing::rng_t rng( 1 );
   for ( auto const& track : tracks->tracks() )
   {
     if ( ++i % 3 == 0 )
     {
-      pts1.push_back( kwiver::testing::random_point2d( 1000.0 ) );
-      pts2.push_back( kwiver::testing::random_point2d( 1000.0 ) );
+      pts1.push_back( kwiver::testing::random_point2d( 1000.0, rng ) );
+      pts2.push_back( kwiver::testing::random_point2d( 1000.0, rng ) );
     }
     else
     {

--- a/arrows/tests/test_estimate_homography.h
+++ b/arrows/tests/test_estimate_homography.h
@@ -90,9 +90,10 @@ TEST(estimate_homography, ideal_points)
 
   // create random points that perfectly correspond via true_H
   std::vector<vector_2d> pts1, pts2;
+  kwiver::testing::rng_t rng( 1 );
   for(unsigned i=0; i<100; ++i)
   {
-    vector_2d v2 = random_point2d(1000.0) + vector_2d(500.0,500.0);
+    vector_2d v2 = random_point2d( 1000.0, rng ) + vector_2d( 500.0, 500.0 );
     pts1.push_back(v2);
     vector_3d v3 = true_H * vector_3d(v2.x(), v2.y(), 1.0);
     pts2.push_back(vector_2d(v3.x()/v3.z(), v3.y()/v3.z()));
@@ -120,13 +121,14 @@ TEST(estimate_homography, noisy_points)
 
   // create random points + noise that approximately correspond via true_H
   std::vector<vector_2d> pts1, pts2;
+  kwiver::testing::rng_t rng( 1 );
   for(unsigned i=0; i<100; ++i)
   {
-    vector_2d v2 = random_point2d(1000.0) + vector_2d(500.0,500.0);
-    pts1.push_back(v2 + random_point2d(0.1));
-    vector_3d v3 = true_H * vector_3d(v2.x(), v2.y(), 1.0);
-    pts2.push_back(vector_2d(v3.x()/v3.z(), v3.y()/v3.z())
-                   + random_point2d(0.1));
+    vector_2d v2 = random_point2d( 1000.0, rng ) + vector_2d( 500.0, 500.0 );
+    pts1.push_back( v2 + random_point2d( 0.1, rng ) );
+    vector_3d v3 = true_H * vector_3d( v2.x(), v2.y(), 1.0 );
+    pts2.push_back( vector_2d( v3.x() / v3.z(), v3.y() / v3.z() ) +
+                    random_point2d( 0.1, rng ) );
   }
 
   std::vector<bool> inliers;
@@ -153,16 +155,17 @@ TEST(estimate_homography, outlier_points)
   // create random points + noise that approximately correspond via true_H
   std::vector<vector_2d> pts1, pts2;
   std::vector<bool> true_inliers;
+  kwiver::testing::rng_t rng( 1 );
   for(unsigned i=0; i<100; ++i)
   {
-    vector_2d v2 = random_point2d(1000.0) + vector_2d(500.0,500.0);
+    vector_2d v2 = random_point2d( 1000.0, rng ) + vector_2d( 500.0, 500.0 );
     pts1.push_back(v2);
     vector_3d v3 = true_H * vector_3d(v2.x(), v2.y(), 1.0);
     pts2.push_back(vector_2d(v3.x()/v3.z(), v3.y()/v3.z()));
     true_inliers.push_back(true);
     if (i%3 == 0)
     {
-      pts2.back() = random_point2d(1000.0) + vector_2d(500.0,500.0);
+      pts2.back() = random_point2d( 1000.0, rng ) + vector_2d( 500.0, 500.0 );
       true_inliers.back() = false;
     }
   }

--- a/arrows/tests/test_estimate_pnp.h
+++ b/arrows/tests/test_estimate_pnp.h
@@ -168,6 +168,7 @@ TEST(estimate_pnp, outlier_points)
   unsigned int i = 0;
   std::vector<vector_2d> pts_projs;
   std::vector<vector_3d> pts_3d;
+  kwiver::testing::rng_t rng( 1 );
   for (auto const& track : tracks->tracks())
   {
     auto lm_id = track->id();
@@ -176,7 +177,7 @@ TEST(estimate_pnp, outlier_points)
 
     if (++i % 3 == 0)
     {
-      pts_projs.push_back(kwiver::testing::random_point2d(1000.0));
+      pts_projs.push_back( kwiver::testing::random_point2d( 1000.0, rng ) );
     }
     else
     {

--- a/arrows/vxl/tests/test_estimate_similarity.cxx
+++ b/arrows/vxl/tests/test_estimate_similarity.cxx
@@ -76,9 +76,10 @@ TEST(estimate_similarity, reprojection_100pts)
 
   cerr << "Constructing 100 original, random points (std dev: 1.0)" << endl;
   std::vector<vector_3d> original_points;
+  kwiver::testing::rng_t rng( 1 );
   for (int i=0; i < 100; ++i)
   {
-    original_points.push_back(kwiver::testing::random_point3d(1.0));
+    original_points.push_back( kwiver::testing::random_point3d( 1.0, rng ) );
   }
 
   cerr << "Constructing crafted similarity transformation" << endl;
@@ -140,9 +141,10 @@ TEST(estimate_similarity, reprojection_4pts)
   cerr << "Constructing 4 original, random points (std dev: 1.0)" << endl;
   std::vector<vector_3d> original_points;
   cerr << "Random points:" << endl;
+  kwiver::testing::rng_t rng( 1 );
   for (int i=0; i < 4; ++i)
   {
-    original_points.push_back(kwiver::testing::random_point3d(1.0));
+    original_points.push_back( kwiver::testing::random_point3d( 1.0, rng) );
     cerr << "\t" << original_points.back() << endl;
   }
 
@@ -183,9 +185,10 @@ TEST(estimate_similarity, reprojection_3pts)
   cerr << "Constructing 3 original, random points (std dev: 1.0)" << endl;
   std::vector<vector_3d> original_points;
   cerr << "Random points:" << endl;
+  kwiver::testing::rng_t rng( 1 );
   for (int i=0; i < 3; ++i)
   {
-    original_points.push_back(kwiver::testing::random_point3d(1.0));
+    original_points.push_back( kwiver::testing::random_point3d( 1.0, rng) );
     cerr << "\t" << original_points.back() << endl;
   }
 
@@ -225,9 +228,10 @@ TEST(estimate_similarity, reprojection_100pts_noisy)
 
   cerr << "Constructing 100 original, random points (std dev: 1.0)" << endl;
   std::vector<vector_3d> original_points;
+  kwiver::testing::rng_t rng( 1 );
   for (int i=0; i < 100; ++i)
   {
-    original_points.push_back(kwiver::testing::random_point3d(1.0));
+    original_points.push_back( kwiver::testing::random_point3d( 1.0, rng ) );
   }
 
   cerr << "Constructing crafted similarity transformation" << endl;
@@ -239,7 +243,8 @@ TEST(estimate_similarity, reprojection_100pts_noisy)
   std::vector<vector_3d> transformed_points;
   for (vector_3d o_vec : original_points)
   {
-    transformed_points.push_back((m_sim * o_vec) + kwiver::testing::random_point3d(0.01));
+    transformed_points.push_back(
+      ( m_sim * o_vec ) + kwiver::testing::random_point3d( 0.01, rng ) );
   }
 
   cerr << "Estimating similarity transformation between point sets" << endl;

--- a/tests/test_random_point.h
+++ b/tests/test_random_point.h
@@ -26,24 +26,21 @@ typedef std::mt19937 rng_t;
 /// normal distribution
 typedef std::normal_distribution<> norm_dist_t;
 
-/// a global random number generator instance
-static rng_t rng;
-
 // ------------------------------------------------------------------
 inline
-kwiver::vital::vector_3d random_point3d(double stdev)
+kwiver::vital::vector_3d random_point3d( double stdev, rng_t& rng )
 {
   norm_dist_t norm( 0.0, stdev );
-  kwiver::vital::vector_3d v(norm(rng), norm(rng), norm(rng));
+  kwiver::vital::vector_3d v( norm( rng ), norm( rng ), norm( rng ) );
   return v;
 }
 
 // ------------------------------------------------------------------
 inline
-kwiver::vital::vector_2d random_point2d(double stdev)
+kwiver::vital::vector_2d random_point2d( double stdev, rng_t& rng )
 {
   norm_dist_t norm( 0.0, stdev );
-  kwiver::vital::vector_2d v(norm(rng), norm(rng));
+  kwiver::vital::vector_2d v( norm( rng ), norm( rng ) );
   return v;
 }
 

--- a/tests/test_scene.h
+++ b/tests/test_scene.h
@@ -128,13 +128,14 @@ noisy_landmarks( kwiver::vital::landmark_map_sptr  landmarks,
 {
   using namespace kwiver::vital;
 
+  kwiver::testing::rng_t rng( 1 );
   landmark_map::map_landmark_t lm_map = landmarks->landmarks();
   for( landmark_map::map_landmark_t::value_type& p : lm_map )
   {
     landmark_sptr l = p.second->clone();
     landmark_d& lm = dynamic_cast<landmark_d&>(*l);
 
-    lm.set_loc( lm.get_loc() + random_point3d( stdev ) );
+    lm.set_loc( lm.get_loc() + random_point3d( stdev, rng ) );
     lm_map[p.first] = l;
   }
   return landmark_map_sptr( new simple_landmark_map( lm_map ) );
@@ -218,6 +219,7 @@ noisy_cameras( kwiver::vital::camera_map_sptr cameras,
   using namespace kwiver::vital;
 
   camera_map::map_camera_t cam_map;
+  kwiver::testing::rng_t rng( 1 );
   for( camera_map::map_camera_t::value_type const& p : cameras->cameras() )
   {
     auto cam_ptr = std::dynamic_pointer_cast<vital::camera_perspective>(p.second);
@@ -226,8 +228,8 @@ noisy_cameras( kwiver::vital::camera_map_sptr cameras,
     simple_camera_perspective& cam =
       dynamic_cast<simple_camera_perspective&>(*c);
 
-    cam.set_center( cam.get_center() + random_point3d( pos_stdev ) );
-    rotation_d rand_rot( random_point3d( rot_stdev ) );
+    cam.set_center( cam.get_center() + random_point3d( pos_stdev, rng ) );
+    rotation_d rand_rot( random_point3d( rot_stdev, rng ) );
     cam.set_rotation( cam.get_rotation() * rand_rot );
 
     cam_map[p.first] = c;
@@ -277,6 +279,7 @@ noisy_tracks( kwiver::vital::feature_track_set_sptr in_tracks, double stdev = 1.
 
   std::vector< track_sptr > tracks = in_tracks->tracks();
   std::vector< track_sptr > new_tracks;
+  kwiver::testing::rng_t rng( 1 );
   for( const track_sptr &t : tracks )
   {
     auto nt = track::create();
@@ -288,7 +291,7 @@ noisy_tracks( kwiver::vital::feature_track_set_sptr in_tracks, double stdev = 1.
       {
         continue;
       }
-      vector_2d loc = fts->feature->loc() + random_point2d(stdev);
+      vector_2d loc = fts->feature->loc() + random_point2d( stdev, rng );
       auto new_fts = std::make_shared<feature_track_state>(*fts);
       new_fts->feature = std::make_shared<feature_d>(loc);
       nt->append(new_fts);
@@ -307,7 +310,7 @@ add_outliers_to_tracks(kwiver::vital::feature_track_set_sptr in_tracks,
 {
   using namespace kwiver::vital;
 
-  std::srand(0);
+  kwiver::testing::rng_t rng( 1 );
   std::vector<track_sptr> tracks = in_tracks->tracks();
   std::vector<track_sptr> new_tracks;
   const int rand_thresh = static_cast<int>(outlier_frac * RAND_MAX);
@@ -325,7 +328,7 @@ add_outliers_to_tracks(kwiver::vital::feature_track_set_sptr in_tracks,
       }
       if(std::rand() < rand_thresh)
       {
-        vector_2d loc = fts->feature->loc() + random_point2d( stdev );
+        vector_2d loc = fts->feature->loc() + random_point2d( stdev, rng );
         auto new_fts = std::make_shared<feature_track_state>(*fts);
         new_fts->feature = std::make_shared<feature_d>(loc);
         nt->append( new_fts );


### PR DESCRIPTION
This PR replaces the `static` rng instance feeding the `random_point_Xd()` functions with a function parameter. Previously, the `static` nature of the rng means that running one test actually affected the behavior of the other tests in the file, since it changed the random seed. This PR ensures consistent behavior no matter if you are running all of a test file's tests (typical user behavior) or only one at a time (how our CI does it). Since changing the random seed changes the points fed into tests, one or two of them need their tolerances expanded slightly.

Hopefully this will fix the test failures with Visual Studio 2019. If not, different seeds or tolerances may need to be tried.

@hdefazio 