### PR TITLE
Increase output precision of floats when writing CSVs

### DIFF
--- a/arrows/core/csv_io.cxx
+++ b/arrows/core/csv_io.cxx
@@ -16,6 +16,7 @@
 #include <limits>
 
 #include <cctype>
+#include <cfloat>
 
 namespace kwiver {
 
@@ -121,6 +122,14 @@ csv_writer
     else if constexpr( std::is_integral_v< T > && std::is_unsigned_v< T > )
     {
       m_ss << static_cast< uint64_t >( value );
+    }
+    else if constexpr( std::is_same_v< T, float > )
+    {
+      m_ss << std::setprecision( FLT_DIG + 1 ) << value;
+    }
+    else if constexpr( std::is_same_v< T, double > )
+    {
+      m_ss << std::setprecision( DBL_DIG + 1 ) << value;
     }
     else
     {

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -15,6 +15,8 @@ Arrows: Core
 
 * Implemented the csv_reader reading std::optional fields.
 
+* Increased the precision of written floats and doubles in the csv_writer.
+
 * Made the transcode applet's failure to open a video result in a more graceful exit.
 
 * Made the transcode applet ask for video settings slightly later, when they


### PR DESCRIPTION
This PR increases the number of digits printed when writing floating-point numbers to a CSV, so that information is not lost in the process.