### PR TITLE
Handle prefix- and payload-only checksums

### DIFF
--- a/arrows/klv/klv_0601.cxx
+++ b/arrows/klv/klv_0601.cxx
@@ -2820,7 +2820,7 @@ klv_0601_wavelength_record_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_0601_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_0601.h
+++ b/arrows/klv/klv_0601.h
@@ -1042,7 +1042,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_running_sum_16_packet_format m_checksum_format;

--- a/arrows/klv/klv_0806.cxx
+++ b/arrows/klv/klv_0806.cxx
@@ -199,7 +199,7 @@ klv_0806_local_set_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_0806_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_0806.h
+++ b/arrows/klv/klv_0806.h
@@ -66,7 +66,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_crc_32_mpeg_packet_format m_checksum_format;

--- a/arrows/klv/klv_0903.cxx
+++ b/arrows/klv/klv_0903.cxx
@@ -174,7 +174,7 @@ klv_0903_local_set_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_0903_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_0903.h
+++ b/arrows/klv/klv_0903.h
@@ -73,7 +73,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_running_sum_16_packet_format m_checksum_format;

--- a/arrows/klv/klv_1002.cxx
+++ b/arrows/klv/klv_1002.cxx
@@ -269,7 +269,7 @@ klv_1002_local_set_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_1002_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_1002.h
+++ b/arrows/klv/klv_1002.h
@@ -180,7 +180,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_crc_16_ccitt_packet_format m_checksum_format;

--- a/arrows/klv/klv_1107.cxx
+++ b/arrows/klv/klv_1107.cxx
@@ -113,7 +113,7 @@ klv_1107_local_set_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_1107_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_1107.h
+++ b/arrows/klv/klv_1107.h
@@ -109,7 +109,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_crc_16_ccitt_packet_format m_checksum_format;

--- a/arrows/klv/klv_1108.cxx
+++ b/arrows/klv/klv_1108.cxx
@@ -223,7 +223,7 @@ klv_1108_local_set_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_1108_local_set_format
-::checksum_format() const
+::packet_checksum_format() const
 {
   return &m_checksum_format;
 }

--- a/arrows/klv/klv_1108.h
+++ b/arrows/klv/klv_1108.h
@@ -204,7 +204,7 @@ public:
   description_() const override;
 
   klv_checksum_packet_format const*
-  checksum_format() const override;
+  packet_checksum_format() const override;
 
 private:
   klv_crc_16_ccitt_packet_format m_checksum_format;

--- a/arrows/klv/klv_data_format.cxx
+++ b/arrows/klv/klv_data_format.cxx
@@ -61,7 +61,23 @@ klv_data_format
 // ----------------------------------------------------------------------------
 klv_checksum_packet_format const*
 klv_data_format
-::checksum_format() const
+::prefix_checksum_format() const
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+klv_checksum_packet_format const*
+klv_data_format
+::payload_checksum_format() const
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+klv_checksum_packet_format const*
+klv_data_format
+::packet_checksum_format() const
 {
   return nullptr;
 }

--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -86,9 +86,18 @@ public:
   std::string
   description() const;
 
-  /// Optionally the checksum format for this data format.
+  /// Return the checksum format for the packet key and length only, or
+  /// `nullptr`.
   virtual klv_checksum_packet_format const*
-  checksum_format() const;
+  prefix_checksum_format() const;
+
+  /// Return the checksum format for the packet payload only, or `nullptr`.
+  virtual klv_checksum_packet_format const*
+  payload_checksum_format() const;
+
+  /// Return the checksum format for the entire packet, or `nullptr`.
+  virtual klv_checksum_packet_format const*
+  packet_checksum_format() const;
 
   /// Return the constraints on the length of this format.
   klv_length_constraints const&


### PR DESCRIPTION
This PR somewhat restructures the KLV packet checksum code to make it possible to define checksums that only operate on the prefix or payload of a packet. This should not significantly change current behavior - just making room for future development.