### PR TITLE
Incorporate codecs into klv_string_format

### DIFF
--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -17,6 +17,7 @@ set( sources
   klv_packet.cxx
   klv_read_write.cxx
   klv_set.cxx
+  klv_string.cxx
   klv_tag_traits.cxx
   klv_timeline.cxx
   klv_unimplemented.cxx
@@ -76,6 +77,7 @@ set( public_headers
   klv_read_write.h
   klv_series.h
   klv_set.h
+  klv_string.h
   klv_timeline.h
   klv_types.h
   klv_unimplemented.h

--- a/arrows/klv/klv_0102.cxx
+++ b/arrows/klv/klv_0102.cxx
@@ -7,6 +7,8 @@
 
 #include "klv_0102.h"
 
+#include <arrows/klv/klv_string.h>
+
 namespace kwiver {
 
 namespace arrows {
@@ -52,13 +54,13 @@ klv_0102_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0102_CLASSIFYING_COUNTRY ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Classifying Country",
       "Country providing the security classification, preceded by '//'.",
       1 },
     { {},
       ENUM_AND_NAME( KLV_0102_SCI_SHI_INFORMATION ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "SCI / SHI Information",
       "Sensitive compartmented information or special handling instructions. "
       "Multiple digraphs, trigraphs, or compartment names are separated by "
@@ -66,47 +68,47 @@ klv_0102_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_CAVEATS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Caveats",
       "Pertinent caveats or code words from each category of the appropriate "
       "security entity register. May be abbreviated or spelled out.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_RELEASING_INSTRUCTIONS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Releasing Instructions",
       "List of country codes, separated by blank spaces, indicating the "
       "countries to which the Motion Imagery is releasable.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_CLASSIFIED_BY ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Classified By",
       "Name and type of authority used to classify the Motion Imagery.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_DERIVED_FROM ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Derived From",
       "Information about the original source of data from which "
       "classification was derived.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_CLASSIFICATION_REASON ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Classification Reason",
       "Reason for classification of the Motion Imagery, or citation from a "
       "document.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_DECLASSIFICATION_DATE ),
-      std::make_shared< klv_string_format >( 8 ),
+      std::make_shared< klv_ascii_format >( 8 ),
       "Declassification Date",
       "Date when the classified material may be automatically declassified",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_CLASSIFICATION_AND_MARKING_SYSTEM ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Classification and Marking System",
       "Classification or marking system used in this set as determined by the "
       "appropriate security entity for the country originating the data.",
@@ -120,14 +122,14 @@ klv_0102_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0102_OBJECT_COUNTRY_CODES ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_16_format >(),
       "Object Country Codes",
       "Country or countries which are the object of the Motion Imagery, "
       "separated the ';' character.",
       1 },
     { {},
       ENUM_AND_NAME( KLV_0102_CLASSIFICATION_COMMENTS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Classification Comments",
       "Security related comments and future format changes.",
       { 0, 1 } },
@@ -183,7 +185,7 @@ klv_0102_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0102_COUNTRY_CODING_METHOD_VERSION_DATE ),
-      std::make_shared< klv_string_format >( 10 ),
+      std::make_shared< klv_ascii_format >( 10 ),
       "Country Coding Method for 'Classifying Country' and "
       "'Releasing Instructions' Version Date",
       "Effective date of the source standard defining the country coding "
@@ -192,7 +194,7 @@ klv_0102_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0102_OBJECT_COUNTRY_CODING_METHOD_VERSION_DATE ),
-      std::make_shared< klv_string_format >( 10 ),
+      std::make_shared< klv_ascii_format >( 10 ),
       "Country Coding Method for 'Object Country Codes' Version Date",
       "Effective date of the source standard defining the country coding "
       "method used for the 'Object Country Codes' field.",

--- a/arrows/klv/klv_0104.cxx
+++ b/arrows/klv/klv_0104.cxx
@@ -5,7 +5,9 @@
 /// \file
 /// Implementation of the KLV 0104 parser.
 
-#include "klv_0104.h"
+#include <arrows/klv/klv_0104.h>
+
+#include <arrows/klv/klv_string.h>
 
 #include <vital/exceptions.h>
 
@@ -82,7 +84,7 @@ klv_0104_traits_lookup()
       1 },
     { { 0x060E2B3401010101, 0x0105050000000000 },
       ENUM_AND_NAME( KLV_0104_EPISODE_NUMBER ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Episode Number",
       "Number to distinguish different missions started on a given day.",
       { 0, 1 } },
@@ -110,20 +112,20 @@ klv_0104_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0101200100000000 },
       ENUM_AND_NAME( KLV_0104_DEVICE_DESIGNATION ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Device Designation",
       "Model name for the platform. Examples: 'Predator', 'Reaper'.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0420010201010000 },
       ENUM_AND_NAME( KLV_0104_IMAGE_SOURCE_DEVICE ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Image Source Device",
       "Name of the currently active sensor. Examples: 'EO Nose', "
       "'IR Mitsubishi PtSi Model 500'.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0701010100000000 },
       ENUM_AND_NAME( KLV_0104_IMAGE_COORDINATE_SYSTEM ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Image Coordinate System",
       "Name of the image coordinate system used.",
       { 0, 1 } },
@@ -247,14 +249,14 @@ klv_0104_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0702010201010000 },
       ENUM_AND_NAME( KLV_0104_START_DATETIME ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Start Datetime",
       "Start time of Motion Imagery Collection. "
       "Format: YYYYMMDDDThhmmss. UTC.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0702010207010000 },
       ENUM_AND_NAME( KLV_0104_EVENT_START_DATETIME ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Event Start Datetime",
       "Start time of scene, project, event, mission, editing event, license, "
       "publication, etc. Format: YYYYMMDDDThhmmss. UTC.",

--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -2,22 +2,23 @@
 // OSI-approved BSD 3-Clause License. See top-level LICENSE file or
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
-#include "klv_0601.h"
+#include <arrows/klv/klv_0601.h>
 
-#include "klv_0806.h"
-#include "klv_0903.h"
-#include "klv_1002.h"
-#include "klv_1010.h"
-#include "klv_1204.h"
-#include "klv_1206.h"
-#include "klv_1601.h"
-#include "klv_1602.h"
-#include "klv_1607.h"
-#include "klv_checksum.h"
-#include "klv_series.hpp"
-#include "klv_length_value.h"
-#include "klv_list.hpp"
-#include "klv_util.h"
+#include <arrows/klv/klv_0806.h>
+#include <arrows/klv/klv_0903.h>
+#include <arrows/klv/klv_1002.h>
+#include <arrows/klv/klv_1010.h>
+#include <arrows/klv/klv_1204.h>
+#include <arrows/klv/klv_1206.h>
+#include <arrows/klv/klv_1601.h>
+#include <arrows/klv/klv_1602.h>
+#include <arrows/klv/klv_1607.h>
+#include <arrows/klv/klv_checksum.h>
+#include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_length_value.h>
+#include <arrows/klv/klv_list.hpp>
+#include <arrows/klv/klv_string.h>
+#include <arrows/klv/klv_util.h>
 
 #include <vital/logger/logger.h>
 
@@ -69,15 +70,13 @@ klv_0601_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0601_MISSION_ID ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Mission ID",
       "Descriptive mission identifier to distinguish an event or sortie.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_PLATFORM_TAIL_NUMBER ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Platform Tail Number",
       "Identifier of platform as posted.",
       { 0, 1 } },
@@ -124,23 +123,20 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_PLATFORM_DESIGNATION ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Platform Designation",
       "Model name for the platform. Examples: 'Predator', 'Reaper'.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_IMAGE_SOURCE_SENSOR ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Image Source Sensor",
       "Name of the currently active sensor. Examples: 'EO Nose', 'TESAR "
       "Imagery'.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_IMAGE_COORDINATE_SYSTEM ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Image Coordinate System",
       "Name of the image coordinate system used.",
       { 0, 1 } },
@@ -488,7 +484,7 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_PLATFORM_CALL_SIGN ),
-      std::make_shared< klv_string_format >( klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Platform Call Sign",
       "Call sign of the platform or operating unit.",
       { 0, 1 } },
@@ -562,7 +558,7 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_ALTERNATE_PLATFORM_NAME ),
-      std::make_shared< klv_string_format >( klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Alternate Platform Name",
       "Name of the platform connected to the UAS via direct datalink. "
       "Examples: 'Apache', 'Rover'.",
@@ -824,23 +820,20 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_STREAM_DESIGNATOR ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Stream Designator",
       "Shorthand descriptor for a particular Motion Imagery data stream, "
       "typically delivered over IP.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_OPERATIONAL_BASE ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Operational Base",
       "Indicates the location for the launch recovery equipment.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_BROADCAST_SOURCE ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Broadcast Source",
       "Location where the Motion Imagery is first broadcast. Examples: "
       "'Creech', 'Cannon'.",
@@ -994,7 +987,7 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_TARGET_ID ),
-      std::make_shared< klv_string_format >( klv_length_constraints{ 1, 32 } ),
+      std::make_shared< klv_utf_8_format >( 32 ),
       "Target ID",
       "Alpha-numeric identification of the target.",
       { 0, 1 } },
@@ -1036,8 +1029,7 @@ klv_0601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0601_COMMUNICATIONS_METHOD ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 127 } ),
+      std::make_shared< klv_utf_8_format >( 127 ),
       "Communications Method",
       "Type of communications used with platform",
       { 0, 1 } },

--- a/arrows/klv/klv_0806.cxx
+++ b/arrows/klv/klv_0806.cxx
@@ -5,12 +5,13 @@
 /// \file
 /// Implementation of the KLV 0806 parser.
 
-#include "klv_0806.h"
+#include <arrows/klv/klv_0806.h>
 
-#include "klv_0806_aoi_set.h"
-#include "klv_0806_poi_set.h"
-#include "klv_0806_user_defined_set.h"
-#include "klv_checksum.h"
+#include <arrows/klv/klv_0806_aoi_set.h>
+#include <arrows/klv/klv_0806_poi_set.h>
+#include <arrows/klv/klv_0806_user_defined_set.h>
+#include <arrows/klv/klv_checksum.h>
+#include <arrows/klv/klv_string.h>
 
 namespace kv = kwiver::vital;
 
@@ -92,7 +93,7 @@ klv_0806_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010103, 0x04010B0100000000 },
       ENUM_AND_NAME( KLV_0806_DIGITAL_VIDEO_FILE_FORMAT ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 127 } ),
       "Digital Video File Format",
       "Video compression being used. Examples: MPEG2, MPEG4, H.264, Analog "
@@ -127,7 +128,7 @@ klv_0806_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101030B000000 },
       ENUM_AND_NAME( KLV_0806_MGRS_LATITUDE_BAND_GRID_SQUARE ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "MGRS Latitude Band and Grid Square",
       "First character is the alpha code for the latitude band. Second and "
       "third are the alpha code for the WGS84 grid square designator.",
@@ -152,7 +153,7 @@ klv_0806_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101030B010000 },
       ENUM_AND_NAME( KLV_0806_FRAME_CENTER_MGRS_LATITUDE_BAND_GRID_SQUARE ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_ascii_format >(),
       "Frame Center MGRS Latitude Band and Grid Square",
       "First character is the alpha code for the latitude band. Second and "
       "third are the alpha code for the WGS84 grid square designator.",

--- a/arrows/klv/klv_0806_aoi_set.cxx
+++ b/arrows/klv/klv_0806_aoi_set.cxx
@@ -5,9 +5,10 @@
 /// \file
 /// Implementation of the KLV 0806 AOI Set parser.
 
-#include "klv_0806_aoi_set.h"
+#include <arrows/klv/klv_0806_aoi_set.h>
 
-#include "klv_0806.h"
+#include <arrows/klv/klv_0806.h>
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -72,27 +73,27 @@ klv_0806_aoi_set_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031B000000 },
       ENUM_AND_NAME( KLV_0806_AOI_SET_TEXT ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 2048 } ),
       "AOI Text",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031D000000 },
       ENUM_AND_NAME( KLV_0806_AOI_SET_SOURCE_ID ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 255 } ),
       "AOI Source ID",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031E000000 },
       ENUM_AND_NAME( KLV_0806_AOI_SET_LABEL ),
-      std::make_shared< klv_string_format >( 16 ),
+      std::make_shared< klv_ascii_format >( 16 ),
       "AOI Label",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E01040301000000 },
       ENUM_AND_NAME( KLV_0806_AOI_SET_OPERATION_ID ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 127 } ),
       "Operation ID",
       "Identifier for the duration of the supporting mission or event "

--- a/arrows/klv/klv_0806_poi_set.cxx
+++ b/arrows/klv/klv_0806_poi_set.cxx
@@ -5,9 +5,10 @@
 /// \file
 /// Implementation of the KLV 0806 POI Set parser.
 
-#include "klv_0806_poi_set.h"
+#include <arrows/klv/klv_0806_poi_set.h>
 
-#include "klv_0806.h"
+#include <arrows/klv/klv_0806.h>
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -61,34 +62,34 @@ klv_0806_poi_set_traits_lookup()
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031B000000 },
       ENUM_AND_NAME( KLV_0806_POI_SET_TEXT ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 2048 } ),
       "POI Text",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031C000000 },
       ENUM_AND_NAME( KLV_0806_POI_SET_SOURCE_ICON ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 127 } ),
       "POI Source Icon",
       "Per MIL-STD-2525B. Icon used in FalconView.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031D000000 },
       ENUM_AND_NAME( KLV_0806_POI_SET_SOURCE_ID ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 255 } ),
       "POI Source ID",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E0101031E000000 },
       ENUM_AND_NAME( KLV_0806_POI_SET_LABEL ),
-      std::make_shared< klv_string_format >( 16 ),
+      std::make_shared< klv_ascii_format >( 16 ),
       "POI Label",
       "User-defined string.",
       { 0, 1 } },
     { { 0x060E2B3401010101, 0x0E01040301000000 },
       ENUM_AND_NAME( KLV_0806_POI_SET_OPERATION_ID ),
-      std::make_shared< klv_string_format >(
+      std::make_shared< klv_ascii_format >(
         klv_length_constraints{ 1, 127 } ),
       "Operation ID",
       "Identifier for the duration of the supporting mission or event "

--- a/arrows/klv/klv_0903.cxx
+++ b/arrows/klv/klv_0903.cxx
@@ -13,6 +13,7 @@
 #include <arrows/klv/klv_1204.h>
 #include <arrows/klv/klv_checksum.h>
 #include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_string.h>
 
 namespace kv = kwiver::vital;
 
@@ -61,7 +62,7 @@ klv_0903_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VMTI_SYSTEM_NAME ),
-      std::make_shared< klv_string_format >( klv_length_constraints{ 1, 32 } ),
+      std::make_shared< klv_utf_8_format >( 32 ),
       "VMTI System Name",
       "Name or description of the VMTI system producing the targets.",
       { 0, 1 } },
@@ -104,8 +105,7 @@ klv_0903_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_SOURCE_SENSOR ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 128 } ),
+      std::make_shared< klv_utf_8_format >( 128 ),
       "VMTI Source Sensor",
       "Name of VMTI source sensor. Examples: 'EO Nose', 'EO Zoom (DLTV)'.",
       { 0, 1 } },

--- a/arrows/klv/klv_0903_algorithm_set.cxx
+++ b/arrows/klv/klv_0903_algorithm_set.cxx
@@ -5,7 +5,9 @@
 /// \file
 /// Implementation of the KLV 0903 algorithm local set parser.
 
-#include "klv_0903_algorithm_set.h"
+#include <arrows/klv/klv_0903_algorithm_set.h>
+
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -40,19 +42,19 @@ klv_0903_algorithm_set_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0903_ALGORITHM_NAME ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Name",
       "Name of algorithm.",
       1 },
     { {},
       ENUM_AND_NAME( KLV_0903_ALGORITHM_VERSION ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Version",
       "Version of algorithm",
       1 },
     { {},
       ENUM_AND_NAME( KLV_0903_ALGORITHM_CLASS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Class",
       "Type of algorithm. Examples: 'detector', 'classifier'.",
       { 0, 1 } },

--- a/arrows/klv/klv_0903_ontology_set.cxx
+++ b/arrows/klv/klv_0903_ontology_set.cxx
@@ -5,7 +5,9 @@
 /// \file
 /// Implementation of the KLV 0903 ontology local set parser.
 
-#include "klv_0903_ontology_set.h"
+#include <arrows/klv/klv_0903_ontology_set.h>
+
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -45,14 +47,14 @@ klv_0903_ontology_set_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_ONTOLOGY_URI ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "URI",
       "Uniform Resource Identifier according to the OWL Web Ontology "
       "Language.",
       1 },
     { {},
       ENUM_AND_NAME( KLV_0903_ONTOLOGY_CLASS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Class",
       "Target class or type, as defined by the ontology.",
       1 } };

--- a/arrows/klv/klv_0903_vchip_set.cxx
+++ b/arrows/klv/klv_0903_vchip_set.cxx
@@ -5,8 +5,9 @@
 /// \file
 /// Implementation of the KLV 0903 VChip local set parser.
 
-#include "klv_0903_vchip_set.h"
+#include <arrows/klv/klv_0903_vchip_set.h>
 
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_util.h>
 
 namespace kwiver {
@@ -35,13 +36,13 @@ klv_0903_vchip_set_traits_lookup()
       0 },
     { {},
       ENUM_AND_NAME( KLV_0903_VCHIP_IMAGE_TYPE ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Image Type",
       "IANA image media subtype. Only 'jpeg' and 'png' are permitted.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VCHIP_IMAGE_URI ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Image URI",
       "URI referring to an image stored on a server.",
       { 0, 1 } },

--- a/arrows/klv/klv_0903_vfeature_set.cxx
+++ b/arrows/klv/klv_0903_vfeature_set.cxx
@@ -5,8 +5,9 @@
 /// \file
 /// Implementation of the KLV 0903 VFeature local set parser.
 
-#include "klv_0903_vfeature_set.h"
+#include <arrows/klv/klv_0903_vfeature_set.h>
 
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_util.h>
 
 namespace kwiver {
@@ -35,14 +36,14 @@ klv_0903_vfeature_set_traits_lookup()
       0 },
     { {},
       ENUM_AND_NAME( KLV_0903_VFEATURE_SCHEMA ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Schema",
       "URI which points to a relevant Observation schema "
       "(http://schemas.opengis.net/om/1.0.0/) or a related schema.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VFEATURE_SCHEMA_FEATURE ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Schema Feature",
       "Geographic Markup Language document structured according to the Schema "
       "tag. May contain one or more observed values for a feature of "

--- a/arrows/klv/klv_0903_vobject_set.cxx
+++ b/arrows/klv/klv_0903_vobject_set.cxx
@@ -5,9 +5,10 @@
 /// \file
 /// Implementation of the KLV 0903 VObject local set parser.
 
-#include "klv_0903_vobject_set.h"
+#include <arrows/klv/klv_0903_vobject_set.h>
 
 #include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_util.h>
 
 namespace kwiver {
@@ -50,13 +51,13 @@ klv_0903_vobject_set_traits_lookup()
       0 },
     { {},
       ENUM_AND_NAME( KLV_0903_VOBJECT_ONTOLOGY ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Ontology",
       "URI referring to a vObject ontology.",
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VOBJECT_ONTOLOGY_CLASS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Ontology Class",
       "Value representing a target class or type, as defined by the Ontology tag.",
       { 0, 1 } },

--- a/arrows/klv/klv_0903_vtrack_set.cxx
+++ b/arrows/klv/klv_0903_vtrack_set.cxx
@@ -12,6 +12,7 @@
 #include <arrows/klv/klv_0903_vtracker_set.h>
 #include <arrows/klv/klv_0903_vtrackitem_pack.h>
 #include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_uuid.h>
 
 namespace kwiver {
@@ -85,7 +86,7 @@ klv_0903_vtrack_set_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VTRACK_ALGORITHM ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Algorithm",
       "Name or description of the algorith or method used to create or "
       "maintain object movement reports or predictions.",
@@ -99,7 +100,7 @@ klv_0903_vtrack_set_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VTRACK_SYSTEM_NAME ),
-      std::make_shared< klv_string_format >( klv_length_constraints{ 1, 32 } ),
+      std::make_shared< klv_utf_8_format >( 32 ),
       "VMTI System Name",
       "Name or description of the VMTI system producing the targets.",
       { 0, 1 } },
@@ -112,8 +113,7 @@ klv_0903_vtrack_set_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_0903_VTRACK_SOURCE_SENSOR ),
-      std::make_shared< klv_string_format >(
-        klv_length_constraints{ 1, 128 } ),
+      std::make_shared< klv_utf_8_format >( 128 ),
       "VMTI Source Sensor",
       "Name of VMTI source sensor. Examples: 'EO Nose', 'EO Zoom (DLTV)'.",
       { 0, 1 } },

--- a/arrows/klv/klv_0903_vtracker_set.cxx
+++ b/arrows/klv/klv_0903_vtracker_set.cxx
@@ -9,6 +9,7 @@
 
 #include <arrows/klv/klv_0903_location_pack.h>
 #include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_uuid.h>
 
 namespace kwiver {
@@ -86,7 +87,7 @@ klv_0903_vtracker_set_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VTRACKER_ALGORITHM ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Algorithm",
       "Name or description of the algorith or method used to create or "
       "maintain object movement reports or predictions.",

--- a/arrows/klv/klv_0903_vtrackitem_pack.cxx
+++ b/arrows/klv/klv_0903_vtrackitem_pack.cxx
@@ -15,6 +15,7 @@
 #include <arrows/klv/klv_0903_vtarget_pack.h>
 #include <arrows/klv/klv_1204.h>
 #include <arrows/klv/klv_series.hpp>
+#include <arrows/klv/klv_string.h>
 #include <arrows/klv/klv_util.h>
 
 namespace kwiver {
@@ -258,7 +259,7 @@ klv_0903_vtrackitem_pack_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_0903_VTRACKITEM_MI_URL ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Motion Imagery URL",
       "A URL for the Motion Imagery, conformant with IETF RFC 3986.",
       { 0, 1 } },

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -9,6 +9,7 @@
 
 #include <arrows/klv/klv_1108_metric_set.h>
 #include <arrows/klv/klv_checksum.h>
+#include <arrows/klv/klv_string.h>
 
 #include <algorithm>
 #include <iomanip>
@@ -293,7 +294,7 @@ klv_1108_traits_lookup()
       1 },
     { { 0x060E2B3401010101, 0x0E01050400000000 },
       ENUM_AND_NAME( KLV_1108_COMPRESSION_LEVEL ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Compression Level",
       "Level of video compression.",
       1 },

--- a/arrows/klv/klv_1108_metric_set.cxx
+++ b/arrows/klv/klv_1108_metric_set.cxx
@@ -5,7 +5,9 @@
 /// \file
 /// Implementation of the KLV 1108 Metric Local Set parser.
 
-#include "klv_1108_metric_set.h"
+#include <arrows/klv/klv_1108_metric_set.h>
+
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -140,13 +142,13 @@ klv_1108_metric_set_traits_lookup()
       0 },
     { { 0x060E2B3401010101, 0x0E01050700000000 }, // "Key" column
       ENUM_AND_NAME( KLV_1108_METRIC_SET_NAME ),  // KWIVER enumeration
-      std::make_shared< klv_string_format >(),    // "Type" column
+      std::make_shared< klv_utf_8_format >(),     // "Type" column
       "Metric Name",                              // "Item Name" column
       "Examples: 'VNIIRS', 'RER', 'GSD'.",        // "Notes" column
       1 },                                        // "M/O" column (mandatory)
     { { 0x060E2B3401010101, 0x0E01050800000000 },
       ENUM_AND_NAME( KLV_1108_METRIC_SET_VERSION ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Metric Version",
       "Alphanumeric denoting calculated values. 'Human' for observed.",
       1 },
@@ -158,7 +160,7 @@ klv_1108_metric_set_traits_lookup()
       1 },
     { { 0x060E2B3401010101, 0x0E01050A00000000 },
       ENUM_AND_NAME( KLV_1108_METRIC_SET_PARAMETERS ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Metric Parameters",
       "Additional information needed to replicate the calculation.",
       { 0, 1 } },

--- a/arrows/klv/klv_1303.cxx
+++ b/arrows/klv/klv_1303.cxx
@@ -5,7 +5,9 @@
 /// \file
 /// Implementation of the KLV 1303 parser's non-templated functions.
 
-#include "klv_1303.hpp"
+#include <arrows/klv/klv_1303.hpp>
+
+#include <arrows/klv/klv_string.h>
 
 namespace kwiver {
 
@@ -51,16 +53,18 @@ KLV_INSTANTIATE( uint64_t );
 #define KLV_INSTANTIATE( FORMAT ) \
   template class klv_1303_mdap_format< FORMAT >;
 
+KLV_INSTANTIATE( klv_ascii_format );
 KLV_INSTANTIATE( klv_ber_format );
 KLV_INSTANTIATE( klv_ber_oid_format );
 KLV_INSTANTIATE( klv_bool_format );
 KLV_INSTANTIATE( klv_lengthless_format< klv_float_format > );
 KLV_INSTANTIATE( klv_lengthless_format< klv_imap_format > );
 KLV_INSTANTIATE( klv_lengthless_format< klv_sflint_format > );
-KLV_INSTANTIATE( klv_sint_format );
-KLV_INSTANTIATE( klv_string_format );
 KLV_INSTANTIATE( klv_lengthless_format< klv_uflint_format > );
+KLV_INSTANTIATE( klv_sint_format );
 KLV_INSTANTIATE( klv_uint_format );
+KLV_INSTANTIATE( klv_utf_16_format );
+KLV_INSTANTIATE( klv_utf_8_format );
 
 #undef KLV_INSTANTIATE
 

--- a/arrows/klv/klv_1601.cxx
+++ b/arrows/klv/klv_1601.cxx
@@ -5,9 +5,10 @@
 /// \file
 /// Implementation of the KLV 1601 parser.
 
-#include "klv_1601.h"
+#include <arrows/klv/klv_1601.h>
 
 #include <arrows/klv/klv_1303.h>
+#include <arrows/klv/klv_string.h>
 
 #include <vital/range/iota.h>
 
@@ -309,13 +310,13 @@ klv_1601_traits_lookup()
       1 },
     { {},
       ENUM_AND_NAME( KLV_1601_ALGORITHM_NAME ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Algorithm Name",
       "Unique identifier for the algorithm used to geo-register the imagery.",
       1 },
     { {},
       ENUM_AND_NAME( KLV_1601_ALGORITHM_VERSION ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Algorithm Version",
       "Unique identifier for the specific version of the algorithm used.",
       1 },
@@ -335,7 +336,7 @@ klv_1601_traits_lookup()
       { 0, 1 } },
     { {},
       ENUM_AND_NAME( KLV_1601_SECOND_IMAGE_NAME ),
-      std::make_shared< klv_string_format >(),
+      std::make_shared< klv_utf_8_format >(),
       "Second Image Name",
       "Unique identifier for the second image used in the geo-registration "
       "process.",

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -173,45 +173,6 @@ klv_uuid_format
 }
 
 // ----------------------------------------------------------------------------
-klv_string_format
-::klv_string_format( klv_length_constraints const& length_constraints )
-  : klv_data_format_< data_type >{ length_constraints }
-{}
-
-// ----------------------------------------------------------------------------
-std::string
-klv_string_format
-::read_typed( klv_read_iter_t& data, size_t length ) const
-{
-  return klv_read_string( data, length );
-}
-
-// ----------------------------------------------------------------------------
-void
-klv_string_format
-::write_typed( std::string const& value,
-               klv_write_iter_t& data, size_t length ) const
-{
-  klv_write_string( value, data, length );
-}
-
-// ----------------------------------------------------------------------------
-size_t
-klv_string_format
-::length_of_typed( std::string const& value ) const
-{
-  return klv_string_length( value );
-}
-
-// ----------------------------------------------------------------------------
-std::string
-klv_string_format
-::description_() const
-{
-  return "String";
-}
-
-// ----------------------------------------------------------------------------
 klv_bool_format
 ::klv_bool_format() : klv_data_format_< bool >( 1 )
 {}

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -356,29 +356,6 @@ protected:
 };
 
 // ----------------------------------------------------------------------------
-/// Interprets data as a string.
-class KWIVER_ALGO_KLV_EXPORT klv_string_format
-  : public klv_data_format_< std::string >
-{
-public:
-  klv_string_format( klv_length_constraints const& length_constraints = {} );
-
-  std::string
-  description_() const override;
-
-protected:
-  std::string
-  read_typed( klv_read_iter_t& data, size_t length ) const override;
-
-  void
-  write_typed( std::string const& value,
-               klv_write_iter_t& data, size_t length ) const override;
-
-  size_t
-  length_of_typed( std::string const& value ) const override;
-};
-
-// ----------------------------------------------------------------------------
 /// Treats data as a single boolean value.
 class KWIVER_ALGO_KLV_EXPORT klv_bool_format
   : public klv_data_format_< bool >

--- a/arrows/klv/klv_string.cxx
+++ b/arrows/klv/klv_string.cxx
@@ -1,0 +1,213 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of the KLV string data formats.
+
+#include <arrows/klv/klv_string.h>
+
+#include <vital/util/text_codec_ascii.h>
+#include <vital/util/text_codec_error_policies.h>
+#include <vital/util/text_codec_transcode.h>
+#include <vital/util/text_codec_utf_16.h>
+#include <vital/util/text_codec_utf_8.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+vital::text_codec::encode_error_policy const&
+encode_error_policy()
+{
+  return vital::text_codec_encode_error_policy_abort::instance();
+}
+
+// ----------------------------------------------------------------------------
+vital::text_codec::decode_error_policy const&
+decode_error_policy()
+{
+  return vital::text_codec_decode_error_policy_abort::instance();
+}
+
+// ----------------------------------------------------------------------------
+template< class Codec >
+Codec const&
+get_text_codec()
+{
+  static Codec const codec =
+    [](){
+      Codec tmp;
+      tmp.set_encode_error_policy( encode_error_policy() );
+      tmp.set_decode_error_policy( decode_error_policy() );
+      return tmp;
+    }();
+  return codec;
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+klv_string_format
+::klv_string_format(
+  vital::text_codec const& codec,
+  klv_length_constraints const& char_constraints,
+  klv_length_constraints const& byte_constraints )
+  : klv_data_format_< data_type >{ byte_constraints },
+    m_codec{ &codec },
+    m_char_constraints{ char_constraints }
+{}
+
+// ----------------------------------------------------------------------------
+klv_string_format
+::~klv_string_format()
+{}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_string_format
+::read_typed( klv_read_iter_t& data, size_t length ) const
+{
+  // Read bytes
+  auto const value = klv_read_string( data, length );
+
+  // Calculate number of characters in those bytes
+  auto const length_tuple = m_codec->decoded_size( value );
+  if( std::get< 0 >( length_tuple ) == vital::text_codec::ABORT )
+  {
+    throw vital::metadata_exception(
+      "string is not valid " + m_codec->name() );
+  }
+
+  // Check character constraints
+  auto const char_count = std::get< 1 >( length_tuple );
+  if( !m_char_constraints.do_allow( char_count ) )
+  {
+    LOG_WARN( vital::get_logger( "klv" ),
+      "format `" << description() << "` "
+      << "received wrong number of characters ( " << char_count << " ) "
+      << "when reading" );
+  }
+
+  return value;
+}
+
+// ----------------------------------------------------------------------------
+void
+klv_string_format
+::write_typed( std::string const& value,
+               klv_write_iter_t& data, size_t length ) const
+{
+  // Calculate number of characters in input
+  auto const length_tuple = m_codec->decoded_size( value );
+  if( std::get< 0 >( length_tuple ) == vital::text_codec::ABORT )
+  {
+    throw vital::metadata_exception(
+      "string is not valid " + m_codec->name() );
+  }
+
+  // Check character constraints
+  auto const char_count = std::get< 1 >( length_tuple );
+  if( !m_char_constraints.do_allow( char_count ) )
+  {
+    LOG_WARN( vital::get_logger( "klv" ),
+      "format `" << description() << "` "
+      << "received wrong number of characters ( " << char_count << " ) "
+      << "when writing" );
+  }
+
+  klv_write_string( value, data, length );
+}
+
+// ----------------------------------------------------------------------------
+size_t
+klv_string_format
+::length_of_typed( std::string const& value ) const
+{
+  return klv_string_length( value );
+}
+
+// ----------------------------------------------------------------------------
+std::string
+klv_string_format
+::description_() const
+{
+  return "String (Encoding: " + m_codec->name() + ")";
+}
+
+// ----------------------------------------------------------------------------
+std::ostream&
+klv_string_format
+::print_typed( std::ostream& os, std::string const& value ) const
+{
+  static vital::text_codec_utf_8 print_codec;
+  auto const transcoded =
+    vital::text_codec_transcode( *m_codec, print_codec, value );
+  if( std::get< 0 >( transcoded ) == vital::text_codec::ABORT )
+  {
+    return os << "<invalid>";
+  }
+  return os << std::get< 1 >( transcoded );
+}
+
+// ----------------------------------------------------------------------------
+vital::text_codec const&
+klv_string_format
+::codec() const
+{
+  return *m_codec;
+}
+
+// ----------------------------------------------------------------------------
+klv_ascii_format
+::klv_ascii_format( klv_length_constraints const& length_constraints )
+  : klv_string_format{
+    get_text_codec< vital::text_codec_ascii >(),
+    length_constraints, length_constraints }
+{}
+
+// ----------------------------------------------------------------------------
+klv_ascii_format
+::~klv_ascii_format()
+{}
+
+// ----------------------------------------------------------------------------
+klv_utf_8_format
+::klv_utf_8_format(
+  klv_length_constraints const& char_constraints,
+  klv_length_constraints const& byte_constraints )
+  : klv_string_format{
+    get_text_codec< vital::text_codec_utf_8 >(),
+    char_constraints, byte_constraints }
+{}
+
+// ----------------------------------------------------------------------------
+klv_utf_8_format
+::~klv_utf_8_format()
+{}
+
+// ----------------------------------------------------------------------------
+klv_utf_16_format
+::klv_utf_16_format(
+  klv_length_constraints const& char_constraints,
+  klv_length_constraints const& byte_constraints )
+  : klv_string_format{
+    get_text_codec< vital::text_codec_utf_16_be >(),
+    char_constraints, byte_constraints }
+{}
+
+// ----------------------------------------------------------------------------
+klv_utf_16_format
+::~klv_utf_16_format()
+{}
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/klv/klv_string.h
+++ b/arrows/klv/klv_string.h
@@ -1,0 +1,95 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Interface to the KLV string data formats.
+
+#include <arrows/klv/klv_data_format.h>
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+#include <vital/util/text_codec.h>
+
+#ifndef KWIVER_ARROWS_KLV_KLV_STRING_H_
+#define KWIVER_ARROWS_KLV_KLV_STRING_H_
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a string.
+class KWIVER_ALGO_KLV_EXPORT klv_string_format
+  : public klv_data_format_< std::string >
+{
+public:
+  klv_string_format(
+    vital::text_codec const& codec,
+    klv_length_constraints const& char_constraints,
+    klv_length_constraints const& byte_constraints );
+  virtual ~klv_string_format();
+
+  std::string description_() const override;
+
+  vital::text_codec const& codec() const;
+
+protected:
+  std::string read_typed(
+    klv_read_iter_t& data, size_t length ) const override;
+
+  void write_typed(
+    std::string const& value, klv_write_iter_t& data, size_t length )
+  const override;
+
+  size_t length_of_typed( std::string const& value ) const override;
+
+  std::ostream& print_typed(
+    std::ostream& os, std::string const& value ) const override;
+
+  vital::text_codec const* m_codec;
+  klv_length_constraints m_char_constraints;
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as an ASCII string.
+class KWIVER_ALGO_KLV_EXPORT klv_ascii_format : public klv_string_format
+{
+public:
+  klv_ascii_format( klv_length_constraints const& length_constraints = {} );
+  virtual ~klv_ascii_format();
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a UTF-8 string.
+class KWIVER_ALGO_KLV_EXPORT klv_utf_8_format : public klv_string_format
+{
+public:
+  klv_utf_8_format(
+    klv_length_constraints const& char_constraints = {},
+    klv_length_constraints const& byte_constraints = {} );
+  virtual ~klv_utf_8_format();
+};
+
+// ----------------------------------------------------------------------------
+/// Interprets data as a UTF-16 string.
+///
+/// The big-endian variation of UTF-16 is used, consistent with the encoding of
+/// integers elsewhere in MISB KLV.
+class KWIVER_ALGO_KLV_EXPORT klv_utf_16_format : public klv_string_format
+{
+public:
+  klv_utf_16_format(
+    klv_length_constraints const& char_constraints = {},
+    klv_length_constraints const& byte_constraints = {} );
+  virtual ~klv_utf_16_format();
+};
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
This PR incorporates knowledge about different text encodings into the KLV code, as MISB uses a few different encodings across the standards. String data is still stored in the native text encoding, but our code is just now a little bit smarter about detecting invalid strings, correctly restricting the length of strings on a character basis rather than on a byte basis, etc. 