### PR TITLE
Map FFmpeg DEBUG log level to vital TRACE

### DIFF
--- a/arrows/ffmpeg/ffmpeg_init.cxx
+++ b/arrows/ffmpeg/ffmpeg_init.cxx
@@ -49,8 +49,10 @@ ffmpeg_kwiver_log_callback( void* ptr, int level, const char* fmt, va_list vl )
       LOG_INFO( ffmpeg_logger, msg );
       break;
     case AV_LOG_VERBOSE:
-    case AV_LOG_DEBUG:
       LOG_DEBUG( ffmpeg_logger, msg );
+      break;
+    case AV_LOG_DEBUG:
+      LOG_TRACE( ffmpeg_logger, msg );
       break;
     default:
       break;


### PR DESCRIPTION
DEBUG is the most verbose FFmpeg log level, and prints stuff like the name of every single CUDA function that is dynamically loaded in. This would be nice to be able to filter out, so this PR demotes it to our most verbose log level, TRACE.