### PR TITLE
Move CMAKE_CXX_STANDARD earlier

### DIFF
--- a/CMake/kwiver-configcheck.cmake
+++ b/CMake/kwiver-configcheck.cmake
@@ -50,13 +50,6 @@ macro(vital_check_optional_feature NAME TEST MESSAGE)
   endif()
 endmacro()
 
-# Set default visibility
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-
-# C++17 is required
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 vital_check_required_feature(CPP_AUTO         auto.cxx            "auto type specifier")
 vital_check_required_feature(CPP_CONSTEXPR    constexpr.cxx       "constant expressions")
 vital_check_required_feature(CPP_DEFAULT_CTOR default-ctor.cxx    "explicitly defaulted constructors")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ set(KWIVER_VERSION_MINOR 7)
 set(KWIVER_VERSION_PATCH 0)
 set(KWIVER_VERSION "${KWIVER_VERSION_MAJOR}.${KWIVER_VERSION_MINOR}.${KWIVER_VERSION_PATCH}")
 
+# C++17 is required
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Set default visibility
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
 # Organize target into folders for IDEs that support it
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
This PR just moves the declaration of the required C++ standard to early in `CMakeLists.txt`. This ensures it is properly set before `include(kwiver-utils)` calls `find_package(pybind11)`.