### PR TITLE
Add ffmpeg_video_input_clip

### DIFF
--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ffmpeg_headers_public
   ffmpeg_init.h
   ffmpeg_util.h
   ffmpeg_video_input.h
+  ffmpeg_video_input_clip.h
   ffmpeg_video_output.h
   ffmpeg_video_raw_image.cxx
   ffmpeg_video_raw_metadata.cxx
@@ -46,6 +47,7 @@ set(ffmpeg_sources
   ffmpeg_init.cxx
   ffmpeg_util.cxx
   ffmpeg_video_input.cxx
+  ffmpeg_video_input_clip.cxx
   ffmpeg_video_output.cxx
   ffmpeg_video_raw_image.cxx
   ffmpeg_video_raw_metadata.cxx

--- a/arrows/ffmpeg/ffmpeg_video_input.h
+++ b/arrows/ffmpeg/ffmpeg_video_input.h
@@ -27,6 +27,11 @@ class KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_input
   : public vital::algo::video_input
 {
 public:
+  enum seek_mode {
+    SEEK_MODE_EXACT,
+    SEEK_MODE_KEYFRAME_BEFORE,
+  };
+
   /// Constructor
   ffmpeg_video_input();
   virtual ~ffmpeg_video_input();
@@ -52,12 +57,17 @@ public:
 
   bool seekable() const override;
   size_t num_frames() const override;
+  double frame_rate() override;
 
   bool next_frame( ::kwiver::vital::timestamp& ts,
                    uint32_t timeout = 0 ) override;
   bool seek_frame( ::kwiver::vital::timestamp& ts,
                    ::kwiver::vital::timestamp::frame_t frame_number,
                    uint32_t timeout = 0 ) override;
+
+  bool seek_frame_( vital::timestamp& ts,
+                    vital::timestamp::frame_t frame_number,
+                    seek_mode mode, uint32_t timeout = 0 );
 
   ::kwiver::vital::timestamp frame_timestamp() const override;
   ::kwiver::vital::image_container_sptr frame_image() override;

--- a/arrows/ffmpeg/ffmpeg_video_input_clip.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input_clip.cxx
@@ -1,0 +1,438 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of FFmpeg video clipping utility.
+
+#include <arrows/ffmpeg/ffmpeg_video_input_clip.h>
+
+#include <arrows/ffmpeg/ffmpeg_video_input.h>
+#include <arrows/ffmpeg/ffmpeg_video_settings.h>
+#include <arrows/ffmpeg/ffmpeg_video_raw_image.h>
+#include <arrows/ffmpeg/ffmpeg_video_raw_metadata.h>
+#include <arrows/ffmpeg/ffmpeg_video_uninterpreted_data.h>
+
+#include <stdexcept>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+class ffmpeg_video_input_clip::impl
+{
+public:
+  impl();
+
+  void seek_to_start();
+  void filter_metadata(
+    vital::metadata_vector& metadata, vital::timestamp const& ts ) const;
+  vital::frame_id_t true_frame_begin() const;
+  vital::frame_id_t true_frame_end() const;
+
+  std::shared_ptr< ffmpeg_video_input > video;
+  vital::frame_id_t frame_begin;
+  vital::frame_id_t frame_end;
+
+  vital::metadata_map_sptr all_metadata;
+  std::string video_name;
+  vital::timestamp initial_timestamp;
+  int64_t initial_pts;
+  bool start_at_keyframe;
+  bool before_first_frame;
+};
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_clip::impl
+::impl()
+  : video{ new ffmpeg_video_input },
+    frame_begin{ 0 },
+    frame_end{ 0 },
+    all_metadata{ nullptr },
+    video_name{},
+    initial_timestamp{},
+    initial_pts{ AV_NOPTS_VALUE },
+    start_at_keyframe{ false },
+    before_first_frame{ true }
+{}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_clip::impl
+::seek_to_start()
+{
+  if( !video->seek_frame_(
+        initial_timestamp, frame_begin,
+        start_at_keyframe
+        ? ffmpeg_video_input::SEEK_MODE_KEYFRAME_BEFORE
+        : ffmpeg_video_input::SEEK_MODE_EXACT ) )
+  {
+    throw_error( "Could not start video clip" );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_clip::impl
+::filter_metadata(
+  vital::metadata_vector& metadata, vital::timestamp const& ts ) const
+{
+  for( auto& md : metadata )
+  {
+    if( md )
+    {
+      md.reset( new vital::metadata( *md ) );
+      md->set_timestamp( ts );
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+vital::frame_id_t
+ffmpeg_video_input_clip::impl
+::true_frame_begin() const
+{
+  return
+    initial_timestamp.has_valid_frame()
+    ? initial_timestamp.get_frame()
+    : frame_begin;
+}
+
+// ----------------------------------------------------------------------------
+vital::frame_id_t
+ffmpeg_video_input_clip::impl
+::true_frame_end() const
+{
+  return
+    video->num_frames()
+    ? std::min< vital::frame_id_t >( frame_end, video->num_frames() )
+    : frame_end;
+}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_clip
+::ffmpeg_video_input_clip()
+  : d{ new impl }
+{
+  attach_logger( "ffmpeg_video_input_clip" );
+}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_clip
+::~ffmpeg_video_input_clip()
+{}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+ffmpeg_video_input_clip
+::get_configuration() const
+{
+  auto config = vital::algo::video_input::get_configuration();
+  config->set_value(
+    "frame_begin", d->frame_begin,
+    "First frame to include in the clip. Indexed from 1." );
+  config->set_value(
+    "frame_end", d->frame_end,
+    "First frame not to include in the clip, i.e. one past the final frame in "
+    "the clip. Indexed from 1." );
+  config->set_value(
+    "start_at_keyframe", d->start_at_keyframe,
+    "Start at the first keyframe before frame_begin, if frame_begin is not a "
+    "keyframe." );
+
+  vital::algo::video_input::
+    get_nested_algo_configuration( "video_input", config, d->video );
+  return config;
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_clip
+::set_configuration( vital::config_block_sptr in_config )
+{
+  auto config = get_configuration();
+  config->merge_config( in_config );
+
+  d->frame_begin =
+    config->get_value< vital::frame_id_t >( "frame_begin", d->frame_begin );
+  d->frame_end =
+    config->get_value< vital::frame_id_t >( "frame_end", d->frame_end );
+  d->start_at_keyframe =
+    config->get_value< bool >( "start_at_keyframe", d->start_at_keyframe );
+
+  d->video->set_configuration( config->subblock_view( "video_input:ffmpeg" ) );
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::check_configuration( vital::config_block_sptr config ) const
+{
+  if( !config->has_value( "frame_begin" ) ||
+      !config->has_value( "frame_end" ) ||
+      !config->has_value( "video_input:type" ) )
+  {
+    return false;
+  }
+
+  auto const frame_begin =
+    config->get_value< vital::frame_id_t >( "frame_begin" );
+  auto const frame_end =
+    config->get_value< vital::frame_id_t >( "frame_end" );
+
+  return frame_begin <= frame_end && frame_begin > 0;
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_clip
+::open( std::string video_name )
+{
+  d->video_name = video_name;
+  d->before_first_frame = true;
+  d->video->open( video_name );
+  d->seek_to_start();
+  auto const raw_image =
+    dynamic_cast< ffmpeg_video_raw_image const* >(
+      d->video->raw_frame_image().get() );
+  if( !raw_image || raw_image->frame_pts == AV_NOPTS_VALUE )
+  {
+    throw std::runtime_error( "Could not acquire PTS of first frame" );
+  }
+  d->initial_pts = raw_image->frame_pts;
+
+  auto const& capabilities = d->video->get_implementation_capabilities();
+  using vi = vital::algo::video_input;
+  for( auto const& capability : {
+    vi::HAS_EOV,
+    vi::HAS_FRAME_NUMBERS,
+    vi::HAS_FRAME_DATA,
+    vi::HAS_FRAME_TIME,
+    vi::HAS_METADATA,
+    vi::HAS_ABSOLUTE_FRAME_TIME,
+    vi::HAS_TIMEOUT,
+    vi::IS_SEEKABLE,
+    vi::HAS_RAW_IMAGE,
+    vi::HAS_RAW_METADATA,
+    vi::HAS_UNINTERPRETED_DATA, } )
+  {
+    set_capability( capability, capabilities.capability( capability ) );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_clip
+::close()
+{
+  d->all_metadata.reset();
+  d->video->close();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::end_of_video() const
+{
+  if( d->before_first_frame )
+  {
+    return false;
+  }
+
+  return
+    d->video->end_of_video() ||
+    ( d->video->frame_timestamp().get_frame() >= d->frame_end );
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::good() const
+{
+  if( d->before_first_frame || end_of_video() )
+  {
+    return false;
+  }
+
+  return d->video->good();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::seekable() const
+{
+  return d->video->seekable();
+}
+
+// ----------------------------------------------------------------------------
+size_t
+ffmpeg_video_input_clip
+::num_frames() const
+{
+  return d->true_frame_end() - d->true_frame_begin();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::next_frame( vital::timestamp& ts, uint32_t timeout )
+{
+  if( end_of_video() )
+  {
+    ts = vital::timestamp{};
+    return false;
+  }
+
+  if( d->before_first_frame )
+  {
+    d->before_first_frame = false;
+    ts = frame_timestamp();
+    return true;
+  }
+
+  vital::timestamp tmp_ts;
+  auto const success =
+    d->video->next_frame( tmp_ts, timeout ) && !end_of_video();
+  ts = success ? frame_timestamp() : vital::timestamp{};
+  return success;
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_clip
+::seek_frame(
+  vital::timestamp& ts, vital::timestamp::frame_t frame_number,
+  uint32_t timeout )
+{
+  if( frame_number > 1 )
+  {
+    frame_number += d->true_frame_begin();
+    frame_number = std::min( frame_number, d->true_frame_end() );
+    return d->video->seek_frame( ts, frame_number, timeout );
+  }
+  else
+  {
+    d->seek_to_start();
+    return good();
+  }
+}
+
+// ----------------------------------------------------------------------------
+vital::timestamp
+ffmpeg_video_input_clip
+::frame_timestamp() const
+{
+  auto video_ts = d->video->frame_timestamp();
+  vital::timestamp ts;
+  if( video_ts.has_valid_frame() )
+  {
+    ts.set_frame( video_ts.get_frame() - d->true_frame_begin() + 1 );
+  }
+  if( video_ts.has_valid_time() && d->initial_timestamp.has_valid_time() )
+  {
+    ts.set_time_usec(
+      video_ts.get_time_usec() - d->initial_timestamp.get_time_usec() );
+  }
+  return ts;
+}
+
+// ----------------------------------------------------------------------------
+vital::image_container_sptr
+ffmpeg_video_input_clip
+::frame_image()
+{
+  return d->before_first_frame ? nullptr : d->video->frame_image();
+}
+
+// ----------------------------------------------------------------------------
+vital::video_raw_image_sptr
+ffmpeg_video_input_clip
+::raw_frame_image()
+{
+  return d->before_first_frame ? nullptr : d->video->raw_frame_image();
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+ffmpeg_video_input_clip
+::frame_metadata()
+{
+  if( d->before_first_frame )
+  {
+    return {};
+  }
+
+  auto result = d->video->frame_metadata();
+  d->filter_metadata( result, frame_timestamp() );
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_raw_metadata_sptr
+ffmpeg_video_input_clip
+::raw_frame_metadata()
+{
+  return d->before_first_frame ? nullptr : d->video->raw_frame_metadata();
+}
+
+// ----------------------------------------------------------------------------
+vital::video_uninterpreted_data_sptr
+ffmpeg_video_input_clip
+::uninterpreted_frame_data()
+{
+  return d->before_first_frame ? nullptr : d->video->uninterpreted_frame_data();
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_map_sptr
+ffmpeg_video_input_clip
+::metadata_map()
+{
+  if( d->all_metadata )
+  {
+    return d->all_metadata;
+  }
+
+  ffmpeg_video_input_clip tmp_video;
+  tmp_video.set_configuration( get_configuration() );
+  tmp_video.open( d->video_name );
+
+  vital::metadata_map::map_metadata_t result;
+  vital::timestamp ts;
+  while( tmp_video.next_frame( ts ) )
+  {
+    result.emplace( ts.get_frame(), tmp_video.frame_metadata() );
+  }
+
+  d->all_metadata.reset(
+    new vital::simple_metadata_map{ std::move( result ) } );
+  return d->all_metadata;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_settings_uptr
+ffmpeg_video_input_clip
+::implementation_settings() const
+{
+  auto const settings = d->video->implementation_settings();
+  auto const ffmpeg_settings =
+    dynamic_cast< ffmpeg_video_settings const* >( settings.get() );
+  if( !ffmpeg_settings )
+  {
+    return nullptr;
+  }
+
+  auto result = *ffmpeg_settings;
+  result.start_timestamp = d->initial_pts;
+  return std::make_unique< ffmpeg_video_settings >( std::move( result ) );
+}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // end namespace

--- a/arrows/ffmpeg/ffmpeg_video_input_clip.h
+++ b/arrows/ffmpeg/ffmpeg_video_input_clip.h
@@ -1,0 +1,76 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of FFmpeg video clipping utility.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_INPUT_CLIP_H
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_INPUT_CLIP_H
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+#include <vital/algo/video_input.h>
+
+#include <memory>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+/// Video input which temporally clips an FFmpeg-sourced video.
+///
+/// This implementation must have access to FFmpeg-level detailed information in
+/// order to properly clip raw streams.
+class KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_input_clip
+  : public vital::algo::video_input
+{
+public:
+  ffmpeg_video_input_clip();
+  virtual ~ffmpeg_video_input_clip();
+
+  PLUGIN_INFO( "ffmpeg_clip", "Clip an FFmpeg-sourced video." )
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  void open( std::string video_name ) override;
+  void close() override;
+
+  bool end_of_video() const override;
+  bool good() const override;
+
+  bool seekable() const override;
+  size_t num_frames() const override;
+
+  bool next_frame( vital::timestamp& ts, uint32_t timeout = 0 ) override;
+  bool seek_frame(
+    vital::timestamp& ts, vital::timestamp::frame_t frame_number,
+    uint32_t timeout = 0 ) override;
+
+  vital::timestamp frame_timestamp() const override;
+  vital::image_container_sptr frame_image() override;
+  vital::video_raw_image_sptr raw_frame_image() override;
+  vital::metadata_vector frame_metadata() override;
+  vital::video_raw_metadata_sptr raw_frame_metadata() override;
+  vital::video_uninterpreted_data_sptr uninterpreted_frame_data() override;
+  vital::metadata_map_sptr metadata_map() override;
+
+  vital::video_settings_uptr implementation_settings() const override;
+
+private:
+  class impl;
+
+  std::unique_ptr< impl > const d;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // end namespace
+
+#endif

--- a/arrows/ffmpeg/register_algorithms.cxx
+++ b/arrows/ffmpeg/register_algorithms.cxx
@@ -9,6 +9,7 @@
 #include <vital/algo/algorithm_factory.h>
 
 #include <arrows/ffmpeg/ffmpeg_video_input.h>
+#include <arrows/ffmpeg/ffmpeg_video_input_clip.h>
 #include <arrows/ffmpeg/ffmpeg_video_output.h>
 
 namespace kwiver {
@@ -30,6 +31,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   }
 
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input >();
+  reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input_clip >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_output >();
 
   reg.mark_module_as_loaded();

--- a/arrows/ffmpeg/tests/CMakeLists.txt
+++ b/arrows/ffmpeg/tests/CMakeLists.txt
@@ -9,8 +9,9 @@ set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_core)
 ##############################
 # Algorithms ffmpeg tests
 ##############################
-kwiver_discover_gtests(ffmpeg video_input_ffmpeg  LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
-kwiver_discover_gtests(ffmpeg video_output_ffmpeg LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_input_ffmpeg       LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_input_ffmpeg_clip  LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_output_ffmpeg      LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 
 if( KWIVER_ENABLE_SERIALIZE_JSON )
   kwiver_discover_gtests(ffmpeg video_input_ffmpeg_klv

--- a/arrows/ffmpeg/tests/common.h
+++ b/arrows/ffmpeg/tests/common.h
@@ -1,0 +1,145 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+#include <test_gtest.h>
+
+#include <arrows/ffmpeg/ffmpeg_video_input.h>
+#include <arrows/ffmpeg/ffmpeg_video_uninterpreted_data.h>
+
+#include <vital/range/iota.h>
+
+namespace ffmpeg = kwiver::arrows::ffmpeg;
+namespace klv = kwiver::arrows::klv;
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+// ----------------------------------------------------------------------------
+// Verify the average difference between pixels is not too high. Some
+// difference is expected due to compression artifacts, but we need to make
+// sure the frame images we get out are generally the same as what we put in.
+void
+expect_eq_images( kv::image const& src_image,
+                  kv::image const& tmp_image,
+                  double epsilon )
+{
+  auto error = 0.0;
+
+  ASSERT_TRUE( src_image.width() == tmp_image.width() );
+  ASSERT_TRUE( src_image.height() == tmp_image.height() );
+  ASSERT_TRUE( src_image.depth() == tmp_image.depth() );
+
+  for( auto const i : kvr::iota( src_image.width() ) )
+  {
+    for( auto const j : kvr::iota( src_image.height() ) )
+    {
+      for( auto const k : kvr::iota( src_image.depth() ) )
+      {
+        error += std::abs(
+          static_cast< double >( src_image.at< uint8_t >( i, j, k ) ) -
+          static_cast< double >( tmp_image.at< uint8_t >( i, j, k ) ) );
+      }
+    }
+  }
+  error /= src_image.width() * src_image.height() * src_image.depth();
+
+  EXPECT_LE( error, epsilon );
+}
+
+// ----------------------------------------------------------------------------
+void
+expect_eq_audio( kv::video_uninterpreted_data_sptr const& src_data,
+                 kv::video_uninterpreted_data_sptr const& tmp_data )
+{
+  ASSERT_EQ( src_data == nullptr, tmp_data == nullptr );
+  if( !src_data )
+  {
+    return;
+  }
+
+  auto const& src_packets =
+    dynamic_cast< ffmpeg::ffmpeg_video_uninterpreted_data const& >( *src_data )
+    .audio_packets;
+  auto const& tmp_packets =
+    dynamic_cast< ffmpeg::ffmpeg_video_uninterpreted_data const& >( *tmp_data )
+    .audio_packets;
+  ASSERT_EQ( src_packets.size(), tmp_packets.size() );
+
+  auto src_it = src_packets.begin();
+  auto tmp_it = tmp_packets.begin();
+  while( src_it != src_packets.begin() && tmp_it != tmp_packets.begin() )
+  {
+    ASSERT_EQ( ( *src_it )->size, ( *tmp_it )->size );
+    EXPECT_TRUE(
+      std::equal( ( *src_it )->data, ( *src_it )->data + ( *src_it )->size,
+                  ( *tmp_it )->data ) );
+    ++src_it;
+    ++tmp_it;
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+expect_eq_videos(
+  kv::algo::video_input& src_is, kv::algo::video_input& tmp_is,
+  double image_epsilon = 0.0, kv::frame_id_t frame_offset = 0,
+  kv::time_usec_t usec_offset = 0, bool allow_different_lengths = false )
+{
+  kv::timestamp src_ts;
+  kv::timestamp tmp_ts;
+
+  // Check each pair of frames for equality
+  for( src_is.next_frame( src_ts ), tmp_is.next_frame( tmp_ts );
+       !src_is.end_of_video() && !tmp_is.end_of_video();
+       src_is.next_frame( src_ts ), tmp_is.next_frame( tmp_ts ) )
+  {
+    SCOPED_TRACE(
+      std::string{ "Frame: " } +
+      std::to_string( src_ts.get_frame() ) + " | " +
+      std::to_string( tmp_ts.get_frame() ) );
+
+    EXPECT_EQ( src_ts.get_frame() + frame_offset, tmp_ts.get_frame() );
+    EXPECT_NEAR(
+      src_ts.get_time_usec() + usec_offset, tmp_ts.get_time_usec(), 1 );
+
+    auto const src_data = src_is.uninterpreted_frame_data();
+    auto const tmp_data = tmp_is.uninterpreted_frame_data();
+    expect_eq_audio( src_data, tmp_data );
+
+    auto const src_image = src_is.frame_image()->get_image();
+    auto const tmp_image = tmp_is.frame_image()->get_image();
+    expect_eq_images( src_image, tmp_image, image_epsilon );
+  }
+  if( !allow_different_lengths )
+  {
+    EXPECT_TRUE( src_is.end_of_video() );
+    EXPECT_TRUE( tmp_is.end_of_video() );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+expect_eq_videos(
+  std::string const& src_path, std::string const& tmp_path,
+  double image_epsilon = 0.0, kv::frame_id_t frame_offset = 0,
+  kv::time_usec_t usec_offset = 0, bool allow_different_lengths = false )
+{
+  ASSERT_GE( frame_offset, 0 );
+  ASSERT_GE( usec_offset, 0 );
+
+  ffmpeg::ffmpeg_video_input src_is;
+  ffmpeg::ffmpeg_video_input tmp_is;
+  src_is.open( src_path );
+  tmp_is.open( tmp_path );
+
+  kv::timestamp ts;
+  for( kv::frame_id_t i = 0; i < frame_offset; ++i )
+  {
+    src_is.next_frame( ts );
+  }
+
+  expect_eq_videos( src_is, tmp_is, image_epsilon );
+
+  src_is.close();
+  tmp_is.close();
+}

--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg_clip.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg_clip.cxx
@@ -1,0 +1,234 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test the FFmpeg video clip input.
+
+#include <test_gtest.h>
+
+#include <arrows/ffmpeg/tests/common.h>
+
+#include <arrows/ffmpeg/ffmpeg_video_input.h>
+#include <arrows/ffmpeg/ffmpeg_video_input_clip.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <filesystem>
+
+namespace ffmpeg = kwiver::arrows::ffmpeg;
+namespace kv = kwiver::vital;
+
+std::filesystem::path g_data_dir;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+void
+configure_input(
+  ffmpeg::ffmpeg_video_input_clip& input,
+  kv::frame_id_t frame_begin, kv::frame_id_t frame_end,
+  bool start_at_keyframe )
+{
+  auto config = input.get_configuration();
+  config->set_value( "frame_begin", frame_begin );
+  config->set_value( "frame_end", frame_end );
+  config->set_value( "start_at_keyframe", start_at_keyframe );
+  EXPECT_TRUE( input.check_configuration( config ) );
+  input.set_configuration( config );
+}
+
+// ----------------------------------------------------------------------------
+void test_clipped(
+  ffmpeg::ffmpeg_video_input_clip& input,
+  std::filesystem::path const& filepath,
+  kv::frame_id_t frame_begin, kv::frame_id_t frame_end,
+  kv::time_usec_t usec_begin )
+{
+  ffmpeg::ffmpeg_video_input unclipped_input;
+  unclipped_input.open( filepath.string() );
+  kv::timestamp ts;
+  for( kv::frame_id_t i = 1; i < frame_begin; ++i )
+  {
+    unclipped_input.next_frame( ts );
+  }
+
+  input.open( filepath.string() );
+  EXPECT_FALSE( input.good() );
+  EXPECT_FALSE( input.end_of_video() );
+  ts = input.frame_timestamp();
+  EXPECT_EQ( 1, ts.get_frame() );
+
+  CALL_TEST(
+    expect_eq_videos,
+    unclipped_input, input, 0.0, -frame_begin + 1, -usec_begin, true );
+
+  EXPECT_FALSE( input.good() );
+  EXPECT_TRUE( input.end_of_video() );
+
+  if( !unclipped_input.end_of_video() )
+  {
+    ts = unclipped_input.frame_timestamp();
+    EXPECT_EQ( frame_end, ts.get_frame() );
+  }
+
+  unclipped_input.close();
+  input.close();
+
+  EXPECT_FALSE( input.good() );
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char* argv[] )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+
+  GET_ARG( 1, g_data_dir );
+
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+class ffmpeg_video_input_clip : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    ffmpeg_video_path = data_dir / "videos/ffmpeg_video.mp4";
+    aphill_video_path = data_dir / "videos/aphill_short.ts";
+  }
+
+  std::filesystem::path ffmpeg_video_path;
+  std::filesystem::path aphill_video_path;
+  TEST_ARG( data_dir );
+};
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, create )
+{
+  EXPECT_NE( nullptr, kv::algo::video_input::create( "ffmpeg_clip" ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, entire_video_exact_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 1, 49, false );
+  CALL_TEST( test_clipped, input, aphill_video_path, 1, 49, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, entire_video_keyframe_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 1, 49, true );
+  CALL_TEST( test_clipped, input, aphill_video_path, 1, 49, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, entire_video_exact_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 1, 51, false );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 1, 51, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, entire_video_keyframe_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 1, 51, true );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 1, 51, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, end_past_end )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 1, 100, false );
+  CALL_TEST( test_clipped, input, aphill_video_path, 1, 49, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, begin_past_end )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 100, 200, false );
+  EXPECT_THROW( input.open( aphill_video_path.string() ), std::runtime_error );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, single_frame )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 20, 21, false );
+  CALL_TEST( test_clipped, input, aphill_video_path, 20, 21, 633'966 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, non_keyframe_exact_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 7, 23, false );
+  CALL_TEST( test_clipped, input, aphill_video_path, 7, 23, 200'200 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, non_keyframe_keyframe_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 7, 23, true );
+  CALL_TEST( test_clipped, input, aphill_video_path, 1, 23, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, non_keyframe_exact_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 7, 23, false );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 7, 23, 1'200'000 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, non_keyframe_keyframe_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 7, 23, true );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 6, 23, 1'000'000 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, keyframe_exact_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 17, 33, false );
+  CALL_TEST( test_clipped, input, aphill_video_path, 17, 33, 533'866 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, keyframe_keyframe_aphill )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 17, 33, true );
+  CALL_TEST( test_clipped, input, aphill_video_path, 17, 33, 533'866 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, keyframe_exact_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 11, 33, false );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 11, 33, 2'000'000 );
+}
+
+// ----------------------------------------------------------------------------
+TEST_F ( ffmpeg_video_input_clip, keyframe_keyframe_ffmpeg )
+{
+  ffmpeg::ffmpeg_video_input_clip input;
+  configure_input( input, 11, 33, true );
+  CALL_TEST( test_clipped, input, ffmpeg_video_path, 11, 33, 2'000'000 );
+}


### PR DESCRIPTION
This PR  adds the `ffmpeg_video_input_clip` class, which is a wrapper around a regular `ffmpeg_video_input` that takes in a frame range in its config, and attempts to behave exactly as if the input video consisted only of that frame range. There is also an option to automatically seek back to the most recent keyframe, to avoid the first few frames being undecodable when copying the raw video stream. Accomplishing this required some significant work to be done on the seeking logic of `ffmpeg_video_input`.