### PR TITLE
Add metadata_stream

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -140,6 +140,7 @@ set( vital_public_headers
   types/mesh.h
   types/metadata.h
   types/metadata_map.h
+  types/metadata_stream.h
   types/metadata_tags.h
   types/metadata_traits.h
   types/object_track_set.h
@@ -216,6 +217,7 @@ set( vital_sources
   types/local_geo_cs.cxx
   types/mesh.cxx
   types/metadata.cxx
+  types/metadata_stream.cxx
   types/metadata_traits.cxx
   types/object_track_set.cxx
   types/point.cxx

--- a/vital/types/metadata_stream.cxx
+++ b/vital/types/metadata_stream.cxx
@@ -1,0 +1,62 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of the metadata stream classes.
+
+#include <vital/types/metadata_stream.h>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+metadata_stream
+::metadata_stream()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_stream
+::~metadata_stream()
+{}
+
+// ----------------------------------------------------------------------------
+std::string
+metadata_stream
+::uri() const
+{
+  return {};
+}
+
+// ----------------------------------------------------------------------------
+config_block_sptr
+metadata_stream
+::config() const
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+metadata_istream
+::metadata_istream()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_istream
+::~metadata_istream()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_ostream
+::metadata_ostream()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_ostream
+::~metadata_ostream()
+{}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/types/metadata_stream.h
+++ b/vital/types/metadata_stream.h
@@ -1,0 +1,107 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of the metadata stream classes.
+
+#ifndef KWIVER_VITAL_METADATA_STREAM_H_
+#define KWIVER_VITAL_METADATA_STREAM_H_
+
+#include <vital/types/metadata.h>
+#include <vital/vital_export.h>
+
+#include <map>
+#include <string>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/// Base class for reading or writing metadata.
+class VITAL_EXPORT metadata_stream
+{
+public:
+  metadata_stream();
+  virtual ~metadata_stream();
+
+  /// Return the URI of the metadata stream. May be empty.
+  virtual std::string uri() const;
+
+  /// Return the configuration used when creating this stream. May be null.
+  virtual config_block_sptr config() const;
+};
+
+// ----------------------------------------------------------------------------
+/// Interface for reading sequential frames of metadata from somewhere.
+class VITAL_EXPORT metadata_istream : public metadata_stream
+{
+public:
+  metadata_istream();
+  virtual ~metadata_istream();
+
+  /// Return the current frame number.
+  ///
+  /// \throw std::invalid_argument If \c at_end() returns \c true.
+  virtual frame_id_t frame_number() const = 0;
+
+  /// Return the metadata associated with the current frame.
+  ///
+  /// \throw std::invalid_argument If \c at_end() returns \c true.
+  virtual metadata_vector metadata() = 0;
+
+  /// Proceed to the next metadata frame, returning \c true on success.
+  ///
+  /// If this function returns \c false and \c at_end() also returns \c false,
+  /// more frames are possible but not currently available, due to e.g.
+  /// network lag or buffering.
+  virtual bool next_frame() = 0;
+
+  /// Return \c true if no more frames may be read from the stream.
+  ///
+  /// A return value of \c true may be due to a true \c EOF, or to some
+  /// implementation-specific error (e.g. file corruption).
+  virtual bool at_end() const = 0;
+};
+
+// ----------------------------------------------------------------------------
+/// Interface for writing sequential frames of metadata to somewhere.
+class VITAL_EXPORT metadata_ostream : public metadata_stream
+{
+public:
+  metadata_ostream();
+  virtual ~metadata_ostream();
+
+  /// Write \p metadata to the stream, returning \c true if further metadata
+  /// can be written.
+  ///
+  /// If this function returns \c false and \c at_end() also returns \c false,
+  /// it may be possible to write more metadata at some point in the future,
+  /// but that is not currently possible due to e.g. a full output buffer.
+  ///
+  /// Any issues with \p metadata itself should be dealt with only via logging,
+  /// i.e. an invalid or unsupported \p metadata object should be ignored, no
+  /// exceptions should be thrown, and this function should return \c true as
+  /// long as future valid metadata can still be written.
+  ///
+  /// \throw std::invalid_argument If \c at_end() returns \c true.
+  virtual bool write_frame(
+    frame_id_t frame_number, metadata_vector const& metadata ) = 0;
+
+  /// Signal that no more metadata will be written to the stream.
+  virtual void write_end() = 0;
+
+  /// Return \c true if no more metadata can be written to the stream.
+  ///
+  /// A return value of \c true may be due to \c write_end() being called, or
+  /// to some implementation-specific error.
+  virtual bool at_end() const = 0;
+};
+
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
To partially address changes requested in #1733, this PR adds a `metadata_stream` interface to vital. The main differences from the existing `metadata_map` are (1) not supporting random access, and (2) having a writing interface as well as reading. Difference (1) is more positive than it might first appear, since requiring random access support means that, wherever the `metadata_map` interface is used, the metadata for an entire video is gathered in memory all at once before a task can begin. Usually this performance hit is unnecessary, since most algorithms operate in a simple forward pass over a video. Future PRs will add concrete instantiations of these interfaces.