### PR TITLE
Prettify dump-klv's printed output

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -25,6 +25,8 @@ Arrows: Core
 * Added pass-throughs for uninterpreted video data in the metadata_filter and
   buffered_metadata_filter video inputs.
 
+* Cleaned up dump-klv's printed output.
+
 Arrows: FFmpeg
 
 * Added check for incoming raw video packets' timestamps and stream indices.

--- a/python/kwiver/vital/tests/test_geo_point.py
+++ b/python/kwiver/vital/tests/test_geo_point.py
@@ -181,7 +181,7 @@ class TestVitalGeoPoint(unittest.TestCase):
 
     def test_to_str_empty(self):
         p1 = gp.GeoPoint()
-        nt.assert_equals(str(p1), "geo_point\n[ empty ]")
+        nt.assert_equals(str(p1), "[ empty ]")
         print("empty geo_point to string:", str(p1), sep='\n')
 
     # Also make sure the doubles roundtrip
@@ -193,25 +193,24 @@ class TestVitalGeoPoint(unittest.TestCase):
         split_str = str(p1).split()
 
         # Initial strings
-        nt.assert_equals(split_str[0], "geo_point")
-        nt.assert_equals(split_str[1], "[")
+        nt.assert_equals(split_str[0], "[")
 
         # Parsing easting
-        easting_out, comma = split_str[2][:-1], split_str[2][-1]
+        easting_out, comma = split_str[1][:-1], split_str[1][-1]
         nt.assert_equals(comma, ",")
         np.testing.assert_almost_equal(float(easting_out), easting_in, decimal=15)
 
         # Parsing northing
-        northing_out, comma = split_str[3][:-1], split_str[3][-1]
+        northing_out, comma = split_str[2][:-1], split_str[2][-1]
         nt.assert_equals(comma, ",")
         np.testing.assert_almost_equal(float(northing_out), northing_in, decimal=15)
 
         # Altitude (0)
-        altitude_out = split_str[4]
+        altitude_out = split_str[3]
         nt.assert_almost_equal(float(altitude_out), 0)
 
-        nt.assert_equals(split_str[5], "]")
-        nt.assert_equals(split_str[6], "@")
-        nt.assert_equals(int(split_str[7]), self.crs_ll)
+        nt.assert_equals(split_str[4], "]")
+        nt.assert_equals(split_str[5], "@")
+        nt.assert_equals(int(split_str[6]), self.crs_ll)
 
         print("geo_point with data:", str(p1), sep='\n')

--- a/python/kwiver/vital/tests/test_metadata_traits.py
+++ b/python/kwiver/vital/tests/test_metadata_traits.py
@@ -43,7 +43,6 @@ from kwiver.vital.types.metadata_traits import *
 from kwiver.vital.types import (
     metadata_tags as mt,
 )
-from kwiver.vital.tests.cpp_helpers import type_check as tc
 
 
 class TestVitalMetaTraits(unittest.TestCase):
@@ -66,7 +65,7 @@ class TestVitalMetaTraits(unittest.TestCase):
                                     mt.tags.VITAL_META_UNIX_TIMESTAMP,
                                     "Unix Timestamp (microseconds)",
                                     "UNIX_TIMESTAMP",
-                                    tc.get_uint64_rep(),
+                                    "uint64",
                                     "Number of microseconds since the Unix epoch, not counting leap seconds.")
 
         self.check_are_valid_traits(tag_traits_by_tag( mt.tags.VITAL_META_SLANT_RANGE ),

--- a/vital/tests/test_geo_point.cxx
+++ b/vital/tests/test_geo_point.cxx
@@ -172,7 +172,7 @@ TEST(geo_point, insert_operator_empty)
   std::stringstream str;
   str << p_empty;
 
-  EXPECT_EQ( "geo_point\n[ empty ]", str.str() );
+  EXPECT_EQ( "[ empty ]", str.str() );
 }
 
 // ----------------------------------------------------------------------------
@@ -216,7 +216,6 @@ TEST_P(geo_point_roundtrip, insert_operator)
   int crs;
   std::string dummy;
 
-  in >> dummy; // geo_point\n
   in >> dummy; // [
   in >> easting;
   in >> northing;

--- a/vital/types/geo_point.cxx
+++ b/vital/types/geo_point.cxx
@@ -99,7 +99,6 @@ void geo_point
 std::ostream&
 operator<<( std::ostream& str, vital::geo_point const& obj )
 {
-  str << "geo_point\n";
   if ( obj.is_empty() )
   {
     str << "[ empty ]";

--- a/vital/types/metadata.cxx
+++ b/vital/types/metadata.cxx
@@ -10,6 +10,7 @@
 #include <vital/types/metadata_traits.h>
 #include <vital/util/demangle.h>
 
+#include <ios>
 #include <typeindex>
 
 #include <cmath>
@@ -49,6 +50,14 @@ struct print_visitor {
   std::ostream& operator()( T const& value ) const
   {
     return os << value;
+  }
+
+  std::ostream& operator()( bool value ) const
+  {
+    auto flags = os.flags();
+    os << std::boolalpha << value;
+    os.flags( flags );
+    return os;
   }
 
   std::ostream& os;
@@ -482,23 +491,16 @@ metadata
 }
 
 // ----------------------------------------------------------------------------
-std::ostream& print_metadata( std::ostream& str, metadata const& metadata )
+std::ostream& print_metadata( std::ostream& os, metadata const& metadata )
 {
-  auto eix = metadata.end();
-  for ( auto ix = metadata.begin(); ix != eix; ix++)
+  for( auto const& entry : metadata )
   {
-    // process metada items
-   std::string name = ix->second->name();
-   kwiver::vital::any data = ix->second->data();
-
-   str << "Metadata item: "
-       << name
-       << " <" << demangle( ix->second->type().name() ) << ">: "
-       << metadata::format_string (ix->second->as_string())
+    os << entry.second->name() << ": "
+       << metadata::format_string( entry.second->as_string() )
        << std::endl;
-  } // end for
+  }
 
-  return str;
+  return os;
 }
 
 // ----------------------------------------------------------------------------

--- a/vital/types/metadata_traits.cxx
+++ b/vital/types/metadata_traits.cxx
@@ -442,7 +442,17 @@ std::string
 metadata_tag_traits
 ::type_name() const
 {
-  return demangle( m_type.name() );
+  static std::map< std::type_index, std::string > const map = {
+    { typeid( bool ), "bool" },
+    { typeid( int ), "int" },
+    { typeid( uint64_t ), "uint64" },
+    { typeid( double ), "double" },
+    { typeid( std::string ), "string" },
+    { typeid( geo_point ), "geo_point" },
+    { typeid( geo_polygon ), "geo_polygon" },
+  };
+
+  return map.at( m_type );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Sample frame of original output:
```
========== Read frame 48 (index 48) ==========


---------------- Metadata from: ts(f: 48, t: 1568233 (Wed Dec 31 18:00:01 1969), d: 0)
Metadata item: Origin of Metadata <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: KLV
Metadata item: Unix Timestamp (microseconds) <unsigned long>: 1221515220926000
Metadata item: Unix Timestamp Source <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: klv
Metadata item: Platform Heading Angle (degrees) <double>: -102.283
Metadata item: Platform Pitch Angle (degrees) <double>: 0.664673
Metadata item: Platform Roll Angle (degrees) <double>: 1.36231
Metadata item: Platform Designation <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: ABCD
Metadata item: Image Width <unsigned long>: 720
Metadata item: Image Height <unsigned long>: 480
Metadata item: Index of Metadata Stream <int>: 1
Metadata item: Is Metadata Stream Synchronous <bool>: 1
Metadata item: Video URI <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: ../../src/test_data/videos/aphill_short.ts
Metadata item: Is Key Frame <bool>: 0
Metadata item: Frame Number <unsigned long>: 48
Metadata item: Video Relative Timestamp <unsigned long>: 1568233
Metadata item: Frame Rate <double>: 29.97
Metadata item: Video Bitrate <unsigned long>: 4000000
Metadata item: Video Compression Type <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: H.264
Metadata item: Video Compression Profile <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: Main
Metadata item: Video Compression Level <std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >>: 4.1
Metadata item: Sensor Geodetic Location (lon/lat/alt) <kwiver::vital::geo_point>: geo_point.[ -77.367953, 38.252153, 1054.4000244140625 ] @ 4326 (67 65 6F 5F 70 6F 69 6E 74 0A 5B 20 2D 37 37 2E 33 36 37 39 35 33 2C 20 33 38 2E 32 35 32 31 35 33 2C 20 31 30 35 34 2E 34 30 30 30 32 34 34 31 34 30 36 32 35 20 5D 20 40 20 34 33 32 36)
Metadata item: Sensor Horizonal Field of View (degrees) <double>: 0.8
Metadata item: Sensor Vertical Field of View (degrees) <double>: 0.6
Metadata item: Slant Range (meters) <double>: 1757.34
Metadata item: Geodetic Frame Center (lon/lat/alt) <kwiver::vital::geo_point>: geo_point.[ -77.354285043062731, 38.245504947946507, nan ] @ 4326 (67 65 6F 5F 70 6F 69 6E 74 0A 5B 20 2D 37 37 2E 33 35 34 32 38 35 30 34 33 30 36 32 37 33 31 2C 20 33 38 2E 32 34 35 35 30 34 39 34 37 39 34 36 35 30 37 2C 20 6E 61 6E 20 5D 20 40 20 34 33 32 36)
Metadata item: Corner Points (lon/lat) <kwiver::vital::geo_polygon>: { -77.354065535034877 / 38.245531895246195, -77.354200990222651 / 38.245336397256558, -77.354501635235408 / 38.245478358183938, -77.354367882964794 / 38.245671065466951 } @ 4326
Metadata item: Angle to North (degrees) <double>: 123.128
Metadata item: Sensor Obliquity Angle (degrees) <double>: -36.8698
```


Sample frame of new output:
```
Frame #     48 @ 1.568233 sec
----------------------------------------------------------------
Metadata packet #1
--------------------------------
Origin of Metadata: KLV
Unix Timestamp (microseconds): 1221515220926000
Unix Timestamp Source: klv
Platform Heading Angle (degrees): -102.283
Platform Pitch Angle (degrees): 0.664673
Platform Roll Angle (degrees): 1.36231
Platform Designation: ABCD
Image Width: 720
Image Height: 480
Index of Metadata Stream: 1
Is Metadata Stream Synchronous: true
Video URI: ../../src/test_data/videos/aphill_short.ts
Is Key Frame: false
Frame Number: 48
Video Relative Timestamp: 1568233
Frame Rate: 29.97
Video Bitrate: 4000000
Video Compression Type: H.264
Video Compression Profile: Main
Video Compression Level: 4.1
Sensor Geodetic Location (lon/lat/alt): [ -77.367953, 38.252153, 1054.4000244140625 ] @ 4326
Sensor Horizonal Field of View (degrees): 0.8
Sensor Vertical Field of View (degrees): 0.6
Slant Range (meters): 1757.34
Geodetic Frame Center (lon/lat/alt): [ -77.354285043062731, 38.245504947946507, nan ] @ 4326
Corner Points (lon/lat): { -77.354065535034877 / 38.245531895246195, -77.354200990222651 / 38.245336397256558, -77.354501635235408 / 38.245478358183938, -77.354367882964794 / 38.245671065466951 } @ 4326
Angle to North (degrees): 123.128
Sensor Obliquity Angle (degrees): -36.8698
```

Suggestions for further formatting tweaks are welcome.