### PR TITLE
Remove erroneous child set warnings

### DIFF
--- a/arrows/klv/klv_set.cxx
+++ b/arrows/klv/klv_set.cxx
@@ -416,7 +416,7 @@ klv_set_format< Key >
 
     history.push_back( traits.tag() );
   }
-  check_tag_counts( result );
+  check_set( result );
 
   return result;
 }
@@ -432,7 +432,7 @@ klv_set_format< Key >
 
   auto const tracker = track_it( data, length );
 
-  check_tag_counts( klv );
+  check_set( klv );
 
   // Identify which entries need to be before other entries
   std::set< klv_lds_key > held_keys;


### PR DESCRIPTION
This PR ensures that amend and segment sets, which are meant to be addenda to their parent set and not sets of their own, will not trigger warnings about not being a proper full set. I wrote all the functions to fix this a while ago, but apparently never actually changed the call sites.

@hdefazio 