### PR TITLE
Add apply_child_klv metadata filter

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(CMAKE_FOLDER "Arrows/KLV")
 
 set( sources
+  apply_child_klv.cxx
   klv_blob.cxx
   klv_checksum.cxx
   klv_convert_vital.cxx
@@ -57,6 +58,7 @@ set( sources
   )
 
 set( public_headers
+  apply_child_klv.h
   klv_all.h
   klv_blob.h
   klv_demuxer.h
@@ -140,6 +142,12 @@ target_link_libraries( kwiver_algo_klv
   PRIVATE       vital
                 vital_logger
   )
+
+
+algorithms_create_plugin( kwiver_algo_klv
+  register_algorithms.cxx
+  )
+
 
 if (KWIVER_ENABLE_TESTS)
   add_subdirectory( tests )

--- a/arrows/klv/apply_child_klv.cxx
+++ b/arrows/klv/apply_child_klv.cxx
@@ -1,0 +1,253 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of apply_child_klv filter.
+
+#include <arrows/klv/apply_child_klv.h>
+
+#include <arrows/klv/klv_0601.h>
+#include <arrows/klv/klv_1607.h>
+#include <arrows/klv/klv_metadata.h>
+
+#include <vital/logger/logger.h>
+#include <vital/range/iterator_range.h>
+
+#include <list>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+klv_1607_child_policy
+klv_0601_child_policy( klv_lds_key tag )
+{
+  if( klv_0601_traits_lookup().by_tag( tag ).tag_count_range().upper() > 1 )
+  {
+    return KLV_1607_CHILD_POLICY_KEEP_BOTH;
+  }
+  return KLV_1607_CHILD_POLICY_KEEP_CHILD;
+}
+
+// ----------------------------------------------------------------------------
+void
+apply_amend( klv_value& value ) {
+  // Extract the local set
+  auto const set_ptr = value.get_ptr< klv_local_set >();
+  if( !set_ptr )
+  {
+    return;
+  }
+  auto& set = *set_ptr;
+
+  // Find amend set(s)
+  std::vector< klv_local_set > valid_amend_sets;
+  auto const amend_range = set.all_at( KLV_0601_AMEND_LOCAL_SET );
+  if( amend_range.size() > 1 )
+  {
+    LOG_WARN(
+      vital::get_logger( "klv.apply_child_klv" ),
+      "Multiple sibling amend sets found. In accordance with the MISP "
+      "Handbook, only one can be applied. This algorithm will choose one "
+      "arbitrarily, which is likely not the desired behavior. Use nested "
+      "amend sets to describe multiple generations of amendments which can be "
+      "applied in succession." );
+  }
+
+  // TODO: Add this code as a config option or delete it:
+  // // Use this code to apply all sibling amend sets in arbitrary order,
+  // // contra the MISP Handbook.
+  // for( auto it = amend_range.begin();
+  //      it != set.end() && it->first == KLV_0601_AMEND_LOCAL_SET; )
+  // {
+  //   apply_amend( it->second );
+  //   auto const amend_ptr = it->second.get_ptr< klv_local_set >();
+  //   if( amend_ptr )
+  //   {
+  //     valid_amend_sets.emplace_back( std::move( *amend_ptr ) );
+  //     it = set.erase( it );
+  //   }
+  //   else
+  //   {
+  //     ++it;
+  //   }
+  // }
+
+  // Find first valid amend set in any order, then remove all of them
+  if( !amend_range.empty() )
+  {
+    while( valid_amend_sets.empty() )
+    {
+      auto& value = amend_range.begin()->second;
+      apply_amend( value );
+      auto const amend_ptr = value.get_ptr< klv_local_set >();
+      if( amend_ptr )
+      {
+        valid_amend_sets.emplace_back( std::move( *amend_ptr ) );
+      }
+    }
+    set.erase( KLV_0601_AMEND_LOCAL_SET );
+  }
+
+  // Apply the chosen amend set(s)
+  for( auto const& amend_set : valid_amend_sets )
+  {
+    klv_1607_apply_child( set, amend_set, klv_0601_child_policy );
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Returns the range of sets created by applying segment sets.
+vital::range::iterator_range< typename std::list< klv_packet >::iterator >
+apply_segment(
+  std::list< klv_packet >& packets,
+  typename std::list< klv_packet >::iterator packet_it )
+{
+  // Extract the local set
+  auto const set_ptr = packet_it->value.get_ptr< klv_local_set >();
+  if( !set_ptr )
+  {
+    return { std::next( packet_it ), std::next( packet_it ) };
+  }
+  auto& set = *set_ptr;
+
+  // Find segment set(s) and remove them
+  std::vector< klv_local_set > segment_sets;
+  auto const segment_range = set.all_at( KLV_0601_SEGMENT_LOCAL_SET );
+  for( auto it = segment_range.begin();
+        it != set.end() && it->first == KLV_0601_SEGMENT_LOCAL_SET; )
+  {
+    auto const segment_ptr = it->second.get_ptr< klv_local_set >();
+    if( segment_ptr )
+    {
+      segment_sets.emplace_back( std::move( *segment_ptr ) );
+      it = set.erase( it );
+    }
+    else
+    {
+      ++it;
+    }
+  }
+  if( segment_sets.empty() )
+  {
+    return { std::next( packet_it ), std::next( packet_it ) };
+  }
+
+  // Apply segment sets to create new packets and erase the original one
+  auto const original_packet_it = packet_it;
+  for( auto const& segment_set : segment_sets )
+  {
+    packet_it =
+      packets.insert(
+        std::next( packet_it ), klv_packet{ packet_it->key, set } );
+    klv_1607_apply_child(
+      packet_it->value.get< klv_local_set >(), segment_set );
+  }
+  auto const begin_it = std::next( original_packet_it );
+  auto const end_it = std::next( packet_it );
+  packets.erase( original_packet_it );
+
+  return { begin_it, end_it };
+}
+
+// ----------------------------------------------------------------------------
+apply_child_klv
+::apply_child_klv()
+{}
+
+// ----------------------------------------------------------------------------
+apply_child_klv
+::~apply_child_klv()
+{}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+apply_child_klv
+::get_configuration() const
+{
+  return algorithm::get_configuration();
+}
+
+// ----------------------------------------------------------------------------
+void
+apply_child_klv
+::set_configuration( vital::config_block_sptr config )
+{
+  auto existing_config = algorithm::get_configuration();
+  existing_config->merge_config( config );
+}
+
+// ----------------------------------------------------------------------------
+bool
+apply_child_klv
+::check_configuration( vital::config_block_sptr config ) const
+{
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+apply_child_klv
+::filter(
+  vital::metadata_vector const& input_metadata,
+  VITAL_UNUSED vital::image_container_scptr const& input_image )
+{
+  vital::metadata_vector results;
+  for( auto const& src_md : input_metadata )
+  {
+    // Case: null
+    if( !src_md )
+    {
+      results.emplace_back( nullptr );
+      continue;
+    }
+
+    // Deep copy. Not 100% sure this is necessary - future config option?
+    results.emplace_back( src_md->clone() );
+
+    // Case: no KLV
+    auto const klv_md = dynamic_cast< klv_metadata* >( results.back().get() );
+    if( !klv_md )
+    {
+      continue;
+    }
+
+    // This is a list instead of a vector for easy segment set insertion
+    std::list< klv_packet > result_klv{
+      klv_md->klv().begin(), klv_md->klv().end() };
+
+    // Apply amend and segment sets
+    for( auto it = result_klv.begin(); it != result_klv.end(); )
+    {
+      // Only ST0601 has segment / amend sets that I am aware of
+      if( it->key != klv_0601_key() || !it->value.valid() )
+      {
+        ++it;
+        continue;
+      }
+
+      // Amend function recurses internally
+      apply_amend( it->value );
+
+      // Segment function recurses using this outer loop
+      it = apply_segment( result_klv, it ).begin();
+    }
+
+    // Move packets back to vector for storage
+    std::vector< klv_packet > tmp_klv( result_klv.size() );
+    std::move( result_klv.begin(), result_klv.end(), tmp_klv.begin() );
+    klv_md->set_klv( tmp_klv );
+  }
+
+  return results;
+}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/apply_child_klv.h
+++ b/arrows/klv/apply_child_klv.h
@@ -1,0 +1,44 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of apply_child_klv filter.
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vital/algo/metadata_filter.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Applies KLV amend and segment sets.
+class KWIVER_ALGO_KLV_EXPORT apply_child_klv
+  : public vital::algo::metadata_filter
+{
+public:
+  apply_child_klv();
+  virtual ~apply_child_klv();
+
+  PLUGIN_INFO( "apply_child_klv",
+               "Produces resultant klv sets from source klv with ST1607 amend "
+               "or segment sets." )
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  vital::metadata_vector filter(
+    vital::metadata_vector const& input_metadata,
+    vital::image_container_scptr const& input_image ) override;
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_1607.cxx
+++ b/arrows/klv/klv_1607.cxx
@@ -39,31 +39,40 @@ klv_1607_child_set_format
 }
 
 // ----------------------------------------------------------------------------
-klv_local_set
-klv_1607_apply_child( klv_local_set const& parent,
-                      klv_local_set const& child )
+void
+klv_1607_apply_child(
+  klv_local_set& parent, klv_local_set const& child,
+  std::function< klv_1607_child_policy( klv_lds_key ) > const& policy_fn )
 {
-  auto result = parent;
-
   // Two loops so that all entries are deleted from parent set before adding
   // any from the child set, in the unlikely case of multiple values per tag
   // in the child set
   for( auto const& entry : child )
   {
-    if( result.count( entry.first ) > 1 )
+    auto const policy =
+      policy_fn ? policy_fn( entry.first ) : KLV_1607_CHILD_POLICY_KEEP_CHILD;
+    if( policy & KLV_1607_CHILD_POLICY_KEEP_PARENT )
+    {
+      continue;
+    }
+
+    if( parent.count( entry.first ) > 1 )
     {
       LOG_WARN( kv::get_logger( "klv" ), "apply_child: "
                 "modifying tag which has multiple values in parent set" );
     }
-    result.erase( entry.first );
+    parent.erase( entry.first );
   }
 
   for( auto const& entry : child )
   {
-    result.add( entry.first, entry.second );
+    auto const policy =
+      policy_fn ? policy_fn( entry.first ) : KLV_1607_CHILD_POLICY_KEEP_CHILD;
+    if( policy & KLV_1607_CHILD_POLICY_KEEP_CHILD )
+    {
+      parent.add( entry.first, entry.second );
+    }
   }
-
-  return result;
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1607.h
+++ b/arrows/klv/klv_1607.h
@@ -19,6 +19,20 @@ namespace arrows {
 namespace klv {
 
 // ----------------------------------------------------------------------------
+///
+enum klv_1607_child_policy
+{
+  KLV_1607_CHILD_POLICY_KEEP_NEITHER = 0,
+  KLV_1607_CHILD_POLICY_KEEP_CHILD   = ( 1 << 0 ),
+  KLV_1607_CHILD_POLICY_KEEP_PARENT  = ( 1 << 1 ),
+  KLV_1607_CHILD_POLICY_KEEP_BOTH    = KLV_1607_CHILD_POLICY_KEEP_CHILD |
+                                       KLV_1607_CHILD_POLICY_KEEP_PARENT,
+};
+
+using klv_1607_child_policy_fn =
+  std::function< klv_1607_child_policy( klv_lds_key ) >;
+
+// ----------------------------------------------------------------------------
 /// Interprets data as a KLV ST1607 amend or segment local set.
 class KWIVER_ALGO_KLV_EXPORT klv_1607_child_set_format
   : public klv_local_set_format
@@ -42,9 +56,10 @@ private:
 ///
 /// \return Modified \p parent.
 KWIVER_ALGO_KLV_EXPORT
-klv_local_set
-klv_1607_apply_child( klv_local_set const& parent,
-                      klv_local_set const& child );
+void
+klv_1607_apply_child(
+  klv_local_set& parent, klv_local_set const& child,
+  klv_1607_child_policy_fn const& policy_fn = nullptr );
 
 // ----------------------------------------------------------------------------
 /// Produce a 'diff' between two local sets in the form of a child local set.

--- a/arrows/klv/klv_set.cxx
+++ b/arrows/klv/klv_set.cxx
@@ -145,11 +145,11 @@ klv_set< Key >
 
 // ----------------------------------------------------------------------------
 template < class Key >
-void
+typename klv_set< Key >::iterator
 klv_set< Key >
 ::erase( const_iterator it )
 {
-  m_items.erase( it );
+  return m_items.erase( it );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_set.h
+++ b/arrows/klv/klv_set.h
@@ -83,7 +83,7 @@ public:
   void
   add( Key const& key, klv_value const& datum );
 
-  void
+  iterator
   erase( const_iterator it );
 
   void

--- a/arrows/klv/register_algorithms.cxx
+++ b/arrows/klv/register_algorithms.cxx
@@ -1,0 +1,40 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Register KLV algorithm implementations.
+
+#include <vital/algo/algorithm_factory.h>
+
+#include <arrows/klv/kwiver_algo_klv_plugin_export.h>
+#include <arrows/klv/apply_child_klv.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+extern "C"
+KWIVER_ALGO_KLV_PLUGIN_EXPORT
+void
+register_factories( kwiver::vital::plugin_loader& vpm )
+{
+  ::kwiver::vital::algorithm_registrar reg( vpm, "arrows.klv" );
+
+  if( reg.is_module_loaded() )
+  {
+    return;
+  }
+
+  reg.register_algorithm< apply_child_klv >();
+
+  reg.mark_module_as_loaded();
+}
+
+} // end namespace ffmpeg
+
+} // end namespace arrows
+
+} // end namespace kwiver

--- a/arrows/klv/tests/CMakeLists.txt
+++ b/arrows/klv/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set( test_libraries kwiver_algo_core kwiver_algo_klv vital )
 # KLV tests
 ##############################
 
+kwiver_discover_gtests( klv apply_child_klv     LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_blob            LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_checksum        LIBRARIES ${test_libraries} )
 kwiver_discover_gtests( klv klv_demuxer         LIBRARIES ${test_libraries} )

--- a/arrows/klv/tests/test_apply_child_klv.cxx
+++ b/arrows/klv/tests/test_apply_child_klv.cxx
@@ -1,0 +1,330 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test the apply_child_klv filter.
+
+#include "data_format.h"
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <arrows/klv/apply_child_klv.h>
+#include <arrows/klv/klv_metadata.h>
+#include <arrows/klv/klv_0601.h>
+#include <arrows/klv/klv_1607.h>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+  return RUN_ALL_TESTS();
+}
+
+namespace kv = kwiver::vital;
+using namespace kwiver::arrows::klv;
+
+// ----------------------------------------------------------------------------
+// Ensure we can create the filter with the factory method.
+TEST ( apply_child_klv, create )
+{
+  EXPECT_NE( nullptr, kv::algo::metadata_filter::create( "apply_child_klv" ) );
+}
+
+// ----------------------------------------------------------------------------
+// No metadata given.
+TEST ( apply_child_klv, empty )
+{
+  apply_child_klv filter;
+  kv::metadata_vector input;
+  auto const output = filter.filter( input, nullptr );
+  EXPECT_EQ( input, output );
+}
+
+// ----------------------------------------------------------------------------
+// Null metadata pointer.
+TEST ( apply_child_klv, null_metadata_sptr )
+{
+  apply_child_klv filter;
+  kv::metadata_vector input{ nullptr };
+  auto const output = filter.filter( input, nullptr );
+  EXPECT_EQ( input, output );
+}
+
+// ----------------------------------------------------------------------------
+// Metadata objects with no KLV attached.
+TEST ( apply_child_klv, non_klv_metadata_sptr )
+{
+  apply_child_klv filter;
+  kv::metadata_vector input{
+    std::make_shared< kv::metadata >(),
+    std::make_shared< kv::metadata >(),
+  };
+  input[ 0 ]->add< kv::VITAL_META_UNIX_TIMESTAMP >( 0 );
+  input[ 1 ]->add< kv::VITAL_META_UNIX_TIMESTAMP >( 1 );
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 2, output.size() );
+  EXPECT_EQ(
+    0, output.at( 0 )->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+  EXPECT_EQ(
+    1, output.at( 1 )->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+}
+
+// ----------------------------------------------------------------------------
+// Metadata object with empty KLV attached.
+TEST ( apply_child_klv, empty_klv )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+  klv_md->set_klv( {} );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  ASSERT_NE( nullptr, output_klv );
+  EXPECT_TRUE( output_klv->klv().empty() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+}
+
+// ----------------------------------------------------------------------------
+// KLV with no child sets.
+TEST ( apply_child_klv, no_children )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+  klv_md->set_klv( {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } } );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  ASSERT_NE( nullptr, output_klv );
+  ASSERT_EQ( 1, output_klv->klv().size() );
+  auto const& output_set =
+    output_klv->klv().at( 0 ).value.get< klv_local_set >();
+  EXPECT_EQ(
+    42, output_set.at( KLV_0601_PRECISION_TIMESTAMP ).get< uint64_t >() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+}
+
+// ----------------------------------------------------------------------------
+// Nested amend sets.
+TEST ( apply_child_klv, amend_only )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+
+  klv_md->set_klv( {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+        { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 43 } },
+        { KLV_0601_MISSION_ID, std::string{ "ID" } },
+        { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+          { KLV_0601_MISSION_ID, std::string{ "BETTER_ID" } },
+          { KLV_0601_PLATFORM_DESIGNATION, {} } } } } } } } } );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  ASSERT_NE( nullptr, output_klv );
+  ASSERT_EQ( 1, output_klv->klv().size() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+  auto const& output_set =
+    output_klv->klv().at( 0 ).value.get< klv_local_set >();
+
+  std::vector< klv_packet > expected_klv = {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 43 } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_MISSION_ID, std::string{ "BETTER_ID" } },
+      { KLV_0601_PLATFORM_DESIGNATION, {} } } } };
+
+  EXPECT_EQ(
+    std::multiset< klv_packet >( expected_klv.begin(), expected_klv.end() ),
+    std::multiset< klv_packet >(
+      output_klv->klv().begin(), output_klv->klv().end() ) );
+}
+
+// ----------------------------------------------------------------------------
+// Sibling amend sets - minimal defined behavior for now except not to crash.
+TEST ( apply_child_klv, sibling_amend )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+
+  klv_md->set_klv( {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_MISSION_ID, std::string{ "ID" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+        { KLV_0601_MISSION_ID, std::string{ "ID_1" } } } },
+      { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } } );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  ASSERT_NE( nullptr, output_klv );
+  ASSERT_EQ( 1, output_klv->klv().size() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+}
+
+// ----------------------------------------------------------------------------
+// Nested segment sets.
+TEST ( apply_child_klv, segment_only )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+
+  klv_md->set_klv( {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_ALT" } },
+        { KLV_0601_MISSION_ID, std::string{ "ID_1" } } } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2_ALT" } },
+        { KLV_0601_MISSION_ID, std::string{ "ID_1" } },
+        { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+          { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } },
+        { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+          { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2_ALT2" } },
+          { KLV_0601_MISSION_ID, std::string{ "ID_3" } } } } } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_MISSION_ID, {} } } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM3" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } } );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+
+  std::vector< klv_packet > expected_klv = {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_ALT" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_1" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_2" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2" } },
+      { KLV_0601_MISSION_ID, {} },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2_ALT" } },
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM2_ALT2" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_3" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM3" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } };
+
+  EXPECT_EQ(
+    std::multiset< klv_packet >( expected_klv.begin(), expected_klv.end() ),
+    std::multiset< klv_packet >(
+      output_klv->klv().begin(), output_klv->klv().end() ) );
+}
+
+// ----------------------------------------------------------------------------
+// Nested segment and amend sets.
+TEST ( apply_child_klv, mixed_children )
+{
+  apply_child_klv filter;
+  auto const klv_md = std::make_shared< klv_metadata >();
+  kv::metadata_vector input{ klv_md };
+
+  klv_md->set_klv( {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } },
+      { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+        { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+          { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_AMEND" } },
+          { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
+            { KLV_0601_MISSION_ID, std::string{ "ID_3" } } } } } } } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_ALT" } },
+        { KLV_0601_MISSION_ID, std::string{ "ID_1" } } } },
+      { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } } );
+  klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
+
+  auto const output = filter.filter( input, nullptr );
+  ASSERT_EQ( 1, output.size() );
+  auto const output_klv =
+    dynamic_cast< klv_metadata* >( output.at( 0 ).get() );
+  EXPECT_EQ(
+    42, output_klv->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+
+  std::vector< klv_packet > expected_klv = {
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_ALT" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_1" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_2" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } },
+    { klv_0601_key(), klv_local_set{
+      { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
+      { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_AMEND" } },
+      { KLV_0601_MISSION_ID, std::string{ "ID_3" } },
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } };
+
+  EXPECT_EQ(
+    std::multiset< klv_packet >( expected_klv.begin(), expected_klv.end() ),
+    std::multiset< klv_packet >(
+      output_klv->klv().begin(), output_klv->klv().end() ) );
+}

--- a/arrows/klv/tests/test_klv_1607.cxx
+++ b/arrows/klv/tests/test_klv_1607.cxx
@@ -56,7 +56,8 @@ TEST ( klv, apply_derive_1607 )
     { 6, 9.0 },
     { 6, 0.0 }, };
 
-  auto const result = klv_1607_apply_child( parent, child );
+  auto result = parent;
+  klv_1607_apply_child( result, child );
   ASSERT_EQ( expected_result, result );
 
   auto const rederived_child = klv_1607_derive_child( parent, result );


### PR DESCRIPTION
This PR creates a metadata filter which applies segment and amend sets to ST0601 KLV packets, outputting the results of the segment and amend operations to be used by downstream algorithms. Note that, at present, this does not update the vital metadata values, nor are there any configuration options. Unit tests are included.

@hdefazio 