### PR TITLE
Remove imagery_enabled

### DIFF
--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg.cxx
@@ -149,39 +149,6 @@ TEST_F ( ffmpeg_video_input, frame_image )
 }
 
 // ----------------------------------------------------------------------------
-// Verify that disabling imagery processing acts as expected and doesn't break
-// anything else.
-TEST_F( ffmpeg_video_input, imagery_disabled )
-{
-  ffmpeg::ffmpeg_video_input input;
-
-  auto config = input.get_configuration();
-  config->set_value< bool >( "imagery_enabled", false );
-  input.set_configuration( config );
-  input.open( aphill_video_path );
-
-  EXPECT_FALSE( input.good() );
-  EXPECT_EQ( input.frame_image(), nullptr );
-
-  size_t frame_count = 0;
-  kv::timestamp ts;
-  while( input.next_frame( ts ) )
-  {
-    ++frame_count;
-    EXPECT_TRUE( input.good() );
-    EXPECT_EQ( input.frame_image(), nullptr );
-    EXPECT_EQ( ts.get_frame(), frame_count );
-
-    auto const md = input.frame_metadata();
-    ASSERT_FALSE( md.empty() );
-    ASSERT_TRUE( md.at( 0 )->has( kv::VITAL_META_UNIX_TIMESTAMP ) );
-  }
-
-  input.close();
-  EXPECT_FALSE( input.good() );
-}
-
-// ----------------------------------------------------------------------------
 // Verify that disabling KLV processing acts as expected and doesn't break
 // anything else.
 TEST_F( ffmpeg_video_input, klv_disabled )

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -22,6 +22,8 @@ Arrows: FFmpeg
 
 * Added functionality to copy the input video's start timestamp when transcoding.
 
+* Removed imagery_enabled option from ffmpeg_video_input.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
As development on `ffmpeg_video_input` continues, it has become clear that we cannot guarantee consistency in the KLV output between runs with and without the `imagery_enabled` option. The original idea behind `imagery_enabled` was to offer a more efficient way to process only the KLV in a video by not passing the video packets to the decoder, if the image data was not to be used. Unfortunately, the requirement that KLV data be consistently associated with a frame is at odds with this, as we cannot fully guarantee that a frame exists except by decoding it. This and a few other issues with the current implementation mean that processing only the KLV may produce incorrect KLV-to-frame correspondence. This makes the KLV-only option sort of useless, and having it in there complicates the logic somewhat, so I think it is best to take it out. Nothing actually uses it right now, to my knowledge.