### PR TITLE
Pad image memory to avoid segfault

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -557,7 +557,7 @@ ffmpeg_video_input::priv::frame_state
   auto const params = parent->video_stream->codecpar;
   auto const width = static_cast< size_t >( params->width );
   auto const height = static_cast< size_t >( params->height );
-  auto const image_size = width * height * depth;
+  auto const image_size = width * height * depth + AV_INPUT_BUFFER_PADDING_SIZE;
 
   // Allocate enough space for the output image
   if( !image_memory || image_memory->size() < image_size )


### PR DESCRIPTION
This PR adds a few bytes of padding onto allocated video image memory, since the image format conversion algorithms packaged with FFmpeg can use vectorized algorithms which potentially write a few bytes past the end of the logical image.

@hdefazio