### PR TITLE
Make flint/imap not override incorrect lengths

### DIFF
--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -392,7 +392,10 @@ size_t
 klv_float_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return m_length_constraints.fixed_or( value.length );
+  return
+    value.length
+    ? value.length
+    : m_length_constraints.fixed_or( m_length_constraints.suggested() );
 }
 
 // ----------------------------------------------------------------------------
@@ -449,7 +452,10 @@ size_t
 klv_sflint_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return m_length_constraints.fixed_or( value.length );
+  return
+    value.length
+    ? value.length
+    : m_length_constraints.fixed_or( m_length_constraints.suggested() );
 }
 
 // ----------------------------------------------------------------------------
@@ -517,7 +523,10 @@ size_t
 klv_uflint_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return m_length_constraints.fixed_or( value.length );
+  return
+    value.length
+    ? value.length
+    : m_length_constraints.fixed_or( m_length_constraints.suggested() );
 }
 
 // ----------------------------------------------------------------------------
@@ -584,7 +593,10 @@ size_t
 klv_imap_format
 ::length_of_typed( klv_lengthy< double > const& value ) const
 {
-  return m_length_constraints.fixed_or( value.length );
+  return
+    value.length
+    ? value.length
+    : m_length_constraints.fixed_or( m_length_constraints.suggested() );
 }
 
 // ----------------------------------------------------------------------------

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -29,3 +29,6 @@ Arrows: KLV
 * Accounted for missing or extra frames in compare-klv.
 
 * Implemented metadata_map_io_csv.load_().
+
+* Modified flint/IMAP behavior to print a warning when writing values with
+  incorrect lengths instead of correcting the length and possibly losing data.


### PR DESCRIPTION
This PR modifies flint and IMAP behavior to print a warning when writing values with incorrect lengths instead of correcting the length and possibly losing data.