### PR TITLE
Add missing error checking for calls to klv_value::get()

### DIFF
--- a/arrows/klv/klv_convert_vital.cxx
+++ b/arrows/klv/klv_convert_vital.cxx
@@ -621,9 +621,11 @@ klv_1108_to_vital_metadata( klv_timeline const& klv_data, uint64_t timestamp,
 
     if( best_metric_set )
     {
-      auto const value =
-        best_metric_set->at( KLV_1108_METRIC_SET_VALUE ).get< double >();
-      vital_data.add( metric.second, value );
+      auto const value = best_metric_set->at( KLV_1108_METRIC_SET_VALUE );
+      if( value.valid() )
+      {
+        vital_data.add( metric.second, value.get< double >() );
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds error handling in a few places where the possibility of KLV parsing having failed earlier in the pipeline is not properly accounted for.

@hdefazio 