### PR TITLE
Prevent crashes when writing out invalid wrapped-int data

### DIFF
--- a/arrows/klv/klv_data_format.h
+++ b/arrows/klv/klv_data_format.h
@@ -485,8 +485,8 @@ protected:
   size_t
   length_of_typed( data_type const& value ) const override
   {
-    return this->m_length_constraints.fixed_or(
-      klv_int_length( static_cast< uint64_t >( value ) ) );
+    auto const int_length = klv_int_length( static_cast< uint64_t >( value ) );
+    return std::max( this->m_length_constraints.fixed_or( 1 ), int_length );
   }
 
   size_t m_length;
@@ -809,8 +809,8 @@ protected:
   size_t
   length_of_typed( std::set< Enum > const& value ) const
   {
-    return this->m_length_constraints.fixed_or(
-      m_format.length_of_( enums_to_bitfield( value ) ) );
+    auto const int_length = m_format.length_of_( enums_to_bitfield( value ) );
+    return std::max( this->m_length_constraints.fixed_or( 1 ), int_length );
   }
 
   Format m_format;

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -66,3 +66,6 @@ Arrows: KLV
 * Modified flint, IMAP, and integer behavior to print a warning when writing
   values with incorrect lengths instead of correcting the length and possibly
   losing data.
+
+* Ensured integer wrapper data formats (enum, enum bitfield) use the same
+  lenient length logic as integers to prevent crashes when writing invalid data.


### PR DESCRIPTION
Currently, fixed-length `int`-like KLV formats (enums and bitfields) will crash if they are asked to write out a value longer than is allowed by the standard (as can happen when incorrect/corrupted data is being processed). With this PR, those formats will no longer crash, instead writing out the value as requested and printing a warning.