### PR TITLE
Add missing std::set< uint16_t > type to KLV JSON exporter

### DIFF
--- a/arrows/serialize/json/klv/load_save_klv.cxx
+++ b/arrows/serialize/json/klv/load_save_klv.cxx
@@ -91,6 +91,7 @@ using klv_type_list =
     std::set< klv_0601_generic_flag_data_bit >,
     std::set< klv_0601_positioning_method_source_bit >,
     std::set< klv_0601_weapon_engagement_status_bit >,
+    std::set< uint16_t >,
     std::string,
     std::vector< klv_0601_payload_record >,
     std::vector< klv_0601_wavelength_record >,

--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -168,6 +168,7 @@ klv_local_set const test_0601_set = {
     KLV_0601_PLATFORM_STATUS_ACTIVE },
   { KLV_0601_SENSOR_CONTROL_MODE,
     KLV_0601_SENSOR_CONTROL_MODE_OFF },
+  { KLV_0601_ACTIVE_PAYLOADS, std::set< uint16_t >{ 0, 1, 3 } },
   { KLV_0601_WEAPONS_STORES,
     std::vector< klv_0601_weapons_store >{
       { 0, 1, 2, 3,

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -25,3 +25,5 @@ Arrows: KLV
 
 * Fixed bug in ST0601 view domain writer which would not write the length of
   the final field.
+
+* Added a missing type to the ST0601 KLV JSON exporter.

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -679,6 +679,17 @@
 			},
 			{
 				"key": {
+					"integer": 139,
+					"string": "Active Payloads"
+				},
+				"value": [
+					0,
+					1,
+					3
+				]
+			},
+			{
+				"key": {
 					"integer": 140,
 					"string": "Weapons Stores"
 				},


### PR DESCRIPTION
The JSON exporter was not updated when the type of the ST0601 Active Payloads tag was changed. This PR fixes that bug.

@hdefazio 