### PR TITLE
Change type of waypoint info field

### DIFF
--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -2181,6 +2181,19 @@ klv_0601_view_domain_format
 
 // ----------------------------------------------------------------------------
 std::ostream&
+operator<<( std::ostream& os, klv_0601_waypoint_info_bit value )
+{
+  static std::string strings[ KLV_0601_WAYPOINT_INFO_BIT_ENUM_END + 1 ] = {
+    "Mode Bit",
+    "Source Bit",
+    "Unknown Waypoint Info Bit" };
+
+  os << strings[ std::min( value, KLV_0601_WAYPOINT_INFO_BIT_ENUM_END ) ];
+  return os;
+}
+
+// ----------------------------------------------------------------------------
+std::ostream&
 operator<<( std::ostream& os, klv_0601_waypoint_record const& value )
 {
   os << "{ "
@@ -2190,19 +2203,8 @@ operator<<( std::ostream& os, klv_0601_waypoint_record const& value )
      << "prosecution order: "
      << value.order
      << ", "
-     << "info: { "
-     << "mode: ";
-  auto const mode = *value.info & 1;
-  os << ( mode
-      ? "manual"
-      : "automated" )
-     << ", "
-     << "source: ";
-  auto const source = ( *value.info >> 1 ) & 1;
-  os << ( source
-      ? "ad hoc"
-      : "pre-planned" )
-     << " }"
+     << "info: "
+     << value.info
      << ", "
      << "location: "
      << value.location
@@ -2250,7 +2252,8 @@ klv_0601_waypoint_record_format
   if( tracker.remaining() )
   {
     // Read waypoint info value
-    result.info = klv_read_ber_oid< uint8_t >( data, tracker.verify( 1 ) );
+    result.info =
+      klv_0601_waypoint_info_format{}.read_( data, tracker.verify( 1 ) );
   }
 
   if( tracker.remaining() )
@@ -2280,7 +2283,8 @@ klv_0601_waypoint_record_format
   if( value.info )
   {
     // Write waypoint info value
-    klv_write_ber_oid( *value.info, data, tracker.verify( 1 ) );
+    klv_0601_waypoint_info_format{}
+      .write_( *value.info, data, tracker.verify( 1 ) );
   }
 
   if( value.location && value.info )

--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -731,12 +731,32 @@ private:
 };
 
 // ----------------------------------------------------------------------------
+/// A set of bit values containing varied information about a waypoint.
+enum klv_0601_waypoint_info_bit : uint8_t
+{
+  // 0 = automated, 1 = manual
+  KLV_0601_WAYPOINT_INFO_BIT_MODE,
+  // 0 = pre-planned, 1 = ad-hoc
+  KLV_0601_WAYPOINT_INFO_BIT_SOURCE,
+  KLV_0601_WAYPOINT_INFO_BIT_ENUM_END,
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+std::ostream&
+operator<<( std::ostream& os, klv_0601_waypoint_info_bit value );
+
+// ----------------------------------------------------------------------------
+using klv_0601_waypoint_info_format =
+  klv_enum_bitfield_format< klv_0601_waypoint_info_bit, klv_ber_oid_format >;
+
+// ----------------------------------------------------------------------------
 /// Aircraft destinations used to navigate the aircraft to certain locations.
 struct klv_0601_waypoint_record
 {
   uint16_t id;
   int16_t order;
-  kwiver::vital::optional< uint8_t > info;
+  kwiver::vital::optional< std::set< klv_0601_waypoint_info_bit > > info;
   kwiver::vital::optional< klv_0601_location_dlp > location;
 };
 

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -458,6 +458,7 @@ KLV_INSTANTIATE( klv_universal_set );
 KLV_INSTANTIATE( klv_uuid );
 KLV_INSTANTIATE( std::set< klv_0601_generic_flag_data_bit > );
 KLV_INSTANTIATE( std::set< klv_0601_positioning_method_source_bit > );
+KLV_INSTANTIATE( std::set< klv_0601_waypoint_info_bit > );
 KLV_INSTANTIATE( std::set< klv_0601_weapon_engagement_status_bit > );
 KLV_INSTANTIATE( std::set< klv_packet > );
 KLV_INSTANTIATE( std::set< uint16_t > );

--- a/arrows/klv/tests/test_klv_0601.cxx
+++ b/arrows/klv/tests/test_klv_0601.cxx
@@ -233,16 +233,22 @@ auto const expected_result = klv_local_set{
   },
   { KLV_0601_WAYPOINT_LIST,
     std::vector< klv_0601_waypoint_record >{
-      { 0, 1, 3,
+      { 0, 1,
+        std::set< klv_0601_waypoint_info_bit >{
+          KLV_0601_WAYPOINT_INFO_BIT_MODE, KLV_0601_WAYPOINT_INFO_BIT_SOURCE },
         klv_0601_location_dlp{ 38.8894219398498535, -77.0351622104644775,
                                200.000000000000000 } },
-      { 1, 2, 2,
+      { 1, 2,
+        std::set< klv_0601_waypoint_info_bit >{
+          KLV_0601_WAYPOINT_INFO_BIT_SOURCE },
         klv_0601_location_dlp{ 38.8892679214477539, -77.0499181747436523,
                                250.000000000000000 } },
-      { 2, 32767, 1,
+      { 2, 32767,
+        std::set< klv_0601_waypoint_info_bit >{
+          KLV_0601_WAYPOINT_INFO_BIT_MODE },
         klv_0601_location_dlp{ 38.8897409439086914, -77.0129330158233643,
                                100.000000000000000 } },
-      { 3, -2, 0,
+      { 3, -2, std::set< klv_0601_waypoint_info_bit >{},
         klv_0601_location_dlp{ 38.8898218870162964, -77.0100920200347900,
                                300.000000000000000 } }
     } },

--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -207,7 +207,9 @@ klv_local_set const test_0601_set = {
       { 7, 13.0, 14.0, "Wavelength" } } },
   { KLV_0601_WAYPOINT_LIST,
     std::vector< klv_0601_waypoint_record >{
-      { 1, -3, 1, kv::nullopt } } },
+      { 1, -3,
+        std::set< klv_0601_waypoint_info_bit >{ KLV_0601_WAYPOINT_INFO_BIT_MODE },
+        kv::nullopt } } },
   { KLV_0601_MIIS_CORE_IDENTIFIER,
     klv_1204_miis_id{
       2,

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -718,7 +718,12 @@
 					{
 						"id": 1,
 						"order": -3,
-						"info": 1,
+						"info": [
+							{
+								"integer": 0,
+								"string": "Mode Bit"
+							}
+						],
 						"location": null
 					}
 				]


### PR DESCRIPTION
This PR changes the type of the "info" bitfield in each ST0601 waypoint to match how we've implemented other KLV bitfields.

@hdefazio 