### PR TITLE
Change ST0903 pack local sets to klv_value

### DIFF
--- a/arrows/klv/klv_0903_vtarget_pack.cxx
+++ b/arrows/klv/klv_0903_vtarget_pack.cxx
@@ -143,8 +143,7 @@ klv_0903_vtarget_pack_format
   klv_0903_vtarget_pack result;
   result.id = klv_read_ber_oid< size_t >( data, tracker.remaining() );
   result.set =
-    klv_0903_vtarget_local_set_format()
-    .read( data, tracker.remaining() ).get< klv_local_set >();
+    klv_0903_vtarget_local_set_format().read( data, tracker.remaining() );
   return result;
 }
 

--- a/arrows/klv/klv_0903_vtarget_pack.h
+++ b/arrows/klv/klv_0903_vtarget_pack.h
@@ -108,7 +108,7 @@ private:
 struct KWIVER_ALGO_KLV_EXPORT klv_0903_vtarget_pack
 {
   uint64_t id;
-  klv_local_set set;
+  klv_value set;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vtrackitem_pack.cxx
+++ b/arrows/klv/klv_0903_vtrackitem_pack.cxx
@@ -70,8 +70,7 @@ klv_0903_vtrackitem_pack_format
   klv_0903_vtrackitem_pack result;
   result.id = klv_read_ber_oid< size_t >( data, tracker.remaining() );
   result.set =
-    klv_0903_vtrackitem_local_set_format()
-    .read( data, tracker.remaining() ).get< klv_local_set >();
+    klv_0903_vtrackitem_local_set_format().read( data, tracker.remaining() );
   return result;
 }
 

--- a/arrows/klv/klv_0903_vtrackitem_pack.h
+++ b/arrows/klv/klv_0903_vtrackitem_pack.h
@@ -71,7 +71,7 @@ operator<<( std::ostream& os, klv_0903_vtrackitem_pack_tag tag );
 struct KWIVER_ALGO_KLV_EXPORT klv_0903_vtrackitem_pack
 {
   uint64_t id;
-  klv_local_set set;
+  klv_value set;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/serialize/json/klv/load_save_klv.cxx
+++ b/arrows/serialize/json/klv/load_save_klv.cxx
@@ -885,6 +885,11 @@ public:
   auto NAME = load< decltype( T::NAME ) >( hyphenify( #NAME ) )
 
 // ----------------------------------------------------------------------------
+// Loads a klv_value into the given variable name.
+#define LOAD_MEMBER_VALUE( NAME, T ) \
+  auto NAME = load( hyphenify( #NAME ), typeid( T ) )
+
+// ----------------------------------------------------------------------------
 // Imports KLV objects. Relies heavily on templates to keep code relatively
 // clean, and to work around the lack of return-type-based function overloading
 // in C++.
@@ -1450,7 +1455,7 @@ struct klv_json_loader : public klv_json_base< load_archive >
   {
     auto const object_scope = push_object();
     LOAD_MEMBER( id );
-    LOAD_MEMBER( set );
+    LOAD_MEMBER_VALUE( set, klv_local_set );
     return { std::move( id ),
              std::move( set ) };
   }
@@ -1460,7 +1465,7 @@ struct klv_json_loader : public klv_json_base< load_archive >
   {
     auto const object_scope = push_object();
     LOAD_MEMBER( id );
-    LOAD_MEMBER( set );
+    LOAD_MEMBER_VALUE( set, klv_local_set );
     return { std::move( id ),
              std::move( set ) };
   }


### PR DESCRIPTION
ST0903 has these somewhat unusual constructs in which local sets are tagged with an id which is not part of the local sets themselves. Currently the local sets are stored directly, but since technically they could be invalid or null, we should store them as `klv_value`s which can properly handle these states. Otherwise, the parsing of the whole construct would fail, even though the accompanying id may be both parsable and potentially useful.