### PR TITLE
Make control command timestamp kv::optional

### DIFF
--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -445,7 +445,7 @@ struct KWIVER_ALGO_KLV_EXPORT klv_0601_control_command
 {
   uint16_t id;
   std::string string;
-  uint64_t timestamp;
+  vital::optional< uint64_t > timestamp;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/tests/test_klv_0601.cxx
+++ b/arrows/klv/tests/test_klv_0601.cxx
@@ -161,7 +161,7 @@ auto const expected_result = klv_local_set{
   { KLV_0601_ALTITUDE_ABOVE_GROUND_LEVEL,      kld{ 2150.0000000000000 } },
   { KLV_0601_RADAR_ALTIMETER,                  kld{ 2154.5000000000000 } },
   { KLV_0601_CONTROL_COMMAND,
-    klv_0601_control_command{ 5, "Fly to Waypoint 1", 0 } },
+    klv_0601_control_command{ 5, "Fly to Waypoint 1", kv::nullopt } },
   { KLV_0601_CONTROL_COMMAND_VERIFICATION_LIST,
     std::vector< uint64_t >{ 3, 7 } },
   { KLV_0601_SENSOR_AZIMUTH_RATE,              kld{  1.0 } },


### PR DESCRIPTION
Fix a small inconsistency in the control command data structure which treats at timestamp of `0` as "timestamp not present", where it would be better to make the timestamp field explicitly `optional`.

@hdefazio 