### PR TITLE
Add ffmpeg_image_io

### DIFF
--- a/arrows/ffmpeg/CMakeLists.txt
+++ b/arrows/ffmpeg/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 set(ffmpeg_headers_public
   ffmpeg_audio_stream_settings.h
   ffmpeg_cuda.h
+  ffmpeg_image_io.h
   ffmpeg_init.h
   ffmpeg_util.h
   ffmpeg_video_input.h
@@ -44,7 +45,9 @@ kwiver_install_headers(
 
 set(ffmpeg_sources
   ffmpeg_audio_stream_settings.cxx
+  ffmpeg_convert_image.cxx
   ffmpeg_cuda.cxx
+  ffmpeg_image_io.cxx
   ffmpeg_init.cxx
   ffmpeg_util.cxx
   ffmpeg_video_input.cxx

--- a/arrows/ffmpeg/ffmpeg_convert_image.cxx
+++ b/arrows/ffmpeg/ffmpeg_convert_image.cxx
@@ -1,0 +1,374 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of FFmpeg image conversion utilities.
+
+#include <arrows/ffmpeg/ffmpeg_convert_image.h>
+
+#include <vital/logger/logger.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Some libav algorithms use vectorized operations, which requires some extra
+// dead memory at the end of buffers, as well as memory alignment
+constexpr size_t padding = AV_INPUT_BUFFER_PADDING_SIZE;
+
+// ----------------------------------------------------------------------------
+// Interpretation of vital images from 1-4 channels
+AVPixelFormat depth_pix_fmts[] = {
+  AV_PIX_FMT_GRAY8,  // Grayscale
+  AV_PIX_FMT_GRAY8A, // Grayscale with alpha
+  AV_PIX_FMT_RGB24,  // RGB
+  AV_PIX_FMT_RGBA,   // RGB with alpha
+  AV_PIX_FMT_NONE, };
+
+// ----------------------------------------------------------------------------
+// JPEG versions of YUV formats are deprecated and cause warnings when used
+AVPixelFormat
+dejpeg_pix_fmt( AVPixelFormat format )
+{
+  switch( format )
+  {
+    case AV_PIX_FMT_YUVJ411P: return AV_PIX_FMT_YUV411P;
+    case AV_PIX_FMT_YUVJ420P: return AV_PIX_FMT_YUV420P;
+    case AV_PIX_FMT_YUVJ422P: return AV_PIX_FMT_YUV422P;
+    case AV_PIX_FMT_YUVJ440P: return AV_PIX_FMT_YUV440P;
+    case AV_PIX_FMT_YUVJ444P: return AV_PIX_FMT_YUV444P;
+    default:
+      return format;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// All YUV formats except JPEG versions default to MPEG limited color range
+AVColorRange color_range_from_pix_fmt( AVPixelFormat format )
+{
+  switch( format )
+  {
+    case AV_PIX_FMT_YUV420P:
+    case AV_PIX_FMT_YUYV422:
+    case AV_PIX_FMT_YUV422P:
+    case AV_PIX_FMT_YUV444P:
+    case AV_PIX_FMT_YUV410P:
+    case AV_PIX_FMT_YUV411P:
+    case AV_PIX_FMT_UYVY422:
+    case AV_PIX_FMT_UYYVYY411:
+    case AV_PIX_FMT_NV12:
+    case AV_PIX_FMT_NV21:
+    case AV_PIX_FMT_YUV440P:
+    case AV_PIX_FMT_YUVA420P:
+    case AV_PIX_FMT_YUV420P16LE:
+    case AV_PIX_FMT_YUV420P16BE:
+    case AV_PIX_FMT_YUV422P16LE:
+    case AV_PIX_FMT_YUV422P16BE:
+    case AV_PIX_FMT_YUV444P16LE:
+    case AV_PIX_FMT_YUV444P16BE:
+    case AV_PIX_FMT_YUV420P9BE:
+    case AV_PIX_FMT_YUV420P9LE:
+    case AV_PIX_FMT_YUV420P10BE:
+    case AV_PIX_FMT_YUV420P10LE:
+    case AV_PIX_FMT_YUV422P10BE:
+    case AV_PIX_FMT_YUV422P10LE:
+    case AV_PIX_FMT_YUV444P9BE:
+    case AV_PIX_FMT_YUV444P9LE:
+    case AV_PIX_FMT_YUV444P10BE:
+    case AV_PIX_FMT_YUV444P10LE:
+    case AV_PIX_FMT_YUV422P9BE:
+    case AV_PIX_FMT_YUV422P9LE:
+    case AV_PIX_FMT_YUVA422P:
+    case AV_PIX_FMT_YUVA444P:
+    case AV_PIX_FMT_YUVA420P9BE:
+    case AV_PIX_FMT_YUVA420P9LE:
+    case AV_PIX_FMT_YUVA422P9BE:
+    case AV_PIX_FMT_YUVA422P9LE:
+    case AV_PIX_FMT_YUVA444P9BE:
+    case AV_PIX_FMT_YUVA444P9LE:
+    case AV_PIX_FMT_YUVA420P10BE:
+    case AV_PIX_FMT_YUVA420P10LE:
+    case AV_PIX_FMT_YUVA422P10BE:
+    case AV_PIX_FMT_YUVA422P10LE:
+    case AV_PIX_FMT_YUVA444P10BE:
+    case AV_PIX_FMT_YUVA444P10LE:
+    case AV_PIX_FMT_YUVA420P16BE:
+    case AV_PIX_FMT_YUVA420P16LE:
+    case AV_PIX_FMT_YUVA422P16BE:
+    case AV_PIX_FMT_YUVA422P16LE:
+    case AV_PIX_FMT_YUVA444P16BE:
+    case AV_PIX_FMT_YUVA444P16LE:
+      return AVCOL_RANGE_MPEG;
+    default:
+      return AVCOL_RANGE_JPEG;
+  }
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+AVPixelFormat
+pix_fmt_from_depth( size_t depth )
+{
+  if( !depth || depth > 4 )
+  {
+    throw_error( "Unsupported depth: ", depth );
+  }
+  return depth_pix_fmts[ depth - 1 ];
+}
+
+// ----------------------------------------------------------------------------
+size_t
+depth_from_pix_fmt( AVPixelFormat pix_fmt )
+{
+  auto const depth_pix_fmt =
+    avcodec_find_best_pix_fmt_of_list( depth_pix_fmts, pix_fmt, true, nullptr );
+
+  for( size_t i = 0; i < 4; ++i )
+  {
+    if( depth_pix_fmts[ i ] == depth_pix_fmt )
+    {
+      return i + 1;
+    }
+  }
+
+  return 3;  // This should never happen, but if it does, default to RGB
+}
+
+// ----------------------------------------------------------------------------
+vital::image_container_sptr
+frame_to_vital_image( AVFrame* frame, sws_context_uptr* cached_sws )
+{
+  throw_error_null( frame, "frame_to_vital_image() given null frame" );
+
+  // Determine pixel formats
+  auto const src_pix_fmt =
+    dejpeg_pix_fmt( static_cast< AVPixelFormat >( frame->format ) );
+  auto const depth = depth_from_pix_fmt( src_pix_fmt );
+  auto const dst_pix_fmt = pix_fmt_from_depth( depth );
+
+  // Allocate memory of correct size
+  auto const width = static_cast< size_t >( frame->width );
+  auto const height = static_cast< size_t >( frame->height );
+  auto const linesize = width * depth;
+  auto const image_size = linesize * height + padding;
+  auto const image_memory =
+    std::make_shared< vital::image_memory >( image_size );
+
+  // Create pixel format converter
+  sws_context_uptr tmp_sws;
+  if( !cached_sws )
+  {
+    cached_sws = &tmp_sws;
+  }
+
+  cached_sws->reset(
+    throw_error_null(
+      sws_getCachedContext(
+        cached_sws->release(),
+        width, height, src_pix_fmt,
+        width, height, dst_pix_fmt,
+        SWS_BICUBIC, nullptr, nullptr, nullptr ),
+      "Could not create image conversion context" ) );
+
+  if( frame->color_range == AVCOL_RANGE_UNSPECIFIED )
+  {
+    // Not using the de-JPEG'd src_pix_fmt
+    frame->color_range = color_range_from_pix_fmt(
+      static_cast< AVPixelFormat >( frame->format ) );
+  }
+
+  if( sws_setColorspaceDetails(
+        cached_sws->get(), sws_getCoefficients( frame->colorspace ),
+        frame->color_range == AVCOL_RANGE_JPEG,
+        sws_getCoefficients( SWS_CS_DEFAULT ), 1, 0, 1 << 16, 1 << 16 ) < 0 )
+  {
+    LOG_WARN(
+      vital::get_logger( "ffmpeg" ),
+      "Could not convert to standardized colorspace; "
+      "image will be decoded as-is" );
+  }
+
+  // Convert pixel format
+  auto const out_data = static_cast< uint8_t* >( image_memory->data() );
+  auto const out_linesize = static_cast< int >( linesize );
+  if( sws_scale(
+        cached_sws->get(),
+        frame->data, frame->linesize,
+        0, height,
+        &out_data, &out_linesize ) != static_cast< int >( height ) )
+  {
+    throw_error( "Could not convert image to vital pixel format" );
+  }
+
+  return std::make_shared< vital::simple_image_container >(
+    vital::image(
+      image_memory, image_memory->data(),
+      width, height, depth,
+      depth, linesize, 1 ) );
+}
+
+// ----------------------------------------------------------------------------
+frame_uptr
+vital_image_to_frame(
+  vital::image_container_scptr const& image,
+  AVCodecContext const* codec_context, sws_context_uptr* cached_sws )
+{
+  if( !image )
+  {
+    throw_error( "vital_image_to_frame() given null image" );
+  }
+
+  if( image->get_image().pixel_traits() !=
+      vital::image_pixel_traits_of< uint8_t >() )
+  {
+    // TODO: Is there an existing conversion function somewhere?
+    throw_error( "Image has unsupported pixel traits (non-uint8)" );
+  }
+
+  // Create frame object for incoming image
+  frame_uptr frame{
+    throw_error_null( av_frame_alloc(), "Could not allocate frame" ) };
+
+  // Determine image dimensions
+  frame->width = image->width();
+  frame->height = image->height();
+
+  auto const src_pix_fmt = pix_fmt_from_depth( image->depth() );
+  frame->format = src_pix_fmt;
+
+  auto const dst_pix_fmt =
+    codec_context ? codec_context->pix_fmt : AV_PIX_FMT_NONE;
+
+  throw_error_code(
+    av_frame_get_buffer( frame.get(), padding ),
+    "Could not allocate frame data" );
+
+  // Give the frame the raw pixel data
+  {
+    auto ptr =
+      static_cast< uint8_t const* >( image->get_image().first_pixel() );
+    auto const i_step = image->get_image().h_step();
+    auto const j_step = image->get_image().w_step();
+    auto const k_step = image->get_image().d_step();
+    if( j_step == static_cast< ptrdiff_t >( image->depth() ) &&
+        k_step == static_cast< ptrdiff_t >( 1 ) )
+    {
+      // Fast method for packed / interleaved data - line by line
+      for( size_t i = 0; i < image->height(); ++i )
+      {
+        std::memcpy(
+          frame->data[ 0 ] + i * frame->linesize[ 0 ], ptr + i * i_step,
+          image->width() * image->depth() );
+      }
+    }
+    // TODO: Add faster method to copy planar data
+    else
+    {
+      // Slow method - pixel by pixel
+      auto const i_step_ptr = i_step - j_step * image->width();
+      auto const j_step_ptr = j_step - k_step * image->depth();
+      auto const k_step_ptr = k_step;
+      auto const i_step_index =
+        frame->linesize[ 0 ] - image->width() * image->depth();
+      size_t index = 0;
+      for( size_t i = 0; i < image->height(); ++i )
+      {
+        for( size_t j = 0; j < image->width(); ++j )
+        {
+          for( size_t k = 0; k < image->depth(); ++k )
+          {
+            frame->data[ 0 ][ index++ ] = *ptr;
+            ptr += k_step_ptr;
+          }
+          ptr += j_step_ptr;
+        }
+        ptr += i_step_ptr;
+        index += i_step_index;
+      }
+    }
+  }
+
+  if( dst_pix_fmt == AV_PIX_FMT_NONE || dst_pix_fmt == frame->format )
+  {
+    // No need to convert the frame
+    return frame;
+  }
+
+  // Allocate a new frame with the desire pixel format
+  frame_uptr converted_frame{
+    throw_error_null( av_frame_alloc(), "Could not allocate frame" ) };
+
+  converted_frame->width = frame->width;
+  converted_frame->height = frame->height;
+  converted_frame->format = dejpeg_pix_fmt( dst_pix_fmt );
+  if( codec_context->color_range == AVCOL_RANGE_UNSPECIFIED )
+  {
+    // Not using the de-JPEG'd converted_frame->format
+    converted_frame->color_range = color_range_from_pix_fmt( dst_pix_fmt );
+  }
+  else
+  {
+    converted_frame->color_range = codec_context->color_range;
+  }
+  converted_frame->colorspace = codec_context->colorspace;
+  converted_frame->color_trc = codec_context->color_trc;
+  converted_frame->color_primaries = codec_context->color_primaries;
+
+  throw_error_code(
+    av_frame_get_buffer( converted_frame.get(), padding ),
+    "Could not allocate frame data" );
+
+  // Create pixel format converter
+  sws_context_uptr tmp_sws;
+  if( !cached_sws )
+  {
+    cached_sws = &tmp_sws;
+  }
+
+  cached_sws->reset(
+    throw_error_null(
+      sws_getCachedContext(
+        cached_sws->release(),
+        frame->width, frame->height, src_pix_fmt,
+        frame->width, frame->height,
+        static_cast< AVPixelFormat >( converted_frame->format ),
+        SWS_BICUBIC, nullptr, nullptr, nullptr ),
+      "Could not create image conversion context" ) );
+
+  if( sws_setColorspaceDetails(
+        cached_sws->get(), sws_getCoefficients( SWS_CS_DEFAULT ), 1,
+        sws_getCoefficients( converted_frame->colorspace ),
+        converted_frame->color_range == AVCOL_RANGE_JPEG,
+        0, 1 << 16, 1 << 16 ) < 0 )
+  {
+    LOG_WARN(
+      vital::get_logger( "ffmpeg" ),
+      "Could not convert to desired colorspace; "
+      "image will be encoded as-is" );
+  }
+
+  // Convert pixel format
+  if( sws_scale(
+        cached_sws->get(),
+        frame->data, frame->linesize,
+        0, frame->height,
+        converted_frame->data, converted_frame->linesize ) != frame->height )
+  {
+    throw_error( "Could not convert image to target pixel format" );
+  }
+
+  return converted_frame;
+}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_convert_image.h
+++ b/arrows/ffmpeg/ffmpeg_convert_image.h
@@ -1,0 +1,45 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of FFmpeg image conversion utilities.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_CONVERT_IMAGE_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_CONVERT_IMAGE_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+
+#include <arrows/ffmpeg/ffmpeg_util.h>
+
+#include <vital/types/image_container.h>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+vital::image_container_sptr frame_to_vital_image(
+  AVFrame* frame, sws_context_uptr* cached_sws = nullptr );
+
+// ----------------------------------------------------------------------------
+frame_uptr vital_image_to_frame(
+  vital::image_container_scptr const& image,
+  AVCodecContext const* codec_context = nullptr,
+  sws_context_uptr* cached_sws = nullptr );
+
+// ----------------------------------------------------------------------------
+AVPixelFormat pix_fmt_from_depth( size_t depth );
+
+// ----------------------------------------------------------------------------
+size_t depth_from_pix_fmt( AVPixelFormat pix_fmt );
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/ffmpeg_image_io.cxx
+++ b/arrows/ffmpeg/ffmpeg_image_io.cxx
@@ -1,0 +1,335 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Definition of the FFmpeg-based image_io algorithm.
+
+#include <arrows/ffmpeg/ffmpeg_image_io.h>
+
+#include <arrows/ffmpeg/ffmpeg_convert_image.h>
+#include <arrows/ffmpeg/ffmpeg_util.h>
+
+extern "C" {
+#include <libavutil/opt.h>
+}
+
+#include <algorithm>
+#include <filesystem>
+#include <map>
+
+#include <cctype>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+AVCodecID
+extension_to_codec_id( std::string const& filename )
+{
+  static std::map< std::string, AVCodecID > const map = {
+    { ".bmp",  AV_CODEC_ID_BMP },
+    { ".j2k",  AV_CODEC_ID_JPEG2000 },
+    { ".jp2",  AV_CODEC_ID_JPEG2000 },
+    { ".jpeg", AV_CODEC_ID_MJPEG },
+    { ".jpg",  AV_CODEC_ID_MJPEG },
+    { ".png",  AV_CODEC_ID_PNG },
+    { ".tga",  AV_CODEC_ID_TARGA },
+    { ".tif",  AV_CODEC_ID_TIFF },
+    { ".tiff", AV_CODEC_ID_TIFF },
+    { ".webp", AV_CODEC_ID_WEBP }, };
+
+  auto extension = std::filesystem::path( filename ).extension().string();
+  std::transform(
+    extension.begin(), extension.end(), extension.begin(),
+    []( unsigned char c ){ return std::tolower( c ); } );
+
+  if( auto const it = map.find( extension ); it != map.end() )
+  {
+    return it->second;
+  }
+  throw std::runtime_error(
+    "Could not determine image format from filename: " + filename );
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+class ffmpeg_image_io::impl
+{
+public:
+  impl();
+
+  std::string codec_name;
+  int quality;
+
+  sws_context_uptr load_image_converter;
+  sws_context_uptr save_image_converter;
+};
+
+// ----------------------------------------------------------------------------
+ffmpeg_image_io::impl
+::impl()
+  : codec_name{},
+    quality{ -1 },
+    load_image_converter{},
+    save_image_converter{}
+{}
+
+// ----------------------------------------------------------------------------
+ffmpeg_image_io
+::ffmpeg_image_io()
+  : d{ new impl }
+{}
+
+// ----------------------------------------------------------------------------
+ffmpeg_image_io
+::~ffmpeg_image_io()
+{}
+
+// ----------------------------------------------------------------------------
+vital::config_block_sptr
+ffmpeg_image_io
+::get_configuration() const
+{
+  auto config = vital::algorithm::get_configuration();
+
+  config->set_value(
+    "codec_name", d->codec_name,
+    "Name of FFmpeg codec to force usage of. "
+    "Only effective when saving images." );
+  config->set_value(
+    "quality", d->quality,
+    "Integer 2-31 controlling compression quality. Higher is lossier." );
+
+  return config;
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_image_io
+::set_configuration( vital::config_block_sptr config_in )
+{
+  auto config = vital::algorithm::get_configuration();
+  config->merge_config( config_in );
+
+  d->codec_name = config->get_value< std::string >( "codec_name", "" );
+  d->quality = config->get_value< int >( "quality", -1 );
+}
+
+// ----------------------------------------------------------------------------
+bool
+ffmpeg_image_io
+::check_configuration( vital::config_block_sptr ) const
+{
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+vital::image_container_sptr
+ffmpeg_image_io
+::load_( std::string const& filename ) const
+{
+  // Open the file
+  format_context_uptr format_context;
+  {
+    AVFormatContext* ptr = nullptr;
+    throw_error_code(
+      avformat_open_input(
+        &ptr, filename.c_str(), av_find_input_format( "image2" ), NULL ),
+      "Could not open input" );
+    format_context.reset( ptr );
+  }
+
+  // Get the stream information by reading a bit of the file
+  throw_error_code(
+    avformat_find_stream_info( format_context.get(), NULL ),
+    "Could not read stream information" );
+
+  // Find "video" (image) stream
+  AVStream* video_stream = nullptr;
+  for( size_t i = 0; i < format_context->nb_streams; ++i )
+  {
+    auto const stream = format_context->streams[ i ];
+    auto const params = stream->codecpar;
+    if( params->codec_type == AVMEDIA_TYPE_VIDEO &&
+        params->width > 0 && params->height > 0 )
+    {
+      video_stream = stream;
+      break;
+    }
+  }
+  throw_error_null( video_stream, "Could not find a valid image in the file" );
+
+  // Create an image codec
+  auto const codec = throw_error_null(
+    avcodec_find_decoder( video_stream->codecpar->codec_id ),
+    "Could not find suitable codec"
+  );
+  codec_context_uptr codec_context{
+    throw_error_null(
+      avcodec_alloc_context3( codec ),
+      "Could not allocate codec context" ) };
+
+  // Configure the codec
+  throw_error_code(
+    avcodec_parameters_to_context(
+      codec_context.get(), video_stream->codecpar ),
+    "Could not configure codec ", pretty_codec_name( codec ) );
+  codec_context->thread_count = 0;
+  codec_context->thread_type = FF_THREAD_SLICE;
+
+  // Initialize the codec
+  throw_error_code(
+    avcodec_open2( codec_context.get(), codec, nullptr ),
+    "Could not open codec ", pretty_codec_name( codec ) );
+
+  // Get raw image data
+  packet_uptr packet{
+    throw_error_null( av_packet_alloc(), "Could not allocate packet" ) };
+  throw_error_code(
+    av_read_frame( format_context.get(), packet.get() ),
+    "Could not parse image" );
+
+  // Give data to the decoder
+  throw_error_code(
+    avcodec_send_packet( codec_context.get(), packet.get() ),
+    "Could not send image to decoder" );
+  throw_error_code(
+    avcodec_send_packet( codec_context.get(), nullptr ),
+    "Could not flush image decoder" );
+
+  // Get the decoded frame
+  frame_uptr frame{
+    throw_error_null( av_frame_alloc(), "Could not allocate frame" ) };
+  throw_error_code(
+    avcodec_receive_frame( codec_context.get(), frame.get() ),
+    "Could not decode image" );
+
+  return frame_to_vital_image( frame.get(), &d->load_image_converter );
+}
+
+// ----------------------------------------------------------------------------
+void
+ffmpeg_image_io
+::save_(
+  std::string const& filename,
+  kwiver::vital::image_container_sptr data ) const
+{
+  if( !data || !data->width() || !data->height() || !data->depth() )
+  {
+    throw_error( "Empty image given to ffmpeg_image_io.save()" );
+  }
+
+  // Allocate output format context
+  format_context_uptr format_context;
+  {
+    AVFormatContext* tmp = nullptr;
+    throw_error_code(
+      avformat_alloc_output_context2(
+        &tmp, nullptr, "image2", filename.c_str() ),
+      "Could not allocate format context" );
+    format_context.reset( tmp );
+  }
+
+  // Force FFmpeg to treat the output as a single image (not a sequence)
+  av_opt_set_int( format_context->priv_data, "update", 1, 0 );
+
+  // Choose image codec
+  auto const codec =
+    throw_error_null(
+      d->codec_name.empty()
+      ? avcodec_find_encoder( extension_to_codec_id( filename ) )
+      : avcodec_find_encoder_by_name( d->codec_name.c_str() ),
+      "Could not find suitable encoder"
+    );
+
+  // Create codec context
+  codec_context_uptr codec_context{
+    throw_error_null(
+      avcodec_alloc_context3( codec ),
+      "Could not allocate codec context" ) };
+
+  // Configure codec
+  codec_context->width = data->width();
+  codec_context->height = data->height();
+  codec_context->time_base = AV_TIME_BASE_Q;
+  if( d->quality >= 0 )
+  {
+    codec_context->flags |= AV_CODEC_FLAG_QSCALE;
+    codec_context->global_quality = d->quality * FF_QP2LAMBDA;
+    codec_context->qmin = codec_context->qmax = d->quality;
+  }
+  codec_context->color_range = AVCOL_RANGE_JPEG;
+
+  // Determine which pixel format to use
+  auto const src_pix_fmt = pix_fmt_from_depth( data->depth() );
+  codec_context->pix_fmt =
+    avcodec_find_best_pix_fmt_of_list(
+      codec->pix_fmts, src_pix_fmt, src_pix_fmt == AV_PIX_FMT_RGBA,
+      nullptr );
+
+  // Create the "video" (image) stream
+  AVStream* video_stream = throw_error_null(
+    avformat_new_stream( format_context.get(), nullptr ),
+    "Could not allocate image stream" );
+  throw_error_code(
+    avcodec_parameters_from_context(
+      video_stream->codecpar, codec_context.get() ),
+    "Could not configure image stream" );
+
+  // Open the output
+  throw_error_code(
+    avcodec_open2( codec_context.get(), codec, nullptr ),
+    "Could not initialize codec" );
+  throw_error_code(
+    avio_open( &format_context->pb, filename.c_str(), AVIO_FLAG_WRITE ),
+    "Could not open image file ", filename );
+
+  // Start writing the file
+  throw_error_code(
+    avformat_write_header( format_context.get(), nullptr ),
+    "Could not write image header" );
+
+  // Convert input image to FFmpeg frame
+  auto const frame =
+    vital_image_to_frame(
+      data,
+      codec_context.get(),
+      &d->save_image_converter );
+  frame->pts = 0;
+
+  // Encode frame
+  throw_error_code(
+    avcodec_send_frame( codec_context.get(), frame.get() ),
+    "Encoder rejected image" );
+  throw_error_code(
+    avcodec_send_frame( codec_context.get(), nullptr ),
+    "Could not flush encoder" );
+
+  // Get encoded frame
+  packet_uptr packet{
+    throw_error_null( av_packet_alloc(), "Could not allocate packet" ) };
+  throw_error_code(
+    avcodec_receive_packet( codec_context.get(), packet.get() ),
+    "Could not encode image" );
+
+  // Write out frame and close out file
+  throw_error_code(
+    av_write_frame( format_context.get(), packet.get() ),
+    "Could not write image to file" );
+  throw_error_code(
+    av_write_trailer( format_context.get() ),
+    "Could not write image trailer" );
+}
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver

--- a/arrows/ffmpeg/ffmpeg_image_io.h
+++ b/arrows/ffmpeg/ffmpeg_image_io.h
@@ -1,0 +1,57 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Declaration of the FFmpeg-based image_io algorithm.
+
+#ifndef KWIVER_ARROWS_FFMPEG_FFMPEG_IMAGE_IO_H_
+#define KWIVER_ARROWS_FFMPEG_FFMPEG_IMAGE_IO_H_
+
+#include <arrows/ffmpeg/kwiver_algo_ffmpeg_export.h>
+
+#include <vital/algo/image_io.h>
+
+#include <memory>
+
+namespace kwiver {
+
+namespace arrows {
+
+namespace ffmpeg {
+
+// ----------------------------------------------------------------------------
+/// Image reader / writer using FFmpeg (libav).
+class KWIVER_ALGO_FFMPEG_EXPORT ffmpeg_image_io
+  : public vital::algo::image_io
+{
+public:
+  ffmpeg_image_io();
+  virtual ~ffmpeg_image_io();
+
+  PLUGIN_INFO( "ffmpeg", "Use FFmpeg to read and write image files." )
+
+  vital::config_block_sptr get_configuration() const override;
+  void set_configuration( vital::config_block_sptr config ) override;
+  bool check_configuration( vital::config_block_sptr config ) const override;
+
+private:
+  vital::image_container_sptr load_(
+    std::string const& filename ) const override;
+
+  void save_(
+    std::string const& filename,
+    kwiver::vital::image_container_sptr data ) const override;
+
+  class impl;
+
+  std::shared_ptr< impl > d;
+};
+
+} // namespace ffmpeg
+
+} // namespace arrows
+
+} // namespace kwiver
+
+#endif

--- a/arrows/ffmpeg/ffmpeg_util.cxx
+++ b/arrows/ffmpeg/ffmpeg_util.cxx
@@ -127,10 +127,6 @@ DEFINE_DELETER( format_context, AVFormatContext )
 // ----------------------------------------------------------------------------
 DEFINE_DELETER( codec_context, AVCodecContext )
 {
-  if( ptr->codec && ptr->codec_type == AVMEDIA_TYPE_VIDEO )
-  {
-    avcodec_flush_buffers( ptr );
-  }
   avcodec_free_context( &ptr );
 }
 

--- a/arrows/ffmpeg/register_algorithms.cxx
+++ b/arrows/ffmpeg/register_algorithms.cxx
@@ -8,6 +8,7 @@
 #include <arrows/ffmpeg/kwiver_algo_ffmpeg_plugin_export.h>
 #include <vital/algo/algorithm_factory.h>
 
+#include <arrows/ffmpeg/ffmpeg_image_io.h>
 #include <arrows/ffmpeg/ffmpeg_video_input.h>
 #include <arrows/ffmpeg/ffmpeg_video_input_clip.h>
 #include <arrows/ffmpeg/ffmpeg_video_input_rewire.h>
@@ -31,6 +32,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
     return;
   }
 
+  reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_image_io >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input_clip >();
   reg.register_algorithm< ::kwiver::arrows::ffmpeg::ffmpeg_video_input_rewire >();

--- a/arrows/ffmpeg/tests/CMakeLists.txt
+++ b/arrows/ffmpeg/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(test_libraries     kwiver_algo_ffmpeg kwiver_algo_klv kwiver_algo_core)
 ##############################
 # Algorithms ffmpeg tests
 ##############################
+kwiver_discover_gtests(ffmpeg image_io_ffmpeg           LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(ffmpeg video_input_ffmpeg        LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(ffmpeg video_input_ffmpeg_clip   LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")
 kwiver_discover_gtests(ffmpeg video_input_ffmpeg_rewire LIBRARIES ${test_libraries} ARGUMENTS "${kwiver_test_data_directory}")

--- a/arrows/ffmpeg/tests/common.h
+++ b/arrows/ffmpeg/tests/common.h
@@ -143,3 +143,16 @@ expect_eq_videos(
   src_is.close();
   tmp_is.close();
 }
+
+
+// ----------------------------------------------------------------------------
+// This will delete the temporary file even if an exception is thrown.
+struct _tmp_file_deleter
+{
+  ~_tmp_file_deleter()
+  {
+    std::remove( tmp_path.c_str() );
+  }
+
+  std::string tmp_path;
+};

--- a/arrows/ffmpeg/tests/test_image_io_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_image_io_ffmpeg.cxx
@@ -1,0 +1,262 @@
+// This file is part of KWIVER, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/kwiver/blob/master/LICENSE for details.
+
+/// \file
+/// Test the FFmpeg image_io implementation
+
+#include <test_tmpfn.h>
+
+#include <arrows/ffmpeg/ffmpeg_image_io.h>
+#include <arrows/ffmpeg/tests/common.h>
+
+#include <vital/plugin_loader/plugin_manager.h>
+
+#include <filesystem>
+#include <limits>
+
+std::filesystem::path g_data_dir;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+template < class T >
+kv::image
+create_test_image( size_t width, size_t height, size_t depth )
+{
+  constexpr double maximum = std::numeric_limits< T >::max();
+  auto image = kv::image{ width, height, depth };
+  for( size_t y = 0; y < height; ++y )
+  {
+    for( size_t x = 0; x < width; ++x )
+    {
+      for( size_t c = 0; c < depth; ++c )
+      {
+        image.at< T >( x, y, c ) =
+          static_cast< T >(
+            maximum / ( height - 1 ) * y -
+            maximum / ( width - 1 ) * x +
+            maximum / ( depth - 1 ) * c );
+      }
+    }
+  }
+  return image;
+}
+
+// ----------------------------------------------------------------------------
+template < class T >
+void
+assert_test_image(
+  kv::image const& image, size_t width, size_t height, size_t depth,
+  size_t epsilon = 0 )
+{
+  ASSERT_EQ( width, image.width() );
+  ASSERT_EQ( height, image.height() );
+  ASSERT_EQ( depth, image.depth() );
+  ASSERT_EQ( kv::image_pixel_traits_of< T >(), image.pixel_traits() );
+
+  constexpr double maximum = std::numeric_limits< T >::max();
+  for( size_t y = 0; y < height; ++y )
+  {
+    for( size_t x = 0; x < width; ++x )
+    {
+      for( size_t c = 0; c < depth; ++c )
+      {
+        ASSERT_NEAR(
+          static_cast< T >(
+            maximum / ( height - 1 ) * y -
+            maximum / ( width - 1 ) * x +
+            maximum / ( depth - 1 ) * c ), image.at< T >( x, y, c ), epsilon );
+      }
+    }
+  }
+}
+
+} // namespace <anonymous>
+
+// ----------------------------------------------------------------------------
+int
+main( int argc, char* argv[] )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  TEST_LOAD_PLUGINS();
+
+  GET_ARG( 1, g_data_dir );
+
+  return RUN_ALL_TESTS();
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, create )
+{
+  EXPECT_NE( nullptr, kv::algo::image_io::create( "ffmpeg" ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, load_png )
+{
+  auto const path = g_data_dir / "images/test.png";
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const loaded_image = io.load( path.string() );
+
+  ASSERT_NE( nullptr, loaded_image );
+
+  ASSERT_EQ( 40, loaded_image->height() );
+  ASSERT_EQ( 60, loaded_image->width() );
+  ASSERT_EQ( 3,  loaded_image->depth() );
+
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 0 ) );
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 1 ) );
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 2 ) );
+
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 59, 0, 0 ) );
+  EXPECT_EQ( 245, loaded_image->get_image().at< uint8_t >( 59, 0, 1 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 59, 0, 2 ) );
+
+  EXPECT_EQ( 245, loaded_image->get_image().at< uint8_t >( 59, 39, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 59, 39, 1 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 59, 39, 2 ) );
+
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 39, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 39, 1 ) );
+  EXPECT_EQ( 245, loaded_image->get_image().at< uint8_t >( 0, 39, 2 ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, load_jpeg )
+{
+  auto const path = g_data_dir / "images/test.jpg";
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const loaded_image = io.load( path.string() );
+
+  ASSERT_NE( nullptr, loaded_image );
+
+  ASSERT_EQ( 32, loaded_image->height() );
+  ASSERT_EQ( 32, loaded_image->width() );
+  ASSERT_EQ( 3,  loaded_image->depth() );
+
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 0 ) );
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 1 ) );
+  EXPECT_EQ( 0, loaded_image->get_image().at< uint8_t >( 0, 0, 2 ) );
+
+  EXPECT_EQ( 1,   loaded_image->get_image().at< uint8_t >( 31, 0, 0 ) );
+  EXPECT_EQ( 240, loaded_image->get_image().at< uint8_t >( 31, 0, 1 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 31, 0, 2 ) );
+
+  EXPECT_EQ( 240, loaded_image->get_image().at< uint8_t >( 31, 31, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 31, 31, 1 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 31, 31, 2 ) );
+
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 31, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 31, 1 ) );
+  EXPECT_EQ( 240, loaded_image->get_image().at< uint8_t >( 0, 31, 2 ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, load_tiff )
+{
+  auto const path = g_data_dir / "images/test.tif";
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const loaded_image = io.load( path.string() );
+
+  ASSERT_NE( nullptr, loaded_image );
+
+  ASSERT_EQ( 32, loaded_image->height() );
+  ASSERT_EQ( 32, loaded_image->width() );
+  ASSERT_EQ( 1,  loaded_image->depth() );
+
+  // This will have to change if / when 16-bit support is added
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 0, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 31, 0, 0 ) );
+  EXPECT_EQ( 239, loaded_image->get_image().at< uint8_t >( 31, 31, 0 ) );
+  EXPECT_EQ( 0,   loaded_image->get_image().at< uint8_t >( 0, 31, 0 ) );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, save_png )
+{
+  auto const path = kwiver::testing::temp_file_name( "test-", ".png" );
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const image = create_test_image< uint8_t >( 32, 64, 3 );
+  io.save( path, std::make_shared< kv::simple_image_container >( image ) );
+
+  _tmp_file_deleter tmp_file_deleter{ path };
+
+  auto const loaded_image = io.load( path );
+  CALL_TEST(
+    assert_test_image< uint8_t >, loaded_image->get_image(), 32, 64, 3, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, save_png_rgba )
+{
+  auto const path = kwiver::testing::temp_file_name( "test-", ".png" );
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const image = create_test_image< uint8_t >( 32, 64, 4 );
+  io.save( path, std::make_shared< kv::simple_image_container >( image ) );
+
+  _tmp_file_deleter tmp_file_deleter{ path };
+
+  auto const loaded_image = io.load( path );
+  CALL_TEST(
+    assert_test_image< uint8_t >, loaded_image->get_image(), 32, 64, 4, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, save_jpeg )
+{
+  auto const path = kwiver::testing::temp_file_name( "test-", ".jpg" );
+
+  ffmpeg::ffmpeg_image_io io;
+
+  // Set JPEG to highest quality
+  auto config = io.get_configuration();
+  config->set_value( "quality", 1 );
+  io.set_configuration( config );
+
+  auto const image = create_test_image< uint8_t >( 64, 32, 3 );
+  io.save( path, std::make_shared< kv::simple_image_container >( image ) );
+
+  _tmp_file_deleter tmp_file_deleter{ path };
+
+  auto const loaded_image = io.load( path );
+  CALL_TEST(
+    assert_test_image< uint8_t >, loaded_image->get_image(), 64, 32, 3, 10 );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, save_tiff )
+{
+  auto const path = kwiver::testing::temp_file_name( "test-", ".tif" );
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const image = create_test_image< uint8_t >( 32, 64, 3 );
+  io.save( path, std::make_shared< kv::simple_image_container >( image ) );
+
+  _tmp_file_deleter tmp_file_deleter{ path };
+
+  auto const loaded_image = io.load( path );
+  CALL_TEST(
+    assert_test_image< uint8_t >, loaded_image->get_image(), 32, 64, 3, 0 );
+}
+
+// ----------------------------------------------------------------------------
+TEST ( ffmpeg_image_io, save_tiff_gray )
+{
+  auto const path = kwiver::testing::temp_file_name( "test-", ".tif" );
+
+  ffmpeg::ffmpeg_image_io io;
+  auto const image = create_test_image< uint8_t >( 32, 64, 1 );
+  io.save( path, std::make_shared< kv::simple_image_container >( image ) );
+
+  _tmp_file_deleter tmp_file_deleter{ path };
+
+  auto const loaded_image = io.load( path );
+  CALL_TEST(
+    assert_test_image< uint8_t >, loaded_image->get_image(), 32, 64, 1, 0 );
+}

--- a/arrows/ffmpeg/tests/test_video_input_ffmpeg_klv.cxx
+++ b/arrows/ffmpeg/tests/test_video_input_ffmpeg_klv.cxx
@@ -136,20 +136,9 @@ protected:
     auto const y = image.height() - 1;
 
     EXPECT_NEAR( 0, image.at< uint8_t >( 0, 0, 0 ), pixel_epsilon );
-    EXPECT_NEAR( 0, image.at< uint8_t >( 0, 0, 1 ), pixel_epsilon );
-    EXPECT_NEAR( 0, image.at< uint8_t >( 0, 0, 2 ), pixel_epsilon );
-
     EXPECT_NEAR( 255, image.at< uint8_t >( 0, y, 0 ), pixel_epsilon );
-    EXPECT_NEAR( 255, image.at< uint8_t >( 0, y, 1 ), pixel_epsilon );
-    EXPECT_NEAR( 255, image.at< uint8_t >( 0, y, 2 ), pixel_epsilon );
-
     EXPECT_NEAR( 0, image.at< uint8_t >( x, y, 0 ), pixel_epsilon );
-    EXPECT_NEAR( 0, image.at< uint8_t >( x, y, 1 ), pixel_epsilon );
-    EXPECT_NEAR( 0, image.at< uint8_t >( x, y, 2 ), pixel_epsilon );
-
     EXPECT_NEAR( 255, image.at< uint8_t >( x, 0, 0 ), pixel_epsilon );
-    EXPECT_NEAR( 255, image.at< uint8_t >( x, 0, 1 ), pixel_epsilon );
-    EXPECT_NEAR( 255, image.at< uint8_t >( x, 0, 2 ), pixel_epsilon );
   }
 
   // Frame number encoded as 32-bit binary number in top row of pixels.
@@ -388,7 +377,7 @@ TEST_F ( ffmpeg_video_input_klv, h265_tricky_klv_verify )
     ASSERT_NE( nullptr, image );
     ASSERT_EQ( 160, image->width() );
     ASSERT_EQ( 120, image->height() );
-    ASSERT_EQ( 3, image->depth() );
+    ASSERT_EQ( 1, image->depth() );
     verify_gray_sentinel( image->get_image() );
 
     // Check frame number code

--- a/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
+++ b/arrows/ffmpeg/tests/test_video_output_ffmpeg.cxx
@@ -107,21 +107,6 @@ protected:
   TEST_ARG( data_dir );
 };
 
-namespace {
-
-// This will delete the temporary file even if an exception is thrown
-struct _tmp_file_deleter
-{
-  ~_tmp_file_deleter()
-  {
-    std::remove( tmp_path.c_str() );
-  }
-
-  std::string tmp_path;
-};
-
-} // namespace
-
 // ----------------------------------------------------------------------------
 // Test that reading, writing, then reading a video produces generally the
 // same result as the first time we read it.

--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -55,6 +55,10 @@ Arrows: FFmpeg
 
 * Added video_input_ffmpeg_rewire.
 
+* Added ffmpeg_image_io.
+
+* Added support for image channel counts from 1-4 (gray, gray+alpha, rgb, rgba).
+
 Arrows: KLV
 
 * Ensured that NaN comparisons happen consistently across all data structures.


### PR DESCRIPTION
This PR adds an FFmpeg-based image saving and loading algorithm. Some of the shared logic between this and the video reader / writer has been pulled out into a separate file. A few notes:
- Full support for loading (and saving) gray, gray+alpha, RGB, or RGBA has been added to both the video and image algorithms, instead of forcing everything to RGB as the video loader used to.
- Precision other than 8 bit is still not supported.
- Manual unofficial benchmarking yielded slightly faster speeds than the OpenCV implementation, but that assumes interlaced color planes in the input image. Separate planes would likely be significantly slower, but I haven't tested it.
- There is a config parameter to control image export quality, potentially useful for e.g. JPEG.