### PR TITLE
Fix length check when reading packet

### DIFF
--- a/arrows/klv/klv_packet.cxx
+++ b/arrows/klv/klv_packet.cxx
@@ -113,11 +113,7 @@ klv_read_packet( klv_read_iter_t& data, size_t max_length )
   // Read length
   auto const length_of_value =
     klv_read_ber< size_t >( data, tracker.remaining() );
-  if( max_length < tracker.remaining() )
-  {
-    VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
-                 "reading klv packet value overflows buffer" );
-  }
+  tracker.verify( length_of_value );
 
   // Verify checksum
   auto const& format = klv_lookup_packet_traits().by_uds_key( key ).format();


### PR DESCRIPTION
This PR fixes a typo where the stated length of the **payload** of a KLV packet is compared against the known length of the **entire** packet. So if the stated payload length is too large by only a few bytes (smaller than the length of the packet header), the check won't catch it, but it will still cause errors down the line.