### PR TITLE
Add video_input_ffmpeg_rewire

### DIFF
--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -24,9 +24,10 @@ set(ffmpeg_headers_public
   ffmpeg_util.h
   ffmpeg_video_input.h
   ffmpeg_video_input_clip.h
+  ffmpeg_video_input_rewire.h
   ffmpeg_video_output.h
-  ffmpeg_video_raw_image.cxx
-  ffmpeg_video_raw_metadata.cxx
+  ffmpeg_video_raw_image.h
+  ffmpeg_video_raw_metadata.h
   ffmpeg_video_settings.h
   ffmpeg_video_uninterpreted_data.h
   )
@@ -48,6 +49,7 @@ set(ffmpeg_sources
   ffmpeg_util.cxx
   ffmpeg_video_input.cxx
   ffmpeg_video_input_clip.cxx
+  ffmpeg_video_input_rewire.cxx
   ffmpeg_video_output.cxx
   ffmpeg_video_raw_image.cxx
   ffmpeg_video_raw_metadata.cxx

--- a/arrows/ffmpeg/ffmpeg_video_input_rewire.cxx
+++ b/arrows/ffmpeg/ffmpeg_video_input_rewire.cxx
@@ -1,0 +1,513 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of the ffmpeg_video_input_rewire class.
+
+#include <arrows/ffmpeg/ffmpeg_video_input_rewire.h>
+
+#include <arrows/ffmpeg/ffmpeg_video_raw_metadata.h>
+#include <arrows/ffmpeg/ffmpeg_video_uninterpreted_data.h>
+#include <arrows/ffmpeg/ffmpeg_util.h>
+
+#include <map>
+#include <tuple>
+
+#include <cstdint>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+struct source_video_input
+{
+  vital::algo::video_input_sptr input;
+  std::string filename;
+};
+
+// ----------------------------------------------------------------------------
+enum { UNMARKED_STREAM = SIZE_MAX };
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+class ffmpeg_video_input_rewire::impl
+{
+public:
+  impl();
+
+  std::map<size_t, source_video_input> video_sources;
+
+  // { source index, stream index } : output index
+  std::map<std::tuple<size_t, size_t>, size_t> rewire_map;
+};
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_rewire::impl
+::impl() : video_sources{}
+{}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_rewire
+::ffmpeg_video_input_rewire() : d{ new impl }
+{}
+
+// ----------------------------------------------------------------------------
+ffmpeg_video_input_rewire
+::~ffmpeg_video_input_rewire()
+{}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+ffmpeg_video_input_rewire
+::get_configuration() const
+{
+  auto config = video_input::get_configuration();
+
+  for( auto const& [index, source] : d->video_sources )
+  {
+    auto const prefix = "source-" + std::to_string( index ) + ":";
+    config->set_value( prefix + "type", "video" );
+    config->set_value( prefix + "filename", source.filename );
+    video_input::get_nested_algo_configuration(
+      prefix + "input", config, source.input );
+  }
+
+  std::map< size_t, std::tuple< size_t, size_t > > reverse_map;
+  for( auto& [key, value] : d->rewire_map )
+  {
+    reverse_map.emplace( value, key );
+  }
+
+  auto first = true;
+  std::stringstream ss;
+  for( auto& [value, key] : reverse_map )
+  {
+    auto [source_index, stream_index] = key;
+    first = first ? false : ( ss << ",", false );
+    ss << source_index << "/";
+    if( stream_index == UNMARKED_STREAM )
+    {
+      ss << "unmarked";
+    }
+    else
+    {
+      ss << stream_index;
+    }
+  }
+  config->set_value( "streams", ss.str() );
+
+  return config;
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_rewire
+::set_configuration( vital::config_block_sptr in_config )
+{
+  auto config = get_configuration();
+  config->merge_config( in_config );
+
+  // Video sources come labeled "source-X", where X is the index. All Xs must
+  // be sequential starting from 0
+  d->video_sources.clear();
+  for( size_t i = 0; true; ++i )
+  {
+    auto const prefix = "source-" + std::to_string( i ) + ":";
+    auto const type = config->get_value< std::string >( prefix + "type", "" );
+
+    if( type == "" )
+    {
+      // Couldn't find type of next source; quit looking
+      break;
+    }
+
+    if( type != "video" )
+    {
+      // We may support other (e.g. metadata_map_io) sources in the future
+      continue;
+    }
+
+    // File to be opened
+    auto const filename =
+      config->get_value< std::string >( prefix + "filename", "" );
+
+    // Create nested video input
+    source_video_input source{ nullptr, filename };
+    video_input::set_nested_algo_configuration(
+      prefix + "input", config, source.input );
+    d->video_sources.emplace( i, std::move( source ) );
+  }
+
+  // Parse the rewiring string, which consists of comma-separated "X/Y" pairs.
+  // X is the index of the source video, and Y is the stream index within that
+  // source video
+  size_t i = 1;
+  d->rewire_map.clear();
+  for( auto const& element :
+       config->get_value_as_vector< std::string >( "streams", "," ) )
+  {
+    std::stringstream ss{ element };
+    std::tuple< size_t, size_t > key;
+    char dummy;
+    std::string stream_index;
+    ss >> std::get< 0 >( key ) >> dummy >> stream_index;
+    std::get< 1 >( key ) =
+      ( stream_index == "unmarked" )
+      ? UNMARKED_STREAM
+      : std::stoull( stream_index );
+    d->rewire_map.emplace( key, i++ );
+  }
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::check_configuration( vital::config_block_sptr config ) const
+{
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_rewire
+::open( VITAL_UNUSED std::string video_name )
+{
+  for( auto& [index, source] : d->video_sources )
+  {
+    source.input->open( source.filename );
+  }
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_video_input_rewire
+::close()
+{
+  for( auto& [index, source] : d->video_sources )
+  {
+    source.input->close();
+  }
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::end_of_video() const
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->end_of_video();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::good() const
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->good();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::seekable() const
+{
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+size_t
+ffmpeg_video_input_rewire
+::num_frames() const
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->num_frames();
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::next_frame( vital::timestamp& ts, uint32_t timeout )
+{
+  auto result = false;
+  for( auto& [index, source] : d->video_sources )
+  {
+    if( index == 0 )
+    {
+      // Timestamp data taken from first video source
+      result = source.input->next_frame( ts, timeout );
+    }
+    else
+    {
+      vital::timestamp tmp_ts;
+      source.input->next_frame( tmp_ts, timeout );
+    }
+  }
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_video_input_rewire
+::seek_frame(
+  VITAL_UNUSED vital::timestamp& ts,
+  VITAL_UNUSED vital::timestamp::frame_t frame_number,
+  VITAL_UNUSED uint32_t timeout )
+{
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+vital::timestamp
+ffmpeg_video_input_rewire
+::frame_timestamp() const
+{
+  // Timestamp data taken from first video source
+  return d->video_sources.at( 0 ).input->frame_timestamp();
+}
+
+// ----------------------------------------------------------------------------
+vital::image_container_sptr
+ffmpeg_video_input_rewire
+::frame_image()
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->frame_image();
+}
+
+// ----------------------------------------------------------------------------
+vital::video_raw_image_sptr
+ffmpeg_video_input_rewire
+::raw_frame_image()
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->raw_frame_image();
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_vector
+ffmpeg_video_input_rewire
+::frame_metadata()
+{
+  vital::metadata_vector result;
+
+  // Find the first non-null metadata from the video stream source
+  vital::metadata_sptr video_md;
+  if( auto const video_metadata =
+        d->video_sources.at( 0 ).input->frame_metadata();
+      !video_metadata.empty() )
+  {
+    for( auto const& md : video_metadata )
+    {
+      if( md )
+      {
+        video_md = md;
+        break;
+      }
+    }
+  }
+
+  for( auto const& [source_index, source] : d->video_sources )
+  {
+    // Skip sources that have ended
+    if( !source.input->good() )
+    {
+      continue;
+    }
+
+    // Map all metadata to its correct destination stream index
+    for( auto const& source_md : source.input->frame_metadata() )
+    {
+      size_t stream_index = UNMARKED_STREAM;
+      if( auto const entry =
+            source_md->find( vital::VITAL_META_VIDEO_DATA_STREAM_INDEX ) )
+      {
+        auto const int_value = entry.get< int >();
+        if( int_value < 0 )
+        {
+          continue;
+        }
+        stream_index = static_cast< size_t >( int_value );
+      }
+
+      auto const key = std::make_tuple( source_index, stream_index );
+      if( auto const it = d->rewire_map.find( key ); it != d->rewire_map.end() )
+      {
+        auto const& md = result.emplace_back( source_md->clone() );
+
+        // Relabel stream index
+        md->add< vital::VITAL_META_VIDEO_DATA_STREAM_INDEX >(
+          static_cast< int >( it->second ) );
+
+        // Overwrite metadata related to video stream
+        for( auto const tag : {
+          vital::VITAL_META_VIDEO_KEY_FRAME,
+          vital::VITAL_META_VIDEO_FRAME_NUMBER,
+          vital::VITAL_META_VIDEO_MICROSECONDS,
+          vital::VITAL_META_VIDEO_FRAME_RATE,
+          vital::VITAL_META_VIDEO_BITRATE,
+          vital::VITAL_META_VIDEO_COMPRESSION_TYPE,
+          vital::VITAL_META_VIDEO_COMPRESSION_PROFILE,
+          vital::VITAL_META_VIDEO_COMPRESSION_LEVEL,
+        } )
+        {
+          if( video_md && video_md->find( tag ) )
+          {
+            md->add( tag, video_md->find( tag ).data() );
+          }
+          else
+          {
+            md->erase( tag );
+          }
+        }
+      }
+    }
+  }
+
+  // Sort output metadata by stream index
+  auto const cmp =
+    []( vital::metadata_sptr const& lhs, vital::metadata_sptr const& rhs )
+    {
+      if( !lhs && rhs )
+      {
+        return true;
+      }
+      if( lhs && !rhs )
+      {
+        return false;
+      }
+      return
+        lhs->find( vital::VITAL_META_VIDEO_DATA_STREAM_INDEX ).get< int >() <
+        rhs->find( vital::VITAL_META_VIDEO_DATA_STREAM_INDEX ).get< int >();
+    };
+  std::sort( result.begin(), result.end(), cmp );
+
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_raw_metadata_sptr
+ffmpeg_video_input_rewire
+::raw_frame_metadata()
+{
+  auto result = std::make_shared< ffmpeg_video_raw_metadata >();
+  for( auto const& [source_index, source] : d->video_sources )
+  {
+    // Skip sources that have ended
+    if( !source.input->good() )
+    {
+      continue;
+    }
+
+    auto const source_md =
+      dynamic_cast< ffmpeg_video_raw_metadata* >(
+        source.input->raw_frame_metadata().get() );
+    if( !source_md )
+    {
+      continue;
+    }
+
+    // Combine packets from all sources
+    for( auto const& packet_info : source_md->packets )
+    {
+      auto const stream_index = packet_info.packet->stream_index;
+      if( stream_index < 0 )
+      {
+        continue;
+      }
+
+      auto const key =
+        std::make_tuple( source_index, static_cast< size_t >( stream_index ) );
+      if( auto const it = d->rewire_map.find( key ); it != d->rewire_map.end() )
+      {
+        auto& new_packet_info = result->packets.emplace_back();
+        new_packet_info.packet.reset(
+          throw_error_null( av_packet_clone( packet_info.packet.get() ),
+          "Failed to clone packet" ) );
+
+        // Relabel stream index
+        new_packet_info.packet->stream_index = it->second;
+        new_packet_info.stream_settings = packet_info.stream_settings;
+      }
+    }
+  }
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_uninterpreted_data_sptr
+ffmpeg_video_input_rewire
+::uninterpreted_frame_data()
+{
+  auto result = std::make_shared< ffmpeg_video_uninterpreted_data >();
+  for( auto const& [source_index, source] : d->video_sources )
+  {
+    // Skip sources that have ended
+    if( !source.input->good() )
+    {
+      continue;
+    }
+
+    auto const source_data_ptr = source.input->uninterpreted_frame_data();
+    auto const source_data =
+      dynamic_cast< ffmpeg_video_uninterpreted_data* >( source_data_ptr.get() );
+    if( !source_data )
+    {
+      continue;
+    }
+
+    // Combine packets from all sources
+    for( auto const& packet : source_data->audio_packets )
+    {
+      auto const stream_index = packet->stream_index;
+      if( stream_index < 0 )
+      {
+        continue;
+      }
+
+      auto const key =
+        std::make_tuple( source_index, static_cast< size_t >( stream_index ) );
+      if( auto const it = d->rewire_map.find( key ); it != d->rewire_map.end() )
+      {
+        auto const new_packet =
+          throw_error_null(
+            av_packet_clone( packet.get() ), "Failed to clone packet" );
+
+        // Relabel stream index
+        new_packet->stream_index = it->second;
+        result->audio_packets.emplace_back( new_packet );
+      }
+    }
+  }
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+vital::metadata_map_sptr
+ffmpeg_video_input_rewire
+::metadata_map()
+{
+  return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+vital::video_settings_uptr
+ffmpeg_video_input_rewire
+::implementation_settings() const
+{
+  // Video data taken from first video source
+  return d->video_sources.at( 0 ).input->implementation_settings();
+}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_video_input_rewire.h
+++ b/arrows/ffmpeg/ffmpeg_video_input_rewire.h
@@ -1,0 +1,75 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of the ffmpeg_video_input_rewire class.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_INPUT_REWIRE_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_VIDEO_INPUT_REWIRE_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+
+#include <vital/algo/video_input.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+/// Video input which assembles multiple streams from other video inputs into a
+/// single video input interface.
+class KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_video_input_rewire
+  : public vital::algo::video_input
+{
+public:
+  PLUGIN_INFO(
+    "ffmpeg_rewire",
+    "Combines media streams from one or more FFmpeg-sourced video inputs." )
+
+  ffmpeg_video_input_rewire();
+  virtual ~ffmpeg_video_input_rewire();
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+  void open( std::string video_name ) override;
+  void close() override;
+
+  bool end_of_video() const override;
+  bool good() const override;
+
+  bool seekable() const override;
+  size_t num_frames() const override;
+
+  bool next_frame( vital::timestamp& ts, uint32_t timeout = 0 ) override;
+  bool seek_frame(
+    vital::timestamp& ts,
+    vital::timestamp::frame_t frame_number,
+    uint32_t timeout = 0 ) override;
+
+  vital::timestamp frame_timestamp() const override;
+  vital::image_container_sptr frame_image() override;
+  vital::video_raw_image_sptr raw_frame_image() override;
+  vital::metadata_vector frame_metadata() override;
+  vital::video_raw_metadata_sptr raw_frame_metadata() override;
+  vital::video_uninterpreted_data_sptr uninterpreted_frame_data() override;
+  vital::metadata_map_sptr metadata_map() override;
+
+  vital::video_settings_uptr implementation_settings() const override;
+
+private:
+  class impl;
+  std::unique_ptr< impl > d;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/register_algorithms.cxx
+++ b/arrows/ffmpeg/register_algorithms.cxx
@@ -10,6 +10,7 @@
 
 #include <arrows/ffmpeg/ffmpeg_video_input.h>
 #include <arrows/ffmpeg/ffmpeg_video_input_clip.h>
+#include <arrows/ffmpeg/ffmpeg_video_input_rewire.h>
 #include <arrows/ffmpeg/ffmpeg_video_output.h>
 
 namespace kwiver {
@@ -32,6 +33,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
 
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input_clip >();
+  reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input_rewire >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_output >();
 
   reg.mark_module_as_loaded();

--- a/arrows/ffmpeg/tests/CMakeLists.txt
+++ b/arrows/ffmpeg/tests/CMakeLists.txt
@@ -4,20 +4,20 @@ set(CMAKE_FOLDER "Arrows/FFmpeg/Tests")
 
 include(kwiver-test-setup)
 
-set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_core)
+set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_klv kwiver_algo_core)
 
 ##############################
 # Algorithms ffmpeg tests
 ##############################
-kwiver_discover_gtests(ffmpeg video_input_ffmpeg       LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
-kwiver_discover_gtests(ffmpeg video_input_ffmpeg_clip  LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
-kwiver_discover_gtests(ffmpeg video_output_ffmpeg      LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_input_ffmpeg        LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_input_ffmpeg_clip   LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_input_ffmpeg_rewire LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
+kwiver_discover_gtests(ffmpeg video_output_ffmpeg       LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 
 if( KWIVER_ENABLE_SERIALIZE_JSON )
   kwiver_discover_gtests(ffmpeg video_input_ffmpeg_klv
     LIBRARIES
       ${test_libraries}
       kwiver_serialize_json_klv
-      kwiver_algo_klv
     ARGUMENTS "${kwiver_test_data_directory}")
 endif()

--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg_rewire.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg_rewire.cxx
@@ -1,0 +1,326 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test the ffmpeg_video_input_rewire class.
+
+#include <tests/test_gtest.h>
+
+#include <arrows/ffmpeg/tests/common.h>
+
+#include <arrows/ffmpeg/ffmpeg_video_input.h>
+#include <arrows/ffmpeg/ffmpeg_video_input_rewire.h>
+
+#include <arrows/klv/klv_metadata.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <filesystem>
+
+namespace ffmpeg = kwiver::arrows::ffmpeg;
+namespace klv = kwiver::arrows::klv;
+namespace kv = kwiver::vital;
+
+std::filesystem::path g_data_dir;
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char* argv[] )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+
+  GET_ARG( 1, g_data_dir );
+
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST( ffmpeg_video_input_rewire, create )
+{
+  EXPECT_NE( nullptr, kv::algo::video_input::create( "ffmpeg_rewire" ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST( ffmpeg_video_input_rewire, video_only )
+{
+  auto const path = ( g_data_dir / "videos/aphill_short.ts" ).string();
+
+  // Configure single input
+  ffmpeg::ffmpeg_video_input_rewire input;
+  auto config = input.get_configuration();
+  config->set_value( "source-0:type", "video" );
+  config->set_value( "source-0:filename", path );
+  config->set_value( "source-0:input:type", "ffmpeg" );
+  config->set_value( "streams", "" );
+  EXPECT_TRUE( input.check_configuration( config ) );
+  input.set_configuration( config );
+  input.open( "" );
+
+  // Open original video directly
+  ffmpeg::ffmpeg_video_input check_input;
+  check_input.open( path );
+
+  kv::timestamp check_ts;
+  kv::timestamp ts;
+
+  // Loop through rewired and original video together
+  for( check_input.next_frame( check_ts ), input.next_frame( ts );
+       !check_input.end_of_video() && !input.end_of_video();
+       check_input.next_frame( check_ts ), input.next_frame( ts ) )
+  {
+    SCOPED_TRACE(
+      std::string{ "Frame: " } +
+      std::to_string( check_ts.get_frame() ) + " | " +
+      std::to_string( ts.get_frame() ) );
+
+    // Timestamps should be the same
+    EXPECT_EQ( check_ts.get_frame(), ts.get_frame() );
+    EXPECT_EQ( check_ts.get_time_usec(), ts.get_time_usec() );
+
+    // Metadata should be empty
+    auto const metadata = input.frame_metadata();
+    EXPECT_EQ( 0, metadata.size() );
+
+    // Images should be identical
+    auto const check_image = check_input.frame_image()->get_image();
+    auto const image = input.frame_image()->get_image();
+    expect_eq_images( check_image, image, 0.0 );
+  }
+
+  // Videos should have the same number of frames
+  EXPECT_TRUE( check_input.end_of_video() );
+  EXPECT_TRUE( input.end_of_video() );
+
+  check_input.close();
+  input.close();
+}
+
+// ----------------------------------------------------------------------------
+TEST( ffmpeg_video_input_rewire, metadata )
+{
+  std::vector< std::string > paths = {
+    ( g_data_dir / "videos/aphill_short.ts" ).string(),
+    ( g_data_dir / "videos/h265_tricky_klv.ts" ).string(),
+    ( g_data_dir / "videos/h264_no_klv.ts" ).string(),
+  };
+  auto const n = paths.size();
+
+  // Configure input to draw from three different videos
+  ffmpeg::ffmpeg_video_input_rewire input;
+  auto config = input.get_configuration();
+  for( size_t i = 0; i < n; ++i )
+  {
+    auto const prefix = "source-" + std::to_string( i ) + ":";
+    config->set_value( prefix + "type", "video" );
+    config->set_value( prefix + "filename", paths[ i ] );
+    config->set_value( prefix + "input:type", "ffmpeg" );
+  }
+  config->set_value( "streams", "2/unmarked,0/1,1/1,1/3" );
+  EXPECT_TRUE( input.check_configuration( config ) );
+  input.set_configuration( config );
+  input.open( "" );
+
+  // Open all original videos directly
+  std::vector< kv::timestamp > check_tss;
+  std::vector< std::shared_ptr< ffmpeg::ffmpeg_video_input > > check_inputs;
+  for( size_t i = 0; i < n; ++i )
+  {
+    check_inputs.emplace_back( new ffmpeg::ffmpeg_video_input );
+    check_inputs.back()->open( paths[ i ] );
+    check_tss.emplace_back();
+  }
+
+  kv::timestamp ts;
+
+  // Loop through rewired and original videos together
+  for( input.next_frame( ts ); !input.end_of_video(); input.next_frame( ts ) )
+  {
+    for( size_t i = 0; i < n; ++i )
+    {
+      check_inputs[ i ]->next_frame( check_tss[ i ] );
+    }
+
+    SCOPED_TRACE(
+      std::string{ "Frame: " } +
+      std::to_string( ts.get_frame() ) );
+
+    // Number of frames must be the same as the first video stream
+    ASSERT_FALSE( check_inputs[ 0 ]->end_of_video() );
+
+    // Timestamps must be the same as the first video stream
+    EXPECT_EQ( check_tss[ 0 ].get_frame(), ts.get_frame() );
+    EXPECT_EQ( check_tss[ 0 ].get_time_usec(), ts.get_time_usec() );
+
+    auto const metadata = input.frame_metadata();
+    if( ts.get_frame() <= 30 ) // Videos 1 and 2 are only 30 frames long
+    {
+      // Check that metadata came frame each input as expected
+      EXPECT_EQ( 4, metadata.size() );
+      for( size_t i = 0; i < 4; ++i )
+      {
+        auto const& entry =
+          metadata.at( i )->find( kv::VITAL_META_VIDEO_DATA_STREAM_INDEX );
+        EXPECT_TRUE( entry );
+        EXPECT_EQ( i + 1, entry.get< int >() );
+      }
+    }
+    else
+    {
+      // Check that metadata came from the one remaining input as expected
+      EXPECT_EQ( 1, metadata.size() );
+      auto const& entry =
+        metadata.at( 0 )->find( kv::VITAL_META_VIDEO_DATA_STREAM_INDEX );
+      EXPECT_TRUE( entry );
+      EXPECT_EQ( 2, entry.get< int >() );
+    }
+
+    for( auto const& md : metadata )
+    {
+      auto const index =
+        md->find( kv::VITAL_META_VIDEO_DATA_STREAM_INDEX ).get< int >();
+
+      if( index == 1 )
+      {
+        // Stream 1 is from the no-KLV video
+        EXPECT_EQ(
+          nullptr, dynamic_cast< klv::klv_metadata const* >( md.get() ) );
+      }
+      else
+      {
+        // Check that the remaining streams have the appropriate KLV data
+        std::map< int, std::pair< size_t, size_t > > mapping{
+          { 2, { 0, 1 } },
+          { 3, { 1, 1 } },
+          { 4, { 1, 3 } },
+        };
+        auto [input_index, stream_index] = mapping.at( index );
+        auto const klv_md =
+          dynamic_cast< klv::klv_metadata const* >( md.get() );
+        auto const check_klv_md =
+          dynamic_cast< klv::klv_metadata const* >(
+            check_inputs.at( input_index )->frame_metadata()
+            .at( stream_index - 1 ).get() );
+        ASSERT_NE( nullptr, klv_md );
+        ASSERT_NE( nullptr, check_klv_md );
+        EXPECT_EQ( check_klv_md->klv(), klv_md->klv() );
+      }
+    }
+
+    // Images must be identical
+    auto const check_image = check_inputs[ 0 ]->frame_image()->get_image();
+    auto const image = input.frame_image()->get_image();
+    expect_eq_images( check_image, image, 0.0 );
+  }
+
+  // Rewired video must have the same number of frames as the first video input
+  check_inputs[ 0 ]->next_frame( check_tss[ 0 ] );
+  EXPECT_TRUE( check_inputs[ 0 ]->end_of_video() );
+
+  for( size_t i = 0; i < n; ++i )
+  {
+    check_inputs[ i ]->close();
+  }
+  input.close();
+}
+
+// ----------------------------------------------------------------------------
+TEST( ffmpeg_video_input_rewire, audio )
+{
+  auto const video_path = ( g_data_dir / "videos/aphill_short.ts" ).string();
+  auto const audio_path = ( g_data_dir / "videos/h264_audio.ts" ).string();
+
+  // Configure audio- and non-audio inputs
+  ffmpeg::ffmpeg_video_input_rewire input;
+  auto config = input.get_configuration();
+  config->set_value( "source-0:type", "video" );
+  config->set_value( "source-0:filename", video_path );
+  config->set_value( "source-0:input:type", "ffmpeg" );
+  config->set_value( "source-1:type", "video" );
+  config->set_value( "source-1:filename", audio_path );
+  config->set_value( "source-1:input:type", "ffmpeg" );
+  config->set_value( "streams", "1/1" );
+  EXPECT_TRUE( input.check_configuration( config ) );
+  input.set_configuration( config );
+  input.open( "" );
+
+  // Open source videos directly
+  ffmpeg::ffmpeg_video_input video_input;
+  ffmpeg::ffmpeg_video_input audio_input;
+  video_input.open( video_path );
+  audio_input.open( audio_path );
+
+  kv::timestamp video_ts;
+  kv::timestamp audio_ts;
+  kv::timestamp ts;
+
+  // Run through rewired and original videos together
+  for( video_input.next_frame( video_ts ),
+       audio_input.next_frame( audio_ts ),
+       input.next_frame( ts );
+       !video_input.end_of_video() && !input.end_of_video();
+       video_input.next_frame( video_ts ),
+       audio_input.next_frame( audio_ts ),
+       input.next_frame( ts ) )
+  {
+    SCOPED_TRACE(
+      std::string{ "Frame: " } +
+      std::to_string( video_ts.get_frame() ) + " | " +
+      std::to_string( ts.get_frame() ) );
+
+    // Timestamps must match first video
+    EXPECT_EQ( video_ts.get_frame(), ts.get_frame() );
+    EXPECT_EQ( video_ts.get_time_usec(), ts.get_time_usec() );
+
+    // Compare audio packets
+    auto const check_audio_ptr = audio_input.uninterpreted_frame_data();
+    auto const audio_ptr = input.uninterpreted_frame_data();
+    if( check_audio_ptr )
+    {
+      // If original video has audio, the rewired video must have the same audio
+      auto const& check_audio =
+        dynamic_cast< ffmpeg::ffmpeg_video_uninterpreted_data const* >(
+          check_audio_ptr.get() )->audio_packets;
+
+      ASSERT_NE( nullptr, audio_ptr );
+      auto const& audio =
+        dynamic_cast< ffmpeg::ffmpeg_video_uninterpreted_data const* >(
+          audio_ptr.get() )->audio_packets;
+
+      auto const cmp =
+        []( ffmpeg::packet_uptr const& lhs, ffmpeg::packet_uptr const& rhs )
+        {
+          return
+            lhs->size == rhs->size &&
+            !std::memcmp( lhs->data, rhs->data, lhs->size );
+        };
+      EXPECT_TRUE(
+        std::equal(
+          check_audio.begin(), check_audio.end(),
+          audio.begin(), audio.end(), cmp ) );
+    }
+    else if( audio_ptr )
+    {
+      // If the original video has no audio but the rewired one does, it must
+      // be empty
+      auto const& audio =
+        dynamic_cast< ffmpeg::ffmpeg_video_uninterpreted_data const* >(
+          audio_ptr.get() )->audio_packets;
+      EXPECT_EQ( 0, audio.size() );
+    }
+
+    // Images must be identical
+    auto const check_image = video_input.frame_image()->get_image();
+    auto const image = input.frame_image()->get_image();
+    expect_eq_images( check_image, image, 0.0 );
+  }
+
+  // Rewired video must be same length as first video input
+  EXPECT_TRUE( video_input.end_of_video() );
+  EXPECT_TRUE( input.end_of_video() );
+
+  video_input.close();
+  audio_input.close();
+  input.close();
+}

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -51,6 +51,8 @@ Arrows: FFmpeg
 
 * Made the MPEG-TS stream id take precedence when determining KLV stream synchronicity.
 
+* Added video_input_ffmpeg_rewire.
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR adds a `video_input` which allows a user to "rewire" streams from some number of other video inputs, using or dropping them as desired, and presenting a unified result. Currently it does not have the functionality to incorporate metadata streams from non-video sources, e.g. JSON, but that is planned for a future PR.