### PR TITLE
Add klv_length_constraints

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -9,6 +9,7 @@ set( sources
   klv_data_format.cxx
   klv_demuxer.cxx
   klv_lengthy.cxx
+  klv_length_constraints.cxx
   klv_key.cxx
   klv_metadata.cxx
   klv_muxer.cxx
@@ -61,6 +62,7 @@ set( public_headers
   klv_blob.h
   klv_demuxer.h
   klv_lengthy.h
+  klv_length_constraints.h
   klv_list.h
   klv_list.hpp
   klv_key.h

--- a/arrows/klv/klv_0102.cxx
+++ b/arrows/klv/klv_0102.cxx
@@ -286,7 +286,7 @@ std::string
 klv_0102_local_set_format
 ::description() const
 {
-  return "security local set of " + length_description();
+  return "security local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0104.cxx
+++ b/arrows/klv/klv_0104.cxx
@@ -37,7 +37,7 @@ std::string
 klv_0104_universal_set_format
 ::description() const
 {
-  return "ST 0104 universal set of " + length_description();
+  return "ST 0104 universal set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -1231,7 +1231,7 @@ std::string
 klv_0601_image_horizon_locations_format
 ::description() const
 {
-  return "image horizon locations of " + length_description();
+  return "image horizon locations of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1305,7 +1305,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_image_horizon_pixel_pack_format
 ::klv_0601_image_horizon_pixel_pack_format()
-  : klv_data_format_< klv_0601_image_horizon_pixel_pack >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -1313,7 +1312,7 @@ std::string
 klv_0601_image_horizon_pixel_pack_format
 ::description() const
 {
-  return "image horizon pixel pack of " + length_description();
+  return "image horizon pixel pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1381,7 +1380,7 @@ DEFINE_STRUCT_CMP(
 
 // ----------------------------------------------------------------------------
 klv_0601_control_command_format
-::klv_0601_control_command_format() : klv_data_format_< data_type >{ 0 }
+::klv_0601_control_command_format()
 {}
 
 // ----------------------------------------------------------------------------
@@ -1443,7 +1442,7 @@ std::string
 klv_0601_control_command_format
 ::description() const
 {
-  return "control command of " + length_description();
+  return "control command of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1472,7 +1471,7 @@ DEFINE_STRUCT_CMP(
 
 // ----------------------------------------------------------------------------
 klv_0601_frame_rate_format
-::klv_0601_frame_rate_format() : klv_data_format_< data_type >{ 0 } {}
+::klv_0601_frame_rate_format() {}
 
 // ----------------------------------------------------------------------------
 klv_0601_frame_rate
@@ -1517,7 +1516,7 @@ std::string
 klv_0601_frame_rate_format
 ::description() const
 {
-  return "frame rate of " + length_description();
+  return "frame rate of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1558,7 +1557,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_country_codes_format
 ::klv_0601_country_codes_format()
-  : klv_data_format_< klv_0601_country_codes >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -1566,7 +1564,7 @@ std::string
 klv_0601_country_codes_format
 ::description() const
 {
-  return "country codes pack of " + length_description();
+  return "country codes pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1761,7 +1759,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_location_dlp_format
 ::klv_0601_location_dlp_format()
-  : klv_data_format_< klv_0601_location_dlp >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -1769,7 +1766,7 @@ std::string
 klv_0601_location_dlp_format
 ::description() const
 {
-  return "location pack of " + length_description();
+  return "location pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -1857,7 +1854,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_airbase_locations_format
 ::klv_0601_airbase_locations_format()
-  : klv_data_format_< klv_0601_airbase_locations >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -1865,7 +1861,7 @@ std::string
 klv_0601_airbase_locations_format
 ::description() const
 {
-  return "airbase locations pack of " + length_description();
+  return "airbase locations pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2040,8 +2036,7 @@ klv_0601_view_domain_interval_format
 klv_0601_view_domain_interval_format
 ::klv_0601_view_domain_interval_format(
   vital::interval< double > const& start_interval )
-  : klv_data_format_< klv_0601_view_domain_interval >{ 0 },
-    m_start_format{ start_interval }
+  : m_start_format{ start_interval }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2049,7 +2044,7 @@ std::string
 klv_0601_view_domain_interval_format
 ::description() const
 {
-  return "view domain interval of " + length_description();
+  return "view domain interval of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2129,7 +2124,6 @@ klv_0601_view_domain_format
 // ----------------------------------------------------------------------------
 klv_0601_view_domain_format
 ::klv_0601_view_domain_format()
-  : klv_data_format_< klv_0601_view_domain >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2137,7 +2131,7 @@ std::string
 klv_0601_view_domain_format
 ::description() const
 {
-  return "view domain pack of " + length_description();
+  return "view domain pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2222,7 +2216,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_waypoint_record_format
 ::klv_0601_waypoint_record_format()
-  : klv_data_format_< klv_0601_waypoint_record >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2230,7 +2223,7 @@ std::string
 klv_0601_waypoint_record_format
 ::description() const
 {
-  return "waypoint pack of " + length_description();
+  return "waypoint pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2396,7 +2389,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_weapons_store_format
 ::klv_0601_weapons_store_format()
-  : klv_data_format_< klv_0601_weapons_store >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2404,7 +2396,7 @@ std::string
 klv_0601_weapons_store_format
 ::description() const
 {
-  return "weapons store pack of " + length_description();
+  return "weapons store pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2555,7 +2547,6 @@ DEFINE_STRUCT_CMP(
 /// Interprets data as a payload record.
 klv_0601_payload_record_format
 ::klv_0601_payload_record_format()
-  : klv_data_format_< klv_0601_payload_record >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2563,7 +2554,7 @@ std::string
 klv_0601_payload_record_format
 ::description() const
 {
-  return "payload pack of " + length_description();
+  return "payload pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2639,7 +2630,6 @@ klv_0601_payload_record_format
 /// Interprets data as a payload list.
 klv_0601_payload_list_format
 ::klv_0601_payload_list_format()
-  : klv_data_format_< std::vector< klv_0601_payload_record > >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2647,7 +2637,7 @@ std::string
 klv_0601_payload_list_format
 ::description() const
 {
-  return "payload list pack of " + length_description();
+  return "payload list pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2732,7 +2722,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0601_wavelength_record_format
 ::klv_0601_wavelength_record_format()
-  : klv_data_format_< klv_0601_wavelength_record >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -2740,7 +2729,7 @@ std::string
 klv_0601_wavelength_record_format
 ::description() const
 {
-  return "wavelength pack of " + length_description();
+  return "wavelength pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -2814,7 +2803,7 @@ std::string
 klv_0601_local_set_format
 ::description() const
 {
-  return "UAS datalink local set of " + length_description();
+  return "UAS datalink local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0806.cxx
+++ b/arrows/klv/klv_0806.cxx
@@ -191,7 +191,7 @@ std::string
 klv_0806_local_set_format
 ::description() const
 {
-  return "ST 0806 local set of " + length_description();
+  return "ST 0806 local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0806_aoi_set.cxx
+++ b/arrows/klv/klv_0806_aoi_set.cxx
@@ -118,7 +118,7 @@ std::string
 klv_0806_aoi_set_format
 ::description() const
 {
-  return "area-of-interest local set of " + length_description();
+  return "area-of-interest local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0806_poi_set.cxx
+++ b/arrows/klv/klv_0806_poi_set.cxx
@@ -113,7 +113,7 @@ std::string
 klv_0806_poi_set_format
 ::description() const
 {
-  return "point-of-interest local set of " + length_description();
+  return "point-of-interest local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0806_user_defined_set.cxx
+++ b/arrows/klv/klv_0806_user_defined_set.cxx
@@ -75,7 +75,7 @@ std::string
 klv_0806_user_defined_data_type_id_format
 ::description() const
 {
-  return "user defined data type / id of " + length_description();
+  return "user defined data type / id of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -135,7 +135,6 @@ operator<<( std::ostream& os, klv_0806_user_defined_data_type value )
 // ----------------------------------------------------------------------------
 klv_0806_user_defined_data_format
 ::klv_0806_user_defined_data_format()
-  : klv_data_format_< klv_0806_user_defined_data >{ 0 }
 {
 }
 
@@ -144,7 +143,7 @@ std::string
 klv_0806_user_defined_data_format
 ::description() const
 {
-  return "user defined data of " + length_description();
+  return "user defined data of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -185,7 +184,7 @@ std::string
 klv_0806_user_defined_set_format
 ::description() const
 {
-  return "user defined local set of " + length_description();
+  return "user defined local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903.cxx
+++ b/arrows/klv/klv_0903.cxx
@@ -167,7 +167,7 @@ std::string
 klv_0903_local_set_format
 ::description() const
 {
-  return "vmti local set of " + length_description();
+  return "vmti local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_algorithm_set.cxx
+++ b/arrows/klv/klv_0903_algorithm_set.cxx
@@ -77,7 +77,7 @@ std::string
 klv_0903_algorithm_local_set_format
 ::description() const
 {
-  return "algorithm local set of " + length_description();
+  return "algorithm local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_location_pack.cxx
+++ b/arrows/klv/klv_0903_location_pack.cxx
@@ -176,7 +176,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0903_location_pack_format
 ::klv_0903_location_pack_format()
-  : klv_data_format_< klv_0903_location_pack >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -184,7 +183,7 @@ std::string
 klv_0903_location_pack_format
 ::description() const
 {
-  return "location pack of " + length_description();
+  return "location pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -257,7 +256,6 @@ klv_0903_location_pack_format
 // ----------------------------------------------------------------------------
 klv_0903_velocity_pack_format
 ::klv_0903_velocity_pack_format()
-  : klv_data_format_< klv_0903_velocity_pack >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -265,7 +263,7 @@ std::string
 klv_0903_velocity_pack_format
 ::description() const
 {
-  return "velocity/acceleration pack of " + length_description();
+  return "velocity/acceleration pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_ontology_set.cxx
+++ b/arrows/klv/klv_0903_ontology_set.cxx
@@ -71,7 +71,7 @@ std::string
 klv_0903_ontology_local_set_format
 ::description() const
 {
-  return "ontology local set of " + length_description();
+  return "ontology local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vchip_set.cxx
+++ b/arrows/klv/klv_0903_vchip_set.cxx
@@ -64,7 +64,7 @@ std::string
 klv_0903_vchip_local_set_format
 ::description() const
 {
-  return "vchip local set of " + length_description();
+  return "vchip local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vfeature_set.cxx
+++ b/arrows/klv/klv_0903_vfeature_set.cxx
@@ -61,7 +61,7 @@ std::string
 klv_0903_vfeature_local_set_format
 ::description() const
 {
-  return "vfeature local set of " + length_description();
+  return "vfeature local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vmask_set.cxx
+++ b/arrows/klv/klv_0903_vmask_set.cxx
@@ -44,14 +44,14 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0903_pixel_run_format
 ::klv_0903_pixel_run_format()
-  : klv_data_format_< klv_0903_pixel_run >{ 0 } {}
+{}
 
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_pixel_run_format
 ::description() const
 {
-  return "pixel run of " + length_description();
+  return "pixel run of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -104,7 +104,7 @@ std::string
 klv_0903_vmask_local_set_format
 ::description() const
 {
-  return "vmask local set of " + length_description();
+  return "vmask local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vobject_set.cxx
+++ b/arrows/klv/klv_0903_vobject_set.cxx
@@ -33,7 +33,7 @@ std::string
 klv_0903_vobject_local_set_format
 ::description() const
 {
-  return "vobject local set of " + length_description();
+  return "vobject local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vtarget_pack.cxx
+++ b/arrows/klv/klv_0903_vtarget_pack.cxx
@@ -78,7 +78,7 @@ std::string
 klv_0903_fpa_index_format
 ::description() const
 {
-  return "fpa index pack of " + length_description();
+  return "fpa index pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -124,14 +124,14 @@ klv_0903_fpa_index_format
 // ----------------------------------------------------------------------------
 klv_0903_vtarget_pack_format
 ::klv_0903_vtarget_pack_format()
-  : klv_data_format_< klv_0903_vtarget_pack >{ 0 } {}
+{}
 
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtarget_pack_format
 ::description() const
 {
-  return "vtarget pack of " + length_description();
+  return "vtarget pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -398,7 +398,7 @@ std::string
 klv_0903_vtarget_local_set_format
 ::description() const
 {
-  return "vtarget local set of " + length_description();
+  return "vtarget local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtrack_set.cxx
+++ b/arrows/klv/klv_0903_vtrack_set.cxx
@@ -152,7 +152,7 @@ std::string
 klv_0903_vtrack_local_set_format
 ::description() const
 {
-  return "vtrack local set of " + length_description();
+  return "vtrack local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtracker_set.cxx
+++ b/arrows/klv/klv_0903_vtracker_set.cxx
@@ -145,7 +145,7 @@ std::string
 klv_0903_vtracker_local_set_format
 ::description() const
 {
-  return "vtracker local set of " + length_description();
+  return "vtracker local set of " + m_length_constraints.description();
 }
 
 } // namespace arrows

--- a/arrows/klv/klv_0903_vtrackitem_pack.cxx
+++ b/arrows/klv/klv_0903_vtrackitem_pack.cxx
@@ -51,14 +51,14 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_0903_vtrackitem_pack_format
 ::klv_0903_vtrackitem_pack_format()
-  : klv_data_format_< klv_0903_vtrackitem_pack >{ 0 } {}
+{}
 
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtrackitem_pack_format
 ::description() const
 {
-  return "vtrackitem pack of " + length_description();
+  return "vtrackitem pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -321,7 +321,7 @@ std::string
 klv_0903_vtrackitem_local_set_format
 ::description() const
 {
-  return "vtrackitem local set of " + length_description();
+  return "vtrackitem local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1002.cxx
+++ b/arrows/klv/klv_1002.cxx
@@ -90,7 +90,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_1002_enumerations_format
 ::klv_1002_enumerations_format()
-  : klv_data_format_< klv_1002_enumerations >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -98,7 +97,7 @@ std::string
 klv_1002_enumerations_format
 ::description() const
 {
-  return "range image enumerations of " + length_description();
+  return "range image enumerations of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -173,7 +172,6 @@ auto const plane_format = klv_float_format{};
 // ----------------------------------------------------------------------------
 klv_1002_section_data_pack_format
 ::klv_1002_section_data_pack_format()
-  : klv_data_format_< klv_1002_section_data_pack >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -181,7 +179,7 @@ std::string
 klv_1002_section_data_pack_format
 ::description() const
 {
-  return "section data pack of " + length_description();
+  return "section data pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -263,7 +261,7 @@ std::string
 klv_1002_local_set_format
 ::description() const
 {
-  return "range image local set of " + length_description();
+  return "range image local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1010.cxx
+++ b/arrows/klv/klv_1010.cxx
@@ -66,16 +66,14 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_1010_sdcc_flp_format
 ::klv_1010_sdcc_flp_format()
-  : klv_data_format_< klv_1010_sdcc_flp >{ 0 },
-    m_sigma_imap{},
+  : m_sigma_imap{},
     m_preceding_keys{}
 {}
 
 // ----------------------------------------------------------------------------
 klv_1010_sdcc_flp_format
 ::klv_1010_sdcc_flp_format( imap_from_key_fn sigma_imap )
-  : klv_data_format_< klv_1010_sdcc_flp >{ 0 },
-    m_sigma_imap{ sigma_imap },
+  : m_sigma_imap{ sigma_imap },
     m_preceding_keys{}
 {}
 
@@ -92,7 +90,7 @@ std::string
 klv_1010_sdcc_flp_format
 ::description() const
 {
-  return "SDCC-FLP of " + length_description();
+  return "SDCC-FLP of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1107.cxx
+++ b/arrows/klv/klv_1107.cxx
@@ -123,7 +123,8 @@ std::string
 klv_1107_local_set_format
 ::description() const
 {
-  return "metric geopositioning local set of " + length_description();
+  return
+    "metric geopositioning local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -118,7 +118,7 @@ std::string
 klv_1108_metric_period_pack_format
 ::description() const
 {
-  return "metric period pack of " + length_description();
+  return "metric period pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -148,7 +148,7 @@ operator<<( std::ostream& os, klv_1108_window_corners_pack const& rhs )
 
 // ----------------------------------------------------------------------------
 klv_1108_window_corners_pack_format
-::klv_1108_window_corners_pack_format() : klv_data_format_< data_type >{ 0 }
+::klv_1108_window_corners_pack_format()
 {}
 
 // ----------------------------------------------------------------------------
@@ -194,7 +194,7 @@ std::string
 klv_1108_window_corners_pack_format
 ::description() const
 {
-  return "window corners pack of " + length_description();
+  return "window corners pack of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -224,7 +224,7 @@ std::string
 klv_1108_local_set_format
 ::description() const
 {
-  return "ST 1108 local set of " + length_description();
+  return "ST 1108 local set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1108_metric_set.cxx
+++ b/arrows/klv/klv_1108_metric_set.cxx
@@ -44,7 +44,6 @@ operator<<( std::ostream& os, klv_1108_metric_implementer const& rhs )
 // ----------------------------------------------------------------------------
 klv_1108_metric_implementer_format
 ::klv_1108_metric_implementer_format()
-  : klv_data_format_< klv_1108_metric_implementer >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -90,7 +89,7 @@ std::string
 klv_1108_metric_implementer_format
 ::description() const
 {
-  return "metric implementer of " + length_description();
+  return "metric implementer of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1202.cxx
+++ b/arrows/klv/klv_1202.cxx
@@ -54,7 +54,9 @@ std::string
 klv_1202_local_set_format
 ::description() const
 {
-  return "generalized transformation local set of " + length_description();
+  return
+    "generalized transformation local set of " +
+    m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1204.cxx
+++ b/arrows/klv/klv_1204.cxx
@@ -74,7 +74,6 @@ DEFINE_STRUCT_CMP(
 // ----------------------------------------------------------------------------
 klv_1204_miis_id_format
 ::klv_1204_miis_id_format()
-  : klv_data_format_< klv_1204_miis_id >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -82,7 +81,7 @@ std::string
 klv_1204_miis_id_format
 ::description() const
 {
-  return "MIIS ID of " + length_description();
+  return "MIIS ID of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1206.cxx
+++ b/arrows/klv/klv_1206.cxx
@@ -301,7 +301,8 @@ std::string
 klv_1206_local_set_format
 ::description() const
 {
-  return "SAR motion imagery local set of " + length_description();
+  return
+    "SAR motion imagery local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1303.hpp
+++ b/arrows/klv/klv_1303.hpp
@@ -47,8 +47,7 @@ template < class Format >
 template < class... Args >
 klv_1303_mdap_format< Format >
 ::klv_1303_mdap_format( Args&&... args )
-  : klv_data_format_< mdap_t >{ 0 },
-    m_format{ std::forward< Args >( args )... }
+  : m_format{ std::forward< Args >( args )... }
 {}
 
 // ----------------------------------------------------------------------------
@@ -57,7 +56,7 @@ std::string
 klv_1303_mdap_format< Format >
 ::description() const
 {
-  return "MDAP/MDARRAY of " + this->length_description();
+  return "MDAP/MDARRAY of " + this->m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -123,7 +122,7 @@ klv_1303_mdap_format< Format >
     case KLV_1303_APA_NATURAL:
       result.apa_params_length = 0;
       format.reset( new Format{ m_format } );
-      format->set_fixed_length( result.element_size );
+      format->set_length_constraints( result.element_size );
       break;
     case KLV_1303_APA_BOOLEAN:
     case KLV_1303_APA_UINT:
@@ -198,7 +197,7 @@ klv_1303_mdap_format< Format >
     }
     case KLV_1303_APA_NATURAL:
       format.reset( new Format{ m_format } );
-      format->set_fixed_length( value.element_size );
+      format->set_length_constraints( value.element_size );
       break;
     case KLV_1303_APA_BOOLEAN:
     case KLV_1303_APA_UINT:

--- a/arrows/klv/klv_1601.cxx
+++ b/arrows/klv/klv_1601.cxx
@@ -86,7 +86,6 @@ operator<<( std::ostream& os, klv_1601_tag tag )
 // ----------------------------------------------------------------------------
 klv_1601_pixel_sdcc_format
 ::klv_1601_pixel_sdcc_format()
-  : klv_data_format_< klv_1303_mdap< double > >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -94,7 +93,7 @@ std::string
 klv_1601_pixel_sdcc_format
 ::description() const
 {
-  return "pixel sdcc mdarray of " + length_description();
+  return "pixel sdcc mdarray of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -185,7 +184,6 @@ klv_1601_pixel_sdcc_format
 // ----------------------------------------------------------------------------
 klv_1601_geographic_sdcc_format
 ::klv_1601_geographic_sdcc_format()
-  : klv_data_format_< klv_1303_mdap< double > >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -193,7 +191,7 @@ std::string
 klv_1601_geographic_sdcc_format
 ::description() const
 {
-  return "geographic sdcc mdarray of " + length_description();
+  return "geographic sdcc mdarray of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -386,7 +384,7 @@ std::string
 klv_1601_local_set_format
 ::description() const
 {
-  return "geo-registration local set of " + length_description();
+  return "geo-registration local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1602.cxx
+++ b/arrows/klv/klv_1602.cxx
@@ -171,7 +171,7 @@ std::string
 klv_1602_local_set_format
 ::description() const
 {
-  return "composite imaging local set of " + length_description();
+  return "composite imaging local set of " + m_length_constraints.description();
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1607.cxx
+++ b/arrows/klv/klv_1607.cxx
@@ -26,7 +26,7 @@ std::string
 klv_1607_child_set_format
 ::description() const
 {
-  return "child set of " + length_description();
+  return "child set of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_checksum.cxx
+++ b/arrows/klv/klv_checksum.cxx
@@ -161,7 +161,7 @@ std::string
 klv_running_sum_16_packet_format
 ::description() const
 {
-  return "running 16-byte sum packet of " + length_description();
+  return "running 16-byte sum packet of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -183,7 +183,7 @@ std::string
 klv_crc_16_ccitt_packet_format
 ::description() const
 {
-  return "CRC-16-CCITT packet of " + length_description();
+  return "CRC-16-CCITT packet of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -205,7 +205,7 @@ std::string
 klv_crc_32_mpeg_packet_format
 ::description() const
 {
-  return "CRC-32-MPEG packet of " + length_description();
+  return "CRC-32-MPEG packet of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -36,7 +36,8 @@ bits_to_decimal_digits( size_t bits )
 
 // ----------------------------------------------------------------------------
 klv_data_format
-::klv_data_format( size_t fixed_length ) : m_fixed_length{ fixed_length }
+::klv_data_format( klv_length_constraints const& length_constraints )
+  : m_length_constraints{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -58,23 +59,6 @@ klv_data_format
 }
 
 // ----------------------------------------------------------------------------
-std::string
-klv_data_format
-::length_description() const
-{
-  std::stringstream ss;
-  if( m_fixed_length )
-  {
-    ss << "length " << m_fixed_length;
-  }
-  else
-  {
-    ss << "variable length";
-  }
-  return ss.str();
-}
-
-// ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_data_format
 ::checksum_format() const
@@ -83,25 +67,25 @@ klv_data_format
 }
 
 // ----------------------------------------------------------------------------
-size_t
+klv_length_constraints const&
 klv_data_format
-::fixed_length() const
+::length_constraints() const
 {
-  return m_fixed_length;
+  return m_length_constraints;
 }
 
 // ----------------------------------------------------------------------------
 void
 klv_data_format
-::set_fixed_length( size_t fixed_length )
+::set_length_constraints( klv_length_constraints const& length_constraints )
 {
-  m_fixed_length = fixed_length;
+  m_length_constraints = length_constraints;
 }
 
 // ----------------------------------------------------------------------------
 klv_blob_format
-::klv_blob_format( size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }
+::klv_blob_format( klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -135,7 +119,7 @@ klv_blob_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "raw bytes of " << length_description();
+  ss << "raw bytes of " << m_length_constraints.description();
   return ss.str();
 }
 
@@ -149,7 +133,7 @@ std::string
 klv_uuid_format
 ::description() const
 {
-  return "UUID of " + length_description();
+  return "UUID of " + m_length_constraints.description();
 }
 
 // ----------------------------------------------------------------------------
@@ -179,8 +163,8 @@ klv_uuid_format
 
 // ----------------------------------------------------------------------------
 klv_string_format
-::klv_string_format( size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }
+::klv_string_format( klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -214,14 +198,14 @@ klv_string_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "string of " << length_description();
+  ss << "string of " << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_uint_format
-::klv_uint_format( size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }
+::klv_uint_format( klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -255,14 +239,14 @@ klv_uint_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "unsigned integer of " << length_description();
+  ss << "unsigned integer of " << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_sint_format
-::klv_sint_format( size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }
+::klv_sint_format( klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -296,13 +280,13 @@ klv_sint_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "signed integer of " << length_description();
+  ss << "signed integer of " << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_ber_format
-::klv_ber_format() : klv_data_format_< data_type >{ 0 }
+::klv_ber_format()
 {}
 
 // ----------------------------------------------------------------------------
@@ -336,14 +320,14 @@ klv_ber_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "BER-encoded unsigned integer of " << length_description();
+  ss << "BER-encoded unsigned integer of "
+     << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_ber_oid_format
 ::klv_ber_oid_format()
-  : klv_data_format_< data_type >{ 0 }
 {}
 
 // ----------------------------------------------------------------------------
@@ -377,14 +361,15 @@ klv_ber_oid_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "BER-OID-encoded unsigned integer of " << length_description();
+  ss << "BER-OID-encoded unsigned integer of "
+     << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_float_format
-::klv_float_format( size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }
+::klv_float_format( klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }
 {}
 
 // ----------------------------------------------------------------------------
@@ -420,7 +405,7 @@ klv_float_format
   auto const flags = os.flags();
 
   // Print the number of digits corresponding to the precision of the format
-  auto const length = m_fixed_length ? m_fixed_length : value.length;
+  auto const length = m_length_constraints.fixed_or( value.length );
   auto const digits = ( length == 4 ) ? ( FLT_DIG + 1 ) : ( DBL_DIG + 1 );
   os << std::setprecision( digits ) << value.value;
 
@@ -434,15 +419,17 @@ klv_float_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "IEEE-754 floating-point number of " << length_description();
+  ss << "IEEE-754 floating-point number of "
+     << m_length_constraints.description();
   return ss.str();
 }
 
 // ----------------------------------------------------------------------------
 klv_sflint_format
 ::klv_sflint_format(
-  vital::interval< double > const& interval, size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }, m_interval{ interval }
+  vital::interval< double > const& interval,
+  klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }, m_interval{ interval }
 {}
 
 // ----------------------------------------------------------------------------
@@ -478,7 +465,7 @@ klv_sflint_format
   auto const flags = os.flags();
 
   // Print the number of digits corresponding to the precision of the format
-  auto const length = m_fixed_length ? m_fixed_length : value.length;
+  auto const length = m_length_constraints.fixed_or( value.length );
   auto const digits = length ? bits_to_decimal_digits( length * 8 )
                              : ( DBL_DIG + 1 );
   os << std::setprecision( digits ) << value.value;
@@ -493,7 +480,7 @@ klv_sflint_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "signed integer of " << length_description()
+  ss << "signed integer of " << m_length_constraints.description()
      << " mapped to range " << m_interval;
   return ss.str();
 }
@@ -509,8 +496,9 @@ klv_sflint_format
 // ----------------------------------------------------------------------------
 klv_uflint_format
 ::klv_uflint_format(
-  vital::interval< double > const& interval, size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }, m_interval{ interval }
+  vital::interval< double > const& interval,
+  klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }, m_interval{ interval }
 {}
 
 // ----------------------------------------------------------------------------
@@ -546,7 +534,7 @@ klv_uflint_format
   auto const flags = os.flags();
 
   // Print the number of digits corresponding to the precision of the format
-  auto const length = m_fixed_length ? m_fixed_length : value.length;
+  auto const length = m_length_constraints.fixed_or( value.length );
   auto const digits = length ? bits_to_decimal_digits( length * 8 )
                              : ( DBL_DIG + 1 );
   os << std::setprecision( digits ) << value.value;
@@ -561,8 +549,8 @@ klv_uflint_format
 ::description() const
 {
   std::stringstream ss;
-  ss    << "unsigned integer of " << length_description() <<
-        " mapped to range " << m_interval;
+  ss << "unsigned integer of " << m_length_constraints.description()
+     << " mapped to range " << m_interval;
   return ss.str();
 }
 
@@ -576,8 +564,9 @@ klv_uflint_format
 
 // ----------------------------------------------------------------------------
 klv_imap_format
-::klv_imap_format( vital::interval< double > const& interval, size_t fixed_length )
-  : klv_data_format_< data_type >{ fixed_length }, m_interval{ interval }
+::klv_imap_format( vital::interval< double > const& interval,
+                   klv_length_constraints const& length_constraints )
+  : klv_data_format_< data_type >{ length_constraints }, m_interval{ interval }
 {}
 
 // ----------------------------------------------------------------------------
@@ -613,7 +602,7 @@ klv_imap_format
   auto const flags = os.flags();
 
   // Print the number of digits corresponding to the precision of the format
-  auto const length = m_fixed_length ? m_fixed_length : value.length;
+  auto const length = m_length_constraints.fixed_or( value.length );
   auto const digits = length ? bits_to_decimal_digits( length * 8 - 1 )
                              : ( DBL_DIG + 1 );
   os << std::setprecision( digits ) << value.value;
@@ -628,7 +617,8 @@ klv_imap_format
 ::description() const
 {
   std::stringstream ss;
-  ss << "IMAP-encoded range " << m_interval << "of " << length_description();
+  ss << "IMAP-encoded range " << m_interval << "of "
+     << m_length_constraints.description();
   return ss.str();
 }
 

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -15,6 +15,7 @@
 #include "klv_uuid.h"
 #include "klv_value.h"
 
+#include <arrows/klv/klv_length_constraints.h>
 #include <arrows/klv/kwiver_algo_klv_export.h>
 #include <vital/exceptions/metadata.h>
 #include <vital/logger/logger.h>
@@ -45,7 +46,7 @@ public:
   /// \param fixed_length The exact length in bytes of this data format. If
   /// zero, the length is variable.
   explicit
-  klv_data_format( size_t fixed_length );
+  klv_data_format( klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_data_format() = default;
@@ -89,20 +90,16 @@ public:
   virtual klv_checksum_packet_format const*
   checksum_format() const;
 
-  /// Return the fixed length of this format, or 0 if length is variable.
-  size_t
-  fixed_length() const;
+  /// Return the constraints on the length of this format.
+  klv_length_constraints const&
+  length_constraints() const;
 
-  /// Set the fixed length of this format.
+  /// Set constraints on the length of this format.
   void
-  set_fixed_length( size_t fixed_length );
+  set_length_constraints( klv_length_constraints const& length_constraints );
 
 protected:
-  /// Describe the length of this data format.
-  std::string
-  length_description() const;
-
-  size_t m_fixed_length;
+  klv_length_constraints m_length_constraints;
 };
 
 using klv_data_format_sptr = std::shared_ptr< klv_data_format >;
@@ -122,7 +119,8 @@ public:
   using data_type = T;
 
   explicit
-  klv_data_format_( size_t fixed_length ) : klv_data_format{ fixed_length }
+  klv_data_format_( klv_length_constraints const& length_constraints = {} )
+    : klv_data_format{ length_constraints }
   {}
 
   virtual
@@ -160,11 +158,11 @@ public:
       VITAL_THROW( kwiver::vital::metadata_exception,
                   "zero length given to read_()" );
     }
-    else if( m_fixed_length && length != m_fixed_length )
+    else if( !m_length_constraints.do_allow( length ) )
     {
       // Invalid length
       LOG_WARN( kwiver::vital::get_logger( "klv" ),
-                "fixed-length format `" << description() <<
+                "format `" << description() <<
                 "` received wrong number of bytes ( " << length << " )" );
     }
 
@@ -200,6 +198,13 @@ public:
     {
       VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
                   "write will overflow buffer" );
+    }
+    else if( !m_length_constraints.do_allow( value_length ) )
+    {
+      // Invalid length
+      LOG_WARN( kwiver::vital::get_logger( "klv" ),
+                "format `" << description() <<
+                "` received wrong number of bytes ( " << value_length << " )" );
     }
 
     // Write the value
@@ -239,7 +244,9 @@ public:
   size_t
   length_of_( T const& value ) const
   {
-    return m_fixed_length ? m_fixed_length : length_of_typed( value );
+    return m_length_constraints.fixed()
+          ? *m_length_constraints.fixed()
+          : length_of_typed( value );
   }
 
   std::type_info const&
@@ -302,7 +309,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_blob_format
   : public klv_data_format_< klv_blob >
 {
 public:
-  klv_blob_format( size_t fixed_length = 0 );
+  klv_blob_format( klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_blob_format() = default;
@@ -351,7 +358,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_string_format
   : public klv_data_format_< std::string >
 {
 public:
-  klv_string_format( size_t fixed_length = 0 );
+  klv_string_format( klv_length_constraints const& length_constraints = {} );
 
   std::string
   description() const override;
@@ -374,7 +381,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_uint_format
   : public klv_data_format_< uint64_t >
 {
 public:
-  klv_uint_format( size_t fixed_length = 0 );
+  klv_uint_format( klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_uint_format() = default;
@@ -400,7 +407,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_sint_format
   : public klv_data_format_< int64_t >
 {
 public:
-  klv_sint_format( size_t fixed_length = 0 );
+  klv_sint_format( klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_sint_format() = default;
@@ -429,8 +436,8 @@ class KWIVER_ALGO_KLV_EXPORT klv_enum_format
 public:
   using data_type = typename std::decay< T >::type;
 
-  klv_enum_format( size_t fixed_length = 1 )
-    : klv_data_format_< data_type >{ fixed_length }
+  klv_enum_format( klv_length_constraints const& length_constraints = { 1 } )
+    : klv_data_format_< data_type >{ length_constraints }
   {}
 
   virtual
@@ -442,7 +449,7 @@ public:
   {
     std::stringstream ss;
     ss << this->type_name() << " enumeration of "
-       << this->length_description();
+       << this->m_length_constraints.description();
     return ss.str();
   }
 
@@ -528,7 +535,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_float_format
   : public klv_data_format_< klv_lengthy< double > >
 {
 public:
-  klv_float_format( size_t fixed_length = 0 );
+  klv_float_format( klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_float_format() = default;
@@ -560,7 +567,8 @@ class KWIVER_ALGO_KLV_EXPORT klv_sflint_format
 {
 public:
   klv_sflint_format(
-    vital::interval< double > const& interval, size_t fixed_length = 0 );
+    vital::interval< double > const& interval,
+    klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_sflint_format() = default;
@@ -597,7 +605,8 @@ class KWIVER_ALGO_KLV_EXPORT klv_uflint_format
 {
 public:
   klv_uflint_format(
-    vital::interval< double > const& interval, size_t fixed_length = 0 );
+    vital::interval< double > const& interval,
+    klv_length_constraints const& length_constraints = {} );
 
   virtual
   ~klv_uflint_format() = default;
@@ -633,7 +642,8 @@ class KWIVER_ALGO_KLV_EXPORT klv_imap_format
 {
 public:
   klv_imap_format(
-    vital::interval< double > const& interval, size_t fixed_length = 0 );
+    vital::interval< double > const& interval,
+    klv_length_constraints const& length_constraints = {} );
 
   std::string
   description() const override;
@@ -669,12 +679,13 @@ public:
 
   template< class... Args >
   klv_lengthless_format( Args&&... args )
-    : klv_data_format_< data_type >{ 0 }, m_format{ args... } {
-    if( !( this->m_fixed_length = m_format.fixed_length() ) )
+    : m_format{ args... } {
+    if( !m_format.length_constraints().fixed() )
     {
       throw std::logic_error( "klv_lengthless_format requires fixed length" );
     }
-    m_format.set_fixed_length( 0 );
+    this->m_length_constraints = m_format.length_constraints();
+    m_format.set_length_constraints( {} );
   }
 
   std::string
@@ -694,19 +705,21 @@ protected:
   write_typed( data_type const& value,
                klv_write_iter_t& data, size_t length ) const
   {
-    m_format.write_( { value, this->m_fixed_length }, data, length );
+    m_format.write_(
+      { value, *this->m_length_constraints.fixed() }, data, length );
   }
 
   size_t
   length_of_typed( VITAL_UNUSED data_type const& value ) const
   {
-    return this->m_fixed_length;
+    return *this->m_length_constraints.fixed();
   }
 
   std::ostream&
   print_typed( std::ostream& os, data_type const& value ) const
   {
-    return m_format.print_( os, { value, this->m_fixed_length } );
+    return m_format.print_(
+      os, { value, *this->m_length_constraints.fixed() } );
   }
 
   Format m_format;
@@ -753,15 +766,15 @@ class KWIVER_ALGO_KLV_EXPORT klv_enum_bitfield_format
 public:
   template< class... Args >
   klv_enum_bitfield_format( Args&&... args )
-    : klv_data_format_< std::set< Enum > >{ 0 }, m_format{ args... } {
-    this->m_fixed_length = m_format.fixed_length();
-    m_format.set_fixed_length( 0 );
+    : m_format{ args... } {
+    this->m_length_constraints = m_format.length_constraints();
+    m_format.set_length_constraints( {} );
   }
 
   std::string
   description() const
   {
-    return "bitfield of " + this->length_description();
+    return "bitfield of " + this->m_length_constraints.description();
   }
 
 protected:

--- a/arrows/klv/klv_length_constraints.cxx
+++ b/arrows/klv/klv_length_constraints.cxx
@@ -1,0 +1,311 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of KLV length constraints class.
+
+#include <arrows/klv/klv_length_constraints.h>
+
+#include <sstream>
+#include <stdexcept>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints()
+{}
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints( size_t fixed_length ) : m_impl{ fixed_length }
+{
+  if( fixed_length == 0 )
+  {
+    throw std::logic_error{ "length constraints cannot include zero" };
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints( size_t minimum, size_t maximum )
+  : m_impl{ vital::interval< size_t >{ minimum, maximum } }
+{
+  if( minimum == 0 || maximum == 0 )
+  {
+    throw std::logic_error{ "length constraints cannot include zero" };
+  }
+  if( minimum == maximum )
+  {
+    throw std::logic_error{ "length constraints cannot exclude all lengths" };
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints( size_t minimum, size_t maximum, size_t suggested )
+  : m_impl{ vital::interval< size_t >{ minimum, maximum } },
+    m_suggested{ suggested }
+{
+  if( minimum == 0 || maximum == 0 )
+  {
+    throw std::logic_error{ "length constraints cannot include zero" };
+  }
+  if( minimum == maximum )
+  {
+    throw std::logic_error{ "length constraints cannot exclude all lengths" };
+  }
+  set_suggested( suggested );
+}
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints( std::set< size_t > const& allowed )
+  : m_impl{ allowed }
+{
+  if( allowed.empty() )
+  {
+    throw std::logic_error{ "length constraints cannot exclude all lengths" };
+  }
+  if( allowed.count( 0 ) )
+  {
+    throw std::logic_error{ "length constraints cannot include zero" };
+  }
+}
+
+// ----------------------------------------------------------------------------
+klv_length_constraints
+::klv_length_constraints( std::set< size_t > const& allowed, size_t suggested )
+  : m_impl{ allowed }, m_suggested{ suggested }
+{
+  if( allowed.empty() )
+  {
+    throw std::logic_error{ "length constraints cannot exclude all lengths" };
+  }
+  if( allowed.count( 0 ) )
+  {
+    throw std::logic_error{ "length constraints cannot include zero" };
+  }
+  set_suggested( suggested );
+}
+
+// ----------------------------------------------------------------------------
+bool
+klv_length_constraints
+::do_allow( size_t length ) const
+{
+  struct visitor
+  {
+    bool
+    operator()( vital::monostate ) const
+    {
+      return true;
+    }
+
+    bool
+    operator()( size_t fixed_length ) const
+    {
+      return length == fixed_length;
+    }
+
+    bool
+    operator()( vital::interval< size_t > const& interval ) const
+    {
+      return interval.contains( length, true, true );
+    }
+
+    bool
+    operator()( std::set< size_t > const& set ) const
+    {
+      return set.count( length );
+    }
+
+    size_t length;
+  };
+
+  return vital::visit( visitor{ length }, m_impl );
+}
+
+// ----------------------------------------------------------------------------
+bool
+klv_length_constraints
+::is_free() const
+{
+  return vital::holds_alternative< vital::monostate >( m_impl );
+}
+
+// ----------------------------------------------------------------------------
+vital::optional< size_t >
+klv_length_constraints
+::fixed() const
+{
+  auto const result = vital::get_if< size_t >( &m_impl );
+  if( result )
+  {
+    return *result;
+  }
+  else
+  {
+    return vital::nullopt;
+  }
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_length_constraints
+::fixed_or( size_t backup ) const
+{
+  auto const result = vital::get_if< size_t >( &m_impl );
+  if( result )
+  {
+    return *result;
+  }
+  else
+  {
+    return backup;
+  }
+}
+
+// ----------------------------------------------------------------------------
+vital::optional< vital::interval< size_t > >
+klv_length_constraints
+::interval() const
+{
+  auto const result = vital::get_if< vital::interval< size_t > >( &m_impl );
+  if( result )
+  {
+    return *result;
+  }
+  else
+  {
+    return vital::nullopt;
+  }
+}
+
+// ----------------------------------------------------------------------------
+vital::optional< std::set< size_t > >
+klv_length_constraints
+::set() const
+{
+  auto const result = vital::get_if< std::set< size_t > >( &m_impl );
+  if( result )
+  {
+    return *result;
+  }
+  else
+  {
+    return vital::nullopt;
+  }
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_length_constraints
+::suggested() const
+{
+  if( m_suggested )
+  {
+    return *m_suggested;
+  }
+
+  struct visitor
+  {
+    size_t
+    operator()( vital::monostate ) const
+    {
+      return 1;
+    }
+
+    size_t
+    operator()( size_t fixed_length ) const
+    {
+      return fixed_length;
+    }
+
+    size_t
+    operator()( vital::interval< size_t > const& interval ) const
+    {
+      return interval.lower();
+    }
+
+    size_t
+    operator()( std::set< size_t > const& set ) const
+    {
+      return *set.begin();
+    }
+  };
+
+  return vital::visit( visitor{}, m_impl );
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_length_constraints
+::set_suggested( size_t length )
+{
+  if( length == 0 || !do_allow( length ) )
+  {
+    throw std::logic_error{
+            "suggested length is not permitted by constraints" };
+  }
+  m_suggested = length;
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_length_constraints
+::description() const
+{
+  struct visitor
+  {
+    void
+    operator()( vital::monostate ) const
+    {
+      os << "unconstrained length";
+    }
+
+    void
+    operator()( size_t fixed_length ) const
+    {
+      os << "exactly " << fixed_length << " bytes";
+    }
+
+    void
+    operator()( vital::interval< size_t > const& interval ) const
+    {
+      os << "between " << interval.lower() << " and " << interval.upper()
+         << " bytes";
+    }
+
+    void
+    operator()( std::set< size_t > const& set ) const
+    {
+      os << "one of these lengths: ";
+      for( auto const& entry : set )
+      {
+        os << entry;
+        if( &entry != &*set.end() )
+        {
+          os << ", ";
+        }
+      }
+    }
+
+    std::ostream& os;
+  };
+
+  std::stringstream ss;
+  vital::visit( visitor{ ss }, m_impl );
+  return ss.str();
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_length_constraints.h
+++ b/arrows/klv/klv_length_constraints.h
@@ -1,0 +1,94 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of KLV length constraints class.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_LENGTH_CONSTRAINTS_H_
+#define KWIVER_ARROWS_KLV_KLV_LENGTH_CONSTRAINTS_H_
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vital/optional.h>
+#include <vital/util/interval.h>
+#include <vital/util/variant/variant.hpp>
+
+#include <set>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Description of how long a variable-length field is allowed to be.
+class KWIVER_ALGO_KLV_EXPORT klv_length_constraints
+{
+public:
+  /// Unconstrained length.
+  klv_length_constraints();
+
+  /// Length must be given value.
+  klv_length_constraints( size_t fixed_length );
+
+  /// Length must be between given values, inclusive on both ends.
+  klv_length_constraints( size_t minimum, size_t maximum );
+  klv_length_constraints( size_t minimum, size_t maximum, size_t suggested );
+
+  /// Length must be one of supplied values.
+  klv_length_constraints( std::set< size_t > const& allowed );
+  klv_length_constraints( std::set< size_t > const& allowed,
+                          size_t suggested );
+
+  /// Returns whether \p length is an allowable length.
+  bool
+  do_allow( size_t length ) const;
+
+  /// Returns \c true if the length is completely unconstrained.
+  bool
+  is_free() const;
+
+  /// Returns the single value the length is fixed to, if it exists.
+  vital::optional< size_t >
+  fixed() const;
+
+  /// Returns the fixed length, or \p backup if the length is not fixed.
+  size_t
+  fixed_or( size_t backup ) const;
+
+  /// Returns the interval of allowed lengths, if it exists.
+  vital::optional< vital::interval< size_t > >
+  interval() const;
+
+  /// Returns the set of allowed lengths, if it exists.
+  vital::optional< std::set< size_t > >
+  set() const;
+
+  /// Return a suggested, valid length.
+  size_t
+  suggested() const;
+
+  /// Set a custom suggestion.
+  void
+  set_suggested( size_t length );
+
+  /// Textual description of the constraints.
+  std::string
+  description() const;
+
+private:
+  vital::variant<
+    vital::monostate, size_t, vital::interval< size_t >, std::set< size_t >
+    > m_impl;
+  vital::optional< size_t > m_suggested;
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/klv/klv_list.hpp
+++ b/arrows/klv/klv_list.hpp
@@ -21,8 +21,7 @@ template < class Format >
 template < class... Args >
 klv_list_format< Format >
 ::klv_list_format( Args&&... args )
-  : klv_data_format_< std::vector< element_t > >{ 0 },
-    m_format{ std::forward< Args >( args )... }
+  : m_format{ std::forward< Args >( args )... }
 {}
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -126,7 +126,7 @@ klv_read_packet( klv_read_iter_t& data, size_t max_length )
   if( checksum_format )
   {
     auto const packet_length = tracker.traversed() + length_of_value;
-    checksum_length = checksum_format->fixed_length();
+    checksum_length = *checksum_format->length_constraints().fixed();
 
     auto it = tracker.begin() + packet_length - checksum_length;
     auto const expected_checksum =
@@ -169,7 +169,7 @@ klv_write_packet( klv_packet const& packet, klv_write_iter_t& data,
   auto const length = format.length_of( packet.value );
   auto const packet_length = klv_packet_length( packet );
   auto const checksum_length =
-    checksum_format ? checksum_format->fixed_length() : 0;
+    checksum_format ? *checksum_format->length_constraints().fixed() : 0;
   if( max_length < length + checksum_length )
   {
     VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
@@ -204,7 +204,7 @@ klv_packet_length( klv_packet const& packet )
   auto const length_of_value = format.length_of( packet.value );
   auto const length_of_length = klv_ber_length( length_of_value );
   auto const length_of_checksum =
-    checksum_format ? checksum_format->fixed_length() : 0;
+    checksum_format ? *checksum_format->length_constraints().fixed() : 0;
   return length_of_key + length_of_length + length_of_value +
          length_of_checksum;
 }

--- a/arrows/klv/klv_series.hpp
+++ b/arrows/klv/klv_series.hpp
@@ -21,8 +21,7 @@ template < class Format >
 template < class... Args >
 klv_series_format< Format >
 ::klv_series_format( Args&&... args )
-  : klv_data_format_< std::vector< element_t > >{ 0 },
-    m_format{ std::forward< Args >( args )... }
+  : m_format{ std::forward< Args >( args )... }
 {}
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_set.cxx
+++ b/arrows/klv/klv_set.cxx
@@ -364,7 +364,7 @@ klv_set< Key >
 template < class Key >
 klv_set_format< Key >
 ::klv_set_format( klv_tag_traits_lookup const& traits )
-  : klv_data_format_< klv_set< Key > >{ 0 }, m_traits( traits )
+  : m_traits( traits )
 {}
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
There are some data formats (strings, floats, IMAP, flint...) where the data can be of variable length, depending on how much information the user wants to encode, or how precise they want to be. The MISB standards put different constraints on these fields depending on the tag: some tags must always be a certain length, some can be any of a range of lengths (e.g 1-4 bytes), and a few have only a handful of discrete lengths to pick from (e.g. a 4-byte raw IEEE float or an 8-byte double). Without this PR, most of these constraints were on the user to self-enforce: only formats with a single fixed length "knew" about that constraint. This PR adds a `klv_length_constraints` class which can be made to represent a wider variety of constraint scenarios. This replaces the `fixed_length` member of `klv_data_format`.

@hdefazio 