### PR TITLE
Make invalid length handling more robust

### DIFF
--- a/arrows/klv/klv_0806_user_defined_set.cxx
+++ b/arrows/klv/klv_0806_user_defined_set.cxx
@@ -103,6 +103,14 @@ klv_0806_user_defined_data_type_id_format
 }
 
 // ----------------------------------------------------------------------------
+size_t
+klv_0806_user_defined_data_type_id_format
+::length_of_typed( klv_0806_user_defined_data_type_id const& ) const
+{
+  return 1;
+}
+
+// ----------------------------------------------------------------------------
 std::ostream&
 operator<<( std::ostream& os, klv_0806_user_defined_data const& value )
 {

--- a/arrows/klv/klv_0806_user_defined_set.h
+++ b/arrows/klv/klv_0806_user_defined_set.h
@@ -84,6 +84,10 @@ private:
   void
   write_typed( klv_0806_user_defined_data_type_id const& value,
                klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed(
+    klv_0806_user_defined_data_type_id const& value ) const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -114,6 +114,14 @@ klv_1108_metric_period_pack_format
 }
 
 // ----------------------------------------------------------------------------
+size_t
+klv_1108_metric_period_pack_format
+::length_of_typed( klv_1108_metric_period_pack const& ) const
+{
+  return 12;
+}
+
+// ----------------------------------------------------------------------------
 std::string
 klv_1108_metric_period_pack_format
 ::description_() const

--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -150,6 +150,9 @@ public:
   void
   write_typed( klv_1108_metric_period_pack const& value,
                klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( klv_1108_metric_period_pack const& value ) const override;
 };
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -242,6 +242,14 @@ klv_bool_format
 }
 
 // ----------------------------------------------------------------------------
+size_t
+klv_bool_format
+::length_of_typed( bool const& ) const
+{
+  return m_length_constraints.fixed_or( 1 );
+}
+
+// ----------------------------------------------------------------------------
 klv_uint_format
 ::klv_uint_format( klv_length_constraints const& length_constraints )
   : klv_data_format_< data_type >{ length_constraints }
@@ -269,7 +277,7 @@ size_t
 klv_uint_format
 ::length_of_typed( uint64_t const& value ) const
 {
-  return klv_int_length( value );
+  return m_length_constraints.fixed_or( klv_int_length( value ) );
 }
 
 // ----------------------------------------------------------------------------
@@ -308,7 +316,7 @@ size_t
 klv_sint_format
 ::length_of_typed( int64_t const& value ) const
 {
-  return klv_int_length( value );
+  return m_length_constraints.fixed_or( klv_int_length( value ) );
 }
 
 // ----------------------------------------------------------------------------
@@ -423,7 +431,7 @@ size_t
 klv_float_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return value.length;
+  return m_length_constraints.fixed_or( value.length );
 }
 
 // ----------------------------------------------------------------------------
@@ -480,7 +488,7 @@ size_t
 klv_sflint_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return value.length;
+  return m_length_constraints.fixed_or( value.length );
 }
 
 // ----------------------------------------------------------------------------
@@ -548,7 +556,7 @@ size_t
 klv_uflint_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return value.length;
+  return m_length_constraints.fixed_or( value.length );
 }
 
 // ----------------------------------------------------------------------------
@@ -615,7 +623,7 @@ size_t
 klv_imap_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return value.length;
+  return m_length_constraints.fixed_or( value.length );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -94,7 +94,7 @@ public:
   klv_length_constraints const&
   length_constraints() const;
 
-/// Set constraints on the length of this format.
+  /// Set constraints on the length of this format.
   void
   set_length_constraints( klv_length_constraints const& length_constraints );
 
@@ -158,15 +158,18 @@ public:
   {
     if( !length )
     {
-      VITAL_THROW( kwiver::vital::metadata_exception,
-                  "zero length given to read_()" );
+      throw vital::metadata_exception{ "zero length given to read_()" };
     }
-    else if( !m_length_constraints.do_allow( length ) )
+
+    if( !m_length_constraints.do_allow( length ) )
     {
       // Invalid length
-      LOG_WARN( kwiver::vital::get_logger( "klv" ),
-                "format `" << description() <<
-                "` received wrong number of bytes ( " << length << " )" );
+      std::stringstream ss;
+      ss << "format `" << description() << "` "
+         << "received illegal number of bytes (" << length << ") "
+         << "when reading";
+
+      LOG_WARN( vital::get_logger( "klv" ), ss.str() );
     }
 
     return read_typed( data, length );
@@ -199,15 +202,24 @@ public:
     auto const value_length = length_of_( value );
     if( value_length > max_length )
     {
-      VITAL_THROW( kwiver::vital::metadata_buffer_overflow,
-                  "write will overflow buffer" );
+      std::stringstream ss;
+      ss << "format `" << description() << "` "
+         << "has been asked to write value `" << to_string( value ) << "`, "
+         << "which is too long (" << value_length << ") "
+         << "for remaining buffer length (" << max_length << ")";
+      throw vital::metadata_buffer_overflow{ ss.str() };
     }
-    else if( !m_length_constraints.do_allow( value_length ) )
+
+    if( !m_length_constraints.do_allow( value_length ) )
     {
       // Invalid length
-      LOG_WARN( kwiver::vital::get_logger( "klv" ),
-                "format `" << description() <<
-                "` received wrong number of bytes ( " << value_length << " )" );
+      std::stringstream ss;
+      ss << "format `" << description() << "` "
+         << "has been asked to write value `" << to_string( value ) << "`, "
+         << "which serializes to an illegal number of bytes "
+         << "(" << value_length << ")";
+
+      LOG_WARN( vital::get_logger( "klv" ), ss.str() );
     }
 
     // Write the value
@@ -221,8 +233,8 @@ public:
     {
       std::stringstream ss;
       ss << "format `" << description() << "`: "
-        << "written length (" << written_length << ") and "
-        << "calculated length (" << value_length <<  ") not equal";
+         << "written length (" << written_length << ") and "
+         << "calculated length (" << value_length <<  ") not equal";
       throw std::logic_error( ss.str() );
     }
   }
@@ -247,9 +259,7 @@ public:
   size_t
   length_of_( T const& value ) const
   {
-    return m_length_constraints.fixed()
-          ? *m_length_constraints.fixed()
-          : length_of_typed( value );
+    return length_of_typed( value );
   }
 
   std::type_info const&
@@ -285,12 +295,7 @@ protected:
                size_t length ) const = 0;
 
   virtual size_t
-  length_of_typed( VITAL_UNUSED T const& value ) const
-  {
-    throw std::logic_error(
-      std::string{} + "data format of type `" + type_name() +
-      "` must either provide a fixed size or override length_of_typed()" );
-  }
+  length_of_typed( T const& value ) const = 0;
 
   virtual std::ostream&
   print_typed( std::ostream& os, T const& value ) const
@@ -396,6 +401,9 @@ protected:
   void
   write_typed( bool const& value,
                klv_write_iter_t& data, size_t length ) const override;
+
+  size_t
+  length_of_typed( bool const& value ) const override;
 };
 
 // ----------------------------------------------------------------------------
@@ -491,7 +499,8 @@ protected:
   size_t
   length_of_typed( data_type const& value ) const override
   {
-    return klv_int_length( static_cast< uint64_t >( value ) );
+    return this->m_length_constraints.fixed_or(
+      klv_int_length( static_cast< uint64_t >( value ) ) );
   }
 
   size_t m_length;
@@ -814,7 +823,8 @@ protected:
   size_t
   length_of_typed( std::set< Enum > const& value ) const
   {
-    return m_format.length_of_( enums_to_bitfield( value ) );
+    return this->m_length_constraints.fixed_or(
+      m_format.length_of_( enums_to_bitfield( value ) ) );
   }
 
   Format m_format;


### PR DESCRIPTION
This PR addresses an edge case when dealing with KLV values that are longer or shorter than they are supposed to be. Some data types, like integers, can pad out the number of bytes as desired with leading zeros and still be interpretable. Some data types, like `struct`-like packed structures, have to be exactly a certain number of bytes and can't be reliably interpreted if they have too many or too few bytes. Both of these cases were already handled satisfactorily. But there is a third case: strings that are supposed to be a particular length (e.g. a three-letter code). Unlike packed structures, they can still be meaningfully interpreted when too long or too short, but unlike integers, they cannot be padded out. The current behavior was to let these pass with a warning when reading, but fatally error when writing, which is undesirable. This PR changes that behavior to allow both reading and writing (with warnings). Minor improvements to the warning code is also included.