### PR TITLE
Fix bug when writing last element of view domain

### DIFF
--- a/arrows/klv/klv_length_value.h
+++ b/arrows/klv/klv_length_value.h
@@ -83,7 +83,7 @@ write_trunc_lv_impl(
   auto const& item = std::get< 0 >( value );
   if( item )
   {
-    format.write_( *item, data, length );
+    klv_write_lv( *item, data, length, format );
   }
 }
 
@@ -107,7 +107,7 @@ write_trunc_lv_impl(
   if( tracker.remaining() )
   {
     auto const remaining = pop_tuple( value );
-    write_trunc_lv_impl( remaining, data, length, formats... );
+    write_trunc_lv_impl( remaining, data, tracker.remaining(), formats... );
   }
 }
 

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -22,3 +22,6 @@ Arrows: KLV
 
 * Fixed bug in KLV packet reader which failed to check if the packet's length
   was larger than the available number of input bytes.
+
+* Fixed bug in ST0601 view domain writer which would not write the length of
+  the final field.


### PR DESCRIPTION
This PR fixes a bug which would not write the length of the final element of the ST0601 view domain field (when present).

@hdefazio 