### PR TITLE
Add metadata_istream_from_video

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -41,6 +41,7 @@ set( plugin_core_headers
   mesh_intersect.h
   mesh_operations.h
   metadata_map_io_csv.h
+  metadata_stream_from_video.h
   read_object_track_set_kw18.h
   read_track_descriptor_set_csv.h
   render_mesh_depth_map.h
@@ -116,6 +117,7 @@ set( plugin_core_sources
   mesh_intersect.cxx
   mesh_operations.cxx
   metadata_map_io_csv.cxx
+  metadata_stream_from_video.cxx
   read_object_track_set_kw18.cxx
   read_track_descriptor_set_csv.cxx
   render_mesh_depth_map.cxx

--- a/arrows/core/metadata_stream_from_video.cxx
+++ b/arrows/core/metadata_stream_from_video.cxx
@@ -1,0 +1,94 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Video-based implementations of the metadata_stream interfaces.
+
+#include <arrows/core/metadata_stream_from_video.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_video
+::metadata_istream_from_video( vital::algo::video_input& video )
+  : m_video{ &video }
+{
+  // If the video input has not been stepped yet, we should move it to the
+  // first frame
+  if( !m_video->good() && !m_video->end_of_video() )
+  {
+    vital::timestamp ts;
+    m_video->next_frame( ts );
+  }
+}
+
+// ----------------------------------------------------------------------------
+metadata_istream_from_video
+::~metadata_istream_from_video()
+{}
+
+// ----------------------------------------------------------------------------
+vital::algo::video_input&
+metadata_istream_from_video
+::video() const
+{
+  return *m_video;
+}
+
+// ----------------------------------------------------------------------------
+vital::frame_id_t
+metadata_istream_from_video
+::frame_number() const
+{
+  if( at_end() )
+  {
+    throw std::invalid_argument(
+            "metadata_istream_from_video::frame_number() "
+            "called at end of stream" );
+  }
+
+  auto const timestamp = m_video->frame_timestamp();
+  return timestamp.has_valid_frame() ? timestamp.get_frame() : 0;
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+metadata_istream_from_video
+::metadata()
+{
+  if( at_end() )
+  {
+    throw std::invalid_argument(
+            "metadata_istream_from_video::metadata() "
+            "called at end of stream" );
+  }
+  return m_video->frame_metadata();
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_istream_from_video
+::next_frame()
+{
+  vital::timestamp ts;
+  return m_video->next_frame( ts );
+}
+
+// ----------------------------------------------------------------------------
+bool
+metadata_istream_from_video
+::at_end() const
+{
+  return !m_video->good();
+}
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/metadata_stream_from_video.h
+++ b/arrows/core/metadata_stream_from_video.h
@@ -1,0 +1,50 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Video-based implementations of the metadata_stream interfaces.
+
+#ifndef KWIVER_ARROWS_CORE_METADATA_STREAM_FROM_VIDEO_H_
+#define KWIVER_ARROWS_CORE_METADATA_STREAM_FROM_VIDEO_H_
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/algo/video_input.h>
+#include <vital/types/metadata_stream.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+// ----------------------------------------------------------------------------
+/// Stream that reads from a \c video_input.
+class KWIVER_ALGO_CORE_EXPORT metadata_istream_from_video
+  : public vital::metadata_istream
+{
+public:
+  /// \param video
+  ///   Video object to read frames of metadata from. Must already be open.
+  explicit metadata_istream_from_video( vital::algo::video_input& video );
+  virtual ~metadata_istream_from_video();
+
+  vital::algo::video_input& video() const;
+
+  vital::frame_id_t frame_number() const override;
+  vital::metadata_vector metadata() override;
+  bool next_frame() override;
+  bool at_end() const override;
+
+private:
+  vital::algo::video_input* m_video;
+};
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ kwiver_discover_gtests(core feature_descriptor_io     LIBRARIES ${test_libraries
 kwiver_discover_gtests(core interpolate_track_spline  LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core mesh_intersect            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core mesh_operations           LIBRARIES ${test_libraries})
+kwiver_discover_gtests(core metadata_stream_from_video
+                                                      LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core render_mesh_depth_map     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core track_set_impl            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core transfer_bbox_with_depth_map

--- a/arrows/core/tests/test_metadata_stream_from_video.cxx
+++ b/arrows/core/tests/test_metadata_stream_from_video.cxx
@@ -1,0 +1,149 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Tests for the metadata_[io]stream_from_map classes.
+
+#include <arrows/core/metadata_stream_from_video.h>
+
+#include <vital/tests/test_metadata_stream.h>
+
+using namespace kwiver::arrows::core;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+class mock_video_input : public algo::video_input
+{
+public:
+  mock_video_input( metadata_map::map_metadata_t const& map )
+    : m_metadata{ map }, m_it{ m_metadata.begin() }, m_good{ false }
+  {}
+
+  void
+  open( std::string ) override {}
+
+  void
+  close() override { m_good = false; }
+
+  bool
+  end_of_video() const override { return m_it == m_metadata.end(); }
+
+  bool
+  good() const override { return m_good; }
+
+  bool
+  seekable() const override { return false; }
+
+  size_t
+  num_frames() const override { return 0; }
+
+  bool
+  next_frame( timestamp& ts, uint32_t = 0 ) override
+  {
+    if( end_of_video() )
+    {
+      return false;
+    }
+
+    if( !m_good )
+    {
+      m_good = true;
+    }
+    else
+    {
+      ++m_it;
+    }
+    ts.set_invalid();
+    if( end_of_video() )
+    {
+      m_good = false;
+      return false;
+    }
+    ts.set_frame( m_it->first );
+    return true;
+  }
+
+  bool
+  seek_frame( timestamp&, frame_id_t, uint32_t = 0 ) override
+  {
+    return false;
+  }
+
+  timestamp
+  frame_timestamp() const
+  {
+    timestamp ts;
+    if( good() )
+    {
+      ts.set_frame( m_it->first );
+    }
+    return ts;
+  }
+
+  image_container_sptr
+  frame_image() override { return nullptr; }
+
+  metadata_vector
+  frame_metadata() override
+  {
+    return good() ? m_it->second : metadata_vector{};
+  }
+
+  metadata_map_sptr
+  metadata_map() override { return nullptr; }
+
+  void
+  set_configuration( config_block_sptr ) override {}
+
+  bool
+  check_configuration( config_block_sptr ) const override { return true; }
+
+private:
+  metadata_map::map_metadata_t m_metadata;
+  metadata_map::map_metadata_t::const_iterator m_it;
+  bool m_good;
+};
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST ( metadata_stream_from_video, istream_empty )
+{
+  metadata_map::map_metadata_t map;
+  mock_video_input video{ map };
+  video.open( "" );
+  metadata_istream_from_video is{ video };
+
+  CALL_TEST( test_istream_at_end, is );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( metadata_stream_from_video, istream )
+{
+  auto const md = std::make_shared< metadata >();
+  md->add< VITAL_META_UNIX_TIMESTAMP >( 5 );
+  metadata_map::map_metadata_t map{
+    { 1, { md } },
+    { 4, { nullptr, md, md } } };
+  mock_video_input video{ map };
+  video.open( "" );
+  metadata_istream_from_video is{ video };
+
+  CALL_TEST( test_istream_frame, is, 1, { md } );
+  ASSERT_TRUE( is.next_frame() );
+  CALL_TEST( test_istream_frame, is, 4, { nullptr, md, md } );
+  ASSERT_FALSE( is.next_frame() );
+
+  CALL_TEST( test_istream_at_end, is );
+}

--- a/vital/tests/test_metadata_stream.h
+++ b/vital/tests/test_metadata_stream.h
@@ -1,0 +1,60 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test utilities for metadata_[io]stream implementations.
+
+#include <vital/types/metadata_stream.h>
+
+#include <tests/test_gtest.h>
+
+using namespace kwiver::vital;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+void
+test_istream_frame(
+  metadata_istream& is, frame_id_t frame, metadata_vector const& md )
+{
+  ASSERT_FALSE( is.at_end() );
+  EXPECT_EQ( frame, is.frame_number() );
+  EXPECT_EQ( md, is.metadata() );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_istream_at_end( metadata_istream& is )
+{
+  // Repeat in case next_frame() changes state
+  for( size_t i = 0; i < 2; ++i )
+  {
+    ASSERT_TRUE( is.at_end() );
+    EXPECT_THROW( is.frame_number(), std::invalid_argument );
+    EXPECT_THROW( is.metadata(), std::invalid_argument );
+    EXPECT_FALSE( is.next_frame() );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+test_ostream_frame(
+  metadata_ostream& os, frame_id_t frame, metadata_vector const& md )
+{
+  ASSERT_FALSE( os.at_end() );
+  ASSERT_NO_THROW( ASSERT_TRUE( os.write_frame( frame, md ) ) );
+}
+
+// ----------------------------------------------------------------------------
+void
+test_ostream_at_end( metadata_ostream& os )
+{
+  ASSERT_TRUE( os.at_end() );
+  EXPECT_THROW( os.write_frame( 1024, {} ), std::invalid_argument );
+  ASSERT_TRUE( os.at_end() );
+  EXPECT_NO_THROW( os.write_end() );
+  ASSERT_TRUE( os.at_end() );
+}
+
+} // namespace <anonymous>

--- a/vital/tests/test_metadata_stream_from_map.cxx
+++ b/vital/tests/test_metadata_stream_from_map.cxx
@@ -5,59 +5,8 @@
 /// \file
 /// Tests for the metadata_[io]stream_from_map classes.
 
+#include <vital/tests/test_metadata_stream.h>
 #include <vital/types/metadata_stream_from_map.h>
-
-#include <tests/test_gtest.h>
-
-using namespace kwiver::vital;
-
-namespace {
-
-// ----------------------------------------------------------------------------
-void
-test_istream_frame(
-  metadata_istream& is, frame_id_t frame, metadata_vector const& md )
-{
-  ASSERT_FALSE( is.at_end() );
-  EXPECT_EQ( frame, is.frame_number() );
-  EXPECT_EQ( md, is.metadata() );
-}
-
-// ----------------------------------------------------------------------------
-void
-test_istream_at_end( metadata_istream& is )
-{
-  // Repeat in case next_frame() changes state
-  for( size_t i = 0; i < 2; ++i )
-  {
-    ASSERT_TRUE( is.at_end() );
-    EXPECT_THROW( is.frame_number(), std::invalid_argument );
-    EXPECT_THROW( is.metadata(), std::invalid_argument );
-    EXPECT_FALSE( is.next_frame() );
-  }
-}
-
-// ----------------------------------------------------------------------------
-void
-test_ostream_frame(
-  metadata_ostream& os, frame_id_t frame, metadata_vector const& md )
-{
-  ASSERT_FALSE( os.at_end() );
-  ASSERT_NO_THROW( ASSERT_TRUE( os.write_frame( frame, md ) ) );
-}
-
-// ----------------------------------------------------------------------------
-void
-test_ostream_at_end( metadata_ostream& os )
-{
-  ASSERT_TRUE( os.at_end() );
-  EXPECT_THROW( os.write_frame( 1024, {} ), std::invalid_argument );
-  ASSERT_TRUE( os.at_end() );
-  EXPECT_NO_THROW( os.write_end() );
-  ASSERT_TRUE( os.at_end() );
-}
-
-} // namespace <anonymous>
 
 // ----------------------------------------------------------------------------
 int


### PR DESCRIPTION
This PR adds an implementation of `metadata_istream` which reads the metadata frames from a video.