### PR TITLE
Make update_klv a buffered_metadata_filter

### DIFF
--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -208,7 +208,7 @@ klv_value&
 klv_value
 ::operator=( T&& rhs )
 {
-  klv_value{ rhs }.swap( *this );
+  klv_value{ std::forward< T >( rhs ) }.swap( *this );
   return *this;
 }
 
@@ -376,24 +376,26 @@ operator<<( std::ostream& os, klv_value const& rhs )
 }
 
 // ----------------------------------------------------------------------------
-#define KLV_INSTANTIATE( T )                         \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  klv_value::klv_value( T&& );                       \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  klv_value::klv_value( T& );                        \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  klv_value::klv_value( T const& );                  \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  klv_value & klv_value::operator= < T >( T && );    \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  T & klv_value::get< T >();                         \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  T const& klv_value::get< T >() const;              \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  T * klv_value::get_ptr< T >() noexcept;            \
-  template KWIVER_ALGO_KLV_EXPORT                    \
-  T const* klv_value::get_ptr< T >() const noexcept; \
-  template class KWIVER_ALGO_KLV_EXPORT              \
+#define KLV_INSTANTIATE( T )                                 \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  klv_value::klv_value( T&& );                               \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  klv_value::klv_value( T& );                                \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  klv_value::klv_value( T const& );                          \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  klv_value & klv_value::operator= < T >( T && );            \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  klv_value & klv_value::operator= < T const& >( T const& ); \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  T & klv_value::get< T >();                                 \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  T const& klv_value::get< T >() const;                      \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  T * klv_value::get_ptr< T >() noexcept;                    \
+  template KWIVER_ALGO_KLV_EXPORT                            \
+  T const* klv_value::get_ptr< T >() const noexcept;         \
+  template class KWIVER_ALGO_KLV_EXPORT                      \
   klv_value::internal_< T >;
 
 KLV_INSTANTIATE( bool );

--- a/arrows/klv/tests/test_update_klv.cxx
+++ b/arrows/klv/tests/test_update_klv.cxx
@@ -27,37 +27,191 @@ namespace kv = kwiver::vital;
 using namespace kwiver::arrows::klv;
 
 // ----------------------------------------------------------------------------
-// Ensure we can create the filter with the factory method.
-TEST ( update_klv, create )
+class update_klv_fixture : public ::testing::Test
 {
-  EXPECT_NE( nullptr, kv::algo::metadata_filter::create( "update_klv" ) );
+protected:
+  // We have to treat the timestamp fields specially, since they should be the
+  // current time and we can't hardcode the correct value for that.
+  void check_metric_times( klv_local_set& set ) const
+  {
+    for( auto& entry : set.all_at( KLV_1108_METRIC_LOCAL_SET ) )
+    {
+      auto& metric_set = entry.second.get< klv_local_set >();
+      ASSERT_EQ( 1, metric_set.count( KLV_1108_METRIC_SET_TIME ) );
+
+      // Check that timestamp is sane - some time between when this was written
+      // and 2100.
+      auto const timestamp =
+        metric_set.at( KLV_1108_METRIC_SET_TIME ).get< uint64_t >();
+      EXPECT_GT( timestamp, 1670000000000000);
+      EXPECT_LT( timestamp, 4102462800000000);
+
+      // Remove the timestamp field
+      metric_set.erase( KLV_1108_METRIC_SET_TIME );
+    }
+  }
+
+  kv::metadata_sptr
+  metric_metadata(
+    uint64_t timestamp, double gsd_value, double vniirs_value ) const
+  {
+    auto const result = new klv_metadata;
+    result->add< kv::VITAL_META_VIDEO_DATA_STREAM_INDEX >( 1 );
+    result->add< kv::VITAL_META_UNIX_TIMESTAMP >( timestamp );
+    result->add< kv::VITAL_META_AVERAGE_GSD >( gsd_value );
+    result->add< kv::VITAL_META_VNIIRS >( vniirs_value );
+    result->add< kv::VITAL_META_VIDEO_BITRATE >( 500000 );
+    result->add< kv::VITAL_META_VIDEO_COMPRESSION_TYPE >( "H.264" );
+    result->add< kv::VITAL_META_VIDEO_COMPRESSION_PROFILE >( "Main" );
+    result->add< kv::VITAL_META_VIDEO_COMPRESSION_LEVEL >( "4.1" );
+    result->add< kv::VITAL_META_VIDEO_FRAME_RATE >( 30.0 );
+    result->add< kv::VITAL_META_IMAGE_WIDTH >( 1280 );
+    result->add< kv::VITAL_META_IMAGE_HEIGHT >( 720 );
+    return kv::metadata_sptr{ result };
+  }
+
+  klv_packet
+  metric_klv(
+    klv_1108_metric_period_pack const& period_pack,
+    double gsd_value, double vniirs_value ) const
+  {
+    return { klv_1108_key(), klv_local_set{
+      { KLV_1108_ASSESSMENT_POINT, KLV_1108_ASSESSMENT_POINT_ARCHIVE },
+      { KLV_1108_METRIC_PERIOD_PACK, period_pack },
+      { KLV_1108_METRIC_LOCAL_SET, klv_local_set{
+        { KLV_1108_METRIC_SET_NAME, std::string{ "GSD" } },
+        { KLV_1108_METRIC_SET_VERSION, std::string{} },
+        { KLV_1108_METRIC_SET_IMPLEMENTER,
+          klv_1108_kwiver_metric_implementer() },
+        { KLV_1108_METRIC_SET_PARAMETERS, std::string{
+          "Geo. mean of horiz. and vert. GSD of central pixel" } },
+        { KLV_1108_METRIC_SET_VALUE, klv_lengthy< double >{ gsd_value } } } },
+      { KLV_1108_METRIC_LOCAL_SET, klv_local_set{
+        { KLV_1108_METRIC_SET_NAME, std::string{ "VNIIRS" } },
+        { KLV_1108_METRIC_SET_VERSION, std::string{ "GIQE5" } },
+        { KLV_1108_METRIC_SET_IMPLEMENTER,
+          klv_1108_kwiver_metric_implementer() },
+        { KLV_1108_METRIC_SET_PARAMETERS, std::string{ "Terms a0, a1 only" } },
+        { KLV_1108_METRIC_SET_VALUE, klv_lengthy< double >{ vniirs_value } } } },
+      { KLV_1108_COMPRESSION_TYPE, KLV_1108_COMPRESSION_TYPE_H264 },
+      { KLV_1108_COMPRESSION_PROFILE, KLV_1108_COMPRESSION_PROFILE_MAIN },
+      { KLV_1108_COMPRESSION_LEVEL, std::string{ "4.1" } },
+      { KLV_1108_COMPRESSION_RATIO, klv_lengthy< double >{ 1327.104 } },
+      { KLV_1108_STREAM_BITRATE, uint64_t{ 500 } },
+      { KLV_1108_DOCUMENT_VERSION, uint64_t{ 3 } } } };
+  }
+
+  void expect_empty_frames( size_t count )
+  {
+    for( size_t i = 0; i < count; ++i )
+    {
+      auto const output = filter.receive();
+      ASSERT_EQ( 1, output.size() );
+
+      auto output_klv =
+        dynamic_cast< klv_metadata const& >( *output[ 0 ] ).klv();
+      EXPECT_EQ( 0, output_klv.size() );
+    }
+  }
+
+  update_klv filter;
+};
+
+// ----------------------------------------------------------------------------
+// Ensure we can create the filter with the factory method.
+TEST_F ( update_klv_fixture, create )
+{
+  EXPECT_NE(
+    nullptr, kv::algo::buffered_metadata_filter::create( "update_klv" ) );
 }
 
 // ----------------------------------------------------------------------------
 // No metadata given.
-TEST ( update_klv, empty )
+TEST_F ( update_klv_fixture, empty )
 {
-  update_klv filter;
   kv::metadata_vector input;
-  auto const output = filter.filter( input, nullptr );
+
+  filter.send( input, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  filter.flush();
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
   EXPECT_EQ( input, output );
+  EXPECT_EQ( 0, filter.available_frames() );
+}
+
+// ----------------------------------------------------------------------------
+// No metadata given.
+TEST_F ( update_klv_fixture, empty_with_delay )
+{
+  auto config = filter.get_configuration();
+  config->set_value< size_t >( "st1108_frequency", 3 );
+  filter.set_configuration( config );
+
+  kv::metadata_vector input;
+
+  filter.send( input, nullptr );
+  EXPECT_EQ( 1, filter.unavailable_frames() );
+  EXPECT_EQ( 0, filter.available_frames() );
+
+  filter.flush();
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( input, output );
+  EXPECT_EQ( 0, filter.available_frames() );
 }
 
 // ----------------------------------------------------------------------------
 // Null metadata pointer.
-TEST ( update_klv, null_metadata_sptr )
+TEST_F ( update_klv_fixture, null_metadata )
 {
-  update_klv filter;
   kv::metadata_vector input{ nullptr };
-  auto const output = filter.filter( input, nullptr );
+
+  filter.send( input, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  filter.flush();
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
   EXPECT_EQ( input, output );
 }
 
 // ----------------------------------------------------------------------------
-// Metadata objects with no KLV attached.
-TEST ( update_klv, non_klv_metadata_sptr )
+// No metadata given.
+TEST_F ( update_klv_fixture, null_metadata_with_delay )
 {
-  update_klv filter;
+  auto config = filter.get_configuration();
+  config->set_value< size_t >( "st1108_frequency", 3 );
+  filter.set_configuration( config );
+
+  kv::metadata_vector input{ nullptr };
+
+  filter.send( input, nullptr );
+  EXPECT_EQ( 1, filter.unavailable_frames() );
+  EXPECT_EQ( 0, filter.available_frames() );
+
+  filter.flush();
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( input, output );
+  EXPECT_EQ( 0, filter.available_frames() );
+}
+
+// ----------------------------------------------------------------------------
+// Metadata objects with no KLV attached.
+TEST_F ( update_klv_fixture, non_klv_metadata )
+{
   kv::metadata_vector input{
     std::make_shared< kv::metadata >(),
     std::make_shared< kv::metadata >(),
@@ -65,7 +219,13 @@ TEST ( update_klv, non_klv_metadata_sptr )
   input[ 0 ]->add< kv::VITAL_META_UNIX_TIMESTAMP >( 0 );
   input[ 0 ]->add< kv::VITAL_META_AVERAGE_GSD >( 12.0 );
   input[ 1 ]->add< kv::VITAL_META_UNIX_TIMESTAMP >( 1 );
-  auto const output = filter.filter( input, nullptr );
+
+  filter.send( input, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( 0, filter.available_frames() );
   ASSERT_EQ( 2, output.size() );
   EXPECT_EQ(
     0, output.at( 0 )->find( kv::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
@@ -75,70 +235,129 @@ TEST ( update_klv, non_klv_metadata_sptr )
 
 // ----------------------------------------------------------------------------
 // Adding in a new ST1108 packet.
-TEST( update_klv, add_st_1108 )
+TEST_F ( update_klv_fixture, add_st1108 )
 {
-  update_klv filter;
-  kv::metadata_vector input{ std::make_shared< klv_metadata >() };
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_DATA_STREAM_INDEX >( 1 );
-  input[ 0 ]->add< kv::VITAL_META_UNIX_TIMESTAMP >( 1 );
-  input[ 0 ]->add< kv::VITAL_META_AVERAGE_GSD >( 12.0 );
-  input[ 0 ]->add< kv::VITAL_META_VNIIRS >( 5.0 );
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_BITRATE >( 500000 );
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_COMPRESSION_TYPE >( "H.264" );
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_COMPRESSION_PROFILE >( "Main" );
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_COMPRESSION_LEVEL >( "4.1" );
-  input[ 0 ]->add< kv::VITAL_META_VIDEO_FRAME_RATE >( 30.0 );
-  input[ 0 ]->add< kv::VITAL_META_IMAGE_WIDTH >( 1280 );
-  input[ 0 ]->add< kv::VITAL_META_IMAGE_HEIGHT >( 720 );
+  kv::metadata_vector input{ metric_metadata( 1, 12.0, 5.0 ) };
 
-  auto const output = filter.filter( input, nullptr );
+  filter.send( input, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 1, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( 0, filter.available_frames() );
   ASSERT_EQ( 1, output.size() );
+
   auto output_klv =
     dynamic_cast< klv_metadata const& >( *output[ 0 ] ).klv();
+  ASSERT_EQ( 1, output_klv.size() );
 
-  // We have to treat the timestamp fields specially, since they should be the
-  // current time and we can't hardcode the correct value for that.
-  auto& set = output_klv[ 0 ].value.get< klv_local_set >();
-  for( auto& entry : set.all_at( KLV_1108_METRIC_LOCAL_SET ) )
-  {
-    auto& metric_set = entry.second.get< klv_local_set >();
-    ASSERT_EQ( 1, metric_set.count( KLV_1108_METRIC_SET_TIME ) );
+  CALL_TEST( check_metric_times, output_klv[ 0 ].value.get< klv_local_set >() );
 
-    // Check that timestamp is sane - some time between when this was written
-    // and 2100.
-    auto const timestamp =
-      metric_set.at( KLV_1108_METRIC_SET_TIME ).get< uint64_t >();
-    EXPECT_GT( timestamp, 1670000000000000);
-    EXPECT_LT( timestamp, 4102462800000000);
-
-    // Remove the timestamp field
-    metric_set.erase( KLV_1108_METRIC_SET_TIME );
-  }
-
-  std::vector< klv_packet > expected_klv { {
-    { klv_1108_key(), klv_local_set{
-      { KLV_1108_ASSESSMENT_POINT, KLV_1108_ASSESSMENT_POINT_ARCHIVE },
-      { KLV_1108_METRIC_PERIOD_PACK, klv_1108_metric_period_pack{ 1, 33333 } },
-      { KLV_1108_METRIC_LOCAL_SET, klv_local_set{
-        { KLV_1108_METRIC_SET_NAME, std::string{ "GSD" } },
-        { KLV_1108_METRIC_SET_VERSION, std::string{} },
-        { KLV_1108_METRIC_SET_IMPLEMENTER,
-          klv_1108_kwiver_metric_implementer() },
-        { KLV_1108_METRIC_SET_PARAMETERS, std::string{} },
-        { KLV_1108_METRIC_SET_VALUE, klv_lengthy< double >{ 12.0 } } } },
-      { KLV_1108_METRIC_LOCAL_SET, klv_local_set{
-        { KLV_1108_METRIC_SET_NAME, std::string{ "VNIIRS" } },
-        { KLV_1108_METRIC_SET_VERSION, std::string{} },
-        { KLV_1108_METRIC_SET_IMPLEMENTER,
-          klv_1108_kwiver_metric_implementer() },
-        { KLV_1108_METRIC_SET_PARAMETERS, std::string{} },
-        { KLV_1108_METRIC_SET_VALUE, klv_lengthy< double >{ 5.0 } } } },
-      { KLV_1108_COMPRESSION_TYPE, KLV_1108_COMPRESSION_TYPE_H264 },
-      { KLV_1108_COMPRESSION_PROFILE, KLV_1108_COMPRESSION_PROFILE_MAIN },
-      { KLV_1108_COMPRESSION_LEVEL, std::string{ "4.1" } },
-      { KLV_1108_COMPRESSION_RATIO, klv_lengthy< double >{ 1327.104 } },
-      { KLV_1108_STREAM_BITRATE, uint64_t{ 500 } },
-      { KLV_1108_DOCUMENT_VERSION, uint64_t{ 3 } } } } } };
+  std::vector< klv_packet > expected_klv {
+    metric_klv( { 1, 33333 }, 12.0, 5.0 )
+  };
 
   EXPECT_EQ( expected_klv, output_klv );
+}
+
+// ----------------------------------------------------------------------------
+// Adding in a new ST1108 packet.
+TEST_F ( update_klv_fixture, add_st1108_with_sample_delay )
+{
+  auto config = filter.get_configuration();
+  config->set_value< size_t >( "st1108_frequency", 3 );
+  config->set_value< std::string >( "st1108_inter", "sample" );
+  filter.set_configuration( config );
+
+  filter.send( { metric_metadata( 1, 12.0, 5.0 ) }, nullptr );
+  filter.send( { metric_metadata( 33334, 13.0, 6.0 ) }, nullptr );
+  filter.send( { metric_metadata( 66667, 14.0, 7.0 ) }, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 3, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( 2, filter.available_frames() );
+  ASSERT_EQ( 1, output.size() );
+
+  auto output_klv =
+    dynamic_cast< klv_metadata const& >( *output[ 0 ] ).klv();
+  ASSERT_EQ( 1, output_klv.size() );
+
+  CALL_TEST( check_metric_times, output_klv[ 0 ].value.get< klv_local_set >() );
+
+  std::vector< klv_packet > expected_klv{
+    metric_klv( { 1, 33333 }, 12.0, 5.0 )
+  };
+
+  EXPECT_EQ( expected_klv, output_klv );
+
+  CALL_TEST( expect_empty_frames, 2 );
+}
+
+// ----------------------------------------------------------------------------
+// Adding in a new ST1108 packet.
+TEST_F ( update_klv_fixture, add_st1108_with_sample_smear_delay )
+{
+  auto config = filter.get_configuration();
+  config->set_value< size_t >( "st1108_frequency", 3 );
+  config->set_value< std::string >( "st1108_inter", "sample_smear" );
+  filter.set_configuration( config );
+
+  filter.send( { metric_metadata( 1, 12.0, 5.0 ) }, nullptr );
+  filter.send( { metric_metadata( 33334, 13.0, 6.0 ) }, nullptr );
+  filter.send( { metric_metadata( 66667, 14.0, 7.0 ) }, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 3, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( 2, filter.available_frames() );
+  ASSERT_EQ( 1, output.size() );
+
+  auto output_klv =
+    dynamic_cast< klv_metadata const& >( *output[ 0 ] ).klv();
+  ASSERT_EQ( 1, output_klv.size() );
+
+  CALL_TEST( check_metric_times, output_klv[ 0 ].value.get< klv_local_set >() );
+
+  std::vector< klv_packet > expected_klv{
+    metric_klv( { 1, 99999 }, 12.0, 5.0 )
+  };
+
+  EXPECT_EQ( expected_klv, output_klv );
+
+  CALL_TEST( expect_empty_frames, 2 );
+}
+
+// ----------------------------------------------------------------------------
+// Adding in a new ST1108 packet.
+TEST_F ( update_klv_fixture, add_st1108_with_mean_delay )
+{
+  auto config = filter.get_configuration();
+  config->set_value< size_t >( "st1108_frequency", 3 );
+  config->set_value< std::string >( "st1108_inter", "mean" );
+  filter.set_configuration( config );
+
+  filter.send( { metric_metadata( 1, 12.0, 5.0 ) }, nullptr );
+  filter.send( { metric_metadata( 33334, 13.0, 6.0 ) }, nullptr );
+  filter.send( { metric_metadata( 66667, 17.0, 10.0 ) }, nullptr );
+  EXPECT_EQ( 0, filter.unavailable_frames() );
+  EXPECT_EQ( 3, filter.available_frames() );
+
+  auto const output = filter.receive();
+  EXPECT_EQ( 2, filter.available_frames() );
+  ASSERT_EQ( 1, output.size() );
+
+  auto output_klv =
+    dynamic_cast< klv_metadata const& >( *output[ 0 ] ).klv();
+  ASSERT_EQ( 1, output_klv.size() );
+
+  CALL_TEST( check_metric_times, output_klv[ 0 ].value.get< klv_local_set >() );
+
+  std::vector< klv_packet > expected_klv{
+    metric_klv( { 1, 99999 }, 14.0, 7.0 )
+  };
+
+  EXPECT_EQ( expected_klv, output_klv );
+
+  CALL_TEST( expect_empty_frames, 2 );
 }

--- a/arrows/klv/update_klv.cxx
+++ b/arrows/klv/update_klv.cxx
@@ -15,6 +15,9 @@
 #include <arrows/klv/klv_1108_metric_set.h>
 #include <arrows/klv/misp_time.h>
 
+#include <vital/range/iterator_range.h>
+
+#include <list>
 #include <optional>
 
 namespace kwiver {
@@ -27,6 +30,9 @@ namespace klv {
 class update_klv::impl
 {
 public:
+  using st1108_buffer_t = std::list< std::vector< klv_packet > >;
+  using md_buffer_t = std::list< vital::metadata_vector >;
+
   struct stream
   {
     stream();
@@ -37,6 +43,7 @@ public:
 
     klv_timeline timeline;
     klv_demuxer demuxer;
+    st1108_buffer_t st1108_buffer;
   };
 
   impl();
@@ -48,20 +55,32 @@ public:
     vital::metadata const& present_data,
     uint64_t timestamp );
 
+  void combine_1108_packets( st1108_buffer_t& packet_frames, size_t count );
+
+  void flush( size_t count );
+
   std::map< int, std::unique_ptr< stream > > streams;
+  md_buffer_t in_buffer;
+  md_buffer_t out_buffer;
+
+  size_t st1108_frequency;
+  std::string st1108_inter;
 };
 
 // ----------------------------------------------------------------------------
 update_klv::impl::stream
 ::stream()
   : timeline{},
-    demuxer{ timeline }
+    demuxer{ timeline },
+    st1108_buffer{}
 {}
 
 // ----------------------------------------------------------------------------
 update_klv::impl
 ::impl()
- : streams{}
+ : streams{},
+   st1108_frequency{ 1 },
+   st1108_inter{ "sample" }
 {}
 
 // ----------------------------------------------------------------------------
@@ -117,14 +136,21 @@ update_klv::impl
       continue;
     }
 
+    // Determine strings describing each metric
     std::string metric_name;
+    std::string version;
+    std::string parameters;
     switch( vital_tag )
     {
       case vital::VITAL_META_AVERAGE_GSD:
         metric_name = "GSD";
+        version = "";
+        parameters = "Geo. mean of horiz. and vert. GSD of central pixel";
         break;
       case vital::VITAL_META_VNIIRS:
         metric_name = "VNIIRS";
+        version = "GIQE5";
+        parameters = "Terms a0, a1 only";
         break;
       default:
         break;
@@ -135,13 +161,12 @@ update_klv::impl
       static_cast< uint64_t >( klv::misp_microseconds_now().count() );
 
     // Package up this metric's info
-    // TODO: What to put for version and parameters?
     klv_local_set metric_set{
       { KLV_1108_METRIC_SET_NAME, metric_name },
-      { KLV_1108_METRIC_SET_VERSION, std::string{} },
+      { KLV_1108_METRIC_SET_VERSION, version },
       { KLV_1108_METRIC_SET_IMPLEMENTER,
         klv_1108_kwiver_metric_implementer() },
-      { KLV_1108_METRIC_SET_PARAMETERS, std::string{} },
+      { KLV_1108_METRIC_SET_PARAMETERS, parameters },
       { KLV_1108_METRIC_SET_TIME, metric_time },
       { KLV_1108_METRIC_SET_VALUE,
         klv_lengthy< double >{ present_entry.as_double(), 8 } }
@@ -161,6 +186,215 @@ update_klv::impl
 }
 
 // ----------------------------------------------------------------------------
+void
+update_klv::impl
+::combine_1108_packets( st1108_buffer_t& packet_frames, size_t count )
+{
+  if( !count )
+  {
+    return;
+  }
+
+  // Sanity check
+  if( packet_frames.size() < count )
+  {
+    throw std::logic_error( "Cannot combine more packets than exist" );
+  }
+
+  // Count off the right number of packets
+  vital::range::iterator_range< st1108_buffer_t::iterator > const frame_range{
+    packet_frames.begin(), std::next( packet_frames.begin(), count ) };
+
+  // Initialize the metric averaging data
+  std::map< klv_local_set, std::pair< double, size_t > > means;
+  std::map< klv_local_set, uint64_t > metric_times;
+  if( st1108_inter == "mean" )
+  {
+    for( auto const& packet : packet_frames.front() )
+    {
+      auto const& parent_set = packet.value.get< klv_local_set >();
+      for( auto const& entry : parent_set.all_at( KLV_1108_METRIC_LOCAL_SET ) )
+      {
+        auto const index_set =
+          klv_1108_create_index_set( parent_set, entry.second );
+        auto const& metric_set = entry.second.get< klv_local_set >();
+
+        // Set initial value
+        auto const value =
+          metric_set
+          .at( KLV_1108_METRIC_SET_VALUE )
+          .get< klv_lengthy< double > >()
+          .value;
+        means.emplace( index_set, std::make_pair( value, 1 ) );
+
+        // Set initial metric calculation timestamp
+        auto const timestamp =
+          metric_set
+          .at( KLV_1108_METRIC_SET_TIME )
+          .get< uint64_t >();
+        metric_times.emplace( index_set, timestamp );
+      }
+    }
+  }
+
+  // Determine the range of time this group of frames spans
+  uint64_t end_timestamp = 0;
+  if( st1108_inter != "sample" )
+  {
+    for( auto const& packet_frame : frame_range )
+    {
+      for( auto const& packet : packet_frame )
+      {
+        auto const& period_pack =
+          packet.value
+          .get< klv_local_set >()
+          .at( KLV_1108_METRIC_PERIOD_PACK )
+          .get< klv_1108_metric_period_pack >();
+        end_timestamp =
+          std::max( end_timestamp, period_pack.timestamp + period_pack.offset );
+      }
+    }
+  }
+
+  // Accumulate the metric averaging data, clearing as we go
+  for( auto it = std::next( frame_range.begin() );
+       it != frame_range.end(); ++it )
+  {
+    if( st1108_inter == "mean" )
+    {
+      for( auto const& packet : *it )
+      {
+        auto const& parent_set = packet.value.get< klv_local_set >();
+        for( auto const& entry :
+             parent_set.all_at( KLV_1108_METRIC_LOCAL_SET ) )
+        {
+          auto const index_set =
+            klv_1108_create_index_set( parent_set, entry.second );
+          auto const& metric_set = entry.second.get< klv_local_set >();
+
+          // Update the value averaging data
+          auto const value =
+            metric_set
+            .at( KLV_1108_METRIC_SET_VALUE )
+            .get< klv_lengthy< double > >()
+            .value;
+          auto const jt =
+            means.emplace( index_set, std::make_pair( 0.0, 0 ) ).first;
+          jt->second.first += value;
+          ++jt->second.second;
+
+          // Update the calculation timestamp
+          auto const timestamp =
+            metric_set
+            .at( KLV_1108_METRIC_SET_TIME )
+            .get< uint64_t >();
+          auto const result = metric_times.emplace( index_set, timestamp );
+          if( !result.second )
+          {
+            result.first->second = std::max( timestamp, result.first->second );
+          }
+        }
+      }
+    }
+    it->clear();
+  }
+
+  // Modify the first frame's packets as appropriate
+  for( auto& packet : packet_frames.front() )
+  {
+    // Set the timestamp to cover the whole time period
+    if( st1108_inter != "sample" )
+    {
+      auto& period_pack =
+        packet.value
+        .get< klv_local_set >()
+        .at( KLV_1108_METRIC_PERIOD_PACK )
+        .get< klv_1108_metric_period_pack >();
+      period_pack.offset = end_timestamp - period_pack.timestamp;
+    }
+
+    // Set each metrics to the average value
+    if( st1108_inter == "mean" )
+    {
+      auto& parent_set = packet.value.get< klv_local_set >();
+
+      // We need to clear and then re-create all metric sets in the first frame,
+      // in case there are metrics that exist in other frames that don't in the
+      // first frame
+      parent_set.erase( KLV_1108_METRIC_LOCAL_SET );
+      for( auto const& entry : means )
+      {
+        auto metric_set =
+          entry.first.at( KLV_1108_METRIC_LOCAL_SET ).get< klv_local_set >();
+
+        // Add metric calculation timestamp
+        metric_set.add(
+          KLV_1108_METRIC_SET_TIME, metric_times.at( entry.first ) );
+
+        // Add average metric value
+        auto const mean = entry.second.first / entry.second.second;
+        metric_set.add(
+          KLV_1108_METRIC_SET_VALUE, klv_lengthy< double >{ mean, 8 } );
+
+        parent_set.add( KLV_1108_METRIC_LOCAL_SET, std::move( metric_set ) );
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+update_klv::impl
+::flush( size_t count )
+{
+  // Combine all the packets in each stream
+  for( auto& entry : streams )
+  {
+    combine_1108_packets( entry.second->st1108_buffer, count );
+  }
+
+  // Collect all the packets from all the streams and put them in the right
+  // metadata objects for each frame
+  for( size_t i = 0; i < count; ++i )
+  {
+    for( auto& entry : streams )
+    {
+      for( auto& md : in_buffer.front() )
+      {
+        auto const stream_index =
+          md->find( vital::VITAL_META_VIDEO_DATA_STREAM_INDEX ).get< int >();
+        if( stream_index != entry.first )
+        {
+          continue;
+        }
+
+        auto const klv_md = dynamic_cast< klv_metadata* >( md.get() );
+        if( !klv_md )
+        {
+          continue;
+        }
+
+        // Found the metadata object that corresponds to this stream on this
+        // frame; put the packets inside
+        auto& packets = entry.second->st1108_buffer.front();
+        klv_md->klv().insert(
+          klv_md->klv().end(),
+          std::make_move_iterator( packets.begin() ),
+          std::make_move_iterator( packets.end() ) );
+
+        break;
+      }
+
+      // Delete packet storage
+      entry.second->st1108_buffer.pop_front();
+    }
+
+    // Mark this frame's metadata as finished
+    out_buffer.splice( out_buffer.end(), in_buffer, in_buffer.begin() );
+  }
+}
+
+// ----------------------------------------------------------------------------
 update_klv
 ::update_klv()
   : d{ new impl }
@@ -176,7 +410,26 @@ vital::config_block_sptr
 update_klv
 ::get_configuration() const
 {
-  return algorithm::get_configuration();
+  auto config = algorithm::get_configuration();
+
+  config->set_value(
+    "st1108_frequency", d->st1108_frequency,
+    "How often (in frames) to encode a ST1108 packet." );
+  config->set_value(
+    "st1108_inter", d->st1108_inter,
+    "How to deal with a group of multiple frames when st1108_frequency > 1. "
+
+    "'sample' will create a packet with the metric values of the first frame "
+    "of the group and associate it with the first frame only, leaving the rest "
+    "of the frames in the group with no associated values. "
+
+    "'sample_smear' will create a packet with the metric values of the first "
+    "frame of the group and associate it with all frames in the group. "
+
+    "'mean' will create a packet with the averages of the group's metric "
+    "values and associate it with all frames in the group." );
+
+  return config;
 }
 
 // ----------------------------------------------------------------------------
@@ -185,6 +438,11 @@ update_klv
 ::set_configuration( vital::config_block_sptr config )
 {
   auto existing_config = algorithm::get_configuration();
+  d->st1108_frequency =
+    config->get_value< size_t >( "st1108_frequency", 1 );
+  d->st1108_inter =
+    config->get_value< std::string >( "st1108_inter", "sample" );
+
   existing_config->merge_config( config );
 }
 
@@ -193,33 +451,35 @@ bool
 update_klv
 ::check_configuration( VITAL_UNUSED vital::config_block_sptr config ) const
 {
-  return true;
+  static std::set< std::string > st1108_inter_options{
+    "sample", "sample_smear", "mean"
+  };
+  return st1108_inter_options.count(
+    config->get_value< std::string >( "st1108_inter", "sample" ) );
 }
 
 // ----------------------------------------------------------------------------
-vital::metadata_vector
+size_t
 update_klv
-::filter(
+::send(
   vital::metadata_vector const& input_metadata,
   VITAL_UNUSED vital::image_container_scptr const& input_image )
 {
-  vital::metadata_vector results;
-  for( auto const& src_md : input_metadata )
+  auto& metadata = d->in_buffer.emplace_back();
+  for( auto const& input_md : input_metadata )
   {
-    // Case: null
-    if( !src_md )
+    // Copy input metadata
+    if ( !input_md )
     {
-      results.emplace_back( nullptr );
+      metadata.emplace_back( nullptr );
       continue;
     }
+    auto& md = *metadata.emplace_back( input_md->clone() );
 
-    // Deep copy
-    results.emplace_back( src_md->clone() );
-
-    // Case: no KLV
-    auto const klv_md = dynamic_cast< klv_metadata* >( results.back().get() );
+    auto const klv_md = dynamic_cast< klv_metadata* >( &md );
     if( !klv_md )
     {
+      // No KLV
       continue;
     }
 
@@ -260,13 +520,67 @@ update_klv
       klv_to_vital_metadata( stream.timeline, timestamp );
 
     // Add any new ST1108 packets
-    auto const new_1108_packets =
-      d->create_1108_packets( *derived_md, *results.back(), timestamp );
-    klv_md->klv().insert(
-      klv_md->klv().end(), new_1108_packets.begin(), new_1108_packets.end() );
+    stream.st1108_buffer.emplace_back(
+      d->create_1108_packets( *derived_md, md, timestamp ) );
   }
 
-  return results;
+  // Fill streams with empty frames if they didn't have any associated metadata
+  for( auto& stream : d->streams )
+  {
+    while( stream.second->st1108_buffer.size() < d->in_buffer.size() )
+    {
+      stream.second->st1108_buffer.emplace_back();
+    }
+  }
+
+  // Process the batched frames
+  if( d->in_buffer.size() >= d->st1108_frequency )
+  {
+    d->flush( d->st1108_frequency );
+  }
+
+  return available_frames();
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+update_klv
+::receive()
+{
+  if( d->out_buffer.empty() )
+  {
+    throw std::runtime_error(
+      "update_klv: receive() called with no available frames" );
+  }
+
+  auto result = std::move( d->out_buffer.front() );
+  d->out_buffer.pop_front();
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+size_t
+update_klv
+::flush()
+{
+  d->flush( d->in_buffer.size() );
+  return available_frames();
+}
+
+// ----------------------------------------------------------------------------
+size_t
+update_klv
+::available_frames() const
+{
+  return d->out_buffer.size();
+}
+
+// ----------------------------------------------------------------------------
+size_t
+update_klv
+::unavailable_frames() const
+{
+  return d->in_buffer.size();
 }
 
 } // namespace klv

--- a/arrows/klv/update_klv.h
+++ b/arrows/klv/update_klv.h
@@ -7,7 +7,7 @@
 
 #include <arrows/klv/kwiver_algo_klv_export.h>
 
-#include <vital/algo/metadata_filter.h>
+#include <vital/algo/buffered_metadata_filter.h>
 
 namespace kwiver {
 
@@ -25,7 +25,7 @@ namespace klv {
 ///   Only feed this filter a single video, in frame order. Past metadata fed
 ///   to it is used in the algorithm.
 class KWIVER_ALGO_KLV_EXPORT update_klv
-  : public vital::algo::metadata_filter
+  : public vital::algo::buffered_metadata_filter
 {
 public:
   update_klv();
@@ -38,9 +38,14 @@ public:
   void set_configuration( vital::config_block_sptr config ) override;
   bool check_configuration( vital::config_block_sptr config ) const override;
 
-  vital::metadata_vector filter(
+  size_t send(
     vital::metadata_vector const& input_metadata,
     vital::image_container_scptr const& input_image ) override;
+  vital::metadata_vector receive() override;
+  size_t flush() override;
+
+  size_t available_frames() const override;
+  size_t unavailable_frames() const override;
 
 private:
   class impl;


### PR DESCRIPTION
Currently, `update_klv` can only look at the current frame's metadata when putting GSD and VNIIRS into KLV packets. However, the ST1108 packets that these metrics go in are somewhat verbose and probably not intended to accompany each frame; that's why they include start and end timestamps. Using the new `buffered_metadata_filter`, this PR modifies `update_klv` to possibly sample or average these metrics over any number of frames, greatly reducing overhead by only encoding one ST1108 packet every `n` frames.