### PR TITLE
Add ability to read fields into std::optional

### DIFF
--- a/arrows/core/csv_io.cxx
+++ b/arrows/core/csv_io.cxx
@@ -338,6 +338,52 @@ struct str_to_int64< true >
     return std::stoll( std::forward< Args >( args )... ); };
 };
 
+// ----------------------------------------------------------------------------
+template< class T >
+struct is_optional : std::false_type
+{};
+
+// ----------------------------------------------------------------------------
+template< class T >
+struct is_optional< std::optional< T > > : std::true_type
+{};
+
+// ----------------------------------------------------------------------------
+template< class T >
+constexpr bool is_optional_v = is_optional< T >::value;
+
+// ----------------------------------------------------------------------------
+template< class T >
+struct decay_optional
+{
+  using type = T;
+};
+
+// ----------------------------------------------------------------------------
+template< class T >
+struct decay_optional< std::optional< T > >
+{
+  using type = T;
+};
+
+// ----------------------------------------------------------------------------
+template< class T >
+using decay_optional_t = typename decay_optional< T >::type;
+
+// ----------------------------------------------------------------------------
+template< class T >
+T bad_parse( std::string const& s )
+{
+  if constexpr( is_optional_v< T > )
+  {
+    return std::nullopt;
+  }
+  else
+  {
+    throw csv_reader::parse_error( s, typeid( T ) );
+  }
+}
+
 }
 
 // ----------------------------------------------------------------------------
@@ -374,7 +420,8 @@ csv_reader
   if constexpr(
     std::is_arithmetic_v< T > ||
     std::is_same_v< T, std::string > ||
-    std::is_same_v< T, csv::skipf_t > )
+    std::is_same_v< T, csv::skipf_t > ||
+    is_optional_v< T > )
   {
     if( !m_first_field && m_is.peek() == m_delim )
     {
@@ -384,6 +431,7 @@ csv_reader
     m_first_field = false;
 
     auto are_in_quotes = m_is.peek() == m_quote;
+    auto const were_in_quotes = are_in_quotes;
     if( are_in_quotes )
     {
       // Skip opening quote character
@@ -501,15 +549,27 @@ csv_reader
       return {};
     }
 
-    // If all we wanted was a string, just return that
+    // Get unquoted field text
     std::string s = ss.str();
-    if constexpr( std::is_same_v< T, std::string > )
+
+    // Check for empty field
+    if constexpr( is_optional_v< T > )
+    {
+      if( s.empty() && !were_in_quotes )
+      {
+        return std::nullopt;
+      }
+    }
+    using decayed_t = decay_optional_t< T >;
+
+    // If all we wanted was a string, just return that
+    if constexpr( std::is_same_v< decayed_t, std::string > )
     {
       return s;
     }
 
     // Convert string to boolean
-    if constexpr( std::is_same_v< T, bool > )
+    if constexpr( std::is_same_v< decayed_t, bool > )
     {
       if( s == "0" || s == "false" )
       {
@@ -520,23 +580,23 @@ csv_reader
         return true;
       }
 
-      throw parse_error( s, typeid( T ) );
+      return bad_parse< T >( s );
     }
 
     // Numbers should not have leading whitespace
-    if constexpr( std::is_arithmetic_v< T > )
+    if constexpr( std::is_arithmetic_v< decayed_t > )
     {
       if( s.empty() || std::isspace( s[ 0 ] ) )
       {
-        throw parse_error( s, typeid( T ) );
+        return bad_parse< T >( s );
       }
     }
 
     // Convert string to integer
-    if constexpr( std::is_integral_v< T > )
+    if constexpr( std::is_integral_v< decayed_t > )
     {
       // Parse into a 64-bit integer
-      using parser_t = str_to_int64< std::is_signed_v< T > >;
+      using parser_t = str_to_int64< std::is_signed_v< decayed_t > >;
       parser_t parser;
       typename parser_t::type value = 0;
       size_t offset = 0;
@@ -546,15 +606,15 @@ csv_reader
       }
       catch( std::exception const& )
       {
-        throw parse_error( s, typeid( T ) );
+        return bad_parse< T >( s );
       }
 
       // Check if reducing to the desired integer size would overflow
-      if( value < std::numeric_limits< T >::lowest() ||
-          value > std::numeric_limits< T >::max() ||
+      if( value < std::numeric_limits< decayed_t >::lowest() ||
+          value > std::numeric_limits< decayed_t >::max() ||
           !offset || offset != s.size() )
       {
-        throw parse_error( s, typeid( T ) );
+        return bad_parse< T >( s );
       }
 
       // Downcast to correct type
@@ -563,14 +623,16 @@ csv_reader
 
     // Parse to floating point
     // Didn't use std::is_floating_point_v because we don't handle long double
-    if constexpr( std::is_same_v< T, float > || std::is_same_v< T, double > )
+    if constexpr(
+      std::is_same_v< decayed_t, float > ||
+      std::is_same_v< decayed_t, double > )
     {
-      T ( *parser )( char const*, char** ) = nullptr;
-      if constexpr( std::is_same_v< T, float > )
+      decayed_t ( *parser )( char const*, char** ) = nullptr;
+      if constexpr( std::is_same_v< decayed_t, float > )
       {
         parser = &std::strtof;
       }
-      if constexpr( std::is_same_v< T, double > )
+      if constexpr( std::is_same_v< decayed_t, double > )
       {
         parser = &std::strtod;
       }
@@ -580,7 +642,7 @@ csv_reader
       auto const value = parser( begin, &end );
       if( end == begin || end != &*s.end() )
       {
-        throw parse_error( s, typeid( T ) );
+        return bad_parse< T >( s );
       }
       return value;
     }
@@ -709,18 +771,31 @@ csv_reader
   template KWIVER_ALGO_CORE_EXPORT T csv_reader::read< T >();
 
 INSTANTIATE_READ( std::string )
+INSTANTIATE_READ( std::optional< std::string > )
 INSTANTIATE_READ( bool )
+INSTANTIATE_READ( std::optional< bool > )
 INSTANTIATE_READ( char )
+INSTANTIATE_READ( std::optional< char > )
 INSTANTIATE_READ( uint8_t )
+INSTANTIATE_READ( std::optional< uint8_t > )
 INSTANTIATE_READ( uint16_t )
+INSTANTIATE_READ( std::optional< uint16_t > )
 INSTANTIATE_READ( uint32_t )
+INSTANTIATE_READ( std::optional< uint32_t > )
 INSTANTIATE_READ( uint64_t )
+INSTANTIATE_READ( std::optional< uint64_t > )
 INSTANTIATE_READ( int8_t )
+INSTANTIATE_READ( std::optional< int8_t > )
 INSTANTIATE_READ( int16_t )
+INSTANTIATE_READ( std::optional< int16_t > )
 INSTANTIATE_READ( int32_t )
+INSTANTIATE_READ( std::optional< int32_t > )
 INSTANTIATE_READ( int64_t )
+INSTANTIATE_READ( std::optional< int64_t > )
 INSTANTIATE_READ( float )
+INSTANTIATE_READ( std::optional< float > )
 INSTANTIATE_READ( double )
+INSTANTIATE_READ( std::optional< double > )
 INSTANTIATE_READ( csv::skipf_t )
 INSTANTIATE_READ( csv::endl_t )
 INSTANTIATE_READ( csv::comment_t )

--- a/arrows/core/csv_io.h
+++ b/arrows/core/csv_io.h
@@ -11,6 +11,7 @@
 #include <arrows/core/kwiver_algo_core_export.h>
 
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -290,7 +291,10 @@ public:
   /// csv::comment_t to begin reading the contents of a comment as regular
   /// fields. Otherwise, comments will be silently skipped. Passing \c
   /// csv::endl_t has the same effect as \c next_line(). Passing \c
-  /// csv::skipf_t has the same effect as \c skip_field().
+  /// csv::skipf_t has the same effect as \c skip_field(). If \p T is a \c
+  /// std::optional, \c std::nullopt will be returned if the field is empty or
+  /// if parsing the field fails. Therefore, \c parse_error will not be thrown
+  /// if \p T is a \c std::optional.
   ///
   /// \throws parse_error If parsing from the current field to type \p T fails.
   /// The current field is skipped if this occurs. A string representation of

--- a/arrows/core/tests/test_csv_io.cxx
+++ b/arrows/core/tests/test_csv_io.cxx
@@ -377,3 +377,30 @@ TEST ( csv_io, read_comment )
   reader.skip_line();
   EXPECT_TRUE( reader.is_at_eof() );
 }
+
+// ----------------------------------------------------------------------------
+TEST ( csv_io, read_optional )
+{
+  std::stringstream ss{ ",,,,,A,Maybe,1L,-10,five,0,true,\"\",5,7.0" };
+  csv_reader reader( ss );
+
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< char > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< bool > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< std::string > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< uint16_t > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< float > >() );
+
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< char > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< bool > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< uint16_t > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< uint16_t > >() );
+  EXPECT_EQ( std::nullopt, reader.read< std::optional< float > >() );
+
+  EXPECT_EQ( 0, reader.read< std::optional< char > >() );
+  EXPECT_EQ( true, reader.read< std::optional< bool > >() );
+  EXPECT_EQ( std::string{}, reader.read< std::optional< std::string > >() );
+  EXPECT_EQ( 5, reader.read< std::optional< uint16_t > >() );
+  EXPECT_EQ( 7.0f, reader.read< std::optional< float > >() );
+
+  EXPECT_TRUE( reader.is_at_eol() );
+}

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -6,3 +6,7 @@ over the previous v1.8.0 release.
 
 Updates
 -------
+
+Arrows: Core
+
+* Implemented the csv_reader reading std::optional fields.


### PR DESCRIPTION
This PR implements the `csv_reader.read()` interface for `std::optional` wrappers around supported field types. This provides an alternate way of handling missing or invalid fields, rather than needing a `try{} catch(parse_error){}` around every read command.