### PR TITLE
Remove dump-klv early return when no metadata stream found

### DIFF
--- a/arrows/core/applets/dump_klv.cxx
+++ b/arrows/core/applets/dump_klv.cxx
@@ -234,13 +234,6 @@ dump_klv
     return EXIT_FAILURE;
   }
 
-  auto const& caps = video_reader->get_implementation_capabilities();
-  if ( !caps.capability( kva::video_input::HAS_METADATA ) )
-  {
-    std::cerr << "No metadata stream found in " << video_file << '\n';
-    return EXIT_FAILURE;
-  }
-
   int count(1);
   kv::timestamp ts;
   kv::wrap_text_block wtb;


### PR DESCRIPTION
This PR allows `dump-klv` to keep running and exit with no failure code on videos where there is no KLV stream. This is an improvement for several reasons. First, it helps differentiate this result from true failures, such as nonexistent filenames or  an uncaught exception. Second, some metadata is still produced for the video, such as number of frames, codec name, bitrate, etc, and the CSV exporter can still write that data fine. Third, the ability to dump frame images has been added to `dump-klv`, which should be able to function even when there isn't a KLV stream. 