### PR TITLE
Fix file_md5 test

### DIFF
--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ kwiver_discover_gtests(vital class_map                      LIBRARIES ${test_lib
 kwiver_discover_gtests(vital enumerate_matrix               LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital essential_matrix               LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital estimate_similarity_transform  LIBRARIES ${test_libraries})
-kwiver_discover_gtests(vital file_md5                       LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}/rpc_data/rpc_data.dat" "a04bf5b37758551864c93663c26f63b0" )
+kwiver_discover_gtests(vital file_md5                       LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}/video_as_images/images/frame_0001.png" "2764c96ee5d3830277313ffb91d343ae" )
 kwiver_discover_gtests(vital fundamental_matrix             LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital geo_MGRS                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital geo_point                      LIBRARIES ${test_libraries})

--- a/vital/util/file_md5.cxx
+++ b/vital/util/file_md5.cxx
@@ -55,7 +55,8 @@ file_md5( const string& fn )
   {
     for ( size_t i = 0; i < digest_size; ++i )
     {
-      oss << std::hex << static_cast<unsigned int>(digest[ i ]);
+      oss << std::hex << std::setw( 2 ) << std::setfill( '0' )
+          << static_cast< unsigned int >( digest[ i ] );
     }
   }
   return oss.str();


### PR DESCRIPTION
On Windows, some git configurations will automatically convert LF line endings to CRLF in the local repo. This causes our `file_md5` test to fail, since the chosen test file and resulting md5 sum are thereby modified. This PR fixes the issue by switching the test file to an arbitrary PNG binary file.

An additional bonus fix is included which prevents elision of leading zeros in each byte when creating the md5 digest (i.e. if the first four byte values are `255, 255, 2, 255`, they should be printed as `ffff02ff` and not `ffff2ff`).