### PR TITLE
Improve KLV format descriptions

### DIFF
--- a/arrows/klv/klv_0102.cxx
+++ b/arrows/klv/klv_0102.cxx
@@ -284,9 +284,9 @@ klv_0102_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0102_local_set_format
-::description() const
+::description_() const
 {
-  return "security local set of " + m_length_constraints.description();
+  return "ST0102 Security LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0102.h
+++ b/arrows/klv/klv_0102.h
@@ -120,7 +120,7 @@ public:
   klv_0102_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0104.cxx
+++ b/arrows/klv/klv_0104.cxx
@@ -35,9 +35,9 @@ klv_0104_universal_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0104_universal_set_format
-::description() const
+::description_() const
 {
-  return "ST 0104 universal set of " + m_length_constraints.description();
+  return "EG0104 Predator UAV US";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0104.h
+++ b/arrows/klv/klv_0104.h
@@ -72,7 +72,7 @@ public:
   klv_0104_universal_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -1254,9 +1254,9 @@ klv_0601_image_horizon_locations_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_image_horizon_locations_format
-::description() const
+::description_() const
 {
-  return "image horizon locations of " + m_length_constraints.description();
+  return "ST0601 Image Horizon Locations Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1335,9 +1335,9 @@ klv_0601_image_horizon_pixel_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_image_horizon_pixel_pack_format
-::description() const
+::description_() const
 {
-  return "image horizon pixel pack of " + m_length_constraints.description();
+  return "ST0601 Image Horizon Pixel Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1465,9 +1465,9 @@ klv_0601_control_command_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_control_command_format
-::description() const
+::description_() const
 {
-  return "control command of " + m_length_constraints.description();
+  return "ST0601 Control Command Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1541,9 +1541,9 @@ klv_0601_frame_rate_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_frame_rate_format
-::description() const
+::description_() const
 {
-  return "frame rate of " + m_length_constraints.description();
+  return "ST0601 Frame Rate Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1589,9 +1589,9 @@ klv_0601_country_codes_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_country_codes_format
-::description() const
+::description_() const
 {
-  return "country codes pack of " + m_length_constraints.description();
+  return "ST0601 Country Codes Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1791,9 +1791,9 @@ klv_0601_location_dlp_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_location_dlp_format
-::description() const
+::description_() const
 {
-  return "location pack of " + m_length_constraints.description();
+  return "ST0601 Location Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -1886,9 +1886,9 @@ klv_0601_airbase_locations_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_airbase_locations_format
-::description() const
+::description_() const
 {
-  return "airbase locations pack of " + m_length_constraints.description();
+  return "ST0601 Airbase Locations Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2069,9 +2069,9 @@ klv_0601_view_domain_interval_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_view_domain_interval_format
-::description() const
+::description_() const
 {
-  return "view domain interval of " + m_length_constraints.description();
+  return "ST0601 View Domain Interval Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2156,9 +2156,9 @@ klv_0601_view_domain_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_view_domain_format
-::description() const
+::description_() const
 {
-  return "view domain pack of " + m_length_constraints.description();
+  return "ST0601 View Domain Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2250,9 +2250,9 @@ klv_0601_waypoint_record_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_waypoint_record_format
-::description() const
+::description_() const
 {
-  return "waypoint pack of " + m_length_constraints.description();
+  return "ST0601 Waypoint Record Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2425,9 +2425,9 @@ klv_0601_weapons_store_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_weapons_store_format
-::description() const
+::description_() const
 {
-  return "weapons store pack of " + m_length_constraints.description();
+  return "ST0601 Weapons Store Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2587,9 +2587,9 @@ klv_0601_payload_record_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_payload_record_format
-::description() const
+::description_() const
 {
-  return "payload pack of " + m_length_constraints.description();
+  return "ST0601 Payload Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2670,9 +2670,9 @@ klv_0601_payload_list_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_payload_list_format
-::description() const
+::description_() const
 {
-  return "payload list pack of " + m_length_constraints.description();
+  return "ST0601 Payload List Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2762,9 +2762,9 @@ klv_0601_wavelength_record_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_wavelength_record_format
-::description() const
+::description_() const
 {
-  return "wavelength pack of " + m_length_constraints.description();
+  return "ST0601 Wavelength Record Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -2836,9 +2836,9 @@ klv_0601_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0601_local_set_format
-::description() const
+::description_() const
 {
-  return "UAS datalink local set of " + m_length_constraints.description();
+  return "ST0601 UAS Datalink LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -328,7 +328,7 @@ public:
   klv_0601_image_horizon_locations_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_image_horizon_locations
@@ -369,7 +369,7 @@ public:
   klv_0601_image_horizon_pixel_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_image_horizon_pixel_pack
@@ -464,7 +464,7 @@ public:
   klv_0601_control_command_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_control_command
@@ -508,7 +508,7 @@ public:
   klv_0601_frame_rate_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_frame_rate
@@ -549,7 +549,7 @@ public:
   klv_0601_country_codes_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_country_codes
@@ -588,7 +588,7 @@ public:
   klv_0601_location_dlp_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_location_dlp
@@ -627,7 +627,7 @@ public:
   klv_0601_airbase_locations_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_airbase_locations
@@ -667,7 +667,7 @@ public:
     vital::interval< double > const& start_interval );
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_view_domain_interval
@@ -711,7 +711,7 @@ public:
   klv_0601_view_domain_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_view_domain
@@ -776,7 +776,7 @@ public:
   klv_0601_waypoint_record_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_waypoint_record
@@ -873,7 +873,7 @@ public:
   klv_0601_weapons_store_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_weapons_store
@@ -938,7 +938,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_0601_payload_record_format
     klv_0601_payload_record_format();
 
     std::string
-    description() const override;
+    description_() const override;
 
   private:
      klv_0601_payload_record
@@ -961,7 +961,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_0601_payload_list_format
     klv_0601_payload_list_format();
 
     std::string
-    description() const override;
+    description_() const override;
 
   private:
     std::vector< klv_0601_payload_record >
@@ -1007,7 +1007,7 @@ public:
   klv_0601_wavelength_record_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0601_wavelength_record
@@ -1039,7 +1039,7 @@ public:
   klv_0601_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_0806.cxx
+++ b/arrows/klv/klv_0806.cxx
@@ -189,9 +189,9 @@ klv_0806_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_local_set_format
-::description() const
+::description_() const
 {
-  return "ST 0806 local set of " + m_length_constraints.description();
+  return "ST0806 RVT LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0806.h
+++ b/arrows/klv/klv_0806.h
@@ -63,7 +63,7 @@ public:
   klv_0806_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_0806_aoi_set.cxx
+++ b/arrows/klv/klv_0806_aoi_set.cxx
@@ -116,9 +116,9 @@ klv_0806_aoi_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_aoi_set_format
-::description() const
+::description_() const
 {
-  return "area-of-interest local set of " + m_length_constraints.description();
+  return "ST0806 Area of Interest LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0806_aoi_set.h
+++ b/arrows/klv/klv_0806_aoi_set.h
@@ -54,7 +54,7 @@ public:
   klv_0806_aoi_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_0806_poi_set.cxx
+++ b/arrows/klv/klv_0806_poi_set.cxx
@@ -111,9 +111,9 @@ klv_0806_poi_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_poi_set_format
-::description() const
+::description_() const
 {
-  return "point-of-interest local set of " + m_length_constraints.description();
+  return "ST0806 Point of Interest LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0806_poi_set.h
+++ b/arrows/klv/klv_0806_poi_set.h
@@ -54,7 +54,7 @@ public:
   klv_0806_poi_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_0806_user_defined_set.cxx
+++ b/arrows/klv/klv_0806_user_defined_set.cxx
@@ -73,9 +73,9 @@ klv_0806_user_defined_data_type_id_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_user_defined_data_type_id_format
-::description() const
+::description_() const
 {
-  return "user defined data type / id of " + m_length_constraints.description();
+  return "ST0806 User Defined Data Type and Id Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -141,9 +141,9 @@ klv_0806_user_defined_data_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_user_defined_data_format
-::description() const
+::description_() const
 {
-  return "user defined data of " + m_length_constraints.description();
+  return "ST0806 User Defined Data Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -182,9 +182,9 @@ klv_0806_user_defined_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0806_user_defined_set_format
-::description() const
+::description_() const
 {
-  return "user defined local set of " + m_length_constraints.description();
+  return "ST0806 User Defined LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0806_user_defined_set.h
+++ b/arrows/klv/klv_0806_user_defined_set.h
@@ -75,7 +75,7 @@ public:
   klv_0806_user_defined_data_type_id_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0806_user_defined_data_type_id
@@ -110,7 +110,7 @@ public:
   klv_0806_user_defined_data_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0806_user_defined_data
@@ -133,7 +133,7 @@ public:
   klv_0806_user_defined_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903.cxx
+++ b/arrows/klv/klv_0903.cxx
@@ -165,9 +165,9 @@ klv_0903_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_local_set_format
-::description() const
+::description_() const
 {
-  return "vmti local set of " + m_length_constraints.description();
+  return "ST0903 VMTI LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903.h
+++ b/arrows/klv/klv_0903.h
@@ -70,7 +70,7 @@ public:
   klv_0903_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_0903_algorithm_set.cxx
+++ b/arrows/klv/klv_0903_algorithm_set.cxx
@@ -75,9 +75,9 @@ klv_0903_algorithm_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_algorithm_local_set_format
-::description() const
+::description_() const
 {
-  return "algorithm local set of " + m_length_constraints.description();
+  return "ST0903 Algorithm LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_algorithm_set.h
+++ b/arrows/klv/klv_0903_algorithm_set.h
@@ -52,7 +52,7 @@ public:
   klv_0903_algorithm_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_location_pack.cxx
+++ b/arrows/klv/klv_0903_location_pack.cxx
@@ -181,9 +181,9 @@ klv_0903_location_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_location_pack_format
-::description() const
+::description_() const
 {
-  return "location pack of " + m_length_constraints.description();
+  return "ST0903 Location Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -261,9 +261,9 @@ klv_0903_velocity_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_velocity_pack_format
-::description() const
+::description_() const
 {
-  return "velocity/acceleration pack of " + m_length_constraints.description();
+  return "ST0903 Velocity or Acceleration Pack";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_location_pack.h
+++ b/arrows/klv/klv_0903_location_pack.h
@@ -106,7 +106,7 @@ public:
   klv_0903_location_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_location_pack
@@ -134,7 +134,7 @@ public:
   klv_0903_velocity_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_velocity_pack

--- a/arrows/klv/klv_0903_ontology_set.cxx
+++ b/arrows/klv/klv_0903_ontology_set.cxx
@@ -69,9 +69,9 @@ klv_0903_ontology_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_ontology_local_set_format
-::description() const
+::description_() const
 {
-  return "ontology local set of " + m_length_constraints.description();
+  return "ST0903 Ontology LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_ontology_set.h
+++ b/arrows/klv/klv_0903_ontology_set.h
@@ -51,7 +51,7 @@ public:
   klv_0903_ontology_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vchip_set.cxx
+++ b/arrows/klv/klv_0903_vchip_set.cxx
@@ -62,9 +62,9 @@ klv_0903_vchip_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vchip_local_set_format
-::description() const
+::description_() const
 {
-  return "vchip local set of " + m_length_constraints.description();
+  return "ST0903 VChip LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vchip_set.h
+++ b/arrows/klv/klv_0903_vchip_set.h
@@ -50,7 +50,7 @@ public:
   klv_0903_vchip_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vfeature_set.cxx
+++ b/arrows/klv/klv_0903_vfeature_set.cxx
@@ -59,9 +59,9 @@ klv_0903_vfeature_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vfeature_local_set_format
-::description() const
+::description_() const
 {
-  return "vfeature local set of " + m_length_constraints.description();
+  return "ST0903 VFeature LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vfeature_set.h
+++ b/arrows/klv/klv_0903_vfeature_set.h
@@ -48,7 +48,7 @@ public:
   klv_0903_vfeature_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vmask_set.cxx
+++ b/arrows/klv/klv_0903_vmask_set.cxx
@@ -49,9 +49,9 @@ klv_0903_pixel_run_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_pixel_run_format
-::description() const
+::description_() const
 {
-  return "pixel run of " + m_length_constraints.description();
+  return "ST0903 Pixel Run Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -102,9 +102,9 @@ klv_0903_vmask_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vmask_local_set_format
-::description() const
+::description_() const
 {
-  return "vmask local set of " + m_length_constraints.description();
+  return "ST0903 VMask LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vmask_set.h
+++ b/arrows/klv/klv_0903_vmask_set.h
@@ -60,7 +60,7 @@ public:
   klv_0903_pixel_run_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_pixel_run
@@ -88,7 +88,7 @@ public:
   klv_0903_vmask_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vobject_set.cxx
+++ b/arrows/klv/klv_0903_vobject_set.cxx
@@ -31,9 +31,9 @@ klv_0903_vobject_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vobject_local_set_format
-::description() const
+::description_() const
 {
-  return "vobject local set of " + m_length_constraints.description();
+  return "ST0903 VObject LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vobject_set.h
+++ b/arrows/klv/klv_0903_vobject_set.h
@@ -46,7 +46,7 @@ public:
   klv_0903_vobject_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vtarget_pack.cxx
+++ b/arrows/klv/klv_0903_vtarget_pack.cxx
@@ -76,9 +76,9 @@ klv_0903_fpa_index_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_fpa_index_format
-::description() const
+::description_() const
 {
-  return "fpa index pack of " + m_length_constraints.description();
+  return "ST0903 FPA Index Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -129,9 +129,9 @@ klv_0903_vtarget_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtarget_pack_format
-::description() const
+::description_() const
 {
-  return "vtarget pack of " + m_length_constraints.description();
+  return "ST0903 VTarget Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -396,9 +396,9 @@ klv_0903_vtarget_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtarget_local_set_format
-::description() const
+::description_() const
 {
-  return "vtarget local set of " + m_length_constraints.description();
+  return "ST0903 VTarget LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtarget_pack.h
+++ b/arrows/klv/klv_0903_vtarget_pack.h
@@ -89,7 +89,7 @@ public:
   klv_0903_fpa_index_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_fpa_index
@@ -128,7 +128,7 @@ public:
   klv_0903_vtarget_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_vtarget_pack
@@ -156,7 +156,7 @@ public:
   klv_0903_vtarget_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_0903_vtrack_set.cxx
+++ b/arrows/klv/klv_0903_vtrack_set.cxx
@@ -150,9 +150,9 @@ klv_0903_vtrack_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtrack_local_set_format
-::description() const
+::description_() const
 {
-  return "vtrack local set of " + m_length_constraints.description();
+  return "ST0903 VTrack LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtrack_set.h
+++ b/arrows/klv/klv_0903_vtrack_set.h
@@ -63,7 +63,7 @@ public:
   klv_0903_vtrack_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtracker_set.cxx
+++ b/arrows/klv/klv_0903_vtracker_set.cxx
@@ -143,9 +143,9 @@ klv_0903_vtracker_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtracker_local_set_format
-::description() const
+::description_() const
 {
-  return "vtracker local set of " + m_length_constraints.description();
+  return "ST0903 VTracker LS";
 }
 
 } // namespace arrows

--- a/arrows/klv/klv_0903_vtracker_set.h
+++ b/arrows/klv/klv_0903_vtracker_set.h
@@ -78,7 +78,7 @@ public:
   klv_0903_vtracker_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtrackitem_pack.cxx
+++ b/arrows/klv/klv_0903_vtrackitem_pack.cxx
@@ -56,9 +56,9 @@ klv_0903_vtrackitem_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtrackitem_pack_format
-::description() const
+::description_() const
 {
-  return "vtrackitem pack of " + m_length_constraints.description();
+  return "ST0903 VTrackItem Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -319,9 +319,9 @@ klv_0903_vtrackitem_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_0903_vtrackitem_local_set_format
-::description() const
+::description_() const
 {
-  return "vtrackitem local set of " + m_length_constraints.description();
+  return "ST0903 VTrackItem LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_0903_vtrackitem_pack.h
+++ b/arrows/klv/klv_0903_vtrackitem_pack.h
@@ -91,7 +91,7 @@ public:
   klv_0903_vtrackitem_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_0903_vtrackitem_pack
@@ -119,7 +119,7 @@ public:
   klv_0903_vtrackitem_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1002.cxx
+++ b/arrows/klv/klv_1002.cxx
@@ -95,9 +95,9 @@ klv_1002_enumerations_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1002_enumerations_format
-::description() const
+::description_() const
 {
-  return "range image enumerations of " + m_length_constraints.description();
+  return "ST1002 Range Image Enumerations Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -177,9 +177,9 @@ klv_1002_section_data_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1002_section_data_pack_format
-::description() const
+::description_() const
 {
-  return "section data pack of " + m_length_constraints.description();
+  return "ST1002 Section Data Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -261,9 +261,9 @@ klv_1002_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1002_local_set_format
-::description() const
+::description_() const
 {
-  return "range image local set of " + m_length_constraints.description();
+  return "ST1002 Range Image LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1002.h
+++ b/arrows/klv/klv_1002.h
@@ -112,7 +112,7 @@ public:
   klv_1002_enumerations_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1002_enumerations
@@ -154,7 +154,7 @@ public:
   klv_1002_section_data_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1002_section_data_pack
@@ -177,7 +177,7 @@ public:
   klv_1002_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_1010.cxx
+++ b/arrows/klv/klv_1010.cxx
@@ -88,9 +88,9 @@ klv_1010_sdcc_flp_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1010_sdcc_flp_format
-::description() const
+::description_() const
 {
-  return "SDCC-FLP of " + m_length_constraints.description();
+  return "ST1010 SDCC-FLP";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1010.h
+++ b/arrows/klv/klv_1010.h
@@ -63,7 +63,7 @@ public:
   explicit klv_1010_sdcc_flp_format( imap_from_key_fn sigma_imap );
 
   std::string
-  description() const override;
+  description_() const override;
 
   void
   set_preceding( std::vector< klv_lds_key > const& preceding_keys );

--- a/arrows/klv/klv_1107.cxx
+++ b/arrows/klv/klv_1107.cxx
@@ -121,10 +121,9 @@ klv_1107_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1107_local_set_format
-::description() const
+::description_() const
 {
-  return
-    "metric geopositioning local set of " + m_length_constraints.description();
+  return "ST1107 Metric Geopositioning LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1107.h
+++ b/arrows/klv/klv_1107.h
@@ -106,7 +106,7 @@ public:
   klv_1107_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -116,9 +116,9 @@ klv_1108_metric_period_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1108_metric_period_pack_format
-::description() const
+::description_() const
 {
-  return "metric period pack of " + m_length_constraints.description();
+  return "ST1108 Metric Period Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -192,9 +192,9 @@ klv_1108_window_corners_pack_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1108_window_corners_pack_format
-::description() const
+::description_() const
 {
-  return "window corners pack of " + m_length_constraints.description();
+  return "ST1108 Window Corners Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -222,9 +222,9 @@ klv_1108_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1108_local_set_format
-::description() const
+::description_() const
 {
-  return "ST 1108 local set of " + m_length_constraints.description();
+  return "ST1108 Interpretability and Quality LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -142,7 +142,7 @@ public:
   klv_1108_metric_period_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_1108_metric_period_pack
   read_typed( klv_read_iter_t& data, size_t length ) const override;
@@ -176,7 +176,7 @@ public:
   klv_1108_window_corners_pack_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1108_window_corners_pack
@@ -198,7 +198,7 @@ public:
   klv_1108_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
   klv_checksum_packet_format const*
   checksum_format() const override;

--- a/arrows/klv/klv_1108_metric_set.cxx
+++ b/arrows/klv/klv_1108_metric_set.cxx
@@ -95,9 +95,9 @@ klv_1108_metric_implementer_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1108_metric_implementer_format
-::description() const
+::description_() const
 {
-  return "metric implementer of " + m_length_constraints.description();
+  return "ST1108 Metric Implementer Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -109,7 +109,7 @@ klv_1108_metric_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1108_metric_local_set_format
-::description() const
+::description_() const
 {
   std::stringstream ss;
   ss << "ST 1108 metric local set";

--- a/arrows/klv/klv_1108_metric_set.h
+++ b/arrows/klv/klv_1108_metric_set.h
@@ -70,7 +70,7 @@ public:
   klv_1108_metric_implementer_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1108_metric_implementer
@@ -93,7 +93,7 @@ public:
   klv_1108_metric_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1202.cxx
+++ b/arrows/klv/klv_1202.cxx
@@ -52,11 +52,9 @@ klv_1202_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1202_local_set_format
-::description() const
+::description_() const
 {
-  return
-    "generalized transformation local set of " +
-    m_length_constraints.description();
+  return "ST1202 Generalized Transformation LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1202.h
+++ b/arrows/klv/klv_1202.h
@@ -72,7 +72,7 @@ public:
   klv_1202_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1204.cxx
+++ b/arrows/klv/klv_1204.cxx
@@ -79,9 +79,9 @@ klv_1204_miis_id_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1204_miis_id_format
-::description() const
+::description_() const
 {
-  return "MIIS ID of " + m_length_constraints.description();
+  return "ST1204 MIIS Identifier Pack";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1204.h
+++ b/arrows/klv/klv_1204.h
@@ -66,7 +66,7 @@ public:
   klv_1204_miis_id_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1204_miis_id

--- a/arrows/klv/klv_1206.cxx
+++ b/arrows/klv/klv_1206.cxx
@@ -299,10 +299,9 @@ klv_1206_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1206_local_set_format
-::description() const
+::description_() const
 {
-  return
-    "SAR motion imagery local set of " + m_length_constraints.description();
+  return "ST1206 SAR Motion Imagery LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1206.h
+++ b/arrows/klv/klv_1206.h
@@ -113,7 +113,7 @@ public:
   klv_1206_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_1303.h
+++ b/arrows/klv/klv_1303.h
@@ -84,7 +84,7 @@ public:
   {}
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   using element_t = typename Format::data_type;

--- a/arrows/klv/klv_1303.hpp
+++ b/arrows/klv/klv_1303.hpp
@@ -385,9 +385,9 @@ operator<<( std::ostream& os, klv_1303_mdap< T > const& value )
 template < class Format >
 std::string
 klv_1303_mdap_format< Format >
-::description() const
+::description_() const
 {
-  return "MDAP/MDARRAY of " + this->m_length_constraints.description();
+  return "ST1303 MDARRAY Pack";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1601.cxx
+++ b/arrows/klv/klv_1601.cxx
@@ -91,9 +91,9 @@ klv_1601_pixel_sdcc_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1601_pixel_sdcc_format
-::description() const
+::description_() const
 {
-  return "pixel sdcc mdarray of " + m_length_constraints.description();
+  return "ST1601 Pixel SDCC MDARRAY Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -189,9 +189,9 @@ klv_1601_geographic_sdcc_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1601_geographic_sdcc_format
-::description() const
+::description_() const
 {
-  return "geographic sdcc mdarray of " + m_length_constraints.description();
+  return "ST1601 Geographic SDCC MDARRAY Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -382,9 +382,9 @@ klv_1601_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1601_local_set_format
-::description() const
+::description_() const
 {
-  return "geo-registration local set of " + m_length_constraints.description();
+  return "ST1601 Geo-Registration LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1601.h
+++ b/arrows/klv/klv_1601.h
@@ -56,7 +56,7 @@ public:
   klv_1601_pixel_sdcc_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1303_mdap< double >
@@ -83,7 +83,7 @@ public:
   klv_1601_geographic_sdcc_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   klv_1303_mdap< double >
@@ -116,7 +116,7 @@ public:
   klv_1601_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_1602.cxx
+++ b/arrows/klv/klv_1602.cxx
@@ -169,9 +169,9 @@ klv_1602_local_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1602_local_set_format
-::description() const
+::description_() const
 {
-  return "composite imaging local set of " + m_length_constraints.description();
+  return "ST1602 Composite Imaging LS";
 }
 
 } // namespace klv

--- a/arrows/klv/klv_1602.h
+++ b/arrows/klv/klv_1602.h
@@ -69,7 +69,7 @@ public:
   klv_1602_local_set_format();
 
   std::string
-  description() const override;
+  description_() const override;
 };
 
 } // namespace klv

--- a/arrows/klv/klv_1607.cxx
+++ b/arrows/klv/klv_1607.cxx
@@ -24,9 +24,9 @@ klv_1607_child_set_format
 // ----------------------------------------------------------------------------
 std::string
 klv_1607_child_set_format
-::description() const
+::description_() const
 {
-  return "child set of " + m_length_constraints.description();
+  return "ST1607 Child LS";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1607.h
+++ b/arrows/klv/klv_1607.h
@@ -41,7 +41,7 @@ public:
   klv_1607_child_set_format( klv_tag_traits_lookup const& traits );
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   void

--- a/arrows/klv/klv_checksum.cxx
+++ b/arrows/klv/klv_checksum.cxx
@@ -209,9 +209,9 @@ klv_crc_8_ccitt_packet_format
 // ----------------------------------------------------------------------------
 std::string
 klv_crc_8_ccitt_packet_format
-::description() const
+::description_() const
 {
-  return "CRC-8-CCITT packet of " + m_length_constraints.description();
+  return "CRC-8-CCITT Checksum Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -231,9 +231,9 @@ klv_running_sum_16_packet_format
 // ----------------------------------------------------------------------------
 std::string
 klv_running_sum_16_packet_format
-::description() const
+::description_() const
 {
-  return "running 16-byte sum packet of " + m_length_constraints.description();
+  return "Running-Sum-16 Checksum Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -253,9 +253,9 @@ klv_crc_16_ccitt_packet_format
 // ----------------------------------------------------------------------------
 std::string
 klv_crc_16_ccitt_packet_format
-::description() const
+::description_() const
 {
-  return "CRC-16-CCITT packet of " + m_length_constraints.description();
+  return "CRC-16-CCITT Checksum Pack";
 }
 
 // ----------------------------------------------------------------------------
@@ -275,9 +275,9 @@ klv_crc_32_mpeg_packet_format
 // ----------------------------------------------------------------------------
 std::string
 klv_crc_32_mpeg_packet_format
-::description() const
+::description_() const
 {
-  return "CRC-32-MPEG packet of " + m_length_constraints.description();
+  return "CRC-32-MPEG Checksum Pack";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_checksum.h
+++ b/arrows/klv/klv_checksum.h
@@ -121,7 +121,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_crc_8_ccitt_packet_format
   klv_crc_8_ccitt_packet_format( klv_bytes_t const& header );
 
   std::string
-  description() const override;
+  description_() const override;
 
   uint64_t
   evaluate( klv_read_iter_t data, size_t length ) const override;
@@ -135,7 +135,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_running_sum_16_packet_format
   klv_running_sum_16_packet_format( klv_bytes_t const& header );
 
   std::string
-  description() const override;
+  description_() const override;
 
   uint64_t
   evaluate( klv_read_iter_t data, size_t length ) const override;
@@ -149,7 +149,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_crc_16_ccitt_packet_format
   klv_crc_16_ccitt_packet_format( klv_bytes_t const& header );
 
   std::string
-  description() const override;
+  description_() const override;
 
   uint64_t
   evaluate( klv_read_iter_t data, size_t length ) const override;
@@ -163,7 +163,7 @@ class KWIVER_ALGO_KLV_EXPORT klv_crc_32_mpeg_packet_format
   klv_crc_32_mpeg_packet_format( klv_bytes_t const& header );
 
   std::string
-  description() const override;
+  description_() const override;
 
   uint64_t
   evaluate( klv_read_iter_t data, size_t length ) const override;

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -83,6 +83,19 @@ klv_data_format
 }
 
 // ----------------------------------------------------------------------------
+std::string
+klv_data_format
+::description() const
+{
+  auto const result = description_();
+  if( m_length_constraints.is_free() )
+  {
+    return result;
+  }
+  return result + " (Length: " + m_length_constraints.description() + ")";
+}
+
+// ----------------------------------------------------------------------------
 klv_blob_format
 ::klv_blob_format( klv_length_constraints const& length_constraints )
   : klv_data_format_< data_type >{ length_constraints }
@@ -116,11 +129,9 @@ klv_blob_format
 // ----------------------------------------------------------------------------
 std::string
 klv_blob_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "raw bytes of " << m_length_constraints.description();
-  return ss.str();
+  return "Raw Bytes";
 }
 
 // ----------------------------------------------------------------------------
@@ -131,9 +142,9 @@ klv_uuid_format
 // ----------------------------------------------------------------------------
 std::string
 klv_uuid_format
-::description() const
+::description_() const
 {
-  return "UUID of " + m_length_constraints.description();
+  return "UUID";
 }
 
 // ----------------------------------------------------------------------------
@@ -195,11 +206,9 @@ klv_string_format
 // ----------------------------------------------------------------------------
 std::string
 klv_string_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "string of " << m_length_constraints.description();
-  return ss.str();
+  return "String";
 }
 
 // ----------------------------------------------------------------------------
@@ -210,9 +219,9 @@ klv_bool_format
 // ----------------------------------------------------------------------------
 std::string
 klv_bool_format
-::description() const
+::description_() const
 {
-  return "bool of " + m_length_constraints.description();
+  return "Boolean";
 }
 
 // ----------------------------------------------------------------------------
@@ -266,11 +275,9 @@ klv_uint_format
 // ----------------------------------------------------------------------------
 std::string
 klv_uint_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "unsigned integer of " << m_length_constraints.description();
-  return ss.str();
+  return "Unsigned Integer";
 }
 
 // ----------------------------------------------------------------------------
@@ -307,11 +314,9 @@ klv_sint_format
 // ----------------------------------------------------------------------------
 std::string
 klv_sint_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "signed integer of " << m_length_constraints.description();
-  return ss.str();
+  return "Signed Integer";
 }
 
 // ----------------------------------------------------------------------------
@@ -347,12 +352,9 @@ klv_ber_format
 // ----------------------------------------------------------------------------
 std::string
 klv_ber_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "BER-encoded unsigned integer of "
-     << m_length_constraints.description();
-  return ss.str();
+  return "Unsigned Integer (Encoding: BER)";
 }
 
 // ----------------------------------------------------------------------------
@@ -388,12 +390,9 @@ klv_ber_oid_format
 // ----------------------------------------------------------------------------
 std::string
 klv_ber_oid_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "BER-OID-encoded unsigned integer of "
-     << m_length_constraints.description();
-  return ss.str();
+  return "Unsigned Integer (Encoding: BER-OID)";
 }
 
 // ----------------------------------------------------------------------------
@@ -446,12 +445,9 @@ klv_float_format
 // ----------------------------------------------------------------------------
 std::string
 klv_float_format
-::description() const
+::description_() const
 {
-  std::stringstream ss;
-  ss << "IEEE-754 floating-point number of "
-     << m_length_constraints.description();
-  return ss.str();
+  return "Float (Encoding: IEEE-754)";
 }
 
 // ----------------------------------------------------------------------------
@@ -507,11 +503,10 @@ klv_sflint_format
 // ----------------------------------------------------------------------------
 std::string
 klv_sflint_format
-::description() const
+::description_() const
 {
   std::stringstream ss;
-  ss << "signed integer of " << m_length_constraints.description()
-     << " mapped to range " << m_interval;
+  ss << "Float (Encoding: Signed Integer) (Range: " << m_interval << ")";
   return ss.str();
 }
 
@@ -576,11 +571,10 @@ klv_uflint_format
 // ----------------------------------------------------------------------------
 std::string
 klv_uflint_format
-::description() const
+::description_() const
 {
   std::stringstream ss;
-  ss << "unsigned integer of " << m_length_constraints.description()
-     << " mapped to range " << m_interval;
+  ss << "Float (Encoding: Unsigned Integer) (Range: " << m_interval << ")";
   return ss.str();
 }
 
@@ -644,11 +638,10 @@ klv_imap_format
 // ----------------------------------------------------------------------------
 std::string
 klv_imap_format
-::description() const
+::description_() const
 {
   std::stringstream ss;
-  ss << "IMAP-encoded range " << m_interval << "of "
-     << m_length_constraints.description();
+  ss << "Float (Encoding: IMAP) (Range: " << m_interval << ")";
   return ss.str();
 }
 

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -83,8 +83,8 @@ public:
   to_string( klv_value const& value ) const;
 
   /// Return a textual description of this data format.
-  virtual std::string
-  description() const = 0;
+  std::string
+  description() const;
 
   /// Optionally the checksum format for this data format.
   virtual klv_checksum_packet_format const*
@@ -94,11 +94,14 @@ public:
   klv_length_constraints const&
   length_constraints() const;
 
-  /// Set constraints on the length of this format.
+/// Set constraints on the length of this format.
   void
   set_length_constraints( klv_length_constraints const& length_constraints );
 
 protected:
+  virtual std::string
+  description_() const = 0;
+
   klv_length_constraints m_length_constraints;
 };
 
@@ -315,7 +318,7 @@ public:
   ~klv_blob_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   klv_blob
@@ -338,7 +341,7 @@ public:
   klv_uuid_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   klv_uuid
@@ -361,7 +364,7 @@ public:
   klv_string_format( klv_length_constraints const& length_constraints = {} );
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   std::string
@@ -384,7 +387,7 @@ public:
   klv_bool_format();
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   bool
@@ -407,7 +410,7 @@ public:
   ~klv_uint_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   uint64_t
@@ -433,7 +436,7 @@ public:
   ~klv_sint_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   int64_t
@@ -465,12 +468,9 @@ public:
   {}
 
   std::string
-  description() const override
+  description_() const override
   {
-    std::stringstream ss;
-    ss << this->type_name() << " enumeration of "
-       << this->m_length_constraints.description();
-    return ss.str();
+    return "Enumeration '" + this->type_name() + "'";
   }
 
 protected:
@@ -509,7 +509,7 @@ public:
   ~klv_ber_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   uint64_t
@@ -535,7 +535,7 @@ public:
   ~klv_ber_oid_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   uint64_t
@@ -561,7 +561,7 @@ public:
   ~klv_float_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   klv_lengthy< double >
@@ -594,7 +594,7 @@ public:
   ~klv_sflint_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
   vital::interval< double >
   interval() const;
@@ -632,7 +632,7 @@ public:
   ~klv_uflint_format() = default;
 
   std::string
-  description() const override;
+  description_() const override;
 
   vital::interval< double >
   interval() const;
@@ -666,7 +666,7 @@ public:
     klv_length_constraints const& length_constraints = {} );
 
   std::string
-  description() const override;
+  description_() const override;
 
   vital::interval< double >
   interval() const;
@@ -709,7 +709,7 @@ public:
   }
 
   std::string
-  description() const
+  description_() const
   {
     return m_format.description();
   }
@@ -792,9 +792,9 @@ public:
   }
 
   std::string
-  description() const
+  description_() const
   {
-    return "bitfield of " + this->m_length_constraints.description();
+    return "Bitfield";
   }
 
 protected:

--- a/arrows/klv/klv_length_constraints.cxx
+++ b/arrows/klv/klv_length_constraints.cxx
@@ -266,33 +266,35 @@ klv_length_constraints
     void
     operator()( std::monostate ) const
     {
-      os << "unconstrained length";
+      os << "Any";
     }
 
     void
     operator()( size_t fixed_length ) const
     {
-      os << "exactly " << fixed_length << " bytes";
+      os << fixed_length;
     }
 
     void
     operator()( vital::interval< size_t > const& interval ) const
     {
-      os << "between " << interval.lower() << " and " << interval.upper()
-         << " bytes";
+      os << interval.lower() << " to " << interval.upper();
     }
 
     void
     operator()( std::set< size_t > const& set ) const
     {
-      os << "one of these lengths: ";
-      for( auto const& entry : set )
+      for( auto it = set.begin(); it != set.end(); ++it )
       {
-        os << entry;
-        if( &entry != &*set.end() )
+        if( it != set.begin() )
         {
-          os << ", ";
+          os << ( ( set.size() > 2 ) ? ", " : " " );
         }
+        if( std::next( it ) == set.end() )
+        {
+          os << "or ";
+        }
+        os << *it;
       }
     }
 

--- a/arrows/klv/klv_list.h
+++ b/arrows/klv/klv_list.h
@@ -27,7 +27,7 @@ public:
   klv_list_format( Args&&... args );
 
   std::string
-  description() const override;
+  description_() const override;
 
 private:
   using element_t = typename Format::data_type;

--- a/arrows/klv/klv_list.hpp
+++ b/arrows/klv/klv_list.hpp
@@ -28,9 +28,9 @@ klv_list_format< Format >
 template < class Format >
 std::string
 klv_list_format< Format >
-::description() const
+::description_() const
 {
-  return "list of " + m_format.description();
+  return "List (Type: " + m_format.description() + ")";
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_series.h
+++ b/arrows/klv/klv_series.h
@@ -33,7 +33,7 @@ public:
   klv_series_format( Args&&... args );
 
   std::string
-  description() const override;
+  description_() const override;
 
 protected:
   std::vector< element_t >

--- a/arrows/klv/klv_series.hpp
+++ b/arrows/klv/klv_series.hpp
@@ -28,9 +28,9 @@ klv_series_format< Format >
 template < class Format >
 std::string
 klv_series_format< Format >
-::description() const
+::description_() const
 {
-  return "series of " + m_format.description();
+  return "Series (Type: " + m_format.description() + ")";
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the consistency and readability of the string descriptions of KLV formats. It also removes some widespread repetition of code (`+ m_length_constraints.description()`).