### PR TITLE
Fix incorrect cast to double

### DIFF
--- a/arrows/core/derive_metadata.cxx
+++ b/arrows/core/derive_metadata.cxx
@@ -155,13 +155,19 @@ get_sensor_location( kwiver::vital::metadata_sptr const& metadata )
   kv::metadata_item const& item =
     metadata->find( kv::VITAL_META_SENSOR_LOCATION );
 
-  if( !item || !std::isfinite( item.as_double() ) )
+  if( item )
   {
-    VITAL_THROW( kv::invalid_value,
-                 "metadata does not contain sensor location" );
+    auto const typed_item = item.get< kv::geo_point >();
+    if( std::isfinite( typed_item.location()[ 0 ] ) &&
+        std::isfinite( typed_item.location()[ 1 ] ) &&
+        std::isfinite( typed_item.location()[ 2 ] ) )
+    {
+      return typed_item;
+    }
   }
 
-  return item.get< kv::geo_point >();
+  VITAL_THROW(
+    kv::invalid_value, "metadata does not contain sensor location" );
 }
 
 // ----------------------------------------------------------------------------
@@ -171,13 +177,19 @@ get_frame_center( kwiver::vital::metadata_sptr const& metadata )
   kv::metadata_item const& item =
     metadata->find( kv::VITAL_META_FRAME_CENTER );
 
-  if( !item || !std::isfinite( item.as_double() ) )
+  if( item )
   {
-    VITAL_THROW( kv::invalid_value,
-                 "metadata does not contain frame center" );
+    auto const typed_item = item.get< kv::geo_point >();
+    if( std::isfinite( typed_item.location()[ 0 ] ) &&
+        std::isfinite( typed_item.location()[ 1 ] ) &&
+        std::isfinite( typed_item.location()[ 2 ] ) )
+    {
+      return typed_item;
+    }
   }
 
-  return item.get< kv::geo_point >();
+  VITAL_THROW(
+    kv::invalid_value, "metadata does not contain frame center" );
 }
 
 // ----------------------------------------------------------------------------

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -15,6 +15,8 @@ Arrows: Core
 * Fixed undefined behavior leading to a crash in track_features_core when the
   track set remained empty after the first frame.
 
+* Fixed an incorrect cast of a geo_point to double in derive_metadata.
+
 Arrows: KLV
 
 * Fixed possible out-of-bounds memory read leading to crash when KLV parsing


### PR DESCRIPTION
This fixes an error in `derive_metadata` where metadata items which contain `geo_point`s are cast to `double`s.