### PR TITLE
Create wrapper around avformat_query_codec()

### DIFF
--- a/arrows/ffmpeg/ffmpeg_cuda.cxx
+++ b/arrows/ffmpeg/ffmpeg_cuda.cxx
@@ -145,8 +145,7 @@ cuda_find_encoders(
     if( av_codec_is_encoder( codec_ptr ) &&
         is_hardware_codec( codec_ptr ) &&
         !( codec_ptr->capabilities & AV_CODEC_CAP_EXPERIMENTAL ) &&
-        avformat_query_codec(
-          &output_format, codec_ptr->id, FF_COMPLIANCE_NORMAL ) &&
+        format_supports_codec( &output_format, codec_ptr->id ) &&
         ( std::string{ codec_ptr->name }.rfind( "_nvenc" ) !=
           std::string::npos ) )
     {

--- a/arrows/ffmpeg/ffmpeg_util.cxx
+++ b/arrows/ffmpeg/ffmpeg_util.cxx
@@ -82,6 +82,21 @@ error_string( int error_code )
 }
 
 // ----------------------------------------------------------------------------
+bool
+format_supports_codec( AVOutputFormat const* format, AVCodecID codec_id )
+{
+  // FFmpeg isn't sure that H.264 and H.265 are supported by TS files, but
+  // they are.
+  if( format->name == std::string{ "mpegts" } &&
+      ( codec_id == AV_CODEC_ID_H264 || codec_id == AV_CODEC_ID_H265 ) )
+  {
+    return true;
+  }
+
+  return avformat_query_codec( format, codec_id, FF_COMPLIANCE_NORMAL ) > 0;
+}
+
+// ----------------------------------------------------------------------------
 #define DEFINE_DELETER( LOWER, UPPER ) \
   void _ ## LOWER ## _deleter::operator()( UPPER* ptr ) const
 

--- a/arrows/ffmpeg/ffmpeg_util.h
+++ b/arrows/ffmpeg/ffmpeg_util.h
@@ -75,6 +75,10 @@ inline T* throw_error_null( T* ptr, Args... args )
 }
 
 // ----------------------------------------------------------------------------
+// Wrapper around avformat_query_codec().
+bool format_supports_codec( AVOutputFormat const* format, AVCodecID codec_id );
+
+// ----------------------------------------------------------------------------
 #define DECLARE_PTRS( LOWER, UPPER )                                     \
 struct _ ## LOWER ## _deleter { void operator()( UPPER* ptr ) const; };  \
 using LOWER ## _uptr = std::unique_ptr< UPPER, _ ## LOWER ## _deleter >; \

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -469,8 +469,7 @@ ffmpeg_video_output::impl::open_video_state
     if( av_codec_is_encoder( codec_ptr ) &&
         !is_hardware_codec( codec_ptr ) &&
         !( codec_ptr->capabilities & AV_CODEC_CAP_EXPERIMENTAL ) &&
-        avformat_query_codec(
-          output_format, codec_ptr->id, FF_COMPLIANCE_STRICT ) > 0 )
+        format_supports_codec( output_format, codec_ptr->id ) )
     {
       possible_codecs.emplace( codec_ptr );
     }


### PR DESCRIPTION
Apparently FFmpeg's "does this file type support this codec" function, `av_query_codec()`, is not sure that H.264 and H.265 video streams can be put in a Transport Stream, even though they can. This PR wraps `av_query_codec()` in a utility function where we can add exceptions for cases like this.

@hdefazio 