### PR TITLE
Expose FFmpeg codec options

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -623,7 +623,12 @@ ffmpeg_video_output::impl::open_video_state
   video_stream->codecpar->height = codec_context->height;
   video_stream->codecpar->format = codec_context->pix_fmt;
 
-  auto const err = avcodec_open2( codec_context.get(), codec, nullptr );
+  AVDictionary* codec_options = nullptr;
+  for( auto const& entry : settings.codec_options )
+  {
+    av_dict_set( &codec_options, entry.first.c_str(), entry.second.c_str(), 0 );
+  }
+  auto const err = avcodec_open2( codec_context.get(), codec, &codec_options );
   if( err < 0 )
   {
     LOG_WARN(

--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -21,7 +21,8 @@ ffmpeg_video_settings
   : frame_rate{ 0, 1 },
     parameters{ avcodec_parameters_alloc() },
     klv_stream_count{ 0 },
-    start_timestamp{ AV_NOPTS_VALUE }
+    start_timestamp{ AV_NOPTS_VALUE },
+    codec_options{}
 {
   if( !parameters )
   {
@@ -36,7 +37,8 @@ ffmpeg_video_settings
   : frame_rate{ other.frame_rate },
     parameters{ avcodec_parameters_alloc() },
     klv_stream_count{ other.klv_stream_count },
-    start_timestamp{ other.start_timestamp }
+    start_timestamp{ other.start_timestamp },
+    codec_options{ other.codec_options }
 {
   throw_error_code(
     avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
@@ -49,7 +51,8 @@ ffmpeg_video_settings
   : frame_rate{ std::move( other.frame_rate ) },
     parameters{ std::move( other.parameters ) },
     klv_stream_count{ std::move( other.klv_stream_count ) },
-    start_timestamp{ other.start_timestamp }
+    start_timestamp{ other.start_timestamp },
+    codec_options{ std::move( other.codec_options ) }
 {}
 
 // ----------------------------------------------------------------------------
@@ -61,7 +64,8 @@ ffmpeg_video_settings
   : frame_rate( frame_rate ),
     parameters{ avcodec_parameters_alloc() },
     klv_stream_count{ klv_stream_count },
-    start_timestamp{ AV_NOPTS_VALUE }
+    start_timestamp{ AV_NOPTS_VALUE },
+    codec_options{}
 {
   if( !parameters )
   {
@@ -89,6 +93,7 @@ ffmpeg_video_settings
     "Could not copy codec parameters" );
   klv_stream_count = other.klv_stream_count;
   start_timestamp = other.start_timestamp;
+  codec_options = other.codec_options;
   return *this;
 }
 
@@ -101,6 +106,7 @@ ffmpeg_video_settings
   parameters = std::move( other.parameters );
   klv_stream_count = std::move( other.klv_stream_count );
   start_timestamp = std::move( other.start_timestamp );
+  codec_options = std::move( other.codec_options );
   return *this;
 }
 

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
+#include <map>
 #include <memory>
 
 namespace kwiver {
@@ -48,6 +49,7 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   codec_parameters_uptr parameters;
   size_t klv_stream_count;
   int64_t start_timestamp; // In AV_TIME_BASE units
+  std::map< std::string, std::string > codec_options;
 };
 using ffmpeg_video_settings_uptr = std::unique_ptr< ffmpeg_video_settings >;
 

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -30,6 +30,8 @@ Arrows: FFmpeg
 
 * Ensured proper clearing of video state even when seek attempts fail.
 
+* Exposed codec options in ffmpeg_video_settings.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR allows manipulation of implementation-specific codec behavior settings that `AVCodecParameters` is too generic to include.