### PR TITLE
Put MVG bundle adjust applet destructor in cxx

### DIFF
--- a/arrows/mvg/applets/bundle_adjust_tool.cxx
+++ b/arrows/mvg/applets/bundle_adjust_tool.cxx
@@ -1277,6 +1277,11 @@ bundle_adjust_tool
   : d( new priv( this ) )
 {}
 
+// ----------------------------------------------------------------------------
+bundle_adjust_tool
+::~bundle_adjust_tool()
+{}
+
 } // mvg
 
 } // arrows

--- a/arrows/mvg/applets/bundle_adjust_tool.h
+++ b/arrows/mvg/applets/bundle_adjust_tool.h
@@ -17,7 +17,7 @@ class KWIVER_ALGO_MVG_APPLETS_EXPORT bundle_adjust_tool
 {
 public:
   bundle_adjust_tool();
-  virtual ~bundle_adjust_tool() override = default;
+  virtual ~bundle_adjust_tool() override;
 
   PLUGIN_INFO(
     "bundle-adjust-tool",


### PR DESCRIPTION
#1682 is still causing issues with Windows CI (see [here](http://canifis:8080/job/KwiverWindowsPR/392/consoleFull) for #1705). I think the `= default` for the destructor may be the problem, as it doesn't know how to destruct the `unique_ptr` when included from `register_applets.cxx`, which doesn't have access to the `priv` definition. We'll see if I'm right when the CI runs on this PR.