### PR TITLE
Add equality operators for metadata_item

### DIFF
--- a/vital/tests/test_metadata.cxx
+++ b/vital/tests/test_metadata.cxx
@@ -50,6 +50,50 @@ TEST( metadata, typed_metadata )
 }
 
 // ----------------------------------------------------------------------------
+TEST( metadata, item_equality )
+{
+  {
+    metadata_item const item1{
+      VITAL_META_METADATA_ORIGIN, std::string{ "origin1" } };
+    metadata_item const item2{
+      VITAL_META_METADATA_ORIGIN, std::string{ "origin1" } };
+    metadata_item const item3{
+      VITAL_META_METADATA_ORIGIN, std::string{ "origin2" } };
+
+    EXPECT_TRUE( item1 == item1 );
+    EXPECT_FALSE( item1 != item1 );
+    EXPECT_TRUE( item1 == item2 );
+    EXPECT_FALSE( item1 != item2 );
+    EXPECT_FALSE( item2 == item3 );
+    EXPECT_TRUE( item2 != item3 );
+  }
+
+  {
+    metadata_item const item1{ VITAL_META_PLATFORM_HEADING_ANGLE, 3.14159 };
+    metadata_item const item2{
+      VITAL_META_PLATFORM_HEADING_ANGLE,
+      std::numeric_limits< double >::quiet_NaN() };
+    metadata_item const item3{
+      VITAL_META_PLATFORM_HEADING_ANGLE,
+      -std::numeric_limits< double >::quiet_NaN() };
+
+    EXPECT_TRUE( item1 == item1 );
+    EXPECT_FALSE( item1 != item1 );
+    EXPECT_TRUE( item2 == item2 );
+    EXPECT_FALSE( item2 != item2 );
+    EXPECT_TRUE( item3 == item3 );
+    EXPECT_FALSE( item3 != item3 );
+
+    EXPECT_TRUE( item1 != item2 );
+    EXPECT_FALSE( item1 == item2 );
+    EXPECT_TRUE( item1 != item3 );
+    EXPECT_FALSE( item1 == item3 );
+    EXPECT_TRUE( item2 != item3 );
+    EXPECT_FALSE( item2 == item3 );
+  }
+}
+
+// ----------------------------------------------------------------------------
 TEST( metadata, add_metadata )
 {
   // create item

--- a/vital/types/metadata.h
+++ b/vital/types/metadata.h
@@ -114,6 +114,9 @@ public:
     }
   }
 
+  bool operator==( metadata_item const& other ) const;
+  bool operator!=( metadata_item const& other ) const;
+
   /// Test if the metadata item is valid.
   bool is_valid() const;
 


### PR DESCRIPTION
This PR adds `==` and `!=` operators to `vital::metadata_item`. The notable special case here is `double` `NaN` values, which would normally never compare equal to each other, so we add custom logic for them.

@hdefazio 