### PR TITLE
Implement packet lookahead for FFmpeg video input

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -397,7 +397,7 @@ ffmpeg_video_output
   result->frame_rate = d->video->video_stream->avg_frame_rate;
   avcodec_parameters_from_context( result->parameters.get(),
                                    d->video->codec_context.get() );
-  result->klv_stream_count = 0; // TODO
+  result->klv_streams = {};
   result->start_timestamp = d->video->format_context->start_time;
   return kwiver::vital::video_settings_uptr{ result };
 }

--- a/arrows/ffmpeg/ffmpeg_video_raw_image.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_raw_image.cxx
@@ -14,7 +14,11 @@ namespace arrows {
 namespace ffmpeg {
 
 ffmpeg_video_raw_image
-::ffmpeg_video_raw_image() : packets{}
+::ffmpeg_video_raw_image()
+  : packets{},
+    frame_dts{ AV_NOPTS_VALUE },
+    frame_pts{ AV_NOPTS_VALUE },
+    is_keyframe{ true }
 {}
 
 } // namespace ffmpeg

--- a/arrows/ffmpeg/ffmpeg_video_raw_image.h
+++ b/arrows/ffmpeg/ffmpeg_video_raw_image.h
@@ -33,6 +33,9 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_raw_image
   operator=( ffmpeg_video_raw_image const& ) = delete;
 
   std::list< packet_uptr > packets;
+  int64_t frame_dts;
+  int64_t frame_pts;
+  bool is_keyframe;
 };
 using ffmpeg_video_raw_image_sptr = std::shared_ptr< ffmpeg_video_raw_image >;
 

--- a/arrows/ffmpeg/ffmpeg_video_raw_metadata.h
+++ b/arrows/ffmpeg/ffmpeg_video_raw_metadata.h
@@ -11,6 +11,8 @@
 #include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
 #include <arrows/ffmpeg/ffmpeg_util.h>
 
+#include <arrows/klv/klv_stream_settings.h>
+
 #include <vital/types/video_raw_metadata.h>
 
 #include <list>
@@ -31,7 +33,15 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_raw_metadata
   ffmpeg_video_raw_metadata&
   operator=( ffmpeg_video_raw_metadata const& ) = delete;
 
-  std::list< packet_uptr > packets;
+  struct packet_info
+  {
+    packet_info();
+
+    packet_uptr packet;
+    klv::klv_stream_settings stream_settings;
+  };
+
+  std::list< packet_info > packets;
 };
 using ffmpeg_video_raw_metadata_sptr =
   std::shared_ptr< ffmpeg_video_raw_metadata >;

--- a/arrows/ffmpeg/ffmpeg_video_settings.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_settings.cxx
@@ -20,7 +20,7 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings()
   : frame_rate{ 0, 1 },
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ 0 },
+    klv_streams{},
     start_timestamp{ AV_NOPTS_VALUE },
     codec_options{}
 {
@@ -36,7 +36,7 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings( ffmpeg_video_settings const& other )
   : frame_rate{ other.frame_rate },
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ other.klv_stream_count },
+    klv_streams{ other.klv_streams },
     start_timestamp{ other.start_timestamp },
     codec_options{ other.codec_options }
 {
@@ -50,7 +50,7 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings( ffmpeg_video_settings&& other )
   : frame_rate{ std::move( other.frame_rate ) },
     parameters{ std::move( other.parameters ) },
-    klv_stream_count{ std::move( other.klv_stream_count ) },
+    klv_streams{ std::move( other.klv_streams ) },
     start_timestamp{ other.start_timestamp },
     codec_options{ std::move( other.codec_options ) }
 {}
@@ -60,10 +60,10 @@ ffmpeg_video_settings
 ::ffmpeg_video_settings(
   size_t width, size_t height,
   AVRational frame_rate,
-  size_t klv_stream_count )
+  std::vector< klv::klv_stream_settings > const& klv_streams )
   : frame_rate( frame_rate ),
     parameters{ avcodec_parameters_alloc() },
-    klv_stream_count{ klv_stream_count },
+    klv_streams{ klv_streams },
     start_timestamp{ AV_NOPTS_VALUE },
     codec_options{}
 {
@@ -91,7 +91,7 @@ ffmpeg_video_settings
   throw_error_code(
     avcodec_parameters_copy( parameters.get(), other.parameters.get() ),
     "Could not copy codec parameters" );
-  klv_stream_count = other.klv_stream_count;
+  klv_streams = other.klv_streams;
   start_timestamp = other.start_timestamp;
   codec_options = other.codec_options;
   return *this;
@@ -104,7 +104,7 @@ ffmpeg_video_settings
 {
   frame_rate = std::move( other.frame_rate );
   parameters = std::move( other.parameters );
-  klv_stream_count = std::move( other.klv_stream_count );
+  klv_streams = std::move( other.klv_streams );
   start_timestamp = std::move( other.start_timestamp );
   codec_options = std::move( other.codec_options );
   return *this;

--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -11,6 +11,8 @@
 #include <arrows/ffmpeg/ffmpeg_util.h>
 #include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
 
+#include <arrows/klv/klv_stream_settings.h>
+
 #include <vital/types/video_settings.h>
 
 extern "C" {
@@ -19,6 +21,7 @@ extern "C" {
 
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace kwiver {
 
@@ -36,7 +39,7 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   ffmpeg_video_settings(
     size_t width, size_t height,
     AVRational frame_rate,
-    size_t klv_stream_count );
+    std::vector< klv::klv_stream_settings > const& klv_streams = {} );
 
   ~ffmpeg_video_settings();
 
@@ -47,7 +50,7 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
 
   AVRational frame_rate;
   codec_parameters_uptr parameters;
-  size_t klv_stream_count;
+  std::vector< klv::klv_stream_settings > klv_streams;
   int64_t start_timestamp; // In AV_TIME_BASE units
   std::map< std::string, std::string > codec_options;
 };

--- a/arrows/klv/CMakeLists.txt
+++ b/arrows/klv/CMakeLists.txt
@@ -17,6 +17,7 @@ set( sources
   klv_packet.cxx
   klv_read_write.cxx
   klv_set.cxx
+  klv_stream_settings.cxx
   klv_string.cxx
   klv_tag_traits.cxx
   klv_timeline.cxx
@@ -77,6 +78,7 @@ set( public_headers
   klv_read_write.h
   klv_series.h
   klv_set.h
+  klv_stream_settings.h
   klv_string.h
   klv_timeline.h
   klv_types.h

--- a/arrows/klv/klv_stream_settings.cxx
+++ b/arrows/klv/klv_stream_settings.cxx
@@ -3,27 +3,33 @@
 // https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
 
 /// \file
-/// Implementation of FFmpeg video raw metadata.
+/// Implementation of settings structure for the creation of a klv stream.
 
-#include "ffmpeg_video_raw_metadata.h"
+#include "klv_stream_settings.h"
+
+#include <climits>
 
 namespace kwiver {
 
 namespace arrows {
 
-namespace ffmpeg {
+namespace klv {
 
 // ----------------------------------------------------------------------------
-ffmpeg_video_raw_metadata
-::ffmpeg_video_raw_metadata() : packets{}
+klv_stream_settings
+::klv_stream_settings()
+  : type{ KLV_STREAM_TYPE_ASYNC },
+    index{ INT_MIN }
 {}
 
 // ----------------------------------------------------------------------------
-ffmpeg_video_raw_metadata::packet_info
-::packet_info() : packet{}, stream_settings{}
-{}
+bool operator==( klv_stream_settings const& lhs,
+                 klv_stream_settings const& rhs )
+{
+  return lhs.type == rhs.type && lhs.index == rhs.index;
+}
 
-} // namespace ffmpeg
+} // namespace klv
 
 } // namespace arrows
 

--- a/arrows/klv/klv_stream_settings.h
+++ b/arrows/klv/klv_stream_settings.h
@@ -1,0 +1,46 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of settings structure for the creation of a klv stream.
+
+#ifndef KWIVER_ARROWS_KLV_KLV_STREAM_SETTINGS_H_
+#define KWIVER_ARROWS_KLV_KLV_STREAM_SETTINGS_H_
+
+#include <arrows/klv/kwiver_algo_klv_export.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace klv {
+
+// ----------------------------------------------------------------------------
+/// Synchronicity of a KLV stream.
+enum klv_stream_type {
+  KLV_STREAM_TYPE_SYNC,
+  KLV_STREAM_TYPE_ASYNC
+};
+
+// ----------------------------------------------------------------------------
+/// Parameters describing the general characteristics of a KLV stream.
+struct KWIVER_ALGO_KLV_EXPORT klv_stream_settings {
+  klv_stream_settings();
+
+  klv_stream_type type;
+  int index;
+};
+
+// ----------------------------------------------------------------------------
+KWIVER_ALGO_KLV_EXPORT
+bool operator==( klv_stream_settings const& lhs,
+                 klv_stream_settings const& rhs );
+
+} // namespace klv
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -34,6 +34,8 @@ Arrows: FFmpeg
 
 * Optimized copying behavior when encoding frames.
 
+* Implemented packet lookahead to ensure stream synchronization.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This code has already been reviewed by @chetnieter and merged in another repo, but these particular improvements should be merged into the main KWIVER repo so that they will be maintained in the future. This MR improves the FFmpeg video reader's logic in cases where different streams are out of sync, have corrupt timestamps, etc.