### PR TITLE
Allow transcode applet to use metadata filters without crashing

### DIFF
--- a/arrows/core/applets/transcode.cxx
+++ b/arrows/core/applets/transcode.cxx
@@ -27,13 +27,6 @@ void
 check_input( kva::video_input_sptr const& input,
              cxxopts::ParseResult const& cmd_args )
 {
-  // Check initialization
-  if( !input )
-  {
-    std::cerr << "Failed to initialize video input." << std::endl;
-    exit( EXIT_FAILURE );
-  }
-
   // Check capabilities
   auto const& capabilities = input->get_implementation_capabilities();
   if( cmd_args.count( "copy-video" ) &&
@@ -136,8 +129,15 @@ transcode_applet
   ::set_nested_algo_configuration( "video_reader", config, input );
   kva::video_input
   ::get_nested_algo_configuration( "video_reader", config, input );
-  check_input( input, cmd_args );
+
+  // Check initialization
+  if( !input )
+  {
+    std::cerr << "Failed to initialize video input." << std::endl;
+    exit( EXIT_FAILURE );
+  }
   input->open( input_filename );
+  check_input( input, cmd_args );
 
   auto const video_settings = input->implementation_settings();
 

--- a/arrows/core/video_input_metadata_filter.cxx
+++ b/arrows/core/video_input_metadata_filter.cxx
@@ -162,6 +162,8 @@ video_input_metadata_filter
   copy_capability( vi::HAS_ABSOLUTE_FRAME_TIME );
   copy_capability( vi::HAS_TIMEOUT );
   copy_capability( vi::IS_SEEKABLE );
+  copy_capability( vi::HAS_RAW_IMAGE );
+  copy_capability( vi::HAS_RAW_METADATA );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Since the metadata filter video input only copies capabilities after the video is opened, this PR moves the capabilities check in the transcode applet to after that point. Additionally, the two raw data copying capabilities are now handled in `video_input_metadata_filter`.

@hdefazio 