### PR TITLE
Enable loading null characters using cereal

### DIFF
--- a/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
+++ b/arrows/serialize/json/klv/tests/test_load_save_klv.cxx
@@ -152,7 +152,7 @@ klv_local_set const test_0601_set = {
   { KLV_0601_PLATFORM_TRUE_AIRSPEED,
     kld{ 2.345, 1 } },
   { KLV_0601_MISSION_ID,
-    std::string{ "TEST STRING" } },
+    std::string{ "TEST\0STRING", 11 } },
   { KLV_0601_IMAGE_HORIZON_PIXEL_PACK,
     klv_0601_image_horizon_pixel_pack{
       1, 2, 3, 4,

--- a/test_data/klv_gold.json
+++ b/test_data/klv_gold.json
@@ -89,7 +89,7 @@
 					"integer": 3,
 					"string": "Mission ID"
 				},
-				"value": "TEST STRING"
+				"value": "TEST\u0000STRING"
 			},
 			{
 				"key": {

--- a/vital/internal/cereal/archives/json.hpp
+++ b/vital/internal/cereal/archives/json.hpp
@@ -637,7 +637,7 @@ namespace cereal
       //! Loads a value from the current node - double overload
       void loadValue(double & val)      { search(); val = itsIteratorStack.back().value().GetDouble(); ++itsIteratorStack.back(); }
       //! Loads a value from the current node - string overload
-      void loadValue(std::string & val) { search(); val = itsIteratorStack.back().value().GetString(); ++itsIteratorStack.back(); }
+      void loadValue(std::string & val) { search(); val = std::string{ itsIteratorStack.back().value().GetString(), itsIteratorStack.back().value().GetStringLength() }; ++itsIteratorStack.back(); }
       //! Loads a nullptr from the current node
       void loadValue(std::nullptr_t&)   { search(); CEREAL_RAPIDJSON_ASSERT(itsIteratorStack.back().value().IsNull()); ++itsIteratorStack.back(); }
 


### PR DESCRIPTION
Our copy-paste of the cereal library does not properly handle loading strings that have a null character (`\0`) embedded in them. This PR fixes that, without trying to fix any of cereal's existing bad style.

@hdefazio 