### PR TITLE
Add CUDA/NVENC video encoders

### DIFF
--- a/arrows/ffmpeg/ffmpeg_cuda.h
+++ b/arrows/ffmpeg/ffmpeg_cuda.h
@@ -58,6 +58,15 @@ inline int throw_error_code_cuda( CUresult error_code, Args... args )
 std::vector< AVCodec const* >
 cuda_find_decoders( AVCodecParameters const& video_params );
 
+// ----------------------------------------------------------------------------
+std::vector< AVCodec const* >
+cuda_find_encoders(
+  AVOutputFormat const& output_format,
+  AVCodecParameters const& video_params );
+
+// ----------------------------------------------------------------------------
+hardware_device_context_uptr cuda_create_context( int device_index );
+
 } // namespace ffmpeg
 
 } // namespace arrows

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -421,51 +421,8 @@ ffmpeg_video_input::priv
 ::cuda_init()
 {
 #ifdef KWIVER_ENABLE_FFMPEG_CUDA
-  // Initialize CUDA
-  throw_error_code_cuda( cuInit( 0 ), "Could not initialize CUDA" );
-
-  // Create FFmpeg CUDA context
-  hardware_device_context_uptr hw_context{
-    throw_error_null(
-      av_hwdevice_ctx_alloc( AV_HWDEVICE_TYPE_CUDA ),
-    "Could not allocate hardware device context" ) };
-
-  auto const cuda_hw_context =
-    static_cast< AVCUDADeviceContext* >(
-      reinterpret_cast< AVHWDeviceContext* >( hw_context->data )->hwctx );
-
-  // Acquire CUDA device
-  CUdevice cu_device;
-  throw_error_code_cuda(
-    cuDeviceGet( &cu_device, cuda_device_index ),
-    "Could not acquire CUDA device " + std::to_string( cuda_device_index ) );
-
-  {
-    constexpr size_t buffer_size = 128;
-    char buffer[ buffer_size ] = {};
-    cuDeviceGetName( buffer, buffer_size - 1, cu_device );
-    LOG_INFO(
-      logger,
-      "Using CUDA device " << cuda_device_index << ": `" << buffer << "`" );
-  }
-
-  // Initialize FFmpeg CUDA context
-  throw_error_code_cuda(
-    cuCtxCreate( &cuda_hw_context->cuda_ctx, 0, cu_device ),
-    "Could not create CUDA context" );
-
-#if LIBAVCODEC_VERSION_MAJOR > 57
-  throw_error_code_cuda(
-    cuStreamCreate( &cuda_hw_context->stream, CU_STREAM_DEFAULT ),
-    "Could not create CUDA stream" );
-#endif
-
-  throw_error_code(
-    av_hwdevice_ctx_init( hw_context.get() ),
-    "Could not initialize hardware device context" );
-
-  // Only keep this hardware context if setup worked
-  hardware_device_context = std::move( hw_context );
+  hardware_device_context =
+    std::move( cuda_create_context( cuda_device_index ) );
 #else
   LOG_DEBUG(
     logger,

--- a/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
@@ -38,8 +38,8 @@ main( int argc, char** argv )
 namespace {
 
 constexpr uint64_t random_seed = 54321;
-constexpr size_t random_image_width = 96;
-constexpr size_t random_image_height = 64;
+constexpr size_t random_image_width = 256;
+constexpr size_t random_image_height = 128;
 
 } // namespace
 


### PR DESCRIPTION
This PR adds the ability to use NVidia's NVenc H.264 and H.265 hardware video encoders on CUDA-enabled devices. Similarly to the CUDA decoders, getting the CUDA encoders to actually work requires a fletch PR, which has not been uploaded yet due to existing PR dependencies.

@hdefazio 