### PR TITLE
Fix cereal loading bug

### DIFF
--- a/arrows/serialize/json/klv/load_save_klv.cxx
+++ b/arrows/serialize/json/klv/load_save_klv.cxx
@@ -287,7 +287,14 @@ protected:
   set_next_name( std::string const& name )
   {
     m_next_name = name;
-    m_archive.setNextName( m_next_name.c_str() );
+    if( name.empty() )
+    {
+      m_archive.setNextName( nullptr );
+    }
+    else
+    {
+      m_archive.setNextName( m_next_name.c_str() );
+    }
   }
 
 private:
@@ -949,6 +956,7 @@ struct klv_json_loader : public klv_json_base< load_archive >
     }
     catch( std::runtime_error const& )
     {
+      set_next_name( "" );
       return false;
     }
   }
@@ -1110,6 +1118,7 @@ struct klv_json_loader : public klv_json_base< load_archive >
       }
       catch( std::runtime_error const& )
       {
+        set_next_name( "" );
         return {};
       }
     }
@@ -1272,7 +1281,9 @@ struct klv_json_loader : public klv_json_base< load_archive >
       locations = load< klv_0601_image_horizon_locations >();
     }
     catch( std::runtime_error const& )
-    {}
+    {
+      set_next_name( "" );
+    }
 
     return { std::move( x0 ),
              std::move( y0 ),

--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -148,6 +148,7 @@ klv_local_set const test_1206_set = {
 klv_local_set const test_0601_set = {
   { KLV_0601_PRECISION_TIMESTAMP,
     uint64_t{ 1234 } },
+  { KLV_0601_PLATFORM_HEADING_ANGLE, {} },
   { KLV_0601_PLATFORM_TRUE_AIRSPEED,
     kld{ 2.345, 1 } },
   { KLV_0601_MISSION_ID,

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -101,6 +101,13 @@
 			},
 			{
 				"key": {
+					"integer": 5,
+					"string": "Platform Heading Angle"
+				},
+				"value": null
+			},
+			{
+				"key": {
 					"integer": 8,
 					"string": "Platform True Airspeed"
 				},


### PR DESCRIPTION
This PR fixes a bug which causes JSON parsing to fail when a member of a local set is completely empty / null, and it is not the last member of that local set. The unit test now covers this edge case.

@hdefazio 