### PR TITLE
Add merge_metadata_streams filter

### DIFF
--- a/arrows/core/CMakeLists.txt
+++ b/arrows/core/CMakeLists.txt
@@ -38,6 +38,7 @@ set( plugin_core_headers
   match_features_fundamental_matrix.h
   match_features_homography.h
   match_tracks.h
+  merge_metadata_streams.h
   mesh_intersect.h
   mesh_operations.h
   metadata_map_io_csv.h
@@ -114,6 +115,7 @@ set( plugin_core_sources
   match_features_fundamental_matrix.cxx
   match_features_homography.cxx
   match_tracks.cxx
+  merge_metadata_streams.cxx
   mesh_intersect.cxx
   mesh_operations.cxx
   metadata_map_io_csv.cxx

--- a/arrows/core/merge_metadata_streams.cxx
+++ b/arrows/core/merge_metadata_streams.cxx
@@ -1,0 +1,135 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of merge_metadata_streams filter.
+
+#include <arrows/core/merge_metadata_streams.h>
+
+#include <algorithm>
+#include <optional>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+// ----------------------------------------------------------------------------
+merge_metadata_streams
+::merge_metadata_streams()
+{
+  this->set_capability( CAN_USE_FRAME_IMAGE, false );
+}
+
+// ----------------------------------------------------------------------------
+merge_metadata_streams
+::~merge_metadata_streams()
+{}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+merge_metadata_streams
+::get_configuration() const
+{
+  return metadata_filter::get_configuration();
+}
+
+// ----------------------------------------------------------------------------
+void
+merge_metadata_streams
+::set_configuration( vital::config_block_sptr )
+{}
+
+// ----------------------------------------------------------------------------
+bool
+merge_metadata_streams
+::check_configuration( vital::config_block_sptr ) const
+{
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+merge_metadata_streams
+::filter(
+  vital::metadata_vector const& input_metadata,
+  vital::image_container_scptr const& input_image )
+{
+  auto const result = std::make_shared< vital::metadata >();
+
+  // Remove any null objects
+  vital::metadata_vector sorted_metadata;
+  for( auto const metadata : input_metadata )
+  {
+    if( metadata )
+    {
+      sorted_metadata.emplace_back( metadata );
+    }
+  }
+
+  // Sort the incoming objects in order from most to least preferred.
+  // Synchronous streams are preferred first, then remaining streams
+  // in order of index.
+  auto const tuplize =
+    []( vital::metadata_sptr const& metadata ) {
+      std::optional< bool > is_async;
+      if( auto const entry =
+            metadata->find( vital::VITAL_META_VIDEO_DATA_STREAM_SYNCHRONOUS );
+          entry.is_valid() )
+      {
+        is_async = !entry.get< bool >();
+      }
+
+      std::optional< int > index;
+      if( auto const entry =
+            metadata->find( vital::VITAL_META_VIDEO_DATA_STREAM_INDEX );
+          entry.is_valid() )
+      {
+        index = entry.get< int >();
+      }
+
+      return std::make_tuple(
+        !is_async.has_value(), is_async,
+        !index.has_value(), index );
+    };
+
+  auto const cmp =
+    [ &tuplize ]( vital::metadata_sptr const& lhs,
+                  vital::metadata_sptr const& rhs ) {
+      return tuplize( lhs ) < tuplize( rhs );
+    };
+
+  std::sort( sorted_metadata.begin(), sorted_metadata.end(), cmp );
+
+  // Import each tag, pulling from preferred streams first
+  for( size_t i = 0; i < vital::VITAL_META_LAST_TAG; ++i )
+  {
+    auto const tag = static_cast< vital::vital_metadata_tag >( i );
+
+    // Since we're merging streams, we need to drop stream-specific tags
+    if( tag == vital::VITAL_META_VIDEO_DATA_STREAM_INDEX ||
+        tag == vital::VITAL_META_VIDEO_DATA_STREAM_SYNCHRONOUS )
+    {
+      continue;
+    }
+
+    for( auto const& metadata : sorted_metadata )
+    {
+      if( auto const entry = metadata->find( tag ); entry.is_valid() )
+      {
+        result->add( entry.tag(), entry.data() );
+        break;
+      }
+    }
+  }
+
+  return { result };
+}
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/core/merge_metadata_streams.h
+++ b/arrows/core/merge_metadata_streams.h
@@ -1,0 +1,48 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of merge_metadata_streams filter.
+
+#ifndef KWIVER_ARROWS_CORE_MERGE_METADATA_STREAMS_H_
+#define KWIVER_ARROWS_CORE_MERGE_METADATA_STREAMS_H_
+
+#include <arrows/core/kwiver_algo_core_export.h>
+
+#include <vital/algo/metadata_filter.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace core {
+
+// ----------------------------------------------------------------------------
+class KWIVER_ALGO_CORE_EXPORT merge_metadata_streams
+  : public vital::algo::metadata_filter
+{
+public:
+  merge_metadata_streams();
+  virtual ~merge_metadata_streams();
+
+  PLUGIN_INFO(
+    "merge_metadata_streams",
+    "Combines multiple metadata streams into exactly one." )
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  vital::metadata_vector filter(
+    vital::metadata_vector const& input_metadata,
+    vital::image_container_scptr const& input_image ) override;
+};
+
+} // namespace core
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/core/tests/CMakeLists.txt
+++ b/arrows/core/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ kwiver_discover_gtests(core detected_object_io        LIBRARIES ${test_libraries
 kwiver_discover_gtests(core dynamic_configuration     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core feature_descriptor_io     LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core interpolate_track_spline  LIBRARIES ${test_libraries})
+kwiver_discover_gtests(core merge_metadata_streams    LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core metadata_map_io_csv       LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core mesh_intersect            LIBRARIES ${test_libraries})
 kwiver_discover_gtests(core mesh_operations           LIBRARIES ${test_libraries})

--- a/arrows/core/tests/test_merge_metadata_streams.cxx
+++ b/arrows/core/tests/test_merge_metadata_streams.cxx
@@ -1,0 +1,84 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test merge_metadata_streams filter.
+
+#include <arrows/core/merge_metadata_streams.h>
+
+#include <gtest/gtest.h>
+
+using namespace kwiver;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char** argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST( merge_metadata_streams, merge_empty )
+{
+  arrows::core::merge_metadata_streams filter;
+  auto const result = filter.filter( {}, nullptr );
+  ASSERT_EQ( 1, result.size() );
+  ASSERT_NE( nullptr, result[ 0 ] );
+  ASSERT_TRUE( result[ 0 ]->empty() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( merge_metadata_streams, merge_null )
+{
+  arrows::core::merge_metadata_streams filter;
+  auto const result = filter.filter( { nullptr, nullptr }, nullptr );
+  ASSERT_EQ( 1, result.size() );
+  ASSERT_NE( nullptr, result[ 0 ] );
+  ASSERT_TRUE( result[ 0 ]->empty() );
+}
+
+// ----------------------------------------------------------------------------
+TEST( merge_metadata_streams, merge_one )
+{
+  arrows::core::merge_metadata_streams filter;
+  auto const md = std::make_shared< vital::metadata >();
+  md->add< vital::VITAL_META_UNIX_TIMESTAMP >( 7 );
+  auto const result = filter.filter( { md }, nullptr );
+  ASSERT_EQ( 1, result.size() );
+  ASSERT_NE( nullptr, result[ 0 ] );
+  ASSERT_EQ( *md, *result[ 0 ] );
+}
+
+// ----------------------------------------------------------------------------
+TEST( merge_metadata_streams, merge_multiple )
+{
+  arrows::core::merge_metadata_streams filter;
+  vital::metadata_vector md = {
+    std::make_shared< vital::metadata >(),
+    std::make_shared< vital::metadata >(),
+    std::make_shared< vital::metadata >()
+  };
+  md[ 0 ]->add< vital::VITAL_META_UNIX_TIMESTAMP >( 0 );
+  md[ 0 ]->add< vital::VITAL_META_MISSION_ID >( "0" );
+  md[ 0 ]->add< vital::VITAL_META_MISSION_NUMBER >( "#" );
+  md[ 1 ]->add< vital::VITAL_META_UNIX_TIMESTAMP >( 1 );
+  md[ 1 ]->add< vital::VITAL_META_MISSION_ID >( "1" );
+  md[ 1 ]->add< vital::VITAL_META_VIDEO_DATA_STREAM_INDEX >( 1 );
+  md[ 1 ]->add< vital::VITAL_META_VIDEO_DATA_STREAM_SYNCHRONOUS >( false );
+  md[ 2 ]->add< vital::VITAL_META_UNIX_TIMESTAMP >( 2 );
+  md[ 2 ]->add< vital::VITAL_META_VIDEO_DATA_STREAM_INDEX >( 2 );
+  md[ 2 ]->add< vital::VITAL_META_VIDEO_DATA_STREAM_SYNCHRONOUS >( true );
+
+  auto const result = filter.filter( md, nullptr );
+  ASSERT_EQ( 1, result.size() );
+  ASSERT_NE( nullptr, result[ 0 ] );
+  ASSERT_EQ( 3, result[ 0 ]->size() );
+  ASSERT_EQ(
+    2, result[ 0 ]->find( vital::VITAL_META_UNIX_TIMESTAMP ).as_uint64() );
+  ASSERT_EQ(
+    "1", result[ 0 ]->find( vital::VITAL_META_MISSION_ID ).as_string() );
+  ASSERT_EQ(
+    "#", result[ 0 ]->find( vital::VITAL_META_MISSION_NUMBER ).as_string() );
+}


### PR DESCRIPTION
This PR adds a `metadata_filter` which merges any number of vital `metadata` objects into one, taking tags from each of them in order of preference. Here we prefer tags from synchronous streams first, then tags from streams with a lower index. Test included.