### PR TITLE
Make paren spacing consistent

### DIFF
--- a/arrows/klv/klv_string.cxx
+++ b/arrows/klv/klv_string.cxx
@@ -90,7 +90,7 @@ klv_string_format
   {
     LOG_WARN( vital::get_logger( "klv" ),
       "format `" << description() << "` "
-      << "received wrong number of characters ( " << char_count << " ) "
+      << "received wrong number of characters (" << char_count << ") "
       << "when reading" );
   }
 
@@ -117,7 +117,7 @@ klv_string_format
   {
     LOG_WARN( vital::get_logger( "klv" ),
       "format `" << description() << "` "
-      << "received wrong number of characters ( " << char_count << " ) "
+      << "received wrong number of characters (" << char_count << ") "
       << "when writing" );
   }
 


### PR DESCRIPTION
This is more consistent with the formatting of other KLV log messages