### PR TITLE
Handle changing video size or pixel format

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -24,6 +24,8 @@ Arrows: FFmpeg
 
 * Removed imagery_enabled option from ffmpeg_video_input.
 
+* Added proper handling for changing size or pixel format mid-video.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
In the unusual case where a video changes resolution or pixel format partway through, we need to re-initialize any FFmpeg filters we are using (deinterlacing by default) to allow them to adapt to this change.