### PR TITLE
Fix integer promotion bug

### DIFF
--- a/arrows/klv/klv_0806_user_defined_set.cxx
+++ b/arrows/klv/klv_0806_user_defined_set.cxx
@@ -97,8 +97,8 @@ klv_0806_user_defined_data_type_id_format
 ::write_typed( klv_0806_user_defined_data_type_id const& value,
                klv_write_iter_t& data, size_t length ) const
 {
-  auto int_value = static_cast< uint8_t >( value.id & 0x3F ) |
-                   static_cast< uint8_t >( value.type << 6 );
+  auto int_value =
+    static_cast< uint8_t >( ( value.id & 0x3F ) | ( value.type << 6 ) );
   klv_write_int( int_value, data, length );
 }
 

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -6,3 +6,8 @@ Updates
 
 Bug Fixes
 ---------
+
+Arrows: KLV
+
+* Fixed an integer promotion bug when writing the ST0806 user defined data
+  type / id field.


### PR DESCRIPTION
This PR fixes a bug in which C++'s arithmetic integer promotion rules cause an integer value to end up as an `int` instead of a `uint8_t`, which messes up the writing operation because `int` is signed.