### PR TITLE
Remove avformat_init_output()

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_output.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_output.cxx
@@ -607,10 +607,6 @@ ffmpeg_video_output::impl::open_video_state
   throw_error_code(
     avformat_write_header( format_context.get(), nullptr ),
     "Could not write video header" );
-
-  throw_error_code(
-    avformat_init_output( format_context.get(), nullptr ),
-    "Could not initialize output stream" );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This is unnecessary now that we always call `avformat_write_header()`, and apparently results in a duplicate PAT entry when writing .ts files.