### PR TITLE
Require C++17

### DIFF
--- a/CMake/kwiver-configcheck.cmake
+++ b/CMake/kwiver-configcheck.cmake
@@ -53,8 +53,8 @@ endmacro()
 # Set default visibility
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-# C++11 is required
-set(CMAKE_CXX_STANDARD 11)
+# C++17 is required
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 vital_check_required_feature(CPP_AUTO         auto.cxx            "auto type specifier")

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -8,6 +8,10 @@ over the previous v1.7.0 release.
 Updates
 -------
 
+KWIVER
+
+ * Adopted C++17.
+
 Vital
 
 Vital Algo


### PR DESCRIPTION
This PR switches KWIVER to the C++17 standard, allowing use of those language features in future development. Those building KWIVER on their local machines will likely need to pull fletch master and upgrade their Boost version to 1.78.0, as the previous supported Boost version is not compatible with C++17. 