### PR TITLE
Add interfacing for copying uninterpreted data streams

### DIFF
--- a/arrows/core/applets/transcode.cxx
+++ b/arrows/core/applets/transcode.cxx
@@ -190,6 +190,13 @@ transcode_applet
       }
     }
 
+    // Transcode uninterpreted data
+    auto const misc_data = input->uninterpreted_frame_data();
+    if( misc_data )
+    {
+      output->add_uninterpreted_data( *misc_data );
+    }
+
     // Transcode image
     if( cmd_args.count( "copy-video" ) )
     {

--- a/arrows/core/video_input_buffered_metadata_filter.cxx
+++ b/arrows/core/video_input_buffered_metadata_filter.cxx
@@ -35,6 +35,7 @@ public:
     kv::timestamp timestamp;
     kv::image_container_sptr image;
     kv::video_raw_image_sptr raw_image;
+    kv::video_uninterpreted_data_sptr uninterpreted_data;
   };
 
   kv::algo::video_input_sptr video_input;
@@ -50,7 +51,8 @@ video_input_buffered_metadata_filter::impl::frame_info
 ::frame_info( kv::algo::video_input& input )
   : timestamp{ input.frame_timestamp() },
     image{ input.frame_image() },
-    raw_image{ input.raw_frame_image() }
+    raw_image{ input.raw_frame_image() },
+    uninterpreted_data{ input.uninterpreted_frame_data() }
 {}
 
 // ----------------------------------------------------------------------------
@@ -148,7 +150,8 @@ video_input_buffered_metadata_filter
     vi::HAS_ABSOLUTE_FRAME_TIME,
     vi::HAS_TIMEOUT,
     vi::HAS_RAW_IMAGE,
-    vi::HAS_RAW_METADATA, } )
+    vi::HAS_RAW_METADATA,
+    vi::HAS_UNINTERPRETED_DATA, } )
   {
     set_capability( capability, capabilities.capability( capability ) );
   }
@@ -343,6 +346,19 @@ video_input_buffered_metadata_filter
   }
 
   return d->frame_metadata;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_uninterpreted_data_sptr
+video_input_buffered_metadata_filter
+::uninterpreted_frame_data()
+{
+  if( end_of_video() || d->frames.empty() )
+  {
+    return nullptr;
+  }
+
+  return d->frames.front().uninterpreted_data;
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/core/video_input_buffered_metadata_filter.h
+++ b/arrows/core/video_input_buffered_metadata_filter.h
@@ -57,6 +57,7 @@ public:
   vital::image_container_sptr frame_image() override;
   vital::video_raw_image_sptr raw_frame_image() override;
   vital::metadata_vector frame_metadata() override;
+  vital::video_uninterpreted_data_sptr uninterpreted_frame_data() override;
   vital::metadata_map_sptr metadata_map() override;
 
   vital::video_settings_uptr implementation_settings() const override;

--- a/arrows/core/video_input_metadata_filter.cxx
+++ b/arrows/core/video_input_metadata_filter.cxx
@@ -164,6 +164,7 @@ video_input_metadata_filter
   copy_capability( vi::IS_SEEKABLE );
   copy_capability( vi::HAS_RAW_IMAGE );
   copy_capability( vi::HAS_RAW_METADATA );
+  copy_capability( vi::HAS_UNINTERPRETED_DATA );
 }
 
 // ----------------------------------------------------------------------------
@@ -242,6 +243,19 @@ video_input_metadata_filter
     return nullptr;
   }
   return m_d->video_input->raw_frame_image();
+}
+
+// ----------------------------------------------------------------------------
+kv::video_uninterpreted_data_sptr
+video_input_metadata_filter
+::uninterpreted_frame_data()
+{
+  if( !m_d->video_input )
+  {
+    return nullptr;
+  }
+
+  return m_d->video_input->uninterpreted_frame_data();
 }
 
 // ----------------------------------------------------------------------------

--- a/arrows/core/video_input_metadata_filter.h
+++ b/arrows/core/video_input_metadata_filter.h
@@ -53,6 +53,7 @@ public:
   kwiver::vital::image_container_sptr frame_image() override;
   kwiver::vital::video_raw_image_sptr raw_frame_image() override;
   kwiver::vital::metadata_vector frame_metadata() override;
+  kwiver::vital::video_uninterpreted_data_sptr uninterpreted_frame_data() override;
   kwiver::vital::metadata_map_sptr metadata_map() override;
 
   kwiver::vital::video_settings_uptr implementation_settings() const override;

--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -1885,6 +1885,7 @@ ffmpeg_video_input
   set_capability( kva::video_input::IS_SEEKABLE, true );
   set_capability( kva::video_input::HAS_RAW_IMAGE, true );
   set_capability( kva::video_input::HAS_RAW_METADATA, true );
+  set_capability( kva::video_input::HAS_UNINTERPRETED_DATA, false );
 
   ffmpeg_init();
 }

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -7,6 +7,10 @@ over the previous v1.8.0 release.
 Updates
 -------
 
+Vital: Types
+
+* Added interfaces for copying uninterpreted video data.
+
 Arrows: Core
 
 * Implemented the csv_reader reading std::optional fields.
@@ -15,6 +19,9 @@ Arrows: Core
 
 * Made the transcode applet ask for video settings slightly later, when they
   might be more accurate.
+
+* Added pass-throughs for uninterpreted video data in the metadata_filter and
+  buffered_metadata_filter video inputs.
 
 Arrows: FFmpeg
 

--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -166,6 +166,7 @@ set( vital_public_headers
   types/video_raw_image.h
   types/video_raw_metadata.h
   types/video_settings.h
+  types/video_uninterpreted_data.h
 )
 
 # ----------------------
@@ -236,6 +237,7 @@ set( vital_sources
   types/video_raw_image.cxx
   types/video_raw_metadata.cxx
   types/video_settings.cxx
+  types/video_uninterpreted_data.cxx
   types/uid.cxx
 )
 

--- a/vital/algo/video_input.cxx
+++ b/vital/algo/video_input.cxx
@@ -27,6 +27,7 @@ algorithm_capabilities::capability_name_t const video_input::HAS_TIMEOUT( "has-t
 algorithm_capabilities::capability_name_t const video_input::IS_SEEKABLE( "is-seekable" );
 algorithm_capabilities::capability_name_t const video_input::HAS_RAW_IMAGE( "has-raw-image" );
 algorithm_capabilities::capability_name_t const video_input::HAS_RAW_METADATA( "has-raw-metadata" );
+algorithm_capabilities::capability_name_t const video_input::HAS_UNINTERPRETED_DATA( "has-uninterpreted-data" );
 
 // ----------------------------------------------------------------------------
 
@@ -64,6 +65,14 @@ video_input
 video_raw_metadata_sptr
 video_input
 ::raw_frame_metadata()
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+video_uninterpreted_data_sptr
+video_input
+::uninterpreted_frame_data()
 {
   return nullptr;
 }

--- a/vital/algo/video_input.h
+++ b/vital/algo/video_input.h
@@ -20,6 +20,7 @@
 #include <vital/types/timestamp.h>
 #include <vital/types/video_raw_image.h>
 #include <vital/types/video_raw_metadata.h>
+#include <vital/types/video_uninterpreted_data.h>
 #include <vital/types/video_settings.h>
 
 #include <string>
@@ -123,6 +124,7 @@ public:
   static const algorithm_capabilities::capability_name_t IS_SEEKABLE;
   static const algorithm_capabilities::capability_name_t HAS_RAW_IMAGE;
   static const algorithm_capabilities::capability_name_t HAS_RAW_METADATA;
+  static const algorithm_capabilities::capability_name_t HAS_UNINTERPRETED_DATA;
 
   virtual ~video_input();
 
@@ -343,6 +345,16 @@ public:
   ///
   /// \return Pointer to raw metadata.
   virtual video_raw_metadata_sptr raw_frame_metadata();
+
+  /// Return an implementation-defined representation of uninterpreted data in
+  /// this frame.
+  ///
+  /// This method enables passage of miscellaneous data - such as audio,
+  /// unrecognized metadata, or secondary image streams - to a video output when
+  /// transcoding.
+  ///
+  /// \return Pointer to uninterpreted data.
+  virtual video_uninterpreted_data_sptr uninterpreted_frame_data();
 
   /// \brief Get metadata map for video.
   ///

--- a/vital/algo/video_output.cxx
+++ b/vital/algo/video_output.cxx
@@ -28,6 +28,10 @@ const algorithm_capabilities::capability_name_t
 video_output::SUPPORTS_METADATA( "supports-metadata" );
 
 // ----------------------------------------------------------------------------
+const algorithm_capabilities::capability_name_t
+video_output::SUPPORTS_UNINTERPRETED_DATA( "supports-uninterpreted-data" );
+
+// ----------------------------------------------------------------------------
 video_output
 ::video_output()
 {
@@ -56,6 +60,15 @@ video_output
 {
   throw std::logic_error{
     "video_output: This implementation does not support raw metadata" };
+}
+
+// ----------------------------------------------------------------------------
+void
+video_output
+::add_uninterpreted_data( video_uninterpreted_data const& misc_data )
+{
+  throw std::logic_error{
+    "video_output: This implementation does not support uninterpreted data" };
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/algo/video_output.h
+++ b/vital/algo/video_output.h
@@ -21,6 +21,7 @@
 #include <vital/types/video_raw_image.h>
 #include <vital/types/video_raw_metadata.h>
 #include <vital/types/video_settings.h>
+#include <vital/types/video_uninterpreted_data.h>
 
 #include <vital/vital_config.h>
 
@@ -60,6 +61,13 @@ public:
   /// This capability indicates if the implementation is able to write
   /// metadata.
   static const algorithm_capabilities::capability_name_t SUPPORTS_METADATA;
+
+  /// Writer can write uninterpreted data.
+  ///
+  /// This capability indicates if the implementation can take data which a
+  /// video input did not interpret and put it back in the video stream.
+  static const algorithm_capabilities::capability_name_t
+  SUPPORTS_UNINTERPRETED_DATA;
 
   virtual ~video_output();
 
@@ -132,10 +140,13 @@ public:
   /// This method writes the raw metadata to the video stream. There is no
   /// guarantee that this functions correctly when intermixed with non-raw
   /// metadata.
-  ///
-  /// For implementations that do not support metadata, this method does
-  /// nothing.
   virtual void add_metadata( video_raw_metadata const& md );
+
+  /// Add a frame of uninterpreted data to the video stream.
+  ///
+  /// This method writes the uninterpreted data to the video stream.
+  virtual void add_uninterpreted_data(
+      video_uninterpreted_data const& misc_data );
 
   /// Extract implementation-specific video encoding settings.
   ///

--- a/vital/types/video_uninterpreted_data.cxx
+++ b/vital/types/video_uninterpreted_data.cxx
@@ -1,0 +1,21 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Implementation of base video uninterpreted data type.
+
+#include <vital/types/video_uninterpreted_data.h>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+video_uninterpreted_data
+::~video_uninterpreted_data()
+{}
+
+} // namespace vital
+
+} // namespace kwiver

--- a/vital/types/video_uninterpreted_data.h
+++ b/vital/types/video_uninterpreted_data.h
@@ -1,0 +1,35 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of base video uninterpreted data type.
+
+#ifndef VITAL_VIDEO_UNINTERPRETED_DATA_H_
+#define VITAL_VIDEO_UNINTERPRETED_DATA_H_
+
+#include <vital/vital_export.h>
+
+#include <memory>
+
+namespace kwiver {
+
+namespace vital {
+
+// ----------------------------------------------------------------------------
+/// Base class for holding a single frame of uninterpreted data.
+struct VITAL_EXPORT video_uninterpreted_data
+{
+  virtual ~video_uninterpreted_data();
+};
+
+using video_uninterpreted_data_sptr =
+  std::shared_ptr< video_uninterpreted_data >;
+using video_uninterpreted_data_uptr =
+  std::unique_ptr< video_uninterpreted_data >;
+
+} // namespace vital
+
+} // namespace kwiver
+
+#endif


### PR DESCRIPTION
This PR adds interfaces and pass-through code enabling the copy of data in a video which our readers cannot currently interpret, but that we may want to preserve when writing the video back out. Audio, secondary video streams, and unrecognized metadata streams are the target examples here. This PR does not actually implement doing the copy, but merely adds room for it in our interfacing and existing tools.