### PR TITLE
Optimize image copying when writing video

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -32,6 +32,8 @@ Arrows: FFmpeg
 
 * Exposed codec options in ffmpeg_video_settings.
 
+* Optimized copying behavior when encoding frames.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR ensures we don't perform a slow, pixel-at-a-time copy when the incoming image is already in a friendly (i.e. packed RGB) format. Since a KWIVER image could theoretically have separate R, G, and B planes or some even stranger memory layout, we have to keep the pixel-at-a-time logic in there, but skipping the slow copy in the most common case speeds up video encoding more than 2x on my machine.