### PR TITLE
Change duplicate 'longitude' to 'latitude'

### DIFF
--- a/arrows/core/metadata_map_io_csv.cxx
+++ b/arrows/core/metadata_map_io_csv.cxx
@@ -173,7 +173,7 @@ special_column_names()
     { { kv::VITAL_META_FRAME_CENTER, 0 },
       "Geodetic Frame Center Longitude (EPSG:4326)" },
     { { kv::VITAL_META_FRAME_CENTER, 1 },
-      "Geodetic Frame Center Longitude (EPSG:4326)" },
+      "Geodetic Frame Center Latitude (EPSG:4326)" },
     { { kv::VITAL_META_FRAME_CENTER, 2 },
       "Geodetic Frame Center Altitude (meters)" },
 


### PR DESCRIPTION
Sadly, #1812 was meant to fix incorrect column headers, but introduced a typo of its own. This PR hopefully finally gets it right.