### PR TITLE
Add sphinx_rtd_theme as an RTD dependency

### DIFF
--- a/doc/manuals/rtd_requirement.txt
+++ b/doc/manuals/rtd_requirement.txt
@@ -1,2 +1,3 @@
 breathe
 sphinx<7.0.0
+sphinx_rtd_theme


### PR DESCRIPTION
Attempting to fix the docs build which has broken again.