### PR TITLE
Increase timeout for sprokit python tests

### DIFF
--- a/python/kwiver/sprokit/tests/sprokit/pipeline/CMakeLists.txt
+++ b/python/kwiver/sprokit/tests/sprokit/pipeline/CMakeLists.txt
@@ -48,7 +48,7 @@ function (kwiver_add_python_run_test group instance)
 
     set_tests_properties(test-python-${group}-${instance}-${scheduler}
       PROPERTIES
-        TIMEOUT 5)
+        TIMEOUT 10)
   endforeach ()
 endfunction ()
 


### PR DESCRIPTION
Occasionally otherwise-successful sprokit tests will run into this 5 second barrier, resulting in random test "failures" which can mess up CI flows. Seems like this number could just be higher.

I think the occasional long delays might be the fault of the plugin loader and not the test bodies, but can't be 100% sure.

@hdefazio 