### PR TITLE
Fixed syntax for plugin loading function call

### DIFF
--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -373,7 +373,7 @@ plugin_loader_impl
 
   reg_fp_t reg_fp = reinterpret_cast< reg_fp_t > ( fp );
 
-  if(m_parent)
+  if( m_parent )
   {
     ( *reg_fp )( *m_parent ); // register plugins
   }

--- a/vital/plugin_loader/plugin_loader.cxx
+++ b/vital/plugin_loader/plugin_loader.cxx
@@ -368,11 +368,15 @@ plugin_loader_impl
   // Save currently opened library in map
   m_library_map[path] = lib_handle;
 
-  typedef void (* reg_fp_t)( plugin_loader* );
+  typedef void (* reg_fp_t)( plugin_loader& );
+
 
   reg_fp_t reg_fp = reinterpret_cast< reg_fp_t > ( fp );
 
-  ( *reg_fp )( m_parent ); // register plugins
+  if(m_parent)
+  {
+    ( *reg_fp )( *m_parent ); // register plugins
+  }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The actual function being called, expects `plugin_loader&` as argument, but `plugin_loader*` was passed.