### PR TITLE
Ensure compile-time compatibility with FFmpeg v5 API changes

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -122,12 +122,16 @@ ffmpeg_klv_stream
     return;
   }
 
-#if LIBAVFORMAT_VERSION_MAJOR > 57
+#if LIBAVCODEC_VERSION_MAJOR > 57
   // Fill in KLV profile (if not previously determined) by looking at packet
   // MPEG-TS stream identifier
   if( stream->codecpar->profile < 0 )
   {
+#if LIBAVCODEC_VERSION_MAJOR > 58
+    size_t length = 0;
+#else
     int length = 0;
+#endif
     auto const stream_id =
       av_packet_get_side_data( packet, AV_PKT_DATA_MPEGTS_STREAM_ID, &length );
     if( length )

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -60,7 +60,11 @@ public:
 
     size_t frame_count;
     format_context_uptr format_context;
+#if LIBAVFORMAT_VERSION_MAJOR > 58
+    AVOutputFormat const* output_format;
+#else
     AVOutputFormat* output_format;
+#endif
     AVStream* video_stream;
     AVStream* metadata_stream;
     codec_context_uptr codec_context;


### PR DESCRIPTION
FFmpeg v5 introduces a few small API tweaks, which are addressed here.