### PR TITLE
Let stream id override KLV stream synchronicity

### DIFF
--- a/arrows/ffmpeg/ffmpeg_video_input.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input.cxx
@@ -155,30 +155,26 @@ ffmpeg_klv_stream
   }
 
 #if LIBAVCODEC_VERSION_MAJOR > 57
-  // Fill in KLV profile (if not previously determined) by looking at packet
-  // MPEG-TS stream identifier
-  if( stream->codecpar->profile < 0 )
-  {
+  // Fill in KLV profile by looking at packet MPEG-TS stream identifier
 #if LIBAVCODEC_VERSION_MAJOR > 58
-    size_t length = 0;
+  size_t length = 0;
 #else
-    int length = 0;
+  int length = 0;
 #endif
-    auto const stream_id =
-      av_packet_get_side_data( packet, AV_PKT_DATA_MPEGTS_STREAM_ID, &length );
-    if( length )
+  auto const stream_id =
+    av_packet_get_side_data( packet, AV_PKT_DATA_MPEGTS_STREAM_ID, &length );
+  if( length )
+  {
+    switch( *stream_id )
     {
-      switch( *stream_id )
-      {
-        case 0xBD:
-          stream->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
-          break;
-        case 0xFC:
-          stream->codecpar->profile = FF_PROFILE_KLVA_SYNC;
-          break;
-        default:
-          break;
-      }
+      case 0xBD:
+        stream->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
+        break;
+      case 0xFC:
+        stream->codecpar->profile = FF_PROFILE_KLVA_SYNC;
+        break;
+      default:
+        break;
     }
   }
 #endif

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -49,6 +49,8 @@ Arrows: FFmpeg
 
 * Fixed bugs causing invalid output when transcoding between .mp4 and .ts files.
 
+* Made the MPEG-TS stream id take precedence when determining KLV stream synchronicity.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
The MPEG-TS stream id, if present, is a more reliable indicator of a stream's sync/async status than the presence of a metadata descriptor in the stream (which fletch's FFmpeg uses to set `stream->codecpar->profile`), since the descriptor is technically allowed in the async case, just not required as with sync streams. So this MR removes the "if not previously set" check, allowing the stream id to override the previously set `profile` value.