### PR TITLE
Add KLV 1108 utilities

### DIFF
--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -217,6 +217,28 @@ KWIVER_ALGO_KLV_EXPORT
 klv_tag_traits_lookup const&
 klv_1108_traits_lookup();
 
+// ----------------------------------------------------------------------------
+/// Creates a local set which can serve as a ST1108 index.
+///
+/// Two parent/metric pairs with the same index and different metric values
+/// are in contradiction. Two pairs with different indices can coherently have
+/// different metric values.
+KWIVER_ALGO_KLV_EXPORT
+klv_local_set
+klv_1108_create_index_set(
+  klv_local_set const& parent_set, klv_value const& metric_set_value );
+
+// ----------------------------------------------------------------------------
+/// Fills in any ST1108 metadata fields derivable from \p vital_data.
+///
+/// Any existing values in \p klv_data will not be overwritten.
+///
+/// \return \c true if all possible klv fields have been filled in.
+KWIVER_ALGO_KLV_EXPORT
+bool
+klv_1108_fill_in_metadata(
+  vital::metadata const& vital_data, klv_local_set& klv_data );
+
 } // namespace klv
 
 } // namespace arrows

--- a/arrows/klv/klv_1108_metric_set.cxx
+++ b/arrows/klv/klv_1108_metric_set.cxx
@@ -42,6 +42,14 @@ operator<<( std::ostream& os, klv_1108_metric_implementer const& rhs )
 }
 
 // ----------------------------------------------------------------------------
+klv_1108_metric_implementer const&
+klv_1108_kwiver_metric_implementer()
+{
+  static klv_1108_metric_implementer const value{ "Kitware", "KWIVER" };
+  return value;
+}
+
+// ----------------------------------------------------------------------------
 klv_1108_metric_implementer_format
 ::klv_1108_metric_implementer_format()
 {}

--- a/arrows/klv/klv_1108_metric_set.h
+++ b/arrows/klv/klv_1108_metric_set.h
@@ -56,6 +56,12 @@ operator<<( std::ostream& os, klv_1108_metric_implementer const& rhs );
 DECLARE_CMP( klv_1108_metric_implementer )
 
 // ----------------------------------------------------------------------------
+/// Returns the implementer object to be used for KWIVER-derived metrics.
+KWIVER_ALGO_KLV_EXPORT
+klv_1108_metric_implementer const&
+klv_1108_kwiver_metric_implementer();
+
+// ----------------------------------------------------------------------------
 /// Interprets data as a KLV 1108 metric local set implementer.
 class KWIVER_ALGO_KLV_EXPORT klv_1108_metric_implementer_format
   : public klv_data_format_< klv_1108_metric_implementer >


### PR DESCRIPTION
This PR provides three functions which will be useful for synthesizing ST1108 (Metric and Interpretability) KLV sets: `klv_1108_create_index_set()`, `klv_1108_fill_in_metadata()`, and `klv_1108_kwiver_metric_implementer()`.

@hdefazio 