### PR TITLE
Replace set_klv() with direct access

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -244,11 +244,11 @@ ffmpeg_klv_stream
   if( smooth_packets )
   {
     muxer.send_frame( timestamp );
-    klv_result.set_klv( muxer.receive_frame() );
+    klv_result.klv() = muxer.receive_frame();
   }
   else
   {
-    klv_result.set_klv( packets );
+    klv_result.klv() = packets;
   }
   klv_result.add< kv::VITAL_META_METADATA_ORIGIN >( "KLV" );
   klv_result.add< kv::VITAL_META_VIDEO_DATA_STREAM_INDEX >( stream->index );

--- a/arrows/klv/apply_child_klv.cxx
+++ b/arrows/klv/apply_child_klv.cxx
@@ -14,6 +14,7 @@
 #include <vital/logger/logger.h>
 #include <vital/range/iterator_range.h>
 
+#include <iterator>
 #include <list>
 
 namespace kwiver {
@@ -238,9 +239,9 @@ apply_child_klv
     }
 
     // Move packets back to vector for storage
-    std::vector< klv_packet > tmp_klv( result_klv.size() );
-    std::move( result_klv.begin(), result_klv.end(), tmp_klv.begin() );
-    klv_md->set_klv( tmp_klv );
+    klv_md->klv().assign(
+      std::make_move_iterator( result_klv.begin() ),
+      std::make_move_iterator( result_klv.end() ) );
   }
 
   return results;

--- a/arrows/klv/klv_metadata.cxx
+++ b/arrows/klv/klv_metadata.cxx
@@ -23,17 +23,17 @@ klv_metadata
 }
 
 // ----------------------------------------------------------------------------
-void
-klv_metadata
-::set_klv( std::vector< klv_packet > const& packets )
-{
-  m_klv_packets = packets;
-}
-
-// ----------------------------------------------------------------------------
 std::vector< klv_packet > const&
 klv_metadata
 ::klv() const
+{
+  return m_klv_packets;
+}
+
+// ----------------------------------------------------------------------------
+std::vector< klv_packet >&
+klv_metadata
+::klv()
 {
   return m_klv_packets;
 }

--- a/arrows/klv/klv_metadata.h
+++ b/arrows/klv/klv_metadata.h
@@ -27,9 +27,8 @@ public:
 
   vital::metadata* clone() const;
 
-  void set_klv( std::vector< klv_packet > const& packets );
-
   std::vector< klv_packet > const& klv() const;
+  std::vector< klv_packet >& klv();
 
 private:
   std::vector< klv_packet > m_klv_packets;

--- a/arrows/klv/tests/test_apply_child_klv.cxx
+++ b/arrows/klv/tests/test_apply_child_klv.cxx
@@ -79,7 +79,7 @@ TEST ( apply_child_klv, empty_klv )
   apply_child_klv filter;
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
-  klv_md->set_klv( {} );
+  klv_md->klv().clear();
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
   auto const output = filter.filter( input, nullptr );
   ASSERT_EQ( 1, output.size() );
@@ -98,10 +98,10 @@ TEST ( apply_child_klv, no_children )
   apply_child_klv filter;
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
-  klv_md->set_klv( {
+  klv_md->klv() = {
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
-      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } } );
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } };
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
 
   auto const output = filter.filter( input, nullptr );
@@ -126,7 +126,7 @@ TEST ( apply_child_klv, amend_only )
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
 
-  klv_md->set_klv( {
+  klv_md->klv() = {
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
       { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
@@ -136,7 +136,7 @@ TEST ( apply_child_klv, amend_only )
         { KLV_0601_MISSION_ID, std::string{ "ID" } },
         { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
           { KLV_0601_MISSION_ID, std::string{ "BETTER_ID" } },
-          { KLV_0601_PLATFORM_DESIGNATION, {} } } } } } } } } );
+          { KLV_0601_PLATFORM_DESIGNATION, {} } } } } } } } };
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
 
   auto const output = filter.filter( input, nullptr );
@@ -171,7 +171,7 @@ TEST ( apply_child_klv, sibling_amend )
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
 
-  klv_md->set_klv( {
+  klv_md->klv() = {
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
       { KLV_0601_MISSION_ID, std::string{ "ID" } },
@@ -179,7 +179,7 @@ TEST ( apply_child_klv, sibling_amend )
       { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
         { KLV_0601_MISSION_ID, std::string{ "ID_1" } } } },
       { KLV_0601_AMEND_LOCAL_SET, klv_local_set{
-        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } } );
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } };
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
 
   auto const output = filter.filter( input, nullptr );
@@ -200,7 +200,7 @@ TEST ( apply_child_klv, segment_only )
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
 
-  klv_md->set_klv( {
+  klv_md->klv() = {
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
       { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
@@ -227,7 +227,7 @@ TEST ( apply_child_klv, segment_only )
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
       { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM3" } },
-      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } } );
+      { KLV_0601_VERSION_NUMBER, uint64_t{ 17 } } } } };
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
 
   auto const output = filter.filter( input, nullptr );
@@ -282,7 +282,7 @@ TEST ( apply_child_klv, mixed_children )
   auto const klv_md = std::make_shared< klv_metadata >();
   kv::metadata_vector input{ klv_md };
 
-  klv_md->set_klv( {
+  klv_md->klv() = {
     { klv_0601_key(), klv_local_set{
       { KLV_0601_PRECISION_TIMESTAMP, uint64_t{ 42 } },
       { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM" } },
@@ -296,7 +296,7 @@ TEST ( apply_child_klv, mixed_children )
         { KLV_0601_PLATFORM_DESIGNATION, std::string{ "PLATFORM_ALT" } },
         { KLV_0601_MISSION_ID, std::string{ "ID_1" } } } },
       { KLV_0601_SEGMENT_LOCAL_SET, klv_local_set{
-        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } } );
+        { KLV_0601_MISSION_ID, std::string{ "ID_2" } } } } } } };
   klv_md->add< kv::VITAL_META_UNIX_TIMESTAMP >( 42 );
 
   auto const output = filter.filter( input, nullptr );

--- a/arrows/klv/update_klv.cxx
+++ b/arrows/klv/update_klv.cxx
@@ -260,12 +260,10 @@ update_klv
       klv_to_vital_metadata( stream.timeline, timestamp );
 
     // Add any new ST1108 packets
-    auto klv_packets = klv_md->klv();
     auto const new_1108_packets =
       d->create_1108_packets( *derived_md, *results.back(), timestamp );
-    klv_packets.insert(
-      klv_packets.end(), new_1108_packets.begin(), new_1108_packets.end() );
-    klv_md->set_klv( klv_packets );
+    klv_md->klv().insert(
+      klv_md->klv().end(), new_1108_packets.begin(), new_1108_packets.end() );
   }
 
   return results;

--- a/arrows/serialize/json/klv/metadata_map_io.cxx
+++ b/arrows/serialize/json/klv/metadata_map_io.cxx
@@ -120,9 +120,7 @@ metadata_map_io_klv
     }
 
     // Add the KLV packet data
-    auto klv_packets = klv_md->klv();
-    klv_packets.emplace_back( std::move( packet.packet ) );
-    klv_md->set_klv( std::move( klv_packets ) );
+    klv_md->klv().emplace_back( std::move( packet.packet ) );
   }
 
   // Convert to vital::metadata_map_sptr


### PR DESCRIPTION
This PR changes the `klv_metadata` interface to allow direct modification of the KLV packets, instead of requiring modifications to be made only in bulk via `set_klv()`. This prevents unnecessary copying / awkward temporary variables when, for example, one just needs to append a single new item to the vector of KLV packets.