### PR TITLE
Add metadata_stream_from_map

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -141,6 +141,7 @@ set( vital_public_headers
   types/metadata.h
   types/metadata_map.h
   types/metadata_stream.h
+  types/metadata_stream_from_map.h
   types/metadata_tags.h
   types/metadata_traits.h
   types/object_track_set.h
@@ -218,6 +219,7 @@ set( vital_sources
   types/mesh.cxx
   types/metadata.cxx
   types/metadata_stream.cxx
+  types/metadata_stream_from_map.cxx
   types/metadata_traits.cxx
   types/object_track_set.cxx
   types/point.cxx

--- a/vital/tests/CMakeLists.txt
+++ b/vital/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ kwiver_discover_gtests(vital mesh                           LIBRARIES ${test_lib
 kwiver_discover_gtests(vital mesh_io                        LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(vital metadata                       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital metadata_io                    LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(vital metadata_stream_from_map       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital point                          LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital polygon                        LIBRARIES ${test_libraries})
 kwiver_discover_gtests(vital rotation                       LIBRARIES ${test_libraries})

--- a/vital/tests/test_metadata_stream_from_map.cxx
+++ b/vital/tests/test_metadata_stream_from_map.cxx
@@ -1,0 +1,122 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Tests for the metadata_[io]stream_from_map classes.
+
+#include <vital/types/metadata_stream_from_map.h>
+
+#include <tests/test_gtest.h>
+
+using namespace kwiver::vital;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+void
+test_istream_frame(
+  metadata_istream& is, frame_id_t frame, metadata_vector const& md )
+{
+  ASSERT_FALSE( is.at_end() );
+  EXPECT_EQ( frame, is.frame_number() );
+  EXPECT_EQ( md, is.metadata() );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_istream_at_end( metadata_istream& is )
+{
+  // Repeat in case next_frame() changes state
+  for( size_t i = 0; i < 2; ++i )
+  {
+    ASSERT_TRUE( is.at_end() );
+    EXPECT_THROW( is.frame_number(), std::invalid_argument );
+    EXPECT_THROW( is.metadata(), std::invalid_argument );
+    EXPECT_FALSE( is.next_frame() );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+test_ostream_frame(
+  metadata_ostream& os, frame_id_t frame, metadata_vector const& md )
+{
+  ASSERT_FALSE( os.at_end() );
+  ASSERT_NO_THROW( ASSERT_TRUE( os.write_frame( frame, md ) ) );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_ostream_at_end( metadata_ostream& os )
+{
+  ASSERT_TRUE( os.at_end() );
+  EXPECT_THROW( os.write_frame( 1024, {} ), std::invalid_argument );
+  ASSERT_TRUE( os.at_end() );
+  EXPECT_NO_THROW( os.write_end() );
+  ASSERT_TRUE( os.at_end() );
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST ( metadata_stream_from_map, istream_empty )
+{
+  metadata_istream_from_map::map_t map;
+  metadata_istream_from_map is{ map };
+
+  CALL_TEST( test_istream_at_end, is );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( metadata_stream_from_map, istream )
+{
+  auto const md = std::make_shared< metadata >();
+  md->add< VITAL_META_UNIX_TIMESTAMP >( 5 );
+  metadata_istream_from_map::map_t map{
+    { 1, { md } },
+    { 3, {} }, };
+  metadata_istream_from_map is{ map };
+
+  CALL_TEST( test_istream_frame, is, 1, { md } );
+  ASSERT_TRUE( is.next_frame() );
+  CALL_TEST( test_istream_frame, is, 3, {} );
+  ASSERT_FALSE( is.next_frame() );
+
+  CALL_TEST( test_istream_at_end, is );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( metadata_stream_from_map, ostream )
+{
+  auto const md = std::make_shared< metadata >();
+  md->add< VITAL_META_UNIX_TIMESTAMP >( 5 );
+  metadata_ostream_from_map::map_t map;
+  metadata_ostream_from_map os{ map };
+
+  CALL_TEST( test_ostream_frame, os, 1, { md } );
+  CALL_TEST( test_ostream_frame, os, 3, { nullptr } );
+  CALL_TEST( test_ostream_frame, os, 1, { nullptr } );
+  CALL_TEST( test_ostream_frame, os, 1, {} );
+  CALL_TEST( test_ostream_frame, os, 5, { md, md } );
+  CALL_TEST( test_ostream_frame, os, 6, {} );
+
+  os.write_end();
+  CALL_TEST( test_ostream_at_end, os );
+
+  metadata_ostream_from_map::map_t expected_map{
+    { 1, { md, nullptr } },
+    { 3, { nullptr } },
+    { 5, { md, md } },
+    { 6, {} }, };
+  EXPECT_EQ( expected_map, map );
+}

--- a/vital/types/metadata_stream_from_map.cxx
+++ b/vital/types/metadata_stream_from_map.cxx
@@ -1,0 +1,154 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Map-based implementations of the metadata_stream interfaces.
+
+#include <vital/types/metadata_stream_from_map.h>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_map
+::metadata_istream_from_map( map_t const& map )
+  : m_map{ &map }, m_it{ map.cbegin() }
+{}
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_map
+::~metadata_istream_from_map()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_map::map_t const&
+metadata_istream_from_map
+::map() const
+{
+  return *m_map;
+}
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_map::iterator_t
+metadata_istream_from_map
+::iterator() const
+{
+  return m_it;
+}
+
+// ----------------------------------------------------------------------------
+frame_id_t
+metadata_istream_from_map
+::frame_number() const
+{
+  if( at_end() )
+  {
+    throw std::invalid_argument(
+            "metadata_istream_from_map::frame_number() "
+            "called at end of stream" );
+  }
+  return m_it->first;
+}
+
+// ----------------------------------------------------------------------------
+metadata_vector
+metadata_istream_from_map
+::metadata()
+{
+  if( at_end() )
+  {
+    throw std::invalid_argument(
+            "metadata_istream_from_map::metadata() "
+            "called at end of stream" );
+  }
+  return m_it->second;
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_istream_from_map
+::next_frame()
+{
+  if( at_end() )
+  {
+    return false;
+  }
+
+  ++m_it;
+
+  return !at_end();
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_istream_from_map
+::at_end() const
+{
+  return m_it == m_map->cend();
+}
+
+// ----------------------------------------------------------------------------
+metadata_ostream_from_map
+::metadata_ostream_from_map( map_t& map )
+  : m_map{ &map }, m_at_end{ false }
+{}
+
+// ----------------------------------------------------------------------------
+metadata_ostream_from_map
+::~metadata_ostream_from_map()
+{}
+
+// ----------------------------------------------------------------------------
+metadata_ostream_from_map::map_t&
+metadata_ostream_from_map
+::map() const
+{
+  return *m_map;
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_ostream_from_map
+::write_frame( frame_id_t frame_number, metadata_vector const& metadata )
+{
+  if( at_end() )
+  {
+    throw std::invalid_argument(
+            "metadata_ostream_from_map::write_frame() "
+            "called at end of stream" );
+  }
+
+  auto const it = m_map->find( frame_number );
+  if( it == m_map->end() )
+  {
+    m_map->emplace( frame_number, metadata );
+  }
+  else
+  {
+    it->second.insert( it->second.end(), metadata.begin(), metadata.end() );
+  }
+
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+void
+metadata_ostream_from_map
+::write_end()
+{
+  m_at_end = true;
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_ostream_from_map
+::at_end() const
+{
+  return m_at_end;
+}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/types/metadata_stream_from_map.h
+++ b/vital/types/metadata_stream_from_map.h
@@ -1,0 +1,82 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Map-based implementations of the metadata_stream interfaces.
+
+#ifndef KWIVER_VITAL_METADATA_STREAM_FROM_MAP_H_
+#define KWIVER_VITAL_METADATA_STREAM_FROM_MAP_H_
+
+#include <vital/types/metadata_stream.h>
+
+#include <map>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/// Stream that reads from an in-memory map that it does not own.
+class VITAL_EXPORT metadata_istream_from_map : public metadata_istream
+{
+public:
+  using map_t = std::map< frame_id_t, metadata_vector >;
+  using iterator_t = map_t::const_iterator;
+
+  /// \param map Map object to read from sequentially.
+  ///
+  /// \warning
+  ///   The caller is responsible for managing the lifetime of \p map, which
+  ///   this object only stores a pointer to.
+  explicit metadata_istream_from_map( map_t const& map );
+
+  virtual ~metadata_istream_from_map();
+
+  map_t const& map() const;
+  iterator_t iterator() const;
+
+  frame_id_t frame_number() const override;
+  metadata_vector metadata() override;
+  bool next_frame() override;
+  bool at_end() const override;
+
+private:
+  map_t const* m_map;
+  iterator_t m_it;
+};
+
+// ----------------------------------------------------------------------------
+/// Stream that writes to an in-memory map that it does not own.
+class VITAL_EXPORT metadata_ostream_from_map : public metadata_ostream
+{
+public:
+  using map_t = std::map< frame_id_t, metadata_vector >;
+  using iterator_t = map_t::iterator;
+
+  /// \param map Map object to write to sequentially.
+  ///
+  /// \warning
+  ///   The caller is responsible for managing the lifetime of \p map, which
+  ///   this object only stores a pointer to.
+  explicit metadata_ostream_from_map( map_t& map );
+
+  virtual ~metadata_ostream_from_map();
+
+  map_t& map() const;
+
+  bool write_frame(
+    frame_id_t frame_number, metadata_vector const& metadata ) override;
+  void write_end() override;
+  bool at_end() const override;
+
+private:
+  map_t* m_map;
+  bool m_at_end;
+};
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
This PR adds a simple implementation of the `metadata_stream` interfaces for reading from or writing to an in-memory map.