### PR TITLE
Revert erroneous video PTS changes

### DIFF
--- a/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
@@ -158,6 +158,9 @@ expect_eq_videos( std::string const& src_path, std::string const& tmp_path,
        !src_is.end_of_video() && !tmp_is.end_of_video();
        src_is.next_frame( src_ts ), tmp_is.next_frame( tmp_ts ) )
   {
+    EXPECT_EQ( src_ts.get_frame(), tmp_ts.get_frame() );
+    EXPECT_EQ( src_ts.get_time_usec(), tmp_ts.get_time_usec() );
+
     auto const src_image = src_is.frame_image()->get_image();
     auto const tmp_image = tmp_is.frame_image()->get_image();
     expect_eq_images( src_image, tmp_image, image_epsilon );


### PR DESCRIPTION
The recent addition of CUDA-accelerated encoding capabilities included an erroneous change which broke the frame timings on normal videos. This PR reverts that change and adds the unit test which should have caught the break in the first place.

@hdefazio