### PR TITLE
Delay discovery of GTest tests

### DIFF
--- a/CMake/utils/kwiver-utils-tests.cmake
+++ b/CMake/utils/kwiver-utils-tests.cmake
@@ -63,6 +63,9 @@
 
 include(GoogleTest)
 
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST CACHE STRING
+    "When to run test discovery: POST_BUILD or PRE_TEST")
+
 option(KWIVER_TEST_ADD_TARGETS "Add targets for tests to the build system" OFF)
 mark_as_advanced(KWIVER_TEST_ADD_TARGETS)
 if (KWIVER_TEST_ADD_TARGETS)


### PR DESCRIPTION
Fixes #1370 with CMake >= 3.18. Shouldn't require updating minimum CMake version, since we are just setting a variable which can be ignored by earlier versions. Of course, actually running the tests will still require `source setup_KWIVER.sh`.