### PR TITLE
Include avcodec/bsf.h

### DIFF
--- a/arrows/ffmpeg/ffmpeg_util.h
+++ b/arrows/ffmpeg/ffmpeg_util.h
@@ -14,6 +14,9 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 87, 100)
+#include <libavcodec/bsf.h>
+#endif
 #include <libavfilter/avfilter.h>
 #include <libavformat/avformat.h>
 #include <libavutil/hwcontext.h>


### PR DESCRIPTION
Using FFmpeg v5.1.2, it appears we have to include the bitstream filter file by name. This was not necessary with v4.1.1, presumably due to it being included somewhere from `libavcodec/avcodec.h`. 