### PR TITLE
Tweak FFmpeg output settings assignment

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -26,6 +26,7 @@ ffmpeg_video_settings
   {
     throw std::runtime_error{ "Could not allocate AVCodecParameters" };
   }
+  parameters->codec_type = AVMEDIA_TYPE_VIDEO;
 }
 
 // ----------------------------------------------------------------------------
@@ -42,6 +43,7 @@ ffmpeg_video_settings
   {
     throw std::runtime_error{ "Could not allocate AVCodecParameters" };
   }
+  parameters->codec_type = AVMEDIA_TYPE_VIDEO;
   parameters->width = width;
   parameters->height = height;
 }


### PR DESCRIPTION
This PR fixes some issues with settings from different sources (`ffmpeg_video_settings`, config values, ffmpeg-suggested values) overriding each other incorrectly. It also ensures that the video stream's codec type is always set to `VIDEO`, which is necessary for `avcodec_parameters_to_context()` to function correctly.

@hdefazio 