### PR TITLE
Enforce dts validity when writing

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -16,6 +16,10 @@ Arrows: Core
 * Made the transcode applet ask for video settings slightly later, when they
   might be more accurate.
 
+Arrows: FFmpeg
+
+* Added check for incoming raw video packets' timestamps and stream indices.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR checks that raw video packets have sensible timestamps (monotonically increasing DTS which is less than PTS), and ensures that the packets' stream indices are set correctly.