### PR TITLE
Better define comparison behavior with NaNs

### DIFF
--- a/arrows/klv/klv_lengthy.cxx
+++ b/arrows/klv/klv_lengthy.cxx
@@ -58,52 +58,7 @@ operator<<( std::ostream& os, klv_lengthy< T > const& value )
 }
 
 // ----------------------------------------------------------------------------
-template < class T >
-bool
-operator<( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value < rhs.value;
-}
-
-// ----------------------------------------------------------------------------
-template < class T >
-bool
-operator>( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value > rhs.value;
-}
-
-// ----------------------------------------------------------------------------
-template < class T >
-bool
-operator<=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value <= rhs.value;
-}
-
-// ----------------------------------------------------------------------------
-template < class T >
-bool
-operator>=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value >= rhs.value;
-}
-
-// ----------------------------------------------------------------------------
-template < class T >
-bool
-operator==( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value == rhs.value;
-}
-
-// ----------------------------------------------------------------------------
-template < class T >
-bool
-operator!=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs )
-{
-  return lhs.value != rhs.value;
-}
+DEFINE_TEMPLATE_CMP( klv_lengthy< T >, &klv_lengthy< T >::value )
 
 // ----------------------------------------------------------------------------
 #define KLV_INSTANTIATE( T )                                                    \

--- a/arrows/klv/klv_lengthy.h
+++ b/arrows/klv/klv_lengthy.h
@@ -43,40 +43,7 @@ std::ostream&
 operator<<( std::ostream& os, klv_lengthy< T > const& value );
 
 // ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator<( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
-
-// ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator>( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
-
-// ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator<=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
-
-// ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator>=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
-
-// ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator==( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
-
-// ----------------------------------------------------------------------------
-template < class T >
-KWIVER_ALGO_KLV_EXPORT
-bool
-operator!=( klv_lengthy< T > const& lhs, klv_lengthy< T > const& rhs );
+DECLARE_TEMPLATE_CMP( klv_lengthy< T > )
 
 } // namespace klv
 

--- a/arrows/klv/klv_util.h
+++ b/arrows/klv/klv_util.h
@@ -86,11 +86,67 @@ operator<<( std::ostream& os, std::set< T > const& value )
 }
 
 // ----------------------------------------------------------------------------
+template< class T >
+struct wrap_cmp_nan
+{
+  explicit wrap_cmp_nan( T const& value ) : value{ value } {}
+
+  bool operator<( wrap_cmp_nan< T > const& other ) const
+  {
+    if constexpr( std::is_floating_point_v< T > )
+    {
+      return value < other.value ||
+             ( std::isnan( value ) && !std::isnan( other.value ) );
+    }
+    else
+    {
+      return value < other.value;
+    }
+  }
+
+  bool operator>( wrap_cmp_nan< T > const& other ) const
+  {
+    return other < *this;
+  }
+
+  bool operator<=( wrap_cmp_nan< T > const& other ) const
+  {
+    return !( other < *this );
+  }
+
+  bool operator>=( wrap_cmp_nan< T > const& other ) const
+  {
+    return !( *this < other );
+  }
+
+  bool operator==( wrap_cmp_nan< T > const& other ) const
+  {
+    if constexpr( std::is_floating_point_v< T > )
+    {
+      return value == other.value ||
+             ( std::isnan( value ) && std::isnan( other.value ) );
+    }
+    else
+    {
+      return value == other.value;
+    }
+  }
+
+  bool operator!=( wrap_cmp_nan< T > const& other ) const
+  {
+    return !( *this == other );
+  }
+
+  T const& value;
+};
+
+// ----------------------------------------------------------------------------
 template< class T, class... Args >
 bool
 struct_lt( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) < std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) <
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------
@@ -98,7 +154,8 @@ template< class T, class... Args >
 bool
 struct_gt( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) > std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) >
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------
@@ -106,7 +163,8 @@ template< class T, class... Args >
 bool
 struct_le( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) <= std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) <=
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------
@@ -114,7 +172,8 @@ template< class T, class... Args >
 bool
 struct_ge( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) >= std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) >=
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------
@@ -122,7 +181,8 @@ template< class T, class... Args >
 bool
 struct_eq( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) == std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) ==
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------
@@ -130,7 +190,8 @@ template< class T, class... Args >
 bool
 struct_ne( T const& lhs, T const& rhs, Args T::*... args )
 {
-  return std::tie( ( lhs.*args )... ) != std::tie( ( rhs.*args )... );
+  return std::make_tuple( wrap_cmp_nan( lhs.*args )... ) !=
+         std::make_tuple( wrap_cmp_nan( rhs.*args )... );
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/klv/klv_value.cxx
+++ b/arrows/klv/klv_value.cxx
@@ -12,6 +12,7 @@
 #include "klv_packet.h"
 #include "klv_series.hpp"
 #include "klv_set.h"
+#include "klv_util.h"
 
 #include <vital/util/demangle.h>
 
@@ -20,30 +21,6 @@ namespace kwiver {
 namespace arrows {
 
 namespace klv {
-
-namespace {
-
-// ----------------------------------------------------------------------------
-template < class T,
-           typename std::enable_if< !std::is_floating_point< T >::value,
-                                    bool >::type = true >
-bool
-equal_or_nan( T const& lhs, T const& rhs )
-{
-  return lhs == rhs;
-}
-
-// ----------------------------------------------------------------------------
-template < class T,
-           typename std::enable_if< std::is_floating_point< T >::value,
-                                    bool >::type = true >
-bool
-equal_or_nan( T const& lhs, T const& rhs )
-{
-  return lhs == rhs || ( std::isnan( lhs ) && std::isnan( rhs ) );
-}
-
-} // namespace
 
 // ----------------------------------------------------------------------------
 klv_bad_value_cast
@@ -130,7 +107,7 @@ public:
     auto const& rhs_item =
       dynamic_cast< internal_< T > const& >( rhs ).m_item;
     // Second, compare values
-    return equal_or_nan( lhs.m_item, rhs_item );
+    return wrap_cmp_nan( lhs.m_item ) == wrap_cmp_nan( rhs_item );
   }
 
   std::ostream&

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -10,3 +10,7 @@ Updates
 Arrows: Core
 
 * Implemented the csv_reader reading std::optional fields.
+
+Arrows: KLV
+
+* Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
`NaN` comparisons always return false, which is not desirable behavior for consistently sorting or comparing. We had already accounted for this when comparing floating-point `klv_value`s, but not for floating-point members of a `struct` (pack). This PR fixes that.