### PR TITLE
Tolerate packets with invalid data

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1034,9 +1034,12 @@ ffmpeg_video_input::priv::open_video_state
           }
 
           // Send packet to decoder
-          throw_error_code(
-            avcodec_send_packet( codec_context.get(), packet.get() ),
-            "Decoder rejected packet" );
+          auto const send_err =
+            avcodec_send_packet( codec_context.get(), packet.get() );
+          if( send_err != AVERROR_INVALIDDATA )
+          {
+            throw_error_code( send_err, "Decoder rejected packet" );
+          }
         }
 
         // KLV packet


### PR DESCRIPTION
We already carry on when FFmpeg fails in decoding a video frame due to invalid or corrupted data, proceeding to the next frame instead of giving up. However, evidently FFmpeg can sometimes detect the invalidity of data immediately when a packet is given to it, as opposed to later during the decoding process. This PR ensures that such early detection does not crash the program.

@hdefazio 