### PR TITLE
Fix packet synchronization bug

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_settings.h
+++ b/arrows/ffmpeg/ffmpeg_video_settings.h
@@ -71,9 +71,9 @@ struct KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_settings
   /// guaranteed to determine the time base in the output video.
   AVRational time_base;
 
-  /// Desired PTS of the first video frame, in AV_TIME_BASE units
-  /// (microseconds). For some formats, the actual first PTS may exceed this
-  /// value to ensure non-negative PTS or DTS.
+  /// Start time of the input video, in AV_TIME_BASE units (microseconds).
+  /// This information is necessary for copied and newly-encoded packets to sync
+  /// correctly.
   int64_t start_timestamp;
 
   /// FFmpeg-defined string options passed to the video codec.

--- a/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
@@ -364,7 +364,7 @@ TEST_F ( ffmpeg_video_output, round_trip_audio )
 // Similar to round_trip_direct, but for a test video with an audio stream.
 TEST_F ( ffmpeg_video_output, round_trip_audio_direct )
 {
-  auto const src_path = data_dir + "/" + short_video_name;
+  auto const src_path = data_dir + "/" + audio_video_name;
   auto const tmp_path =
     kwiver::testing::temp_file_name( "test-ffmpeg-output-", ".ts" );
 


### PR DESCRIPTION
This bug got missed in #1802 due to a typo in one of the unit tests causing it to run on the wrong video file. Run on the correct file, the unit test fails, alerting us that copying both the video and audio streams causes a desync between them. The bug may be fixed by adjusting how we adjust timestamps in accordance with `start_timestamp` - instead of having FFmpeg shift all packets forward, then manually shifting back the ones that are direct from the original video (and therefore already take `start_timestamp` into account), we tell FFmpeg to do nothing and manually shift forward packets that aren't from the original video (i.e. only video packets encoded by us). Alternately, we could have added backward shifting to the copied video packets and kept the rest as is, but this results in code duplication and is probably less clear anyway.