### PR TITLE
Fix MISP timestamp writing byte bug

### DIFF
--- a/arrows/klv/misp_time.cxx
+++ b/arrows/klv/misp_time.cxx
@@ -166,7 +166,8 @@ write_misp_timestamp( misp_timestamp value, klv_write_iter_t& data,
   ++data;
 
   auto timestamp =
-    is_nano ? value.nanoseconds().count() : value.microseconds().count();
+    static_cast< uint64_t >(
+      is_nano ? value.nanoseconds().count() : value.microseconds().count() );
   for( auto const i :
        kwiver::vital::range::iota( misp_detail::timestamp_length ) )
   {
@@ -179,8 +180,8 @@ write_misp_timestamp( misp_timestamp value, klv_write_iter_t& data,
     else
     {
       // Write the next most significant byte
-      constexpr uint64_t mask = 0xFF << 7;
-      *data = timestamp & mask;
+      constexpr uint64_t mask = 0xFFull;
+      *data = ( timestamp >> ( 7 * 8 ) ) & mask;
       timestamp <<= 8;
     }
     ++data;


### PR DESCRIPTION
This PR fixes two oversights in the MISP timestamp writing code: `<< 7` shifts seven bits, not seven bytes as intended, and `std::chrono::nanoseconds` uses an `int64_t` internally, not an `uint64_t` as the MISP timestamp format requires.