### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+python:
+  install:
+    - requirements: doc/manuals/rtd_requirement.txt
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: doc/manuals/conf.py

--- a/doc/manuals/rtd_requirement.txt
+++ b/doc/manuals/rtd_requirement.txt
@@ -1,1 +1,2 @@
 breathe
+sphinx<7.0.0


### PR DESCRIPTION
This should hopefully fix the currently-failing `readthedocs` CI build.