### PR TITLE
Add move and copy constructors

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -31,6 +31,26 @@ ffmpeg_video_settings
 
 // ----------------------------------------------------------------------------
 ffmpeg_video_settings
+::ffmpeg_video_settings( ffmpeg_video_settings const& other )
+  : frame_rate{ other.frame_rate },
+    parameters{ avcodec_parameters_alloc() },
+    klv_stream_count{ other.klv_stream_count }
+{
+  throw_error_code(
+    avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
+    "Could not copy codec parameters" );
+}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings
+::ffmpeg_video_settings( ffmpeg_video_settings&& other )
+  : frame_rate{ std::move( other.frame_rate ) },
+    parameters{ std::move( other.parameters ) },
+    klv_stream_count{ std::move( other.klv_stream_count ) }
+{}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings
 ::ffmpeg_video_settings(
   size_t width, size_t height,
   AVRational frame_rate,
@@ -52,6 +72,31 @@ ffmpeg_video_settings
 ffmpeg_video_settings
 ::~ffmpeg_video_settings()
 {}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings&
+ffmpeg_video_settings
+::operator=( ffmpeg_video_settings const& other )
+{
+  frame_rate = other.frame_rate;
+  parameters.reset( avcodec_parameters_alloc() );
+  throw_error_code(
+    avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
+    "Could not copy codec parameters" );
+  klv_stream_count = other.klv_stream_count;
+  return *this;
+}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_settings&
+ffmpeg_video_settings
+::operator=( ffmpeg_video_settings&& other )
+{
+  frame_rate = std::move( other.frame_rate );
+  parameters = std::move( other.parameters );
+  klv_stream_count = std::move( other.klv_stream_count );
+  return *this;
+}
 
 } // namespace ffmpeg
 

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -30,13 +30,19 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   : public vital::video_settings
 {
   ffmpeg_video_settings();
-
+  ffmpeg_video_settings( ffmpeg_video_settings const& other );
+  ffmpeg_video_settings( ffmpeg_video_settings&& other );
   ffmpeg_video_settings(
     size_t width, size_t height,
     AVRational frame_rate,
     size_t klv_stream_count );
 
   ~ffmpeg_video_settings();
+
+  ffmpeg_video_settings&
+  operator=( ffmpeg_video_settings const& other );
+  ffmpeg_video_settings&
+  operator=( ffmpeg_video_settings&& other );
 
   AVRational frame_rate;
   codec_parameters_uptr parameters;


### PR DESCRIPTION
This PR simply adds move and copy constructors for `ffmpeg_video_settings`, to specify how to deal with the `unique_ptr` member variable.

@hdefazio 