### PR TITLE
Adjust configure helper verbosity

### DIFF
--- a/CMake/tools/kwiver-configure-git-helper.cmake
+++ b/CMake/tools/kwiver-configure-git-helper.cmake
@@ -3,10 +3,10 @@
 # ``__SOURCE_PATH__`` and ``__TEMP_PATH__``
 #
 
-message(STATUS "Source Path       : '${__SOURCE_PATH__}'")
-message(STATUS "Intermediate Path : '${__TEMP_PATH__}'")
-message(STATUS "Output Path       : '${__OUTPUT_PATH__}'")
-message(STATUS "Project Root      : '${KWIVER_SOURCE_DIR}'")
+message(TRACE "Source Path       : '${__SOURCE_PATH__}'")
+message(TRACE "Intermediate Path : '${__TEMP_PATH__}'")
+message(TRACE "Output Path       : '${__OUTPUT_PATH__}'")
+message(VERBOSE "Project Root      : '${KWIVER_SOURCE_DIR}'")
 
 if(NOT EXISTS "${__SOURCE_PATH__}")
   message(FATAL_ERROR "Source file for configuration did not exist! -> ${__SOURCE_PATH__}")
@@ -47,10 +47,10 @@ if (Git_FOUND AND IS_DIRECTORY "${KWIVER_SOURCE_DIR}/.git")
     set(kwiver_git_dirty "dirty")
   endif ()
 
-  message(STATUS "version: ${KWIVER_VERSION}")
-  message(STATUS "git hash: ${kwiver_git_hash}")
-  message(STATUS "git short hash: ${kwiver_git_hash_short}")
-  message(STATUS "git dirty: ${kwiver_git_dirty}")
+  message(VERBOSE "version: ${KWIVER_VERSION}")
+  message(VERBOSE "git hash: ${kwiver_git_hash}")
+  message(VERBOSE "git short hash: ${kwiver_git_hash_short}")
+  message(VERBOSE "git dirty: ${kwiver_git_dirty}")
 endif ()
 
 # There are TWO configures here on purpose. The second configure containing
@@ -68,4 +68,3 @@ configure_file(
   "${__OUTPUT_PATH__}"
   COPYONLY
   )
-

--- a/CMake/tools/kwiver-configure-helper.cmake
+++ b/CMake/tools/kwiver-configure-helper.cmake
@@ -3,9 +3,9 @@
 # ``__SOURCE_PATH__`` and ``__TEMP_PATH__``
 #
 
-message(STATUS "Source Path       : '${__SOURCE_PATH__}'")
-message(STATUS "Intermediate Path : '${__TEMP_PATH__}'")
-message(STATUS "Output Path       : '${__OUTPUT_PATH__}'")
+message(TRACE "Source Path       : '${__SOURCE_PATH__}'")
+message(TRACE "Intermediate Path : '${__TEMP_PATH__}'")
+message(TRACE "Output Path       : '${__OUTPUT_PATH__}'")
 if(NOT EXISTS "${__SOURCE_PATH__}")
   message(FATAL_ERROR "Source file for configuration did not exist! -> ${__SOURCE_PATH__}")
 endif()

--- a/CMake/utils/kwiver-utils-configuration.cmake
+++ b/CMake/utils/kwiver-utils-configuration.cmake
@@ -64,6 +64,7 @@ function(kwiver_configure_file name source dest)
     OUTPUT  "${dest}"
     COMMAND "${CMAKE_COMMAND}"
             ${gen_command_args}
+            "-DCMAKE_MESSAGE_LOG_LEVEL:STRING=${CMAKE_MESSAGE_LOG_LEVEL}"
             "-D__SOURCE_PATH__:PATH=${source}"
             "-D__TEMP_PATH__:PATH=${temp_file}"
             "-D__OUTPUT_PATH__:PATH=${dest}"


### PR DESCRIPTION
This PR downgrades the verbosity classification of a few configuration messages. This does not change the default behavior (they are still printed as long as the log level is not set), but allows them to be filtered out if a user, like myself, does not need to see details of how python test files are copied every time KWIVER is built.