### PR TITLE
Only initialize image writer if we're going to use it

### DIFF
--- a/arrows/core/applets/dump_klv.cxx
+++ b/arrows/core/applets/dump_klv.cxx
@@ -173,10 +173,13 @@ dump_klv
     "metadata_serializer", config, metadata_serializer_ptr );
   kva::metadata_map_io::get_nested_algo_configuration(
     "metadata_serializer", config, metadata_serializer_ptr );
-  kva::image_io::set_nested_algo_configuration(
-    "image_writer", config, image_writer );
-  kva::image_io::get_nested_algo_configuration(
-    "image_writer", config, image_writer );
+  if( cmd_args.count( "frames" ) )
+  {
+    kva::image_io::set_nested_algo_configuration(
+      "image_writer", config, image_writer );
+    kva::image_io::get_nested_algo_configuration(
+      "image_writer", config, image_writer );
+  }
 
   // Check to see if we are to dump config
   if ( cmd_args.count("output") )
@@ -209,7 +212,8 @@ dump_klv
     return EXIT_FAILURE;
   }
 
-  if( !kva::image_io::check_nested_algo_configuration(
+  if( cmd_args.count( "frames" ) &&
+      !kva::image_io::check_nested_algo_configuration(
          "image_writer", config ) )
   {
     std::cerr << "Invalid image_writer config" << std::endl;

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -20,3 +20,5 @@ Arrows: KLV
 * Throw an exception when reading an out-of-bounds IMAP value.
 
 * Made the compare-klv applet's failure to open a video result in a more graceful exit.
+
+* Disabled initialization of image writer in dump-klv if no images are to be written.


### PR DESCRIPTION
Exactly what it says in the title, to enable 'light' builds of KWIVER with no OpenCV to still run `dump-klv`.