### PR TITLE
Account for missing frames in compare-klv

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -22,3 +22,5 @@ Arrows: KLV
 * Made the compare-klv applet's failure to open a video result in a more graceful exit.
 
 * Disabled initialization of image writer in dump-klv if no images are to be written.
+
+* Accounted for missing or extra frames in compare-klv.


### PR DESCRIPTION
This PR ensures that `compare-klv` will let one video "catch up" if it has a frame that the other one does not. Previously, the frames were simply run through in order, but that meant that if one video was missing e.g. frame 100, then for the rest of the videos the frame numbers being compared would be mismatched by one (99 vs 99, then 100 vs 101, 101 vs 102, etc), giving the impression of there being many more differences than are actually present.