### PR TITLE
Copy input video start timestamp when transcoding

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1558,6 +1558,7 @@ ffmpeg_video_input::priv::open_video_state
   ffmpeg_video_settings_uptr result{ new ffmpeg_video_settings{} };
   result->frame_rate = frame_rate();
   result->klv_stream_count = klv_streams.size();
+  result->start_timestamp = format_context->start_time;
 
   if( codec_context )
   {

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -398,6 +398,7 @@ ffmpeg_video_output
   avcodec_parameters_from_context( result->parameters.get(),
                                    d->video->codec_context.get() );
   result->klv_stream_count = 0; // TODO
+  result->start_timestamp = d->video->format_context->start_time;
   return kwiver::vital::video_settings_uptr{ result };
 }
 
@@ -427,6 +428,9 @@ ffmpeg_video_output::impl::open_video_state
     format_context.reset( tmp );
   }
   output_format = format_context->oformat;
+
+  // Set timestamp value to start at
+  format_context->output_ts_offset = settings.start_timestamp;
 
   // Prioritization scheme for codecs:
   // (1) Match ffmpeg settings passed to constructor if present

--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -20,7 +20,8 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings()
   : frame_rate{ 0, 1 },
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ 0 }
+    klv_stream_count{ 0 },
+    start_timestamp{ AV_NOPTS_VALUE }
 {
   if( !parameters )
   {
@@ -34,7 +35,8 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings( ffmpeg_video_settings const& other )
   : frame_rate{ other.frame_rate },
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ other.klv_stream_count }
+    klv_stream_count{ other.klv_stream_count },
+    start_timestamp{ other.start_timestamp }
 {
   throw_error_code(
     avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
@@ -46,7 +48,8 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings( ffmpeg_video_settings&& other )
   : frame_rate{ std::move( other.frame_rate ) },
     parameters{ std::move( other.parameters ) },
-    klv_stream_count{ std::move( other.klv_stream_count ) }
+    klv_stream_count{ std::move( other.klv_stream_count ) },
+    start_timestamp{ other.start_timestamp }
 {}
 
 // ----------------------------------------------------------------------------
@@ -57,7 +60,8 @@ ffmpeg_video_settings
   size_t klv_stream_count )
   : frame_rate( frame_rate ),
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ klv_stream_count }
+    klv_stream_count{ klv_stream_count },
+    start_timestamp{ AV_NOPTS_VALUE }
 {
   if( !parameters )
   {
@@ -84,6 +88,7 @@ ffmpeg_video_settings
     avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
     "Could not copy codec parameters" );
   klv_stream_count = other.klv_stream_count;
+  start_timestamp = other.start_timestamp;
   return *this;
 }
 
@@ -95,6 +100,7 @@ ffmpeg_video_settings
   frame_rate = std::move( other.frame_rate );
   parameters = std::move( other.parameters );
   klv_stream_count = std::move( other.klv_stream_count );
+  start_timestamp = std::move( other.start_timestamp );
   return *this;
 }
 

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -47,6 +47,7 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   AVRational frame_rate;
   codec_parameters_uptr parameters;
   size_t klv_stream_count;
+  int64_t start_timestamp; // In AV_TIME_BASE units
 };
 using ffmpeg_video_settings_uptr = std::unique_ptr< ffmpeg_video_settings >;
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -20,6 +20,8 @@ Arrows: FFmpeg
 
 * Added check for incoming raw video packets' timestamps and stream indices.
 
+* Added functionality to copy the input video's start timestamp when transcoding.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR adds a `start_timestamp` member to `ffmpeg_video_settings`, allowing us to maintain the start PTS when transcoding a video. Probably not that important in most situations, but can't hurt.