### PR TITLE
Ensure we don't segfault when KLV parsing fails

### DIFF
--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -145,6 +145,7 @@ public:
   klv_value
   read( klv_read_iter_t& data, size_t length ) const override final
   {
+    auto const begin = data;
     if( !length )
     {
       // Zero length: null / unknown value
@@ -161,7 +162,7 @@ public:
       // Return blob if parsing failed
       LOG_ERROR( kwiver::vital::get_logger( "klv" ),
                 "error occurred during parsing: " << e.what() );
-      return klv_read_blob( data, length );
+      return klv_read_blob( ( data = begin ), length );
     }
   }
 

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -14,3 +14,8 @@ Arrows: Core
 
 * Fixed undefined behavior leading to a crash in track_features_core when the
   track set remained empty after the first frame.
+
+Arrows: KLV
+
+* Fixed possible out-of-bounds memory read leading to crash when KLV parsing
+  fails.


### PR DESCRIPTION
This PR fixes a bug in the "backup system" when KLV parsing fails, where the read iterator didn't get reset properly.

@hdefazio 