### PR TITLE
Enable FFmpeg threading by default

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1003,6 +1003,9 @@ ffmpeg_video_input::priv::open_video_state
       av_buffer_ref( parent->hardware_device_context.get() );
   }
 
+  codec_context->thread_count = 0;
+  codec_context->thread_type = FF_THREAD_FRAME;
+
   // Open codec
   auto const err = avcodec_open2( codec_context.get(), codec, NULL );
   if( err < 0 )

--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -557,6 +557,9 @@ ffmpeg_video_output::impl::open_video_state
     throw_error_null(
       avcodec_alloc_context3( codec ), "Could not allocate codec context" ) );
 
+  codec_context->thread_count = 0;
+  codec_context->thread_type = FF_THREAD_FRAME;
+
   // Fill in fields from given settings
   if( codec->id == settings.parameters->codec_id )
   {


### PR DESCRIPTION
This PR tells FFmpeg to use its internal multithreading capabilities when encoding and decoding frames. Some encoders, e.g. libx264, have this enabled by default already, but most decoders do not, unnecessarily slowing down processing. Perhaps a future PR will add config parameters to allow manual control over the number of threads, but for right now FFmpeg gets to choose.