### PR TITLE
Increase GTest discovery timeout

### DIFF
--- a/CMake/utils/kwiver-utils-tests.cmake
+++ b/CMake/utils/kwiver-utils-tests.cmake
@@ -201,7 +201,7 @@ function (kwiver_discover_gtests MODULE NAME)
 
   set(EXTRA_ARGS TEST_PREFIX ${MODULE}:)
   if (_ARGUMENTS)
-    list(APPEND EXTRA_ARGS EXTRA_ARGS ${_ARGUMENTS})
+    list(APPEND EXTRA_ARGS EXTRA_ARGS ${_ARGUMENTS} DISCOVERY_TIMEOUT 30)
   endif()
 
   kwiver_build_test(${MODULE}-${NAME} _LIBRARIES ${_SOURCES})


### PR DESCRIPTION
Sometimes CI (notably Mac but sometimes Windows) errors out, saying that gtest timed out when discovering tests. This causes CI pipeline failures even when nothing is truly wrong. This PR increases the test discovery timeout in hopes of preventing these false negatives.

@hdefazio 